### PR TITLE
Update to template with rubocop exclusion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,11 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 17
 
+# Template files have long lines before tag replacement
+Metrics/LineLength:
+  Exclude:
+    - docs/*.rb
+
 Metrics/MethodLength:
   Max: 113
 

--- a/docs/template-test_router.rb
+++ b/docs/template-test_router.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 require File.expand_path('../ciscotest', __FILE__)
-require File.expand_path('../../lib/cisco_node_utils/router___RESOURCE_NAME__',
+require File.expand_path('../../lib/cisco_node_utils/router_X__RESOURCE_NAME__X',
                          __FILE__)
 
 # TestX__CLASS_NAME__X - Minitest for X__CLASS_NAME__X node utility class
@@ -87,12 +87,12 @@ class TestX__CLASS_NAME__X < CiscoTestCase
     rtr = X__CLASS_NAME__X.new(id)
     val = 5 # This value depends on property bounds
     rtr.X__PROPERTY_INT__X = val
-    assert_equal(rtr.X__PROPERTY_INT__X, val, "__PROPERTY_INT__ is not #{val}")
+    assert_equal(rtr.X__PROPERTY_INT__X, val, "X__PROPERTY_INT__X is not #{val}")
 
     # Get default value from yaml
     val = node.config_get_default('X__RESOURCE_NAME__X', 'X__PROPERTY_INT__X')
     rtr.X__PROPERTY_INT__X = val
-    assert_equal(rtr.X__PROPERTY_INT__X, val, "__PROPERTY_INT__ is not #{val}")
+    assert_equal(rtr.X__PROPERTY_INT__X, val, "X__PROPERTY_INT__X is not #{val}")
   end
 
   def test_router_X__PROPERTY_BOOL__X


### PR DESCRIPTION
The feature template that we use in our developer guide was missing the correct replacement tags.  When I added them the result was a rubocop 'Line is too long.' error.  I made the changes and added a robocop exclusion for our template files under docs.
