### PR TITLE
Git hook enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Changelog
 * Added support for ntp_server (@hunner)
 * Added git hooks to streamline certain processes:
   * Validate commit message format for consistency
-  * Don't allow commit of code failing Rubocop lint checks
-  * Don't allow push if Rubocop is failing any check
+  * Don't allow commit of code failing RuboCop `--lint` checks
+  * If RuboCop is failing any check, warn on commit (but don't fail), and fail on push.
   * Don't allow push without updating CHANGELOG.md
   * Once git hooks are installed, automatically update them on pull/merge (if possible).
   * If using [git-flow]:

--- a/bin/git/hooks/commit-msg/enforce_style
+++ b/bin/git/hooks/commit-msg/enforce_style
@@ -6,6 +6,8 @@
 message_file = ARGV[0]
 full_message = File.read(message_file)
 message_lines = full_message.split("\n")
+# Omit comment lines - they don't need to be validated!
+message_lines = message_lines.select { |i| i.empty? || i[/^[^#]/] }
 
 $errors = 0 # rubocop:disable Style/GlobalVars
 
@@ -28,6 +30,8 @@ end
 # 2. Limit the subject line to 50 characters
 if message_lines.first.length > 50
   failure 'First line of commit message should be no more than 50 characters'
+  puts message_lines.first
+  puts '^' * 50
 end
 
 # 3. Capitalize the subject line
@@ -59,6 +63,9 @@ end
 # 6. Wrap the body at 72 characters
 if message_lines.any? { |line| line.length > 72 }
   failure 'Wrap the body at 72 characters'
+  puts '-' * 72
+  puts message_lines.select { |line| line.length > 72 }.join("\n")
+  puts '-' * 72
 end
 
 # 7. Use the body to explain what and why vs. how
@@ -67,7 +74,7 @@ end
 if $errors > 0 # rubocop:disable Style/GlobalVars
   puts 'Rejected commit message:'
   puts '{'
-  puts full_message
+  puts message_lines.join("\n")
   puts '}'
 end
 

--- a/bin/git/hooks/pre-commit/rubocop
+++ b/bin/git/hooks/pre-commit/rubocop
@@ -8,5 +8,13 @@
 # commit work-in-progress code to their local branch. We will do a full
 # rubocop run of all checks as part of the pre-push hook
 
+step_name "Running RuboCop lint checks"
 rubocop --lint
 check_rc "Please fix RuboCop lint failures before committing."
+
+# Do a full rubocop run to warn the user, but don't block a commit by it.
+step_name "Running all RuboCop checks"
+rubocop
+rc=$?
+[ $rc -eq 0 ] || echo -e "\t...[ ${YELLOW}WARNING${RESET} ] Fix all RuboCop failures before pushing upstream"
+exit 0


### PR DESCRIPTION
- commit-msg-enforce_style:
  - do not fail due to contents of comment lines
  - if line length constraints are validated, print the lines that are failing
- pre-commit-rubocop:
  - still only enforce `rubocop --lint`
  - however, also do a full `rubocop` run and warn the user if it reports any non-lint issues.
