### PR TITLE
Add assert_show_match/refute_show_match test APIs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,10 +2,10 @@
 
 # Baseline code complexity metrics - we should try and reduce these over time
 Metrics/AbcSize:
-  Max: 63
+  Max: 62
 
 Metrics/ClassLength:
-  Max: 725
+  Max: 722
 
 Metrics/CyclomaticComplexity:
   Max: 17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Changelog
   * Code coverage calculation using [SimpleCov]
   * Full Minitest suite can be run by `rake test`
   * UUT can be specified by the `NODE` environment variable or at runtime, in addition to the classic method of command line arguments to `ruby test_my_file.rb`
+  * Added `config` and `(assert|refute)_show_match` helper methods for testing.
 * Added `bin/check_metric_limits.rb` helper script in support of refactoring.
 
 ### Fixed

--- a/docs/README-develop-node-utils-APIs.md
+++ b/docs/README-develop-node-utils-APIs.md
@@ -179,7 +179,9 @@ end
 
 * A minitest should be created to validate the new APIs. Minitests are stored in the tests directory: `tests/`
 
-* Tests may use `config(cmd1, cmd2, ...)` and `@device.cmd("show ...")` to access the CLI directly set up tests and validate expected outcomes. The tests directory contains many examples of how these are used.
+* Tests may use `config(cmd1, cmd2, ...)` to access the CLI directly to set up tests.
+
+* Tests may use `@device.cmd("show ...")` or the helper methods `assert_show_match` and `refute_show_match` to validate expected outcomes in the CLI. The tests directory contains many examples of how these are used.
 
 * Our minitest will be very basic since the API itself is very basic. Use `template-test_feature.rb` to create a minitest for the tunnel resource:
 
@@ -638,18 +640,17 @@ class TestRouterEigrp < CiscoTestCase
   def test_router_create_destroy_one
     id = 'blue'
     rtr = RouterEigrp.new(id)
-    s = @device.cmd("show runn | i 'router eigrp #{id}'")
-    assert_match(s, /^router eigrp #{id}$/,
-                 "Error: failed to create router eigrp #{id}")
+    @default_show_command = "show runn | i 'router eigrp #{id}'")
+    assert_show_match(pattern: /^router eigrp #{id}$/,
+                      msg:     "failed to create router eigrp #{id}")
 
     rtr.destroy
-    s = @device.cmd("show runn | i 'router eigrp #{id}'")
-    refute_match(s, /^router eigrp #{id}$/,
-                 "Error: failed to destroy router eigrp #{id}")
+    refute_show_match(pattern: /^router eigrp #{id}$/,
+                      msg:     "failed to destroy router eigrp #{id}")
 
-    s = @device.cmd("show runn | i 'feature eigrp'")
-    refute_match(s, /^feature eigrp$/,
-                 "Error: failed to disable feature eigrp")
+    refute_show_match(command: "show runn | i 'feature eigrp'",
+                      pattern: /^feature eigrp$/,
+                      msg:     "failed to disable feature eigrp")
   end
 
   def test_router_create_destroy_multiple
@@ -658,23 +659,23 @@ class TestRouterEigrp < CiscoTestCase
     id2 = 'red'
     rtr2 = RouterEigrp.new(id2)
 
+    @default_show_command = "show runn | i 'router eigrp'"
+
     s = @device.cmd("show runn | i 'router eigrp'")
     assert_match(s, /^router eigrp #{id1}$/)
     assert_match(s, /^router eigrp #{id2}$/)
 
     rtr1.destroy
-    s = @device.cmd("show runn | i 'router eigrp #{id1}'")
-    refute_match(s, /^router eigrp #{id1}$/,
-                 "Error: failed to destroy router eigrp #{id1}")
+    refute_show_match(pattern: /^router eigrp #{id1}$/,
+                      msg:     "failed to destroy router eigrp #{id1}")
 
     rtr2.destroy
-    s = @device.cmd("show runn | i 'router eigrp #{id2}'")
-    refute_match(s, /^router eigrp #{id2}$/,
-                 "Error: failed to destroy router eigrp #{id2}")
+    refute_show_match(pattern: /^router eigrp #{id2}$/,
+                      msg:     "failed to destroy router eigrp #{id2}")
 
-    s = @device.cmd("show runn | i 'feature eigrp'")
-    refute_match(s, /^feature eigrp$/,
-                 "Error: failed to disable feature eigrp")
+    refute_show_match(command: "show runn | i 'feature eigrp'",
+                      pattern: /^feature eigrp$/,
+                      msg:     "failed to disable feature eigrp")
   end
 
   def test_router_maximum_paths

--- a/docs/template-test_router.rb
+++ b/docs/template-test_router.rb
@@ -40,18 +40,17 @@ class TestX__CLASS_NAME__X < CiscoTestCase
   def test_router_create_destroy_one
     id = 'blue'
     rtr = X__CLASS_NAME__X.new(id)
-    s = @device.cmd("show runn | i 'router X__RESOURCE_NAME__X #{id}'")
-    assert_match(s, /^router X__RESOURCE_NAME__X #{id}$/,
-                 "Error: failed to create router X__RESOURCE_NAME__X #{id}")
+    @default_show_command = "show runn | i 'router X__RESOURCE_NAME__X #{id}'"
+    assert_show_match(pattern: /^router X__RESOURCE_NAME__X #{id}$/,
+                      msg:     "failed to create router X__RESOURCE_NAME__X #{id}")
 
     rtr.destroy
-    s = @device.cmd("show runn | i 'router X__RESOURCE_NAME__X #{id}'")
-    refute_match(s, /^router X__RESOURCE_NAME__X #{id}$/,
-                 "Error: failed to destroy router X__RESOURCE_NAME__X #{id}")
+    refute_show_match(pattern: /^router X__RESOURCE_NAME__X #{id}$/,
+                      msg:     "failed to destroy router X__RESOURCE_NAME__X #{id}")
 
-    s = @device.cmd("show runn | i 'feature X__RESOURCE_NAME__X'")
-    refute_match(s, /^feature X__RESOURCE_NAME__X$/,
-                 'Error: failed to disable feature X__RESOURCE_NAME__X')
+    refute_show_match(command: "show runn | i 'feature X__RESOURCE_NAME__X'",
+                      pattern: /^feature X__RESOURCE_NAME__X$/,
+                      msg:     'failed to disable feature X__RESOURCE_NAME__X')
   end
 
   def test_router_create_destroy_multiple
@@ -60,23 +59,23 @@ class TestX__CLASS_NAME__X < CiscoTestCase
     id2 = 'red'
     rtr2 = X__CLASS_NAME__X.new(id2)
 
+    @default_show_command = "show runn | i 'router X__RESOURCE_NAME__X'"
+
     s = @device.cmd("show runn | i 'router X__RESOURCE_NAME__X'")
     assert_match(s, /^router X__RESOURCE_NAME__X #{id1}$/)
     assert_match(s, /^router X__RESOURCE_NAME__X #{id2}$/)
 
     rtr1.destroy
-    s = @device.cmd("show runn | i 'router X__RESOURCE_NAME__X #{id1}'")
-    refute_match(s, /^router X__RESOURCE_NAME__X #{id1}$/,
-                 "Error: failed to destroy router X__RESOURCE_NAME__X #{id1}")
+    refute_show_match(pattern: /^router X__RESOURCE_NAME__X #{id1}$/,
+                      msg:     "failed to destroy router X__RESOURCE_NAME__X #{id1}")
 
     rtr2.destroy
-    s = @device.cmd("show runn | i 'router X__RESOURCE_NAME__X #{id2}'")
-    refute_match(s, /^router X__RESOURCE_NAME__X #{id2}$/,
-                 "Error: failed to destroy router X__RESOURCE_NAME__X #{id2}")
+    refute_show_match(pattern: /^router X__RESOURCE_NAME__X #{id2}$/,
+                      msg:     "failed to destroy router X__RESOURCE_NAME__X #{id2}")
 
-    s = @device.cmd("show runn | i 'feature X__RESOURCE_NAME__X'")
-    refute_match(s, /^feature X__RESOURCE_NAME__X$/,
-                 'Error: failed to disable feature X__RESOURCE_NAME__X')
+    refute_show_match(command: "show runn | i 'feature X__RESOURCE_NAME__X'",
+                      pattern: /^feature X__RESOURCE_NAME__X$/,
+                      msg:     'failed to disable feature X__RESOURCE_NAME__X')
   end
 
   def test_router_X__PROPERTY_INT__X

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -100,7 +100,40 @@ class TestCase < Test::Unit::TestCase
   end
 
   def config(*args)
-    @device.cmd("configure terminal\n" + args.join("\n") + "\nend")
+    # Send the entire config as one string but be sure not to return until
+    # we are safely back out of config mode, i.e. prompt is
+    # 'switch#' not 'switch(config)#' or 'switch(config-if)#' etc.
+    @device.cmd('String' => "configure terminal\n" + args.join("\n") + "\nend",
+                'Match'  => /^[^()]+[$%#>] \z/n)
+  end
+
+  def assert_show_match(pattern: nil, command: nil, msg: nil)
+    pattern ||= @default_output_pattern
+    refute_nil(pattern)
+    command ||= @default_show_command
+    refute_nil(command)
+
+    output = @device.cmd(command)
+    msg = message(msg) do
+      "Expected #{mu_pp pattern} to match " \
+      "output of '#{mu_pp command}':\n#{output}"
+    end
+    assert pattern =~ output, msg
+    pattern.match(output)
+  end
+
+  def refute_show_match(pattern: nil, command: nil, msg: nil)
+    pattern ||= @default_output_pattern
+    refute_nil(pattern)
+    command ||= @default_show_command
+    refute_nil(command)
+
+    output = @device.cmd(command)
+    msg = message(msg) do
+      "Expected #{mu_pp pattern} to NOT match " \
+      "output of '#{mu_pp command}':\n#{output}"
+    end
+    refute pattern =~ output, msg
   end
 end
 # rubocop:enable Style/ClassVars

--- a/tests/test_node_ext.rb
+++ b/tests/test_node_ext.rb
@@ -16,6 +16,11 @@ require File.expand_path('../ciscotest', __FILE__)
 
 # TestNodeExt - Minitest for abstracted Node APIs
 class TestNodeExt < CiscoTestCase
+  def assert_output_check(command: nil, pattern: nil, msg: nil, check: nil)
+    md = assert_show_match(command: command, pattern: pattern, msg: msg)
+    assert_equal(md[1], check, msg)
+  end
+
   def show_run_ospf
     "\
 router ospf foo
@@ -163,64 +168,47 @@ vrf blue",
     ref = cmd_ref.lookup('show_version', 'description')
     assert(ref, 'Error, reference not found')
 
-    s = @device.cmd("#{ref.test_config_get}")
-    pattern = ref.test_config_get_regex
-    md = pattern.match(s)
-    assert(md, "Error, no match found for #{pattern}")
-    assert_equal(md[1], product_description,
-                 'Error, Product description does not match')
+    assert_output_check(command: ref.test_config_get,
+                        pattern: ref.test_config_get_regex,
+                        check:   product_description,
+                        msg:     'Error, Product description does not match')
   end
 
   def test_node_get_product_id
-    product_id = node.product_id
-    s = @device.cmd('show inventory | no-more')
-    pattern = /NAME: \"Chassis\".*\nPID: (\S+)/
-    md = pattern.match(s)
-    assert(md, "Error, no match found for #{pattern}")
-    assert_equal(md[1], product_id,
-                 'Error, Product id does not match')
+    assert_output_check(command: 'show inventory | no-more',
+                        pattern: /NAME: \"Chassis\".*\nPID: (\S+)/,
+                        check:   node.product_id,
+                        msg:     'Error, Product id does not match')
   end
 
   def test_node_get_product_version_id
-    version_id = node.product_version_id
-    s = @device.cmd('show inventory | no-more')
-    pattern = /NAME: \"Chassis\".*\n.*VID: (\w+)/
-    md = pattern.match(s)
-    assert(md, "Error, no match found for #{pattern}")
-    assert_equal(md[1], version_id,
-                 'Error, Version id does not match')
+    assert_output_check(command: 'show inventory | no-more',
+                        pattern: /NAME: \"Chassis\".*\n.*VID: (\w+)/,
+                        check:   node.product_version_id,
+                        msg:     'Error, Version id does not match')
   end
 
   def test_node_get_product_serial_number
-    serial_number = node.product_serial_number
-    s = @device.cmd('show inventory | no-more')
-    pattern = /NAME: \"Chassis\".*\n.*SN: (\w+)/
-    md = pattern.match(s)
-    assert(md, "Error, no match found for #{pattern}")
-    assert_equal(md[1], serial_number,
-                 'Error, Serial number does not match')
+    assert_output_check(command: 'show inventory | no-more',
+                        pattern: /NAME: \"Chassis\".*\n.*SN: (\w+)/,
+                        check:   node.product_serial_number,
+                        msg:     'Error, Serial number does not match')
   end
 
   def test_node_get_os
-    os = node.os
-    s = @device.cmd('show version | no-more')
-    pattern = /\n(Cisco.*)\n/
-    md = pattern.match(s)
-    assert(md, "Error, no match found for #{pattern}")
-    assert_equal(md[1], os,
-                 'Error, OS version does not match')
+    assert_output_check(command: 'show version | no-more',
+                        pattern: /\n(Cisco.*)\n/,
+                        check:   node.os,
+                        msg:     'Error, OS version does not match')
   end
 
   def test_node_get_os_version
-    os_version = node.os_version
     ref = cmd_ref.lookup('show_version', 'version')
     assert(ref, 'Error, reference not found')
-    s = @device.cmd("#{ref.test_config_get}")
-    pattern = ref.test_config_get_regex[1]
-    md = pattern.match(s)
-    assert(md, "Error, no match found for #{pattern}")
-    assert_equal(md[1], os_version,
-                 'Error, OS version does not match')
+    assert_output_check(command: ref.test_config_get,
+                        pattern: ref.test_config_get_regex[1],
+                        check:   node.os_version,
+                        msg:     'Error, OS version does not match')
   end
 
   def test_node_get_host_name_when_not_set
@@ -336,11 +324,9 @@ vrf blue",
     pattern = /.*System uptime:\s+(\d+) days, (\d+) hours, (\d+) minutes, (\d+) seconds/
     # rubocop:enable Metrics/LineLength
 
-    s = @device.cmd('show system uptime | no-more')
+    md = assert_show_match(command: 'show system uptime | no-more',
+                           pattern: pattern)
     node_uptime = node.system_uptime
-
-    md = pattern.match(s)
-    assert(md, "Error, no match found for #{pattern}")
 
     observed_system_uptime = (
       (md[1].to_i * 86_400) +
@@ -357,40 +343,34 @@ vrf blue",
     last_reset_time = node.last_reset_time
     ref = cmd_ref.lookup('show_version', 'last_reset_time')
     assert(ref, 'Error, reference not found')
-    s = @device.cmd("#{ref.test_config_get}")
-    pattern = ref.test_config_get_regex
-    md = pattern.match(s)
     # N9k doesn't provide this info at present.
     if !last_reset_time.empty?
-      assert(md, "Error, no match found for #{pattern}")
-      assert_equal(md[1], last_reset_time,
-                   'Error, Last reset time does not match')
+      assert_output_check(command: ref.test_config_get,
+                          pattern: ref.test_config_get_regex,
+                          check:   last_reset_time,
+                          msg:     'Error, Last reset time does not match')
     else
-      assert(!md, "Error, output found in ASCII '#{md}' but not in node")
+      refute_show_match(command: ref.test_config_get,
+                        pattern: ref.test_config_get_regex,
+                        msg:     'output found in ASCII but not in node')
     end
   end
 
   def test_node_get_last_reset_reason
-    last_reset_reason = node.last_reset_reason
     ref = cmd_ref.lookup('show_version', 'last_reset_reason')
     assert(ref, 'Error, reference not found')
-    s = @device.cmd("#{ref.test_config_get}")
-    pattern = ref.test_config_get_regex
-    md = pattern.match(s)
-    refute_nil(md, 'ERROR: last reset reason not shown')
-    assert(md, "Error, no match found for #{pattern}")
-    assert_equal(md[1], last_reset_reason,
-                 'Error, Last reset reason does not match')
+    assert_output_check(command: ref.test_config_get,
+                        pattern: ref.test_config_get_regex,
+                        check:   node.last_reset_reason,
+                        msg:     'Error, Last reset reason does not match')
   end
 
   def test_node_get_system_cpu_utilization
     cpu_utilization = node.system_cpu_utilization
     ref = cmd_ref.lookup('system', 'resources')
     assert(ref, 'Error, reference not found')
-    s = @device.cmd("#{ref.test_config_get}")
-    pattern = ref.test_config_get_regex
-    md = pattern.match(s)
-    assert(md, "Error, md not populated, #{s}")
+    md = assert_show_match(command: ref.test_config_get,
+                           pattern: ref.test_config_get_regex)
     observed_cpu_utilization = md[1].to_f + md[2].to_f
     delta = cpu_utilization - observed_cpu_utilization
     assert(delta > -15.0 && delta < 15.0,
@@ -398,22 +378,20 @@ vrf blue",
   end
 
   def test_node_get_boot
-    boot = node.boot
     ref = cmd_ref.lookup('show_version', 'boot_image')
     assert(ref, 'Error, reference not found')
-    s = @device.cmd("#{ref.test_config_get}")
-    s =~ ref.test_config_get_regex
-    assert_equal(Regexp.last_match(1), boot,
-                 'Error, Kickstart Image does not match')
+    assert_output_check(command: ref.test_config_get,
+                        pattern: ref.test_config_get_regex,
+                        check:   node.boot,
+                        msg:     'Error, Kickstart Image does not match')
   end
 
   def test_node_get_system
-    system = node.system
     ref = cmd_ref.lookup('show_version', 'system_image')
     assert(ref, 'Error, reference not found')
-    s = @device.cmd("#{ref.test_config_get}")
-    s =~ ref.test_config_get_regex
-    assert_equal(Regexp.last_match(1), system,
-                 'Error, System Image does not match')
+    assert_output_check(command: ref.test_config_get,
+                        pattern: ref.test_config_get_regex,
+                        check:   node.system,
+                        msg:     'Error, System Image does not match')
   end
 end

--- a/tests/test_router_ospf.rb
+++ b/tests/test_router_ospf.rb
@@ -17,14 +17,13 @@ require File.expand_path('../../lib/cisco_node_utils/router_ospf', __FILE__)
 
 # TestRouterOspf - Minitest for the RouterOspf node utility class.
 class TestRouterOspf < CiscoTestCase
-  def routerospf_routers_destroy(routers)
-    routers.each_value(&:destroy)
+  def setup
+    super
+    @default_show_command = "show run | include '^router ospf .*'"
   end
 
-  def get_routerospf_match_line(name)
-    s = @device.cmd("show run | include '^router ospf .*'")
-    cmd = 'router ospf'
-    /#{cmd}\s#{name}/.match(s)
+  def routerospf_routers_destroy(routers)
+    routers.each_value(&:destroy)
   end
 
   def test_routerospf_collection_empty
@@ -41,8 +40,7 @@ class TestRouterOspf < CiscoTestCase
                  'RouterOspf collection is empty')
     # validate the collection
     routers.each_key do |name|
-      line = get_routerospf_match_line(name)
-      assert_equal(false, line.nil?)
+      assert_show_match(pattern: /router ospf #{name}/)
     end
     routerospf_routers_destroy(routers)
   end
@@ -56,43 +54,31 @@ class TestRouterOspf < CiscoTestCase
   def test_routerospf_create_valid
     name = 'ospfTest'
     ospf = RouterOspf.new(name)
-    line = get_routerospf_match_line(name)
-    # puts "cfg line: #{line}"
-    assert_equal(false, line.nil?,
-                 "Error: 'router ospf ospfTest' not configured")
+    assert_show_match(pattern: /router ospf #{name}/,
+                      msg:     "'router ospf ospfTest' not configured")
     ospf.destroy
   end
 
   def test_routerospf_create_valid_no_feature
     name = 'ospfTest'
     ospf = RouterOspf.new(name)
-    line = get_routerospf_match_line(name)
-    # puts "cfg line: #{line}"
-    assert_equal(false, line.nil?,
-                 "Error: 'router ospf ospfTest' not configured")
+    assert_show_match(pattern: /router ospf #{name}/,
+                      msg:     "'router ospf ospfTest' not configured")
     ospf.destroy
 
-    s = @device.cmd('show run all | no-more')
-    cmd = 'feature ospf'
-    line = /#{cmd}/.match(s)
-    assert_equal(true, line.nil?,
-                 "Error: 'feature ospf' still configured")
+    refute_show_match(command: 'show run all | no-more',
+                      pattern: /feature ospf/,
+                      msg:     "Error: 'feature ospf' still configured")
   end
 
   def test_routerospf_create_valid_multiple
     name = 'ospfTest_1'
     ospf_1 = RouterOspf.new(name)
-    line = get_routerospf_match_line(name)
-    # puts "cfg line: #{line}"
-    assert_equal(false, line.nil?,
-                 "Error: 'router ospf ospfTest_1' not configured")
+    assert_show_match(pattern: /router ospf #{name}/)
 
     name = 'ospfTest_2'
     ospf_2 = RouterOspf.new(name)
-    line = get_routerospf_match_line(name)
-    # puts "cfg line: #{line}"
-    assert_equal(false, line.nil?,
-                 "Error: 'router ospf ospfTest_1' not configured")
+    assert_show_match(pattern: /router ospf #{name}/)
 
     ospf_1.destroy
     ospf_2.destroy
@@ -101,8 +87,7 @@ class TestRouterOspf < CiscoTestCase
   def test_routerospf_get_name
     name = 'ospfTest'
     ospf = RouterOspf.new(name)
-    line = get_routerospf_match_line(name)
-    # puts "cfg line: #{line}"
+    line = assert_show_match(pattern: /router ospf #{name}/)
     name = line.to_s.split(' ').last
     # puts "name from cli: #{name}"
     # puts "name from get: #{routerospf.name}"
@@ -115,26 +100,20 @@ class TestRouterOspf < CiscoTestCase
     name = 'ospfTest'
     ospf = RouterOspf.new(name)
     ospf.destroy
-    line = get_routerospf_match_line(name)
-    # puts "cfg line: #{line}"
-    assert_equal(true, line.nil?,
-                 "Error: 'router ospf ospfTest' not destroyed")
+    refute_show_match(pattern: /router ospf #{name}/,
+                      msg:     "'router ospf ospfTest' not destroyed")
   end
 
   def test_routerospf_create_valid_multiple_delete_one
     name = 'ospfTest_1'
     ospf_1 = RouterOspf.new(name)
-    line = get_routerospf_match_line(name)
-    # puts "cfg line: #{line}"
-    assert_equal(false, line.nil?,
-                 "Error: #{name}, not configured")
+    assert_show_match(pattern: /router ospf #{name}/,
+                      msg:     "Error: #{name}, not configured")
 
     name = 'ospfTest_2'
     ospf_2 = RouterOspf.new(name)
-    line = get_routerospf_match_line(name)
-    # puts "cfg line: #{line}"
-    assert_equal(false, line.nil?,
-                 "Error: #{name}, not configured")
+    assert_show_match(pattern: /router ospf #{name}/,
+                      msg:     "Error: #{name}, not configured")
 
     ospf_1.destroy
 
@@ -147,9 +126,8 @@ class TestRouterOspf < CiscoTestCase
     assert_equal(true, routers.key?(name),
                  "Error: #{name}, not found in the collection")
     # validate the collection
-    line = get_routerospf_match_line(name)
-    assert_equal(false, line.nil?,
-                 "Error: #{name}, instance not found")
+    assert_show_match(pattern: /router ospf #{name}/,
+                      msg:     "Error: #{name}, instance not found")
     ospf_2.destroy
   end
 end

--- a/tests/test_snmpcommunity.rb
+++ b/tests/test_snmpcommunity.rb
@@ -30,6 +30,11 @@ class TestSnmpCommunity < CiscoTestCase
   DEFAULT_SNMP_COMMUNITY_GROUP = 'network-operator'
   DEFAULT_SNMP_COMMUNITY_ACL = ''
 
+  def setup
+    super
+    @default_show_command = 'show run snmp all | no-more'
+  end
+
   def test_snmpcommunity_collection_empty
     # This test requires all the snmp communities removed from device
     s = @device.cmd('show run snmp all | no-more')
@@ -122,11 +127,8 @@ class TestSnmpCommunity < CiscoTestCase
     name = 'cisco'
     group = 'network-operator'
     snmpcommunity = SnmpCommunity.new(name, group)
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server community'
-    line = /#{cmd}\s#{name}\sgroup\s#{group}/.match(s)
-    # puts "line: #{line}"
-    assert_equal(false, line.nil?)
+    assert_show_match(
+      pattern: /snmp-server community\s#{name}\sgroup\s#{group}/)
     cleanup_snmpcommunity(snmpcommunity)
   end
 
@@ -134,11 +136,8 @@ class TestSnmpCommunity < CiscoTestCase
     name = 'cisco128lab'
     group = 'network-operator'
     snmpcommunity = SnmpCommunity.new(name, group)
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server community'
-    line = /#{cmd}\s#{name}\sgroup\s#{group}/.match(s)
-    # puts "line: #{line}"
-    assert_equal(false, line.nil?)
+    assert_show_match(
+      pattern: /snmp-server community\s#{name}\sgroup\s#{group}/)
     cleanup_snmpcommunity(snmpcommunity)
   end
 
@@ -187,10 +186,8 @@ class TestSnmpCommunity < CiscoTestCase
     # new group
     group = 'network-admin'
     snmpcommunity.group = group
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server community'
-    line = /#{cmd}\s#{name}\sgroup\s#{group}/.match(s)
-    assert_equal(false, line.nil?)
+    assert_show_match(
+      pattern: /snmp-server community\s#{name}\sgroup\s#{group}/)
     cleanup_snmpcommunity(snmpcommunity)
   end
 
@@ -201,20 +198,14 @@ class TestSnmpCommunity < CiscoTestCase
     # new group identity
     group = 'vdc-admin'
     snmpcommunity.group = group
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server community'
-    line = /#{cmd}\s#{name}\sgroup\s#{group}/.match(s)
-    # puts line
-    assert_equal(false, line.nil?)
+    assert_show_match(
+      pattern: /snmp-server community\s#{name}\sgroup\s#{group}/)
 
     # Restore group default
     group = SnmpCommunity.default_group
     snmpcommunity.group = group
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server community'
-    line = /#{cmd}\s#{name}\sgroup\s#{group}/.match(s)
-    # puts line
-    assert_equal(false, line.nil?)
+    assert_show_match(
+      pattern: /snmp-server community\s#{name}\sgroup\s#{group}/)
 
     cleanup_snmpcommunity(snmpcommunity)
   end
@@ -224,10 +215,8 @@ class TestSnmpCommunity < CiscoTestCase
     group = 'network-operator'
     snmpcommunity = SnmpCommunity.new(name, group)
     snmpcommunity.destroy
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server community'
-    line = /#{cmd}\s#{name}\sgroup\s#{group}/.match(s)
-    assert_equal(true, line.nil?)
+    refute_show_match(
+      pattern: /snmp-server community\s#{name}\sgroup\s#{group}/)
   end
 
   def test_snmpcommunity_acl_get_no_acl
@@ -243,10 +232,9 @@ class TestSnmpCommunity < CiscoTestCase
     group = 'network-operator'
     snmpcommunity = SnmpCommunity.new(name, group)
     snmpcommunity.acl = 'ciscoacl'
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server community'
-    line = /#{cmd}\s#{name}\suse-acl\s\S+/.match(s)
-    acl = line.to_s.gsub(/#{cmd}\s#{name}\suse-acl\s/, '').strip
+    line = assert_show_match(
+      pattern: /snmp-server community\s#{name}\suse-acl\s\S+/)
+    acl = line.to_s.gsub(/snmp-server community\s#{name}\suse-acl\s/, '').strip
     assert_equal(snmpcommunity.acl, acl)
     cleanup_snmpcommunity(snmpcommunity)
   end
@@ -267,11 +255,8 @@ class TestSnmpCommunity < CiscoTestCase
     acl = 'ciscoadminacl'
     snmpcommunity = SnmpCommunity.new(name, group)
     snmpcommunity.acl = acl
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server community'
-    line = /#{cmd}\s#{name}\suse-acl\s#{acl}/.match(s)
-    # puts "line: #{line}"
-    assert_equal(false, line.nil?)
+    assert_show_match(
+      pattern: /snmp-server community\s#{name}\suse-acl\s#{acl}/)
     cleanup_snmpcommunity(snmpcommunity)
   end
 
@@ -282,17 +267,12 @@ class TestSnmpCommunity < CiscoTestCase
     snmpcommunity = SnmpCommunity.new(name, group)
     # puts "set acl #{acl}"
     snmpcommunity.acl = acl
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server community'
-    line = /#{cmd}\s#{name}\suse-acl\s#{acl}/.match(s)
-    # puts "line: #{line}"
-    assert_equal(false, line.nil?)
+    assert_show_match(
+      pattern: /snmp-server community\s#{name}\suse-acl\s#{acl}/)
     # remove acl
     snmpcommunity.acl = ''
-    s = @device.cmd('show run snmp all | no-more')
-    line = /#{cmd}\s#{name}\suse-acl\s#{acl}/.match(s)
-    # puts "line: #{line}"
-    assert_equal(true, line.nil?)
+    refute_show_match(
+      pattern: /snmp-server community\s#{name}\suse-acl\s#{acl}/)
     cleanup_snmpcommunity(snmpcommunity)
   end
 
@@ -302,11 +282,8 @@ class TestSnmpCommunity < CiscoTestCase
     acl = 'cisco_test_acl'
     snmpcommunity = SnmpCommunity.new(name, group)
     snmpcommunity.acl = acl
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server community'
-    line = /#{cmd}\s#{name}\suse-acl\s#{acl}/.match(s)
-    # puts "line: #{line}"
-    assert_equal(false, line.nil?)
+    assert_show_match(
+      pattern: /snmp-server community\s#{name}\suse-acl\s#{acl}/)
 
     # Check default_acl
     assert_equal(DEFAULT_SNMP_COMMUNITY_ACL,
@@ -316,10 +293,8 @@ class TestSnmpCommunity < CiscoTestCase
     # Set acl to default
     acl = SnmpCommunity.default_acl
     snmpcommunity.acl = acl
-    s = @device.cmd('show run snmp all | no-more')
-    line = /#{cmd}\s#{name}\suse-acl\s#{acl}/.match(s)
-    # puts "line: #{line}"
-    assert_equal(true, line.nil?)
+    refute_show_match(
+      pattern: /snmp-server community\s#{name}\suse-acl\s#{acl}/)
     cleanup_snmpcommunity(snmpcommunity)
   end
 end

--- a/tests/test_snmpgroup.rb
+++ b/tests/test_snmpgroup.rb
@@ -20,8 +20,7 @@ class TestSnmpGroup < CiscoTestCase
   # NXOS snmp groups will not be empty
   def test_snmpgroup_collection_not_empty
     snmpgroups = SnmpGroup.groups
-    assert_equal(false, snmpgroups.empty?,
-                 'SnmpGroup collection is empty')
+    refute_empty(snmpgroups)
   end
 
   def test_snmpgroup_collection_valid

--- a/tests/test_snmpserver.rb
+++ b/tests/test_snmpserver.rb
@@ -25,6 +25,11 @@ class TestSnmpServer < CiscoTestCase
   DEFAULT_SNMP_SERVER_PROTOCOL_ENABLE = true
   DEFAULT_SNMP_SERVER_TCP_SESSION_AUTH = true
 
+  def setup
+    super
+    @default_show_command = 'show run snmp all | no-more'
+  end
+
   def test_snmpserver_aaa_user_cache_timeout_set_invalid_upper_range
     snmpserver = SnmpServer.new
     assert_raises(Cisco::CliError) do
@@ -43,9 +48,8 @@ class TestSnmpServer < CiscoTestCase
     snmpserver = SnmpServer.new
     newtimeout = 1400
     snmpserver.aaa_user_cache_timeout = newtimeout
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server aaa-user cache-timeout'
-    line = /#{cmd} (\d+)/.match(s)
+    line = assert_show_match(
+      pattern: /snmp-server aaa-user cache-timeout (\d+)/)
     timeout = line.to_s.split(' ').last.to_i
     assert_equal(timeout, newtimeout)
     # set to default
@@ -57,18 +61,16 @@ class TestSnmpServer < CiscoTestCase
     snmpserver = SnmpServer.new
     snmpserver.aaa_user_cache_timeout =
       snmpserver.default_aaa_user_cache_timeout
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server aaa-user cache-timeout'
-    line = /#{cmd} (\d+)/.match(s)
+    line = assert_show_match(
+      pattern: /snmp-server aaa-user cache-timeout (\d+)/)
     timeout = line.to_s.split(' ').last.to_i
     assert_equal(timeout, snmpserver.aaa_user_cache_timeout)
   end
 
   def test_snmpserver_aaa_user_cache_timeout_get
     snmpserver = SnmpServer.new
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server aaa-user cache-timeout'
-    line = /#{cmd} (\d+)/.match(s)
+    line = assert_show_match(
+      pattern: /snmp-server aaa-user cache-timeout (\d+)/)
     timeout = line.to_s.split(' ').last.to_i
     assert_equal(timeout, snmpserver.aaa_user_cache_timeout)
   end
@@ -76,8 +78,8 @@ class TestSnmpServer < CiscoTestCase
   def test_snmpserver_sys_contact_get
     snmpserver = SnmpServer.new
     snmpserver.contact = 'test-contact'
-    s = @device.cmd('show snmp | no-more')
-    line = /sys contact: [^\n\r]+/.match(s)
+    line = assert_show_match(command: 'show snmp | no-more',
+                             pattern: /sys contact: [^\n\r]+/)
     contact = ''
     contact = line.to_s.gsub('sys contact:', '').strip unless line.nil?
     # puts "contact : #{line}, #{snmpserver.contact}"
@@ -106,8 +108,8 @@ class TestSnmpServer < CiscoTestCase
     snmpserver = SnmpServer.new
     newcontact = 'mvenkata_test# contact'
     snmpserver.contact = newcontact
-    s = @device.cmd('show snmp | no-more')
-    line = /sys contact: [^\n\r]+/.match(s)
+    line = assert_show_match(command: 'show snmp | no-more',
+                             pattern: /sys contact: [^\n\r]+/)
     # puts "line: #{line}"
     contact = line.to_s.gsub('sys contact:', '').strip
     assert_equal(contact, newcontact)
@@ -120,8 +122,8 @@ class TestSnmpServer < CiscoTestCase
     # newcontact = "Test{}(%tuvy@_cisco contact$#!@1234^&*()_+"
     newcontact = 'user@example.com @$%&}test ]|[#_@test contact'
     snmpserver.contact = newcontact
-    s = @device.cmd('show snmp | no-more')
-    line = /sys contact: [^\n\r]+/.match(s)
+    line = assert_show_match(command: 'show snmp | no-more',
+                             pattern: /sys contact: [^\n\r]+/)
     # puts "line: #{line}"
     contact = line.to_s.gsub('sys contact:', '').strip
     assert_equal(contact, newcontact)
@@ -132,8 +134,8 @@ class TestSnmpServer < CiscoTestCase
   def test_snmpserver_sys_contact_set_default
     snmpserver = SnmpServer.new
     snmpserver.contact = snmpserver.default_contact
-    s = @device.cmd('show snmp | no-more')
-    line = /sys contact: [^\n\r]+/.match(s)
+    line = assert_show_match(command: 'show snmp | no-more',
+                             pattern: /sys contact: [^\n\r]*/)
     contact = ''
     contact = line.to_s.gsub('sys contact:', '').strip unless line.nil?
     assert_equal(contact, snmpserver.default_contact)
@@ -143,8 +145,8 @@ class TestSnmpServer < CiscoTestCase
     snmpserver = SnmpServer.new
     # set location
     snmpserver.location = 'test-location'
-    s = @device.cmd('show snmp | no-more')
-    line = /sys location: [^\n\r]+/.match(s)
+    line = assert_show_match(command: 'show snmp | no-more',
+                             pattern: /sys location: [^\n\r]+/)
     location = ''
     location = line.to_s.gsub('sys location:', '').strip unless line.nil?
     # puts "location : #{location}, #{snmpserver.location}"
@@ -171,8 +173,8 @@ class TestSnmpServer < CiscoTestCase
     snmpserver = SnmpServer.new
     newlocation = 'bxb-300-2-1 test location'
     snmpserver.location = newlocation
-    s = @device.cmd('show snmp | no-more')
-    line = /sys location: [^\n\r]+/.match(s)
+    line = assert_show_match(command: 'show snmp | no-more',
+                             pattern: /sys location: [^\n\r]+/)
     location = line.to_s.gsub('sys location:', '').strip
     assert_equal(location, newlocation)
     # set to default
@@ -183,8 +185,8 @@ class TestSnmpServer < CiscoTestCase
     snmpserver = SnmpServer.new
     newlocation = 'bxb-300 2nd floor test !$%^33&&*) location'
     snmpserver.location = newlocation
-    s = @device.cmd('show snmp | no-more')
-    line = /sys location: [^\n\r]+/.match(s)
+    line = assert_show_match(command: 'show snmp | no-more',
+                             pattern: /sys location: [^\n\r]+/)
     location = line.to_s.gsub('sys location:', '').strip
     assert_equal(location, newlocation)
     # set to default
@@ -195,8 +197,8 @@ class TestSnmpServer < CiscoTestCase
     snmpserver = SnmpServer.new
     #    snmpserver.location = snmpserver.default_location
     snmpserver.location = 'FOO'
-    s = @device.cmd('show snmp | no-more')
-    line = /sys location: [^\n\r]+/.match(s)
+    line = assert_show_match(command: 'show snmp | no-more',
+                             pattern: /sys location: [^\n\r]+/)
     location = ''
     location = line.to_s.gsub('sys location:', '').strip unless line.nil?
     assert_equal(location, snmpserver.location)
@@ -207,9 +209,7 @@ class TestSnmpServer < CiscoTestCase
   def test_snmpserver_packetsize_get
     snmpserver = SnmpServer.new
     snmpserver.packet_size = 2000
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server packetsize'
-    line = /#{cmd} (\d+)/.match(s)
+    line = assert_show_match(pattern: /snmp-server packetsize (\d+)/)
     packetsize = 0
     packetsize = line.to_s.split(' ').last.to_i unless line.nil?
     assert_equal(packetsize, snmpserver.packet_size)
@@ -237,9 +237,7 @@ class TestSnmpServer < CiscoTestCase
     snmpserver = SnmpServer.new
     newpacketsize = 1600
     snmpserver.packet_size = newpacketsize
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server packetsize'
-    line = /#{cmd} (\d+)/.match(s)
+    line = assert_show_match(pattern: /snmp-server packetsize (\d+)/)
     packetsize = line.to_s.split(' ').last.to_i
     assert_equal(packetsize, newpacketsize)
     # unset to default
@@ -248,26 +246,19 @@ class TestSnmpServer < CiscoTestCase
 
   def test_snmpserver_packetsize_set_default
     snmpserver = SnmpServer.new
-
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server packetsize'
-    line = /#{cmd} (\d+)/.match(s)
-    packetsize = line.to_s.split(' ').last.to_i
-    assert_equal(packetsize, snmpserver.packet_size,
+    refute_show_match(pattern: /snmp-server packetsize (\d+)/)
+    assert_equal(0, snmpserver.packet_size,
                  'Error: Snmp Server, packet size not default')
 
     snmpserver.packet_size = 850
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server packetsize'
-    line = /#{cmd} (\d+)/.match(s)
+    line = assert_show_match(pattern: /snmp-server packetsize (\d+)/)
     packetsize = line.to_s.split(' ').last.to_i
     assert_equal(packetsize, snmpserver.packet_size,
                  'Error: Snmp Server, packet size not default')
 
     snmpserver.packet_size = snmpserver.default_packet_size
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server packetsize'
-    line = /#{cmd} (\d+)/.match(s)
+    # TODO: this seems weird, why is default_packet_size not 0 as above?
+    line = assert_show_match(pattern: /snmp-server packetsize (\d+)/)
     packetsize = line.to_s.split(' ').last.to_i
     assert_equal(packetsize, snmpserver.packet_size,
                  'Error: Snmp Server, packet size not default')
@@ -281,11 +272,8 @@ class TestSnmpServer < CiscoTestCase
     # Get orginal packet size
     org_packet_size = snmpserver.packet_size
     snmpserver.packet_size = 0
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server packetsize'
-    line = /#{cmd} (\d+)/.match(s)
-    packetsize = line.to_s.split(' ').last.to_i
-    assert_equal(packetsize, snmpserver.packet_size,
+    refute_show_match(pattern: /snmp-server packetsize (\d+)/)
+    assert_equal(0, snmpserver.packet_size,
                  'Error: Snmp Server, packet size not unset')
 
     # Restore packet size
@@ -301,10 +289,11 @@ class TestSnmpServer < CiscoTestCase
     # default is false
     snmpserver.global_enforce_priv = false
     device_enabled = snmpserver.global_enforce_priv?
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'no snmp-server globalEnforcePriv'
-    line = /#{cmd}/.match(s)
-    assert_equal(line.nil?, device_enabled)
+    if device_enabled
+      refute_show_match(pattern: /no snmp-server globalEnforcePriv/)
+    else
+      assert_show_match(pattern: /no snmp-server globalEnforcePriv/)
+    end
     # set to default
     snmpserver.global_enforce_priv = snmpserver.default_global_enforce_priv
   end
@@ -313,10 +302,11 @@ class TestSnmpServer < CiscoTestCase
     snmpserver = SnmpServer.new
     snmpserver.global_enforce_priv = true
     device_enabled = snmpserver.global_enforce_priv?
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server globalEnforcePriv'
-    line = /#{cmd}/.match(s)
-    assert_equal(!line.nil?, device_enabled)
+    if device_enabled
+      refute_show_match(pattern: /no snmp-server globalEnforcePriv/)
+    else
+      assert_show_match(pattern: /no snmp-server globalEnforcePriv/)
+    end
     # set to default
     snmpserver.global_enforce_priv = snmpserver.default_global_enforce_priv
   end
@@ -324,11 +314,7 @@ class TestSnmpServer < CiscoTestCase
   def test_snmpserver_global_enforce_priv_set_enabled
     snmpserver = SnmpServer.new
     snmpserver.global_enforce_priv = true
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server globalEnforcePriv'
-    line = /#{cmd}/.match(s)
-    # puts "line : #{line}"
-    assert_equal(!line.nil?, true)
+    assert_show_match(pattern: /snmp-server globalEnforcePriv/)
     # set to default
     snmpserver.global_enforce_priv = snmpserver.default_global_enforce_priv
   end
@@ -336,10 +322,7 @@ class TestSnmpServer < CiscoTestCase
   def test_snmpserver_global_enforce_priv_set_disabled
     snmpserver = SnmpServer.new
     snmpserver.global_enforce_priv = false
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'no snmp-server globalEnforcePriv'
-    line = /#{cmd}/.match(s)
-    assert_equal(line.nil?, false)
+    assert_show_match(pattern: /no snmp-server globalEnforcePriv/)
     # set to default
     snmpserver.global_enforce_priv = snmpserver.default_global_enforce_priv
   end
@@ -348,9 +331,7 @@ class TestSnmpServer < CiscoTestCase
     snmpserver = SnmpServer.new
     # set default
     snmpserver.protocol = true
-    cmd = '^snmp-server protocol enable'
-    s = @device.cmd("show run snmp all | i '#{cmd}'")
-    assert_match(/#{cmd}/, s)
+    assert_show_match(pattern: /^snmp-server protocol enable/)
     # set to default
     snmpserver.protocol = snmpserver.default_protocol
   end
@@ -359,11 +340,11 @@ class TestSnmpServer < CiscoTestCase
     snmpserver = SnmpServer.new
     snmpserver.protocol = false
     device_enabled = snmpserver.protocol?
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'no snmp-server protocol enable'
-    line = /#{cmd}/.match(s)
-    # puts "line #{line}"
-    assert_equal(line.nil?, device_enabled)
+    if device_enabled
+      assert_show_match(pattern: /^snmp-server protocol enable/)
+    else
+      assert_show_match(pattern: /no snmp-server protocol enable/)
+    end
     # set to default
     snmpserver.protocol = snmpserver.default_protocol
   end
@@ -371,11 +352,7 @@ class TestSnmpServer < CiscoTestCase
   def test_snmpserver_protocol_set_enabled
     snmpserver = SnmpServer.new
     snmpserver.protocol = true
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server protocol enable'
-    line = /#{cmd}/.match(s)
-    # puts "line : #{line}"
-    assert_equal(!line.nil?, true)
+    assert_show_match(pattern: /^snmp-server protocol enable/)
     # set to default
     snmpserver.protocol = snmpserver.default_protocol
   end
@@ -383,11 +360,7 @@ class TestSnmpServer < CiscoTestCase
   def test_snmpserver_protocol_set_disabled
     snmpserver = SnmpServer.new
     snmpserver.protocol = false
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'no snmp-server protocol enable'
-    line = /#{cmd}/.match(s)
-    # puts "line : #{line}"
-    assert_equal(line.nil?, false)
+    assert_show_match(pattern: /no snmp-server protocol enable/)
     # set to default
     snmpserver.protocol = snmpserver.default_protocol
   end
@@ -397,10 +370,11 @@ class TestSnmpServer < CiscoTestCase
     # default value is false
     snmpserver.tcp_session_auth = false
     device_enabled = snmpserver.tcp_session_auth?
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'no snmp-server tcp-session auth'
-    line = /#{cmd}/.match(s)
-    assert_equal(line.nil?, device_enabled)
+    if device_enabled
+      assert_show_match(pattern: /^snmp-server tcp-session auth/)
+    else
+      assert_show_match(pattern: /no snmp-server tcp-session auth/)
+    end
     # set to default
     snmpserver.tcp_session_auth = snmpserver.default_tcp_session_auth
   end
@@ -408,9 +382,7 @@ class TestSnmpServer < CiscoTestCase
   def test_snmpserver_tcp_session_auth_get_enabled
     snmpserver = SnmpServer.new
     snmpserver.tcp_session_auth = true
-    cmd = '^snmp-server tcp-session auth'
-    s = @device.cmd("show run snmp all | i '#{cmd}'")
-    assert_match(/#{cmd}/, s)
+    assert_show_match(pattern: /^snmp-server tcp-session auth/)
     # set to default
     snmpserver.tcp_session_auth = snmpserver.default_tcp_session_auth
   end
@@ -418,11 +390,7 @@ class TestSnmpServer < CiscoTestCase
   def test_snmpserver_tcp_session_auth_set_enabled
     snmpserver = SnmpServer.new
     snmpserver.tcp_session_auth = true
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'snmp-server tcp-session auth'
-    line = /#{cmd}/.match(s)
-    # puts "line : #{line}"
-    assert_equal(!line.nil?, true)
+    assert_show_match(pattern: /^snmp-server tcp-session auth/)
     # set to default
     snmpserver.tcp_session_auth = snmpserver.default_tcp_session_auth
   end
@@ -430,11 +398,7 @@ class TestSnmpServer < CiscoTestCase
   def test_snmpserver_tcp_session_auth_set_default
     snmpserver = SnmpServer.new
     snmpserver.tcp_session_auth = false
-    s = @device.cmd('show run snmp all | no-more')
-    cmd = 'no snmp-server tcp-session auth'
-    line = /#{cmd}/.match(s)
-    # puts "line : #{line}"
-    assert_equal(line.nil?, false)
+    assert_show_match(pattern: /no snmp-server tcp-session auth/)
     # set to default
     snmpserver.tcp_session_auth = snmpserver.default_tcp_session_auth
   end

--- a/tests/test_tacacs_server_host.rb
+++ b/tests/test_tacacs_server_host.rb
@@ -24,11 +24,11 @@ DEFAULT_TACACS_SERVER_HOST_ENCRYPTION_PASSWORD = ''
 
 # TestTacacsServerHost - Minitest for TacacsServerHost node utility
 class TestTacacsServerHost < CiscoTestCase
-  def get_tacacsserverhost_match_line(host_name)
-    s = @device.cmd('show run all | no-more')
-    cmd = 'tacacs-server host'
-    pattern = /#{cmd}\s(#{host_name})(.*)/
-    pattern.match(s)
+  def setup
+    super
+    @host_name = 'testhost'
+    @default_show_command = 'show run all | no-more'
+    @default_output_pattern = /tacacs-server host\s(#{@host_name})(.*)/
   end
 
   def test_tacacsserverhost_collection_empty
@@ -73,48 +73,39 @@ class TestTacacsServerHost < CiscoTestCase
 
   def test_tacacsserverhost_create_valid
     host = TacacsServerHost.new('testhost')
-    line = get_tacacsserverhost_match_line('testhost')
-    refute_nil(line, 'Error: Tacacs Host not created')
+    assert_show_match(msg: 'Error: Tacacs Host not created')
     host.destroy
   end
 
   def test_tacacsserverhost_destroy
-    host_name = 'testhost'
-    host = TacacsServerHost.new(host_name)
-    line = get_tacacsserverhost_match_line(host_name)
-    refute_nil(line, 'Error: Tacacs Host not created')
+    host = TacacsServerHost.new(@host_name)
+    assert_show_match(msg: 'Error: Tacacs Host not created')
     host.destroy
 
-    line = get_tacacsserverhost_match_line(host_name)
-    assert_nil(line, 'Error: Tacacs Host still present')
+    refute_show_match(msg: 'Error: Tacacs Host still present')
   end
 
   def test_tacacsserverhost_get_name
-    host_name = 'testhost'
-    host = TacacsServerHost.new(host_name)
-    line = get_tacacsserverhost_match_line(host_name)
-    refute_nil(line, 'Error: Tacacs Host not found')
-    assert_equal(host_name, line.captures[0],
-                 "Error: #{host_name} name mismatch")
-    assert_equal(host_name, host.name,
-                 "Error: #{host_name} name get value mismatch")
+    host = TacacsServerHost.new(@host_name)
+    line = assert_show_match(msg: 'Error: Tacacs Host not found')
+    assert_equal(@host_name, line.captures[0],
+                 "Error: #{@host_name} name mismatch")
+    assert_equal(@host_name, host.name,
+                 "Error: #{@host_name} name get value mismatch")
     host.destroy
   end
 
   def test_tacacsserverhost_get_name_preconfigured
-    host_name = 'testhost'
+    config("tacacs-server host #{@host_name}")
 
-    config("tacacs-server host #{host_name}")
-
-    line = get_tacacsserverhost_match_line(host_name)
+    line = assert_show_match(msg: 'Error: Tacacs Host not found')
     hosts = TacacsServerHost.hosts()
 
-    refute_nil(line, 'Error: Tacacs Host not found')
-    assert_equal(host_name, line.captures[0],
-                 "Error: #{host_name} name mismatch")
-    refute_nil(hosts[host_name], "Error: #{host_name} not retrieved.")
-    assert_equal(host_name, hosts[host_name].name,
-                 "Error: #{host_name} name get value mismatch")
+    assert_equal(@host_name, line.captures[0],
+                 "Error: #{@host_name} name mismatch")
+    refute_nil(hosts[@host_name], "Error: #{@host_name} not retrieved.")
+    assert_equal(@host_name, hosts[@host_name].name,
+                 "Error: #{@host_name} name get value mismatch")
 
     hosts.each_value(&:destroy)
   end
@@ -125,18 +116,20 @@ class TestTacacsServerHost < CiscoTestCase
 
     config("tacacs-server host #{host_name}", "tacacs-server host #{host_ip}")
 
-    line_name = get_tacacsserverhost_match_line(host_name)
-    line_ip = get_tacacsserverhost_match_line(host_ip)
+    line_name = assert_show_match(
+      pattern: /tacacs-server host\s(testhost\.example\.com)(.*)/,
+      msg:     'Error: Tacacs Host not found')
+    line_ip = assert_show_match(
+      pattern: /tacacs-server host\s(192\.168\.1\.1)(.*)/,
+      msg:     'Error: Tacacs Host not found')
     hosts = TacacsServerHost.hosts
 
-    refute_nil(line_name, 'Error: Tacacs Host not found')
     assert_equal(host_name, line_name.captures[0],
                  "Error: #{host_name} name mismatch")
     refute_nil(hosts[host_name], "Error: #{host_name} not retrieved.")
     assert_equal(host_name, hosts[host_name].name,
                  "Error: #{host_name} name get value mismatch")
 
-    refute_nil(line_ip, 'Error: Tacacs Host not found')
     assert_equal(host_ip, line_ip.captures[0],
                  "Error: #{host_ip} name mismatch")
     refute_nil(hosts[host_ip], "Error: #{host_ip} not retrieved.")
@@ -147,8 +140,7 @@ class TestTacacsServerHost < CiscoTestCase
   end
 
   def test_tacacsserverhost_get_port
-    host_name = 'testhost'
-    host = TacacsServerHost.new(host_name)
+    host = TacacsServerHost.new(@host_name)
 
     # not previously configured
     port = DEFAULT_TACACS_SERVER_HOST_PORT
@@ -156,7 +148,7 @@ class TestTacacsServerHost < CiscoTestCase
 
     # when configured
     port = 1138
-    config("tacacs-server host #{host_name} port #{port}")
+    config("tacacs-server host #{@host_name} port #{port}")
     assert_equal(port, host.port, 'Error: Tacacs Host port incorrect')
 
     host.destroy
@@ -172,13 +164,11 @@ class TestTacacsServerHost < CiscoTestCase
   end
 
   def test_tacacsserverhost_set_port
-    host_name = 'testhost'
-    host = TacacsServerHost.new(host_name)
+    host = TacacsServerHost.new(@host_name)
 
     port = 1138
     host.port = port
-    line = get_tacacsserverhost_match_line(host_name)
-    refute_nil(line, 'Error: Tacacs Host not found')
+    line = assert_show_match(msg: 'Error: Tacacs Host not found')
     md = /port\s(\d*)/.match(line.captures[1])
     refute_nil(md, 'Error: Tacacs Host port not found')
     assert_equal(port, md.captures[0].to_i, 'Error: Tacacs Host port mismatch')
@@ -192,8 +182,7 @@ class TestTacacsServerHost < CiscoTestCase
     s = @device.cmd("show run | i 'tacacs.*timeout'")[/^tacacs.*timeout.*$/]
     config("no #{s}") if s
 
-    host_name = 'testhost'
-    host = TacacsServerHost.new(host_name)
+    host = TacacsServerHost.new(@host_name)
 
     # not previously configured
     timeout = DEFAULT_TACACS_SERVER_HOST_TIMEOUT
@@ -201,7 +190,7 @@ class TestTacacsServerHost < CiscoTestCase
 
     # when configured
     timeout = 30
-    config("tacacs-server host #{host_name} timeout #{timeout}")
+    config("tacacs-server host #{@host_name} timeout #{timeout}")
     assert_equal(timeout, host.timeout, 'Error: Tacacs Host timeout incorrect')
 
     host.destroy
@@ -217,13 +206,11 @@ class TestTacacsServerHost < CiscoTestCase
   end
 
   def test_tacacsserverhost_set_timeout
-    host_name = 'testhost'
-    host = TacacsServerHost.new(host_name)
+    host = TacacsServerHost.new(@host_name)
 
     timeout = 30
     host.timeout = timeout
-    line = get_tacacsserverhost_match_line(host_name)
-    refute_nil(line, 'Error: Tacacs Host not found')
+    line = assert_show_match(msg: 'Error: Tacacs Host not found')
     md = /timeout\s(\d*)/.match(line.captures[1])
     refute_nil(md, 'Error: Tacacs Host timeout not found')
     assert_equal(timeout, md.captures[0].to_i,
@@ -234,13 +221,11 @@ class TestTacacsServerHost < CiscoTestCase
   end
 
   def test_tacacsserverhost_unset_timeout
-    host_name = 'testhost'
-    host = TacacsServerHost.new(host_name)
+    host = TacacsServerHost.new(@host_name)
 
     timeout = DEFAULT_TACACS_SERVER_HOST_TIMEOUT
     host.timeout = timeout
-    line = get_tacacsserverhost_match_line(host_name)
-    refute_nil(line, 'Error: Tacacs Host not found')
+    line = assert_show_match(msg: 'Error: Tacacs Host not found')
     md = /timeout\s(\d*)/.match(line.captures[1])
     assert_nil(md, 'Error: Tacacs Host timeout found')
     assert_equal(timeout, host.timeout, 'Error: Tacacs Host timeout incorrect')
@@ -249,8 +234,7 @@ class TestTacacsServerHost < CiscoTestCase
   end
 
   def test_tacacsserverhost_get_encryption_type
-    host_name = 'testhost'
-    host = TacacsServerHost.new(host_name)
+    host = TacacsServerHost.new(@host_name)
 
     # when not configured
     enctype = TACACS_SERVER_ENC_UNKNOWN
@@ -261,7 +245,7 @@ class TestTacacsServerHost < CiscoTestCase
     # when configured
     enctype = TACACS_SERVER_ENC_NONE
     sh_run_enctype = TACACS_SERVER_ENC_CISCO_TYPE_7
-    config("tacacs-server host #{host_name} key #{enctype} TEST")
+    config("tacacs-server host #{@host_name} key #{enctype} TEST")
     assert_equal(sh_run_enctype, host.encryption_type,
                  'Error: Tacacs Host encryption type incorrect')
     host.destroy
@@ -277,8 +261,7 @@ class TestTacacsServerHost < CiscoTestCase
   end
 
   def test_tacacsserverhost_get_encryption_password
-    host_name = 'testhost'
-    host = TacacsServerHost.new(host_name)
+    host = TacacsServerHost.new(@host_name)
 
     # when not configured
     pass = DEFAULT_TACACS_SERVER_HOST_ENCRYPTION_PASSWORD
@@ -288,7 +271,7 @@ class TestTacacsServerHost < CiscoTestCase
     # when configured
     pass = 'TEST'
     sh_run_pass = 'WAWY'
-    config("tacacs-server host #{host_name} key 0 #{pass}")
+    config("tacacs-server host #{@host_name} key 0 #{pass}")
     assert_equal(sh_run_pass, host.encryption_password,
                  'Error: Tacacs Host encryption password incorrect')
     host.destroy
@@ -303,8 +286,7 @@ class TestTacacsServerHost < CiscoTestCase
   end
 
   def test_tacacsserverhost_set_key
-    host_name = 'testhost'
-    host = TacacsServerHost.new(host_name)
+    host = TacacsServerHost.new(@host_name)
 
     enctype = TACACS_SERVER_ENC_NONE
     sh_run_enctype = TACACS_SERVER_ENC_CISCO_TYPE_7
@@ -312,8 +294,7 @@ class TestTacacsServerHost < CiscoTestCase
     sh_run_pass = 'WAWY'
     host.encryption_key_set(enctype, pass)
 
-    line = get_tacacsserverhost_match_line(host_name)
-    refute_nil(line, 'Error: Tacacs Host not found')
+    line = assert_show_match(msg: 'Error: Tacacs Host not found')
     md = /key\s(\d*)\s(\S*)/.match(line.captures[1])
     refute_nil(md, 'Error: Tacacs Host encryption not found')
     assert_equal(sh_run_enctype, md.captures[0].to_i,
@@ -335,8 +316,7 @@ class TestTacacsServerHost < CiscoTestCase
     s = @device.cmd("show run | i 'tacacs.*host'")[/^tacacs.*host.*$/]
     config("no #{s}") if s
 
-    host_name = 'testhost'
-    host = TacacsServerHost.new(host_name)
+    host = TacacsServerHost.new(@host_name)
 
     # First configure key value. Whether that can be passed
     # will be decided by test_tacacsserverhost_set_key
@@ -349,8 +329,7 @@ class TestTacacsServerHost < CiscoTestCase
     pass = DEFAULT_TACACS_SERVER_HOST_ENCRYPTION_PASSWORD
     host.encryption_key_set(enctype, pass)
 
-    line = get_tacacsserverhost_match_line(host_name)
-    refute_nil(line, 'Error: Tacacs Host not found')
+    line = assert_show_match(msg: 'Error: Tacacs Host not found')
     md = /key\s(\d*)\s(\S*)/.match(line.captures[1])
     assert_nil(md, 'Error: Tacacs Host encryption found')
     assert_equal(enctype, host.encryption_type,


### PR DESCRIPTION
We have a very common pattern in minitest where we execute some show command over the telnet connection, match it against some regexp pattern, and succeed or fail based on the result. This PR adds a couple of helper methods `assert_show_match` and `refute_show_match` to support this pattern.

```
assert_show_match(command: 'show run all | no-more',
                  pattern: /interface port-channel 1/,
                  msg:     'port-channel is not present but it should be')
```

If your `command` and/or `pattern` are the same throughout a test case or throughout a test suite, you can set the test case instance variables `@default_show_command` and/or `@default_output_pattern` which serve as defaults for these parameters:

```
@default_show_command = 'show run interface all | include "interface" | no-more'
assert_output_match(pattern: /interface port-channel 10/)
refute_output_match(pattern: /interface port-channel 11/)
refute_output_match(pattern: /interface port-channel 12/)
assert_output_match(pattern: /interface port-channel 13/)
```
