### PR TITLE
Add redistribute property to bgp_af

### DIFF
--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -470,5 +470,38 @@ module Cisco
     def default_networks
       config_get_default('bgp_af', 'network')
     end
+
+    #
+    # Redistribute (Getter/Setter/Default)
+    #
+
+    # Build an array of all redistribute commands currently on the device
+    def redistribute
+      cmds = config_get('bgp_af', 'redistribute', @get_args)
+      cmds.nil? ? default_redistribute : cmds.each(&:compact!)
+    end
+
+    # redistribute setter.
+    # Process a hash of redistribute commands from delta_add_remove().
+    def redistribute=(should)
+      delta_hash = Utils.delta_add_remove(should, redistribute)
+      return if delta_hash.values.flatten.empty?
+      [:add, :remove].each do |action|
+        CiscoLogger.debug("redistribute delta #{@get_args}\n #{action}: " \
+                          "#{delta_hash[action]}")
+        delta_hash[action].each do |protocol, policy|
+          state = (action == :add) ? '' : 'no'
+          set_args_keys(state: state, protocol: protocol, policy: policy)
+
+          # route-map/policy may be optional on some platforms
+          cmd = policy.nil? ? 'redistribute' : 'redistribute_policy'
+          config_set('bgp_af', cmd, @set_args)
+        end
+      end
+    end
+
+    def default_redistribute
+      config_get_default('bgp_af', 'redistribute')
+    end
   end
 end

--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -106,5 +106,21 @@ module Cisco
       network = address + '/' + mask unless mask.nil?
       network
     end
+
+    # Helper to build a hash of add/remove commands for a nested array.
+    # Useful for network, redistribute, etc.
+    #   should: an array of expected cmds (manifest/recipe)
+    #  current: an array of existing cmds on the device
+    def self.delta_add_remove(should, current=[])
+      # Remove nil entries from array
+      should.each(&:compact!) unless should.empty?
+      delta = { add: should - current, remove: current - should }
+
+      # Delete entries from :remove if f1 is an update to an existing command
+      delta[:add].each do |id, _|
+        delta[:remove].delete_if { |f1, f2| [f1, f2] if f1.to_s == id.to_s }
+      end
+      delta
+    end # delta_add_remove
   end # class Utils
 end   # module Cisco

--- a/lib/cisco_node_utils/command_reference_common_bgp.yaml
+++ b/lib/cisco_node_utils/command_reference_common_bgp.yaml
@@ -241,6 +241,15 @@ bgp_af:
     config_set_append: '<state> network <network> <route_map>'
     default_value: ""
 
+  redistribute:
+    config_get_token_append: '/^redistribute (\S+ ?\S+?) ?(?:route-map (\S+))?$/'
+    config_set_append: '<state> redistribute <protocol>'
+    default_value: []
+
+  redistribute_policy:
+    # route-map/policy is optional on some platforms, required on others
+    config_set_append: '<state> redistribute <protocol> route-map <policy>'
+
 bgp_neighbor:
   _template:
     config_get: "show running bgp all"

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -1104,4 +1104,122 @@ class TestRouterBgpAF < CiscoTestCase
                       "Error: device should contain network #{network}")
     end
   end
+
+  ##
+  ## redistribute
+  ##
+
+  def test_redistribute
+    vrfs = %w(default red)
+    afs = [%w(ipv4 unicast), %w(ipv6 unicast)]
+    vrfs.each do |vrf|
+      afs.each do |af|
+        dbg = sprintf('[VRF %s AF %s]', vrf, af.join('/'))
+        af = RouterBgpAF.new(1, vrf, af)
+        redistribute_cmd(af, dbg)
+      end
+    end
+  end
+
+  def redistribute_cmd(af, dbg)
+    # rubocop:disable Style/WordArray
+    # Initial 'should' state
+    ospf = (dbg.include? 'ipv6') ? 'ospfv3 3' : 'ospf 3'
+    master = [['direct',  'rm_direct'],
+              ['lisp',    'rm_lisp'],
+              ['static',  'rm_static'],
+              ['eigrp 1', 'rm_eigrp'],
+              ['isis 2',  'rm_isis'],
+              [ospf,      'rm_ospf'],
+              ['rip 4',   'rm_rip']]
+    # rubocop:enable Style/WordArray
+
+    # Test: all protocols w/route-maps are set when current is empty.
+    should = master.clone
+    af.redistribute = should
+    result = af.redistribute
+    assert_equal(should.sort, result.sort,
+                 "#{dbg} Test 1. From empty, to all protocols")
+
+    # Test: remove half of the protocols
+    should.shift(4)
+    af.redistribute = should
+    result = af.redistribute
+    assert_equal(should.sort, result.sort,
+                 "#{dbg} Test 2. Remove half of the protocols")
+
+    # Test: restore the removed protocols
+    should = master.clone
+    af.redistribute = should
+    result = af.redistribute
+    assert_equal(should.sort, result.sort,
+                 "#{dbg} Test 3. Restore the removed protocols")
+
+    # Test: Change route-maps on existing commands
+    should = master.map { |prot_only, rm| [prot_only, "#{rm}_2"] }
+    af.redistribute = should
+    result = af.redistribute
+    assert_equal(should.sort, result.sort,
+                 "#{dbg} Test 4. Restore the removed protocols")
+
+    # Test: 'default'
+    should = af.default_redistribute
+    af.redistribute = should
+    result = af.redistribute
+    assert_equal(should.sort, result.sort,
+                 "#{dbg} Test 5. 'Default'")
+  end
+
+  ##
+  ## common utilities
+  ##
+
+  def test_utils_delta_add_remove
+    # Note: AF context is not needed. This test is only validating the
+    # delta_add_remove class method and does not test directly on the device.
+
+    # rubocop:disable Style/WordArray
+    # Initial 'should' state
+    should = [['direct',  'rm_direct'],
+              ['lisp',    'rm_lisp'],
+              ['static',  'rm_static'],
+              ['eigrp 1', 'rm_eigrp'],
+              ['isis 2',  'rm_isis'],
+              ['ospf 3',  'rm_ospf'],
+              ['rip 4',   'rm_rip']]
+    # rubocop:enable Style/WordArray
+
+    # Test: Check delta when every protocol is specified and has a route-map.
+    current = []
+    expected = { add: should, remove: [] }
+    result = Utils.delta_add_remove(should, current)
+    assert_equal(expected, result, 'Test 1. delta mismatch')
+
+    # Test: Check delta when should is the same as current.
+    current = should.clone
+    expected = { add: [], remove: [] }
+    result = Utils.delta_add_remove(should, current)
+    assert_equal(expected, result, 'Test 2. delta mismatch')
+
+    # Test: Move half the 'current' entries to 'should'. Check delta.
+    should = current.shift(4)
+    expected = { add: should, remove: current }
+    result = Utils.delta_add_remove(should, current)
+    assert_equal(expected, result, 'Test 3. delta mismatch')
+
+    # Test: Remove the route-maps from the current list. Check delta.
+    #       Note: The :remove list should be empty since this is just
+    #       an update of the route-map.
+    should = current.map { |prot_only, _route_map| [prot_only] }
+    expected = { add: should, remove: [] }
+    result = Utils.delta_add_remove(should, current)
+    assert_equal(expected, result, 'Test 4. delta mismatch')
+
+    # Test: Check empty inputs
+    should = []
+    current = []
+    expected = { add: [], remove: [] }
+    result = Utils.delta_add_remove(should, current)
+    assert_equal(expected, result, 'Test 5. delta mismatch')
+  end
 end


### PR DESCRIPTION
Add a common Utils.delta_add_remove helper function to build
an add/remove hash for network, redistribute, etc.

Note that this command is modeled after the network property that Mike has already coded.
He or I will refactor network to follow the redistribute model.

rubocop: clean
minitest: clean
