### PR TITLE
The handle Cisco::Node config_get nil

### DIFF
--- a/lib/cisco_node_utils/name_server.rb
+++ b/lib/cisco_node_utils/name_server.rb
@@ -37,13 +37,13 @@ module Cisco
     end
 
     def self.nameservers
-      # Join and split because config_get returns array of strings separated by
-      # spaces (regexes are a subset of PDA)
-      hosts = config_get('dnsclient', 'name_server').join(' ').split(' ')
+      hosts = config_get('dnsclient', 'name_server')
       return {} if hosts.nil?
 
       hash = {}
-      hosts.each do |name|
+      # Join and split because config_get returns array of strings separated by
+      # spaces (regexes are a subset of PDA)
+      hosts.join(' ').split(' ').each do |name|
         hash[name] = NameServer.new(name, false)
       end
       hash

--- a/tests/test_name_server.rb
+++ b/tests/test_name_server.rb
@@ -34,14 +34,14 @@ class TestNameServer < CiscoTestCase
 
   def no_nameserver_google
     # Turn the feature off for a clean test.
-    config('no ip name-server 8.8.8.8',
-           'no ip name-server 2001:4860:4860::8888')
+    config('no ip name-server 7.7.7.7',
+           'no ip name-server 2001:4860:4860::7777')
   end
 
   # TESTS
 
   def test_nameserver_create_destroy_single_ipv4
-    id = '8.8.8.8'
+    id = '7.7.7.7'
     refute_includes(Cisco::NameServer.nameservers, id)
 
     ns = Cisco::NameServer.new(id)
@@ -53,7 +53,7 @@ class TestNameServer < CiscoTestCase
   end
 
   def test_nameserver_create_destroy_single_ipv6
-    id = '2001:4860:4860::8888'
+    id = '2001:4860:4860::7777'
     refute_includes(Cisco::NameServer.nameservers, id)
 
     ns = Cisco::NameServer.new(id)
@@ -65,10 +65,10 @@ class TestNameServer < CiscoTestCase
   end
 
   def test_router_create_destroy_multiple
-    id1 = '8.8.8.8'
-    id2 = '2001:4860:4860::8888'
+    id1 = '7.7.7.7'
+    id2 = '2001:4860:4860::7777'
     refute_includes(Cisco::NameServer.nameservers, id1)
-    refute_includes(Cisco::NameServer.nameservers, id2)
+    refute_includes(Cisco::NameServer.nameservers, id1)
 
     ns1 = Cisco::NameServer.new(id1)
     ns2 = Cisco::NameServer.new(id2)


### PR DESCRIPTION
The nxapi change to return empty string on ascii empty response does not
propagate the empty string past Cisco::Node.config_get; config_get
returns nil on an empty response. This change handles nil correctly.
