### PR TITLE
change maxas-limit default value to 0

### DIFF
--- a/lib/cisco_node_utils/command_reference_common_bgp.yaml
+++ b/lib/cisco_node_utils/command_reference_common_bgp.yaml
@@ -108,7 +108,7 @@ bgp:
   maxas_limit:
     config_get_token_append: '/^maxas-limit (\d+)$/'
     config_set_append: '<state> maxas-limit <limit>'
-    default_value: ~
+    default_value: 0
 
   neighbor_fib_down_accelerate:
     config_get_token_append: '/^neighbor-down fib-accelerate$/'

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -564,7 +564,7 @@ class TestRouterBgp < CiscoTestCase
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_equal(bgp.default_maxas_limit, bgp.maxas_limit,
-                 'bgp maxas-limit should be set to default value')
+                 'bgp maxas-limit should be default value')
     bgp.destroy
   end
 


### PR DESCRIPTION
1.The default value is out of the valid range just use it to disable the function.
reference to ebgp-multihop

2.pass the minitest
