### PR TITLE
Fix another bug in snmpuser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Changelog
 
 ### Fixed
 
-* Fixed a bug in SnmpUser.auth_password_equal? and SnmpUser.priv_password_equal? that reported incorrectly when the passwords are unset.
+* Fixed several bugs in `SnmpUser.(auth|priv)_password_equal?`
 * Added missing steps to CONTRIBUTING.md and README-develop-node-utils-APIs.md
 * Fixed a bug in `test_interface.rb` that was keeping it from properly exercising the `negotiate_auto` functionality.
 

--- a/lib/cisco_node_utils/snmpuser.rb
+++ b/lib/cisco_node_utils/snmpuser.rb
@@ -202,82 +202,97 @@ module Cisco
       config_get_default('snmp_user', 'engine_id')
     end
 
-    # passwords are hashed and so cannot be retrieved directly, but can be
-    # checked for equality. this is done by creating a fake user with the
+    # Passwords are hashed and so cannot be retrieved directly, but can be
+    # checked for equality. This is done by creating a fake user with the
     # password and then comparing the hashes
-    def auth_password_equal?(passwd, is_localized=false)
-      passwd = passwd.to_s unless passwd.is_a?(String)
-      return true if passwd.empty? && _auth_sym_to_str(auth_protocol).empty?
-      return false if passwd.empty? || _auth_sym_to_str(auth_protocol).empty?
-      dummypw = passwd
-      pw = nil
+    def auth_password_equal?(input_pw, is_localized=false)
+      input_pw = input_pw.to_s unless input_pw.is_a?(String)
+      # If we provide no password, and no password present, it's a match!
+      return true if input_pw.empty? && auth_protocol == :none
+      # If we provide no password, but a password is present, or vice versa...
+      return false if input_pw.empty? || auth_protocol == :none
+      # OK, we have an input password, and a password is configured
+      current_pw = auth_password
+      if current_pw.nil?
+        fail "SNMP user #{@name} #{@engine_id} has auth #{auth_protocol} " \
+             "but no password?\n" + @@node.show('show run snmp all')
+      end
 
       if is_localized
-        # In this case, the password is hashed. We only need to get current
-        # running config to compare
-        pw = auth_password
+        # In this case, the password is already hashed.
+        hashed_pw = input_pw
       else
         # In this case passed in password is clear text while the running
-        # config is hashed value. We need to hash the
-        # passed in clear text to hash
+        # config is hashed value. We need to hash the passed in clear text.
 
-        # create dummy user
+        # Create dummy user
         config_set('snmp_user', 'user', '', 'dummy_user', '',
-                   "auth #{_auth_sym_to_str(auth_protocol)} #{dummypw}",
+                   "auth #{_auth_sym_to_str(auth_protocol)} #{input_pw}",
                    '', '',
                    @engine_id.empty? ? '' : "engineID #{@engine_id}")
 
-        # retrieve password hashes
-        dummypw = SnmpUser.auth_password('dummy_user', @engine_id)
-        pw = auth_password
+        # Retrieve password hashes
+        hashed_pw = SnmpUser.auth_password('dummy_user', @engine_id)
+        if hashed_pw.nil?
+          fail "SNMP dummy user #{dummy_user} #{@engine_id} was configured " \
+               "but password is missing?\n" + @@node.show('show run snmp all')
+        end
 
-        # delete dummy user
+        # Delete dummy user
         config_set('snmp_user', 'user', 'no', 'dummy_user', '',
-                   "auth #{_auth_sym_to_str(auth_protocol)} #{dummypw}",
+                   "auth #{_auth_sym_to_str(auth_protocol)} #{hashed_pw}",
                    '', 'localizedkey',
                    @engine_id.empty? ? '' : "engineID #{@engine_id}")
       end
-      return false if pw.nil? || dummypw.nil?
-      pw == dummypw
+      hashed_pw == current_pw
     end
 
-    def priv_password_equal?(passwd, is_localized=false)
-      passwd = passwd.to_s unless passwd.is_a?(String)
-      return true if passwd.empty? && _auth_sym_to_str(auth_protocol).empty?
-      return false if passwd.empty? || _auth_sym_to_str(auth_protocol).empty?
-      dummypw = passwd
-      pw = nil
+    # Passwords are hashed and so cannot be retrieved directly, but can be
+    # checked for equality. This is done by creating a fake user with the
+    # password and then comparing the hashes
+    def priv_password_equal?(input_pw, is_localized=false)
+      input_pw = input_pw.to_s unless input_pw.is_a?(String)
+      # If no input password, and no password present, true!
+      return true if input_pw.empty? && priv_protocol == :none
+      # Otherwise, if either one is missing, false!
+      return false if input_pw.empty? || priv_protocol == :none
+      # Otherwise, we have both input and configured passwords to compare
+      current_pw = priv_password
+      if current_pw.nil?
+        fail "SNMP user #{@name} #{@engine_id} has priv #{priv_protocol} " \
+             "but no password?\n" + @@node.show('show run snmp all')
+      end
 
       if is_localized
-        # In this case, the password is hashed. We only need to get current
-        # and compare directly
-        pw = priv_password
+        # In this case, the password is already hashed.
+        hashed_pw = input_pw
       else
         # In this case passed in password is clear text while the running
-        # config is hashed value. We need to hash the
-        # passed in clear text to hash
+        # config is hashed value. We need to hash the passed in clear text.
 
-        # create dummy user
+        # Create dummy user
         config_set('snmp_user', 'user', '', 'dummy_user', '',
-                   "auth #{_auth_sym_to_str(auth_protocol)} #{dummypw}",
-                   "priv #{_priv_sym_to_str(priv_protocol)} #{dummypw}",
+                   "auth #{_auth_sym_to_str(auth_protocol)} #{input_pw}",
+                   "priv #{_priv_sym_to_str(priv_protocol)} #{input_pw}",
                    '',
                    @engine_id.empty? ? '' : "engineID #{@engine_id}")
 
-        # retrieve password hashes
+        # Retrieve password hashes
         dummyau = SnmpUser.auth_password('dummy_user', @engine_id)
-        dummypw = SnmpUser.priv_password('dummy_user', @engine_id)
-        pw = priv_password
+        hashed_pw = SnmpUser.priv_password('dummy_user', @engine_id)
+        if hashed_pw.nil?
+          fail "SNMP dummy user #{dummy_user} #{@engine_id} was configured " \
+               "but password is missing?\n" + @@node.show('show run snmp all')
+        end
 
-        # delete dummy user
+        # Delete dummy user
         config_set('snmp_user', 'user', 'no', 'dummy_user', '',
                    "auth #{_auth_sym_to_str(auth_protocol)} #{dummyau}",
-                   "priv #{_priv_sym_to_str(priv_protocol)} #{dummypw}",
+                   "priv #{_priv_sym_to_str(priv_protocol)} #{hashed_pw}",
                    'localizedkey',
                    @engine_id.empty? ? '' : "engineID #{@engine_id}")
       end
-      return false if pw.nil? || dummypw.nil?
-      pw == dummypw
+      hashed_pw == current_pw
     end
 
     private


### PR DESCRIPTION
Refactor auth_password_equal? and priv_password_equal?
Fix a bug in priv_password_equal? (was exiting early if auth_protocol
unset, instead of if priv_protocol is unset).
Raise errors in several cases that should never be hit.
This fixes some intermittent failures in snmpuser minitest.
