### PR TITLE
Tri-state prop changes

### DIFF
--- a/lib/cisco_node_utils/bgp_neighbor_af.rb
+++ b/lib/cisco_node_utils/bgp_neighbor_af.rb
@@ -211,8 +211,7 @@ module Cisco
     def additional_paths_receive
       val = config_get('bgp_neighbor_af', 'additional_paths_receive', @get_args)
       return default_additional_paths_receive if val.nil?
-      return :disable if /disable/.match(val.first)
-      :enable
+      /disable/.match(val.first) ? :disable : :enable
     end
 
     def additional_paths_receive=(val)
@@ -237,8 +236,7 @@ module Cisco
     def additional_paths_send
       val = config_get('bgp_neighbor_af', 'additional_paths_send', @get_args)
       return default_additional_paths_send if val.nil?
-      return :disable if /disable/.match(val.first)
-      :enable
+      /disable/.match(val.first) ? :disable : :enable
     end
 
     def additional_paths_send=(val)
@@ -515,8 +513,7 @@ module Cisco
     def soft_reconfiguration_in
       val = config_get('bgp_neighbor_af', 'soft_reconfiguration_in', @get_args)
       return default_soft_reconfiguration_in if val.nil?
-      return :always if /always/.match(val.first)
-      :enable
+      /always/.match(val.first) ? :always : :enable
     end
 
     def soft_reconfiguration_in=(val)

--- a/lib/cisco_node_utils/bgp_neighbor_af.rb
+++ b/lib/cisco_node_utils/bgp_neighbor_af.rb
@@ -205,64 +205,54 @@ module Cisco
 
     # -----------------------
     # <state> capability additional-paths receive <disable>
-    # Nvgens as True -OR- True with 'disable' keyword
-    def cap_add_paths_receive_get
-      val = config_get('bgp_neighbor_af', 'cap_add_paths_receive', @get_args)
-      return nil if val.nil?
-      (val.shift[/disable/]) ? 'disable' : true
+    #   :enable  = capability additional-paths receive
+    #   :disable = capability additional-paths receive disable
+    #   :inherit = no capability additional-paths receive
+    def additional_paths_receive
+      val = config_get('bgp_neighbor_af', 'additional_paths_receive', @get_args)
+      return default_additional_paths_receive if val.nil?
+      return :disable if /disable/.match(val.first)
+      :enable
     end
 
-    def cap_add_paths_receive
-      cap_add_paths_receive_get.nil? ? false : true
+    def additional_paths_receive=(val)
+      val = val.to_sym
+      if val == default_additional_paths_receive
+        set_args_keys(state: 'no', disable: '')
+      else
+        set_args_keys(state: '', disable: (val == :enable) ? '' : 'disable')
+      end
+      config_set('bgp_neighbor_af', 'additional_paths_receive', @set_args)
     end
 
-    def cap_add_paths_receive_disable
-      cap_add_paths_receive_get.to_s[/disable/] ? true : false
-    end
-
-    def cap_add_paths_receive_set(state, disable=false)
-      set_args_keys(state:   (state ? '' : 'no'),
-                    disable: (disable ? 'disable' : ''))
-      config_set('bgp_neighbor_af', 'cap_add_paths_receive', @set_args)
-    end
-
-    def default_cap_add_paths_receive
-      config_get_default('bgp_neighbor_af', 'cap_add_paths_receive')
-    end
-
-    def default_cap_add_paths_receive_disable
-      config_get_default('bgp_neighbor_af', 'cap_add_paths_receive_disable')
+    def default_additional_paths_receive
+      config_get_default('bgp_neighbor_af', 'additional_paths_receive').to_sym
     end
 
     # -----------------------
     # <state> capability additional-paths send <disable>
-    # Nvgens as True -OR- True with 'disable' keyword
-    def cap_add_paths_send_get
-      val = config_get('bgp_neighbor_af', 'cap_add_paths_send', @get_args)
-      return nil if val.nil?
-      (val.shift[/disable/]) ? 'disable' : true
+    #   :enable  = capability additional-paths send
+    #   :disable = capability additional-paths send disable
+    #   :inherit = no capability additional-paths send
+    def additional_paths_send
+      val = config_get('bgp_neighbor_af', 'additional_paths_send', @get_args)
+      return default_additional_paths_send if val.nil?
+      return :disable if /disable/.match(val.first)
+      :enable
     end
 
-    def cap_add_paths_send
-      cap_add_paths_send_get.nil? ? false : true
+    def additional_paths_send=(val)
+      val = val.to_sym
+      if val == default_additional_paths_send
+        set_args_keys(state: 'no', disable: '')
+      else
+        set_args_keys(state: '', disable: (val == :enable) ? '' : 'disable')
+      end
+      config_set('bgp_neighbor_af', 'additional_paths_send', @set_args)
     end
 
-    def cap_add_paths_send_disable
-      cap_add_paths_send_get.to_s[/disable/] ? true : false
-    end
-
-    def cap_add_paths_send_set(state, disable=false)
-      set_args_keys(state:   (state ? '' : 'no'),
-                    disable: (disable ? 'disable' : ''))
-      config_set('bgp_neighbor_af', 'cap_add_paths_send', @set_args)
-    end
-
-    def default_cap_add_paths_send
-      config_get_default('bgp_neighbor_af', 'cap_add_paths_send')
-    end
-
-    def default_cap_add_paths_send_disable
-      config_get_default('bgp_neighbor_af', 'cap_add_paths_send_disable')
+    def default_additional_paths_send
+      config_get_default('bgp_neighbor_af', 'additional_paths_send').to_sym
     end
 
     # -----------------------
@@ -519,33 +509,28 @@ module Cisco
 
     # -----------------------
     # <state> soft-reconfiguration inbound <always>
-    # Nvgens as True with optional 'always' keyword
-    def soft_reconfiguration_in_get
-      val = config_get('bgp_neighbor_af', 'soft_reconfiguration_in', @get_args)
-      return nil if val.nil?
-      (val.shift[/always/]) ? 'always' : true
-    end
-
+    #   :enable  = soft-reconfiguration inbound
+    #   :always = soft-reconfiguration inbound always
+    #   :inherit = no soft-reconfiguration inbound
     def soft_reconfiguration_in
-      soft_reconfiguration_in_get.nil? ? false : true
+      val = config_get('bgp_neighbor_af', 'soft_reconfiguration_in', @get_args)
+      return default_soft_reconfiguration_in if val.nil?
+      return :always if /always/.match(val.first)
+      :enable
     end
 
-    def soft_reconfiguration_in_always
-      soft_reconfiguration_in_get.to_s[/always/] ? true : false
-    end
-
-    def soft_reconfiguration_in_set(state, always=false)
-      set_args_keys(state:  (state ? '' : 'no'),
-                    always: (always ? 'always' : ''))
+    def soft_reconfiguration_in=(val)
+      val = val.to_sym
+      if val == default_soft_reconfiguration_in
+        set_args_keys(state: 'no', always: '')
+      else
+        set_args_keys(state: '', always: (val == :enable) ? '' : 'always')
+      end
       config_set('bgp_neighbor_af', 'soft_reconfiguration_in', @set_args)
     end
 
     def default_soft_reconfiguration_in
-      config_get_default('bgp_neighbor_af', 'soft_reconfiguration_in')
-    end
-
-    def default_soft_reconfiguration_in_always
-      config_get_default('bgp_neighbor_af', 'soft_reconfiguration_in_always')
+      config_get_default('bgp_neighbor_af', 'soft_reconfiguration_in').to_sym
     end
 
     # -----------------------

--- a/lib/cisco_node_utils/command_reference_common_bgp.yaml
+++ b/lib/cisco_node_utils/command_reference_common_bgp.yaml
@@ -368,21 +368,15 @@ bgp_neighbor_af:
     config_set_append: '<state> as-override'
     default_value: false
 
-  cap_add_paths_receive:
+  additional_paths_receive:
     config_get_token_append: '/^capability additional-paths receive(?: disable)?/'
     config_set_append: '<state> capability additional-paths receive <disable>'
-    default_value: false
+    default_value: 'inherit'
 
-  cap_add_paths_receive_disable:
-    default_value: false
-
-  cap_add_paths_send:
+  additional_paths_send:
     config_get_token_append: '/^capability additional-paths send(?: disable)?/'
     config_set_append: '<state> capability additional-paths send <disable>'
-    default_value: false
-
-  cap_add_paths_send_disable:
-    default_value: false
+    default_value: 'inherit'
 
   default_originate:
     config_get_token_append: '/^default-originate(?: route-map .*)?/'
@@ -446,10 +440,7 @@ bgp_neighbor_af:
   soft_reconfiguration_in:
     config_get_token_append: '/^soft-reconfiguration inbound(?: always)?/'
     config_set_append: '<state> soft-reconfiguration inbound <always>'
-    default_value: false
-
-  soft_reconfiguration_in_always:
-    default_value: false
+    default_value: 'inherit'
 
   soo:
     config_get_token_append: '/^soo (.*)$/'

--- a/tests/test_bgp_neighbor_af.rb
+++ b/tests/test_bgp_neighbor_af.rb
@@ -214,6 +214,35 @@ class TestRouterBgpNeighborAF < CiscoTestCase
   end
 
   # ---------------------------------
+  # tri-state properties:
+  #   additional_paths_receive
+  #   additional_paths_send
+  #   soft_reconfiguration_in
+  def test_tri_states
+    @@matrix.values.each do |af_args|
+      af, dbg = clean_af(af_args)
+
+      %w(additional_paths_receive additional_paths_send).each do |k|
+        [:enable, :disable, :inherit, 'enable', 'disable', 'inherit',
+         af.send("default_#{k}")
+        ].each do |val|
+          af.send("#{k}=", val)
+          assert_equal(val.to_sym, af.send(k), "#{dbg} Error: #{k}")
+        end
+      end
+
+      %w(soft_reconfiguration_in).each do |k|
+        [:enable, :always, :inherit, 'enable', 'always', 'inherit',
+         af.send("default_#{k}")
+        ].each do |val|
+          af.send("#{k}=", val)
+          assert_equal(val.to_sym, af.send(k), "#{dbg} Error: #{k}")
+        end
+      end
+    end
+  end
+
+  # ---------------------------------
   def test_advertise_map
     @@matrix.values.each do |af_args|
       af, dbg = clean_af(af_args)
@@ -280,58 +309,6 @@ class TestRouterBgpNeighborAF < CiscoTestCase
     af.allowas_in_set(true, af.default_allowas_in_max)
     assert_equal(af.default_allowas_in_max, af.allowas_in_max,
                  "Test 6. #{dbg} Failed to set True with default Value")
-  end
-
-  # ---------------------------------
-  def test_cap_add_paths
-    @@matrix.values.each do |af_args|
-      af, dbg = clean_af(af_args)
-      cap_add_paths(af, dbg)
-    end
-  end
-
-  def cap_add_paths(af, dbg)
-    %w(cap_add_paths_receive cap_add_paths_send).each do |k|
-      # Test basic true
-      af.send("#{k}_set", true)
-      assert(af.send(k),
-             "Test 1. #{dbg} [#{k}_set] failed to set state to True")
-
-      # Test true with disable, from true
-      af.send("#{k}_set", true, true)
-      assert(af.send("#{k}_disable"),
-             "Test 2. #{dbg} [#{k}_set] Failed to set True with disable")
-
-      # Test false while disabled
-      af.send("#{k}_set", false)
-      refute(af.send(k),
-             "Test 3. #{dbg} [#{k}_set] Failed to set False while disabled")
-
-      # Test true with disable, from false
-      af.send("#{k}_set", true, true)
-      assert(af.send("#{k}_disable"),
-             "Test 4. #{dbg} [#{k}_set] Failed to set True with disable " \
-             'from false')
-
-      # Test default_state
-      def_state = af.send("default_#{k}")
-      af.send("#{k}_set", def_state)
-      assert_equal(def_state, af.send(k),
-                   "Test 5. #{dbg} [#{k}_set] Failed to set state to default")
-
-      # Test true with default disable state
-      def_disable = af.send("default_#{k}_disable")
-      af.send("#{k}_set", true, def_disable)
-      assert_equal(def_disable, af.send("#{k}_disable"),
-                   "Test 6. #{dbg} [#{k}_set] Failed to set True with " \
-                   'default disable')
-
-      # Test false with true disable state
-      af.send("#{k}_set", false, true)
-      refute(af.send("#{k}_disable"),
-             "Test 7. #{dbg} [#{k}_set] Failed to set False with True " \
-             'disable state')
-    end
   end
 
   # ---------------------------------
@@ -564,47 +541,6 @@ class TestRouterBgpNeighborAF < CiscoTestCase
     af.send_community = af.default_send_community
     assert_equal(v, af.send_community,
                  "Test 10. #{dbg} Failed to set state to default")
-  end
-
-  # ---------------------------------
-  def test_soft_reconfiguration_in
-    @@matrix.values.each do |af_args|
-      af, dbg = clean_af(af_args)
-      soft_reconfiguration_in(af, dbg)
-    end
-  end
-
-  def soft_reconfiguration_in(af, dbg)
-    # Test basic true
-    af.soft_reconfiguration_in_set(true)
-    assert(af.soft_reconfiguration_in,
-           "Test 1. #{dbg} Failed to set True")
-
-    # Test true with always
-    af.soft_reconfiguration_in_set(true, true)
-    assert(af.soft_reconfiguration_in_always,
-           "Test 2. #{dbg} Failed to set True with Always")
-
-    # Test false with always
-    af.soft_reconfiguration_in_set(false)
-    refute(af.soft_reconfiguration_in,
-           "Test 3. #{dbg} Failed to set False")
-
-    # Test true with always, from false
-    af.soft_reconfiguration_in_set(true, true)
-    assert(af.soft_reconfiguration_in_always,
-           "Test 4. #{dbg} Failed to set True with Always, from false")
-
-    # Test default_state
-    af.soft_reconfiguration_in_set(af.default_soft_reconfiguration_in)
-    refute(af.soft_reconfiguration_in,
-           "Test 5. #{dbg} Failed to set to default")
-
-    # Test true with Always set to default
-    af.soft_reconfiguration_in_set(true,
-                                   af.default_soft_reconfiguration_in_always)
-    refute(af.soft_reconfiguration_in_always,
-           "Test 6. #{dbg} Failed to set True with default Always")
   end
 
   # ---------------------------------


### PR DESCRIPTION
Change these props to use tri-state values
  additional-paths [receive | send] [disable]
  soft-reconfiguration inbound

This is for CSCuw40269. 
I originally implemented these properties as multiple boolean properties (e.g.: cap_add_paths_send & cap_add_paths_send_disable); Jie had the same problem with log_neighbor_changes but coded it as a tri-state instead (:enable, :disable, :inherit). The team voted for the tri-states so this is just converting my props over to do the same. On the plus side it's reduced a lot of puppet code.

I also changed the prop names from cap_add_paths_\* to additional_paths_\* to match what bgp_af used.

Minitest, rubocop are clean. Puppet PR will follow shortly.
