### PR TITLE
Adding 'route-map' support to bgp_neighbor_af

### DIFF
--- a/lib/cisco_node_utils/bgp_neighbor_af.rb
+++ b/lib/cisco_node_utils/bgp_neighbor_af.rb
@@ -462,6 +462,53 @@ module Cisco
     end
 
     # -----------------------
+    # <state> route-map <str> in
+    def route_map_in
+      str = config_get('bgp_neighbor_af', 'route_map_in', @get_args)
+      return default_route_map_in if str.nil?
+      str.shift.strip
+    end
+
+    def route_map_in=(str)
+      str.strip! unless str.nil?
+      if str == default_route_map_in
+        state = 'no'
+        # Current route-map name is required for removal
+        str = route_map_in
+        return if str.nil?
+      end
+      set_args_keys(state: state, str: str)
+      config_set('bgp_neighbor_af', 'route_map_in', @set_args)
+    end
+
+    def default_route_map_in
+      config_get_default('bgp_neighbor_af', 'route_map_in')
+    end
+
+    # -----------------------
+    # <state> route-map <str> out
+    def route_map_out
+      str = config_get('bgp_neighbor_af', 'route_map_out', @get_args)
+      return default_route_map_out if str.nil?
+      str.shift.strip
+    end
+
+    def route_map_out=(str)
+      str.strip! unless str.nil?
+      if str == default_route_map_out
+        state = 'no'
+        # Current route-map name is required for removal
+        str = route_map_out
+      end
+      set_args_keys(state: state, str: str)
+      config_set('bgp_neighbor_af', 'route_map_out', @set_args)
+    end
+
+    def default_route_map_out
+      config_get_default('bgp_neighbor_af', 'route_map_out')
+    end
+
+    # -----------------------
     # <state route-reflector-client
     def route_reflector_client
       state = config_get('bgp_neighbor_af', 'route_reflector_client', @get_args)

--- a/lib/cisco_node_utils/command_reference_common_bgp.yaml
+++ b/lib/cisco_node_utils/command_reference_common_bgp.yaml
@@ -433,6 +433,16 @@ bgp_neighbor_af:
     config_set_append: '<state> next-hop-third-party'
     default_value: true
 
+  route_map_in:
+    config_get_token_append: '/^route-map (\S+) in$/'
+    config_set_append: '<state> route-map <str> in'
+    default_value: ''
+
+  route_map_out:
+    config_get_token_append: '/^route-map (\S+) out$/'
+    config_set_append: '<state> route-map <str> out'
+    default_value: ''
+
   route_reflector_client:
     config_get_token_append: '/^route-reflector-client$/'
     config_set_append: '<state> route-reflector-client'

--- a/tests/test_bgp_neighbor_af.rb
+++ b/tests/test_bgp_neighbor_af.rb
@@ -191,6 +191,8 @@ class TestRouterBgpNeighborAF < CiscoTestCase
     props = {
       filter_list_in:  'filt-in-name',
       filter_list_out: 'filt-out-name',
+      route_map_in:    'route-map-in-name',
+      route_map_out:   'route-map-out-name',
       unsuppress_map:  'unsupp-map-name',
     }
 


### PR DESCRIPTION
The route-map property was missing from the initial commit for bgp_neighbor_af.

This new code is an identical copy/replace of filter-list in/out.

Minitest/rubocop runs clean. Skipped CHANGELOG update since this is already covered by the entry for bgp_neighbor_af.
