### PR TITLE
Specified minimum ruby and rubygems versions

### DIFF
--- a/cisco_node_utils.gemspec
+++ b/cisco_node_utils.gemspec
@@ -23,6 +23,9 @@ Currently supports NX-OS nodes.
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version     = '>= 1.9.3'
+  spec.required_rubygems_version = '>= 2.1.0'
+
   spec.add_development_dependency 'minitest', '>= 2.5.1', '< 5.0.0'
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Rubygems version below 2.1 do not support semantic versioning and will cause builds to fail.

> [!] There was an error parsing `Gemfile`: There was a ArgumentError while loading cisco_node_utils.gemspec: 
> Malformed version number string 1.0.2-dev from
>   /home/robgrie/forks/cisco-network-node-utils/cisco_node_utils.gemspec:8:in `block in <main>'
> . Bundler cannot continue.

Puppet and Chef support Ruby version 1.9.3 or higher, so our minimum required Ruby version is now specified at 1.9.3
