### PR TITLE
Fixes and extensions bgp_af

### DIFF
--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -133,7 +133,12 @@ module Cisco
       route_map.strip!
       if route_map.empty?
         state = 'no'
-        route_map = next_hop_route_map
+        # Dummy routemap required if not configured.
+        if next_hop_route_map.empty?
+          route_map = 'dummy_routemap'
+        else
+          route_map = next_hop_route_map
+        end
       end
       set_args_keys(state: state, route_map: route_map)
       config_set('bgp_af', 'next_hop_route_map', @set_args)
@@ -206,7 +211,12 @@ module Cisco
       route_map.strip!
       if route_map.empty?
         state = 'no'
-        route_map = additional_paths_selection
+        # Dummy routemap required if not configured.
+        if additional_paths_selection.empty?
+          route_map = 'dummy_routemap'
+        else
+          route_map = additional_paths_selection
+        end
       end
       set_args_keys(state: state, route_map: route_map)
       config_set('bgp_af', 'additional_paths_selection', @set_args)

--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -223,12 +223,12 @@ module Cisco
     # dampen_igp_metric
     def dampen_igp_metric
       result = config_get('bgp_af', 'dampen_igp_metric', @get_args)
-      result.nil? ? default_dampen_igp_metric : result.first.to_i
+      result ? result.first.to_i : nil
     end
 
     def dampen_igp_metric=(val)
-      set_args_keys(state: (val == default_dampen_igp_metric) ? 'no' : '',
-                    num:   (val == default_dampen_igp_metric) ? '' : val)
+      set_args_keys(state: (val.nil?) ? 'no' : '',
+                    num:   (val.nil?) ? '' : val)
       config_set('bgp_af', 'dampen_igp_metric', @set_args)
     end
 
@@ -271,6 +271,66 @@ module Cisco
       end
 
       val
+    end
+
+    # Return true if dampening is enabled, else false.
+    def dampening_state
+      !dampening.nil?
+    end
+
+    # For all of the following dampening getters, haf_time, reuse_time,
+    # suppress_time, and max_suppress_time, return nil if dampening
+    # is not configured, but also return nil if a dampening routemap
+    # is configured because they are mutually exclusive.
+    def dampening_half_time
+      return nil if dampening.nil? || dampening_routemap_configured?
+      if dampening.is_a?(Array)
+        dampening[0].to_i
+      else
+        default_dampening_half_time
+      end
+    end
+
+    def dampening_reuse_time
+      return nil if dampening.nil? || dampening_routemap_configured?
+      if dampening.is_a?(Array)
+        dampening[1].to_i
+      else
+        default_dampening_reuse_time
+      end
+    end
+
+    def dampening_suppress_time
+      return nil if dampening.nil? || dampening_routemap_configured?
+      if dampening.is_a?(Array)
+        dampening[2].to_i
+      else
+        default_dampening_suppress_time
+      end
+    end
+
+    def dampening_max_suppress_time
+      return nil if dampening.nil? || dampening_routemap_configured?
+      if dampening.is_a?(Array)
+        dampening[3].to_i
+      else
+        default_dampening_max_suppress_time
+      end
+    end
+
+    def dampening_routemap
+      if dampening.nil? || (dampening.is_a?(String) && dampening.size > 0)
+        return dampening
+      end
+      default_dampening_routemap
+    end
+
+    def dampening_routemap_configured?
+      if dampening_routemap.is_a?(String) && dampening_routemap.size > 0
+        true
+      else
+        false
+      end
     end
 
     def dampening=(damp_array)
@@ -326,6 +386,30 @@ module Cisco
 
     def default_dampening
       config_get_default('bgp_af', 'dampening')
+    end
+
+    def default_dampening_state
+      config_get_default('bgp_af', 'dampening_state')
+    end
+
+    def default_dampening_max_suppress_time
+      config_get_default('bgp_af', 'dampening_max_suppress_time')
+    end
+
+    def default_dampening_half_time
+      config_get_default('bgp_af', 'dampening_half_time')
+    end
+
+    def default_dampening_reuse_time
+      config_get_default('bgp_af', 'dampening_reuse_time')
+    end
+
+    def default_dampening_routemap
+      config_get_default('bgp_af', 'dampening_routemap')
+    end
+
+    def default_dampening_suppress_time
+      config_get_default('bgp_af', 'dampening_suppress_time')
     end
 
     #

--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -278,7 +278,7 @@ module Cisco
       !dampening.nil?
     end
 
-    # For all of the following dampening getters, haf_time, reuse_time,
+    # For all of the following dampening getters, half_time, reuse_time,
     # suppress_time, and max_suppress_time, return nil if dampening
     # is not configured, but also return nil if a dampening routemap
     # is configured because they are mutually exclusive.

--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -469,7 +469,7 @@ module Cisco
     # Build an array of all network commands currently on the device
     def networks
       cmds = config_get('bgp_af', 'network', @get_args)
-      cmds.nil? ? default_networks : (cmds.each &:compact!)
+      cmds.nil? ? default_networks : cmds.each(&:compact!)
     end
 
     # networks setter.
@@ -495,7 +495,7 @@ module Cisco
     #  current: an array of existing cmds on the device
     def delta_add_remove(should, current=[])
       # Remove nil entries from array
-      should.each &:compact! unless should.empty?
+      should.each(&:compact!) unless should.empty?
       delta = { add: should - current, remove: current - should }
 
       # Delete entries from :remove if f1 is an update to an existing command

--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -475,7 +475,7 @@ module Cisco
     # networks setter.
     # Processes a hash of network commands from delta_add_remove().
     def networks=(should_list)
-      delta_hash = delta_add_remove(should_list, networks)
+      delta_hash = Utils.delta_add_remove(should_list, networks)
       return if delta_hash.values.flatten.empty?
       [:add, :remove].each do |action|
         CiscoLogger.debug("networks delta #{@get_args}\n #{action}: " \
@@ -488,21 +488,6 @@ module Cisco
           config_set('bgp_af', 'network', @set_args)
         end
       end
-    end
-
-    # Helper to build a hash of add/remove commands.
-    #   should: an array of expected cmds (manifest/recipe)
-    #  current: an array of existing cmds on the device
-    def delta_add_remove(should, current=[])
-      # Remove nil entries from array
-      should.each(&:compact!) unless should.empty?
-      delta = { add: should - current, remove: current - should }
-
-      # Delete entries from :remove if f1 is an update to an existing command
-      delta[:add].each do |id, _|
-        delta[:remove].delete_if { |f1, f2| [f1, f2] if f1.to_s == id.to_s }
-      end
-      delta
     end
 
     def default_networks

--- a/lib/cisco_node_utils/command_reference_common_bgp.yaml
+++ b/lib/cisco_node_utils/command_reference_common_bgp.yaml
@@ -204,7 +204,7 @@ bgp_af:
   client_to_client:
     config_get_token_append: '/^client-to-client reflection$/'
     config_set_append: '<state> client-to-client reflection'
-    default_value: false
+    default_value: true
 
   dampen_igp_metric:
     config_get_token_append: '/^dampen-igp-metric (\d+)$/'

--- a/lib/cisco_node_utils/command_reference_common_bgp.yaml
+++ b/lib/cisco_node_utils/command_reference_common_bgp.yaml
@@ -206,11 +206,6 @@ bgp_af:
     config_set_append: '<state> client-to-client reflection'
     default_value: false
 
-  default_information:
-    config_get_token_append: '/^default-information originate$/'
-    config_set_append: '<state> default-information originate'
-    default_value: false
-
   dampen_igp_metric:
     config_get_token_append: '/^dampen-igp-metric (\d+)$/'
     config_set_append: '<state> dampen-igp-metric <num>'
@@ -238,6 +233,11 @@ bgp_af:
 
   dampening_suppress_time:
     default_value: 2000
+
+  default_information:
+    config_get_token_append: '/^default-information originate$/'
+    config_set_append: '<state> default-information originate'
+    default_value: false
 
   next_hop_route_map:
     config_get_token_append: '/^nexthop route-map (.*)$/'

--- a/lib/cisco_node_utils/command_reference_common_bgp.yaml
+++ b/lib/cisco_node_utils/command_reference_common_bgp.yaml
@@ -214,12 +214,30 @@ bgp_af:
   dampen_igp_metric:
     config_get_token_append: '/^dampen-igp-metric (\d+)$/'
     config_set_append: '<state> dampen-igp-metric <num>'
-    default_value: false
+    default_value: 600
 
   dampening:
     config_get_token_append: '/^dampening(?: (?:(\d+) (\d+) (\d+) (\d+)|route-map (.*)))?$/'
     config_set_append: '<state> dampening <route_map> <decay> <reuse> <suppress> <suppress_max>'
     default_value: ""
+
+  dampening_state:
+    default_value: true
+
+  dampening_max_suppress_time:
+    default_value: 45
+
+  dampening_half_time:
+    default_value: 15
+
+  dampening_reuse_time:
+    default_value: 750
+
+  dampening_routemap:
+    default_value: ""
+
+  dampening_suppress_time:
+    default_value: 2000
 
   next_hop_route_map:
     config_get_token_append: '/^nexthop route-map (.*)$/'
@@ -229,7 +247,7 @@ bgp_af:
   network:
     config_get_token_append: '/^network (\S+) ?(?:route-map )?(\S+)?$/'
     config_set_append: '<state> network <network> <route_map>'
-    default_value: ""
+    default_value: []
 
 bgp_neighbor:
   _template:

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -867,7 +867,7 @@ class TestRouterBgpAF < CiscoTestCase
     # Set and verify 'is' network list contains more items then
     # the 'should' network list.
     #
-    #il.each { |network, rtmap| bgp_af.network_set(network, rtmap) }
+    # il.each { |network, rtmap| bgp_af.network_set(network, rtmap) }
 
     config_list = bgp_af.delta_add_remove(sl, il)
     assert_empty(config_list[:add],
@@ -925,7 +925,7 @@ class TestRouterBgpAF < CiscoTestCase
     networks_delta_is_greaterthan_should(asn, vrf, af, il, sl)
   end
 
-  def networks_delta_is_lessthan_should(asn, vrf, af, il1, sl1, il2, sl2)
+  def networks_delta_is_lessthan_should(asn, vrf, af, _il1, sl1, il2, sl2)
     /ipv4/.match(af) ? af = %w(ipv4 unicast) : af = %w(ipv6 unicast)
     bgp_af = RouterBgpAF.new(asn, vrf, af)
 

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -172,6 +172,9 @@ class TestRouterBgpAF < CiscoTestCase
     assert_match(pattern, af_string,
                  "Error: 'client-to-client reflection' is not configured " \
                    'and should be')
+
+    assert(bgp_af.client_to_client,
+           "Error: 'client-to-client is not configured but should be")
     #
     # Unset and verify
     #

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -732,419 +732,79 @@ class TestRouterBgpAF < CiscoTestCase
   ##
   ## network
   ##
-  def networks_delta_same(asn, vrf, af, il1, sl1, il2, sl2)
-    /ipv4/.match(af) ? af = %w(ipv4 unicast) : af = %w(ipv6 unicast)
-    bgp_af = RouterBgpAF.new(asn, vrf, af)
 
-    #
-    # Set and verify 'is' and 'should' network list contain
-    # items and are identical
-    config_list = bgp_af.delta_add_remove(sl1, il1)
-    assert_empty(config_list[:add],
-                 'Error: config_list[:add] should be empty')
-    assert_empty(config_list[:remove],
-                 'Error: config_list[:remove] should be empty')
-
-    # Apply should_list
-    bgp_af.networks = sl1
-
-    # Verify is_list on device
-    sl1.each do |network|
-      assert_includes(bgp_af.networks, network,
-                      "Error: device should contain network #{network}")
-    end
-
-    # Cleanup for next test section
-    bgp_af.networks = []
-    assert_empty(bgp_af.networks,
-                 'Error: all networks should have been removed')
-
-    #
-    # Set and verify 'is' and 'should' network list contain
-    # the same number of items but they differ.
-    #
-    config_list = bgp_af.delta_add_remove(sl2, il2)
-    assert_equal(3, config_list[:add].size,
-                 'Error: config_list[:add] should contain 3 items')
-    assert_equal(2, config_list[:remove].size,
-                 'Error: config_list[:remove] should contain 2 items')
-    assert_includes(config_list[:add], sl2[0],
-                    "Error: config_list[:add] should contain #{sl2[0]}")
-    assert_includes(config_list[:add], sl2[1],
-                    "Error: config_list[:add] should contain #{sl2[1]}")
-    assert_includes(config_list[:add], sl2[3],
-                    "Error: config_list[:add] should contain #{sl2[3]}")
-    assert_includes(config_list[:remove], il2[1],
-                    "Error: config_list[:remove] should contain #{il2[1]}")
-    assert_includes(config_list[:remove], il2[3],
-                    "Error: config_list[:remove] should contain #{il2[3]}")
-
-    # Apply should_list
-    bgp_af.networks = sl2
-
-    # Verify is_list on device
-    sl2.each do |network|
-      assert_includes(bgp_af.networks, network,
-                      "Error: device should contain network #{network}")
+  def test_network
+    vrfs = %w(default red)
+    afs = [%w(ipv4 unicast), %w(ipv6 unicast)]
+    vrfs.each do |vrf|
+      afs.each do |af|
+        dbg = sprintf('[VRF %s AF %s]', vrf, af.join('/'))
+        af_obj = RouterBgpAF.new(1, vrf, af)
+        network_cmd(af_obj, dbg, af[0])
+      end
     end
   end
 
-  def test_networks_delta_same
-    # Both is_list1(il1) and should_list1(sl1) are identical
-    il1 = sl1 = [
-      ['192.168.5.0/24', 'rtmap1'],
-      ['192.168.6.0/24', 'rtmap2'],
-      ['192.168.7.0/24', 'rtmap3'],
-      ['192.168.9.0/24'],
-    ]
-    # Item 1, 2 and 4 differ between is_list2(il2) and should_list2(sl2)
-    il2 = [
-      ['192.168.5.0/24', 'rtmap1'],
-      ['192.168.6.0/24', 'rtmap2'],
-      ['192.168.7.0/24', 'rtmap3'],
-      ['192.168.9.0/24'],
-    ]
-    sl2 = [
-      ['192.168.5.0/24', 'rtmap8'],
-      ['192.168.55.0/24'],
-      ['192.168.7.0/24', 'rtmap3'],
-      ['192.168.99.0/24'],
-    ]
-    # Test ipv4 unicast, vrf red, default and blue
-    asn = '55'
-    vrf = 'red'
-    af = 'ipv4 unicast'
-    networks_delta_same(asn, vrf, af, il1, sl1, il2, sl2)
-    asn = '55'
-    vrf = 'default'
-    af = 'ipv4 unicast'
-    networks_delta_same(asn, vrf, af, il1, sl1, il2, sl2)
-    asn = '55'
-    vrf = 'blue'
-    af = 'ipv4 unicast'
-    networks_delta_same(asn, vrf, af, il1, sl1, il2, sl2)
-
-    # Both is_list1(il1) and should_list1(sl1) are identical
-    il1 = sl1 = [
-      ['2000:123:38::/64', 'rtmap1'],
-      ['2000:123:39::/64', 'rtmap2'],
-      ['2000:123:40::/64', 'rtmap3'],
-      ['2000:123:41::/64'],
-    ]
-    # Item 1, 2 and 4 differ between is_list2(il2) and should_list2(sl2)
-    il2 = [
-      ['2000:123:38::/64', 'rtmap1'],
-      ['2000:123:39::/64', 'rtmap2'],
-      ['2000:123:40::/64', 'rtmap3'],
-      ['2000:123:41::/64'],
-    ]
-    sl2 = [
-      ['2000:123:38::/64', 'rtmap8'],
-      ['2000:123:5::/64'],
-      ['2000:123:40::/64', 'rtmap3'],
-      ['2000:123:9::/64'],
-    ]
-    # Test ipv6 unicast, vrf red, default and blue
-    asn = '55'
-    vrf = 'default'
-    af = 'ipv6 unicast'
-    networks_delta_same(asn, vrf, af, il1, sl1, il2, sl2)
-    asn = '55'
-    vrf = 'red'
-    af = 'ipv6 unicast'
-    networks_delta_same(asn, vrf, af, il1, sl1, il2, sl2)
-    asn = '55'
-    vrf = 'green'
-    af = 'ipv6 unicast'
-    networks_delta_same(asn, vrf, af, il1, sl1, il2, sl2)
-  end
-
-  def networks_delta_is_greaterthan_should(asn, vrf, af, il, sl)
-    /ipv4/.match(af) ? af = %w(ipv4 unicast) : af = %w(ipv6 unicast)
-    bgp_af = RouterBgpAF.new(asn, vrf, af)
-
-    #
-    # Set and verify 'is' network list contains more items then
-    # the 'should' network list.
-    #
-    # il.each { |network, rtmap| bgp_af.network_set(network, rtmap) }
-
-    config_list = bgp_af.delta_add_remove(sl, il)
-    assert_empty(config_list[:add],
-                 'Error: config_list[:add] should be empty')
-    assert_equal(1, config_list[:remove].size,
-                 'Error: config_list[:remove] should contain one item')
-    assert_equal(il[1], config_list[:remove][0],
-                 'Error: config_list[:remove] has the wrong network')
-
-    # Apply should_list
-    bgp_af.networks = sl
-
-    # Verify is_list on device
-    sl.each do |network|
-      assert_includes(bgp_af.networks, network,
-                      "Error: device should contain network #{network}")
-    end
-  end
-
-  def test_networks_delta_is_greaterthan_should
-    # is_list(il) has an additional item 4
-    il = [
-      ['192.168.5.0/24', 'rtmap1'],
-      ['192.168.6.0/24', 'rtmap2'],
-      ['192.168.7.0/24', 'rtmap3'],
-      ['192.168.9.0/24'],
-    ]
-    sl = [
-      ['192.168.5.0/24', 'rtmap1'],
-      ['192.168.7.0/24', 'rtmap3'],
-      ['192.168.9.0/24'],
-    ]
-    # Test ipv4 unicast vrf red
-    asn = '55'
-    vrf = 'red'
-    af = 'ipv4 unicast'
-    networks_delta_is_greaterthan_should(asn, vrf, af, il, sl)
-
-    # is_list(il) has an additional item 4
-    il = [
-      ['2000:123:38::/64', 'rtmap1'],
-      ['2000:123:39::/64', 'rtmap2'],
-      ['2000:123:40::/64', 'rtmap3'],
-      ['2000:123:41::/64'],
-    ]
-    sl = [
-      ['2000:123:38::/64', 'rtmap1'],
-      ['2000:123:40::/64', 'rtmap3'],
-      ['2000:123:41::/64'],
-    ]
-    # Test ipv6 unicast vrf red
-    asn = '55'
-    vrf = 'red'
-    af = 'ipv6 unicast'
-    networks_delta_is_greaterthan_should(asn, vrf, af, il, sl)
-  end
-
-  def networks_delta_is_lessthan_should(asn, vrf, af, _il1, sl1, il2, sl2)
-    /ipv4/.match(af) ? af = %w(ipv4 unicast) : af = %w(ipv6 unicast)
-    bgp_af = RouterBgpAF.new(asn, vrf, af)
-
-    #
-    # Set and verify 'is' network list contains less items then
-    # the 'should' network list.
-    config_list = bgp_af.delta_add_remove(sl1, il2)
-    assert_equal(1, config_list[:add].size,
-                 'Error: config_list[:add] should contain 1 item')
-    assert_empty(config_list[:remove],
-                 'Error: config_list[:remove] should be empty')
-    assert_equal(sl1[3], config_list[:add][0],
-                 'Error: config_list[:add] has the wrong network')
-
-    # Apply should_list
-    bgp_af.networks = sl1
-
-    # Verify is_list on device
-    sl1.each do |network|
-      assert_includes(bgp_af.networks, network,
-                      "Error: device should contain network #{network}")
+  def network_cmd(af, dbg, afi)
+    # Initial 'should' state
+    if /ipv6/.match(afi)
+      master = [
+        ['2000:123:38::/64', 'rtmap1'],
+        ['2000:123:39::/64', 'rtmap2'],
+        ['2000:123:40::/64', 'rtmap3'],
+        ['2000:123:41::/64'],
+        ['2000:123:42::/64', 'rtmap5'],
+        ['2000:123:43::/64', 'rtmap6'],
+        ['2000:123:44::/64'],
+        ['2000:123:45::/64', 'rtmap7'],
+      ]
+    else
+      master = [
+        ['192.168.5.0/24', 'rtmap1'],
+        ['192.168.6.0/24', 'rtmap2'],
+        ['192.168.7.0/24', 'rtmap3'],
+        ['192.168.8.0/24'],
+        ['192.168.9.0/24', 'rtmap5'],
+        ['192.168.10.0/24', 'rtmap6'],
+        ['192.168.11.0/24'],
+        ['192.168.12.0/24', 'rtmap7'],
+      ]
     end
 
-    # Cleanup for next test section
-    bgp_af.networks = []
-    assert_empty(bgp_af.networks,
-                 'Error: all networks should have been removed')
+    # Test: all networks are set when current is empty.
+    should = master.clone
+    af.networks = should
+    result = af.networks
+    assert_equal(should.sort, result.sort,
+                 "#{dbg} Test 1. From empty, to all networks")
 
-    #
-    # Set and verify 'is' network list contains less items then
-    # the 'should' network list and some of the items are
-    # different
+    # Test: remove half of the networks
+    should.shift(4)
+    af.networks = should
+    result = af.networks
+    assert_equal(should.sort, result.sort,
+                 "#{dbg} Test 2. Remove half of the networks")
 
-    config_list = bgp_af.delta_add_remove(sl2, il2)
-    assert_equal(2, config_list[:add].size,
-                 'Error: config_list[:add] should contain 2 items')
-    assert_equal(1, config_list[:remove].size,
-                 'Error: config_list[:remove] should contain 1 item')
-    assert_includes(config_list[:add], sl2[0],
-                    "Error: config_list[:add] should contain #{sl2[0]}")
-    assert_includes(config_list[:add], sl2[3],
-                    "Error: config_list[:add] should contain #{sl2[3]}")
-    assert_includes(config_list[:remove], il2[0],
-                    "Error: config_list[:remove] should contain #{il2[0]}")
+    # Test: restore the removed networks
+    should = master.clone
+    af.networks = should
+    result = af.networks
+    assert_equal(should.sort, result.sort,
+                 "#{dbg} Test 3. Restore the removed networks")
 
-    # Apply should list
-    bgp_af.networks = sl2
+    # Test: Change route-maps on existing networks
+    should = master.map { |network, rm| [network, "#{rm}_55"] }
+    af.networks = should
+    result = af.networks
+    assert_equal(should.sort, result.sort,
+                 "#{dbg} Test 4. Chane route-map on existing networks")
 
-    # Verify is_list on device
-    sl2.each do |network|
-      assert_includes(bgp_af.networks, network,
-                      "Error: device should contain network #{network}")
-    end
-  end
-
-  def test_networks_delta_is_lessthan_should
-    # Lists are identical except for additional item 4 in
-    # should list (sl1)
-    il1 = [
-      ['192.168.5.0/24', 'rtmap1'],
-      ['192.168.6.0/24', 'rtmap2'],
-      ['192.168.7.0/24', 'rtmap3']]
-    sl1 = [
-      ['192.168.5.0/24', 'rtmap1'],
-      ['192.168.6.0/24', 'rtmap2'],
-      ['192.168.7.0/24', 'rtmap3'],
-      ['192.168.9.0/24'],
-    ]
-    # Item 1 in both lists are different
-    # Additonal item 4 in should list (sl2)
-    il2 = [
-      ['192.168.5.0/24', 'rtmap1'],
-      ['192.168.6.0/24', 'rtmap2'],
-      ['192.168.7.0/24', 'rtmap3'],
-    ]
-    sl2 = [
-      ['192.168.55.0/24', 'rtmap55'],
-      ['192.168.6.0/24', 'rtmap2'],
-      ['192.168.7.0/24', 'rtmap3'],
-      ['192.168.9.0/24'],
-    ]
-    # Test ipv4 unicast vrf default
-    asn = '55'
-    vrf = 'default'
-    af = 'ipv4 unicast'
-    networks_delta_is_lessthan_should(asn, vrf, af, il1, sl1, il2, sl2)
-
-    # Lists are identical except for additional item 4 in
-    # should list (sl1)
-    il1 = [
-      ['2000:123:38::/64', 'rtmap1'],
-      ['2000:123:39::/64', 'rtmap2'],
-      ['2000:123:40::/64', 'rtmap3']]
-    sl1 = [
-      ['2000:123:38::/64', 'rtmap1'],
-      ['2000:123:39::/64', 'rtmap2'],
-      ['2000:123:40::/64', 'rtmap3'],
-      ['2000:123:41::/64'],
-    ]
-    # Item 1 in both lists are different
-    # Additonal item 4 in should list (sl2)
-    il2 = [
-      ['2000:123:38::/64', 'rtmap1'],
-      ['2000:123:39::/64', 'rtmap2'],
-      ['2000:123:40::/64', 'rtmap3'],
-    ]
-    sl2 = [
-      ['2000:155:55::/64', 'rtmap1'],
-      ['2000:123:39::/64', 'rtmap2'],
-      ['2000:123:40::/64', 'rtmap3'],
-      ['2000:123:41::/64'],
-    ]
-    # Test ipv6 unicast vrf default
-    asn = '55'
-    vrf = 'default'
-    af = 'ipv6 unicast'
-    networks_delta_is_lessthan_should(asn, vrf, af, il1, sl1, il2, sl2)
-  end
-
-  def test_networks_is_list_empty
-    bgp_af = RouterBgpAF.new('55', 'default', %w(ipv6 unicast))
-
-    sl = [
-      ['2000:123:38::/64', 'rtmap1'],
-      ['2000:123:39::/64', 'rtmap2'],
-    ]
-
-    config_list = bgp_af.delta_add_remove(sl)
-    assert_equal(2, config_list[:add].size,
-                 'Error: config_list[:add] should contain 2 items')
-    assert_empty(config_list[:remove],
-                 'Error: config_list[:remove] should be empty')
-
-    # Apply should_list
-    bgp_af.networks = sl
-
-    # Verify is_list on device
-    sl.each do |network|
-      assert_includes(bgp_af.networks, network,
-                      "Error: device should contain network #{network}")
-    end
-  end
-
-  def test_networks_scale
-    asn = '55'
-    vrf = 'blue'
-    af = %w(ipv4 unicast)
-    bgp_af = RouterBgpAF.new(asn, vrf, af)
-
-    #
-    # Configure 50 networks and then add and remove from the list
-    #
-    should_list = []
-    (1..50).each do |x|
-      should_list.push ["192.168.#{x}.0/24", "rtmap#{x}"]
-    end
-    bgp_af.networks = should_list
-
-    config_list = bgp_af.delta_add_remove(should_list, bgp_af.networks)
-    assert_empty(config_list[:add],
-                 'Error: config_list[:add] should be empty')
-    assert_empty(config_list[:remove],
-                 'Error: config_list[:remove] should be empty')
-
-    # Verify is_list on device
-    should_list.each do |network|
-      assert_includes(bgp_af.networks, network,
-                      "Error: device should contain network #{network}")
-    end
-
-    # Change the second half of the list to new values
-    (25..50).each { |x| should_list[x] = ["10.168.#{x}.0/24", "rtmap#{x}"] }
-
-    # Add new values with route maps
-    (51..80).each { |x| should_list[x] = ["10.55.#{x}.0/24", "rtmap#{x}"] }
-
-    # Add new values without route maps
-    (81..90).each { |x| should_list[x] = ["10.55.#{x}.0/24"] }
-
-    # Apply config_list
-    bgp_af.networks = should_list
-
-    # Verify is_list on device
-    should_list.each do |network|
-      assert_includes(bgp_af.networks, network,
-                      "Error: device should contain network #{network}")
-    end
-
-    # Cleanup
-    bgp_af.networks = []
-    assert_empty(bgp_af.networks,
-                 'Error: all networks should have been removed')
-  end
-
-  def test_networks_routemap_change
-    asn = '55'
-    vrf = 'blue'
-    af = %w(ipv4 unicast)
-    bgp_af = RouterBgpAF.new(asn, vrf, af)
-
-    il = [['192.168.5.0/24', 'rtmap1']]
-    sl = [['192.168.5.0/24', 'rtmap2']]
-
-    config_list = bgp_af.delta_add_remove(sl, il)
-    assert_equal(1, config_list[:add].size,
-                 'Error: config_list[:add] should contain 1 item')
-    assert_empty(config_list[:remove],
-                 'Error: config_list[:remove] should be empty')
-    assert_equal('rtmap2', config_list[:add][0][1],
-                 "Error: config_list[:add] routemap value should be 'rtmap2'")
-
-    # Apply should list
-    bgp_af.networks = sl
-
-    # Verify should_list on device
-    sl.each do |network|
-      assert_includes(bgp_af.networks, network,
-                      "Error: device should contain network #{network}")
-    end
+    # Test: 'default'
+    should = af.default_networks
+    af.networks = should
+    result = af.networks
+    assert_equal(should.sort, result.sort,
+                 "#{dbg} Test 5. 'Default'")
   end
 
   ##

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -740,14 +740,14 @@ class TestRouterBgpAF < CiscoTestCase
       afs.each do |af|
         dbg = sprintf('[VRF %s AF %s]', vrf, af.join('/'))
         af_obj = RouterBgpAF.new(1, vrf, af)
-        network_cmd(af_obj, dbg, af[0])
+        network_cmd(af_obj, dbg)
       end
     end
   end
 
-  def network_cmd(af, dbg, afi)
+  def network_cmd(af, dbg)
     # Initial 'should' state
-    if /ipv6/.match(afi)
+    if /ipv6/.match(dbg)
       master = [
         ['2000:123:38::/64', 'rtmap1'],
         ['2000:123:39::/64', 'rtmap2'],
@@ -797,7 +797,7 @@ class TestRouterBgpAF < CiscoTestCase
     af.networks = should
     result = af.networks
     assert_equal(should.sort, result.sort,
-                 "#{dbg} Test 4. Chane route-map on existing networks")
+                 "#{dbg} Test 4. Change route-map on existing networks")
 
     # Test: 'default'
     should = af.default_networks
@@ -862,7 +862,7 @@ class TestRouterBgpAF < CiscoTestCase
     af.redistribute = should
     result = af.redistribute
     assert_equal(should.sort, result.sort,
-                 "#{dbg} Test 4. Restore the removed protocols")
+                 "#{dbg} Test 4. Change route-maps on existing commands")
 
     # Test: 'default'
     should = af.default_redistribute


### PR DESCRIPTION
Fixes and extensions needed to support dampening_igp_metric, dampening and networks properties.

Summary
1) Fixed bug in dampen_igp_metric and refactored tests.
2) Added additional helper methods for dampen.
3) Fixed bug for networks causing a failure when is_list is empty.
4) Fixed default value for client-to-client
5) Fixed bugs in next_hop_route_map and additional_paths_selection
6) Refactored to use new streamlined networks code
- rubocop passes
- all minitests pass
