### PR TITLE
XR interface support, part 1

### DIFF
--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -58,6 +58,21 @@ module Cisco
     end
   end
 
+  # General utility class
+  class Utils
+    require 'ipaddr'
+
+    def self.length_to_bitmask(length)
+      IPAddr.new('255.255.255.255').mask(length).to_s
+    end
+
+    def self.bitmask_to_length(bitmask)
+      # Convert bitmask to a 32-bit integer,
+      # convert that to binary, and count the 1s
+      IPAddr.new(bitmask).to_i.to_s(2).count('1')
+    end
+  end
+
   # ChefUtils - helper class for Chef code generation
   class ChefUtils
     def self.generic_prop_set(klass, rlbname, props)

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -44,13 +44,21 @@ feature_lacp:
   config_set: "%s feature lacp"
 
 feature_vlan:
-  config_get: "show running | i ^feature"
-  config_get_token: '/^feature interface-vlan$/'
-  config_set: "%s feature interface-vlan"
+  grpc:
+    config_get: ~
+    config_set: ~
+  nxapi:
+    config_get: "show running | i ^feature"
+    config_get_token: '/^feature interface-vlan$/'
+    config_set: "%s feature interface-vlan"
 
 ipv4_addr_mask:
-  config_get_token_append: '/^ip address ([0-9\.]+)[\s\/](.*)/'
-  config_set_append: "%s ip address %s"
+  nxapi:
+    config_get_token_append: '/^ip address ([0-9\.]+)[\s\/](.*)/'
+    config_set_append: "%s ip address %s"
+  grpc:
+    config_get_token_append: '/^ipv4 address ([0-9\.]+) (.*)/'
+    config_set_append: '%s ipv4 address %s'
 
 ipv4_address:
   default_value: ~
@@ -59,11 +67,18 @@ ipv4_netmask_length:
   default_value: ~
 
 ipv4_proxy_arp:
-  config_get_token_append: '/^ip proxy-arp$/'
-  config_set_append: "%s ip proxy-arp"
   default_value: false
+  nxapi:
+    config_get_token_append: '/^ip proxy-arp$/'
+    config_set_append: "%s ip proxy-arp"
+  grpc:
+    config_get_token_append: '/^proxy-arp$/'
+    config_set_append: "%s proxy-arp"
 
 ipv4_redirects_loopback:
+  test_config_result:
+    false: RuntimeError
+    true: RuntimeError
   nxapi:
     /N7K/:
       default_value: false
@@ -74,19 +89,39 @@ ipv4_redirects_loopback:
       config_get_token_append: '/^((?:no )?ip redirects)$/'
       config_set_append: "%s ip redirects"
       default_value: true
-  test_config_get_regex: ['/^\s+no ip redirects/']
-  test_config_result:
-    false: RuntimeError
-    true: RuntimeError
+      test_config_get_regex: [
+      '/^\s+ip redirects/',
+      '/^\s+no ip redirects/'
+      ]
+  grpc:
+    config_get_token_append: '/^((?:no )?ipv4 redirects)$/'
+    config_set_append: "%s ipv4 redirects"
+    default_value: false
+    test_config_get_regex: [
+    '/^\s+ipv4 redirects/',
+    '/^\s+no ipv4 redirects/'
+    ]
 
 ipv4_redirects_other_interfaces:
-  config_get_token_append: '/^((?:no )?ip redirects)$/'
-  config_set_append: "%s ip redirects"
-  default_value: true
-  test_config_get_regex: ['/^\s+no ip redirects/']
   test_config_result:
     false: false
     true: true
+  nxapi:
+    config_get_token_append: '/^((?:no )?ip redirects)$/'
+    config_set_append: "%s ip redirects"
+    default_value: true
+    test_config_get_regex: [
+    '/^\s+ip redirects/',
+    '/^\s+no ip redirects/'
+    ]
+  grpc:
+    config_get_token_append: '/^((?:no )?ipv4 redirects)$/'
+    config_set_append: "%s ipv4 redirects"
+    default_value: false
+    test_config_get_regex: [
+    '/^\s+ipv4 redirects/',
+    '/^\s+no ipv4 redirects/'
+    ]
 
 mtu:
   config_get_token_append: '/^mtu (.*)$/'
@@ -94,19 +129,31 @@ mtu:
   default_value: 1500
 
 negotiate_auto_ethernet:
-  /(N7K|C3064)/:
-    config_get: ~
-    config_set: ~
-    config_get_token: ~
-    default_value: false
-  else:
-    config_get_token_append: '/^negotiate auto$/'
-    config_set_append: "%s negotiate auto"
-    default_value: true
-  test_config_get_regex: [
-  '/^\s+no negotiate auto/',
-  '/^\s+negotiate auto/'
-  ]
+  nxapi:
+    test_config_get_regex: [
+    '/^\s+no negotiate auto/',
+    '/^\s+negotiate auto/'
+    ]
+    /(N7K|C3064)/:
+      config_get: ~
+      config_set: ~
+      config_get_token: ~
+      default_value: false
+    else:
+      config_get_token_append: '/^negotiate auto$/'
+      config_set_append: "%s negotiate auto"
+      default_value: true
+  grpc:
+    # TODO: which XR platforms *do* support this?
+    /XRV/:
+      config_get: ~
+      config_set: ~
+      config_get_token: ~
+      default_value: false
+    else:
+      config_get_token_append: '^/negotiation auto$/'
+      config_set_append: "%s negotiation auto"
+      default_value: true
 
 negotiate_auto_other_interfaces:
   config_get: ~
@@ -117,19 +164,24 @@ negotiate_auto_other_interfaces:
     true: RuntimeError
 
 negotiate_auto_portchannel:
-  /N7K/:
-    config_get: ~
-    config_get_token: ~
-    config_set: ~
-    default_value: false
-  else:
-    config_get_token_append: '/^negotiate auto$/'
-    config_set_append: "%s negotiate auto"
+  nxapi:
+    test_config_get_regex: [
+    '/^\s+no negotiate auto/',
+    '/^\s+negotiate auto/'
+    ]
+    /N7K/:
+      config_get: ~
+      config_get_token: ~
+      config_set: ~
+      default_value: false
+    else:
+      config_get_token_append: '/^negotiate auto$/'
+      config_set_append: "%s negotiate auto"
+      default_value: true
+  grpc:
+    config_get_token_append: '^/negotiation auto$/'
+    config_set_append: "%s negotiation auto"
     default_value: true
-  test_config_get_regex: [
-  '/^\s+no negotiate auto/',
-  '/^\s+negotiate auto/'
-  ]
 
 shutdown:
   config_get_token_append: '/^shutdown$/'
@@ -157,7 +209,8 @@ shutdown_unknown:
   default_value: true
 
 shutdown_vlan:
-  default_value: true
+  nxapi:
+    default_value: true
 
 svi_autostate:
   config_get_token_append: '/^autostate$/'
@@ -226,9 +279,13 @@ system_default_switchport_shutdown:
   # default_value: n/a. This is a user-configurable system default.
 
 vrf:
-  config_get_token_append: '/^vrf member (.*)/'
-  config_set_append: "%s vrf member %s"
   default_value: ""
+  nxapi:
+    config_get_token_append: '/^vrf member (.*)/'
+    config_set_append: "%s vrf member %s"
+  grpc:
+    config_get_token_append: '/^vrf (.*)/'
+    config_set_append: "%s vrf %s"
 
 vtp:
   config_get_token_append: '/^vtp *$/'

--- a/lib/cisco_node_utils/node_util.rb
+++ b/lib/cisco_node_utils/node_util.rb
@@ -34,6 +34,14 @@ module Cisco
       self.class.node
     end
 
+    def self.client
+      node.client
+    end
+
+    def client
+      node.client
+    end
+
     def self.config_get(*args)
       node.config_get(*args)
     end

--- a/tests/.rubocop.yml
+++ b/tests/.rubocop.yml
@@ -3,13 +3,13 @@ inherit_from: ../.rubocop.yml
 # Code complexity metrics for the tests/ subdirectory
 
 Metrics/AbcSize:
-  Enabled: false
+  Max: 149 # ouch!
 
 Metrics/CyclomaticComplexity:
   Max: 15
 
 Metrics/MethodLength:
-  Max: 86
+  Max: 88
 
 Metrics/PerceivedComplexity:
   Max: 17

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -126,6 +126,8 @@ class TestCase < Minitest::Test
     @device.cmd('String' => "configure terminal\n" + args.join("\n") + "\nend",
                 # NX-OS has a space after '#', IOS XR does not
                 'Match'  => /^[^()]+[$%#>] *\z/n)
+  rescue Net::ReadTimeout => e
+    raise "Timeout when configuring:\n#{args.join("\n")}\n\n#{e}"
   end
 
   def assert_show_match(pattern: nil, command: nil, msg: nil)

--- a/tests/test_interface_switchport.rb
+++ b/tests/test_interface_switchport.rb
@@ -57,6 +57,29 @@ class TestInterfaceSwitchport < CiscoTestCase
     config("#{state} system default switchport shutdown")
   end
 
+  def test_interface_get_access_vlan
+    interface = Interface.new(interfaces[0])
+    interface.switchport_mode = :disabled
+    interface.switchport_mode = :access
+    assert_equal(DEFAULT_IF_ACCESS_VLAN, interface.access_vlan)
+    interface_ethernet_default(interfaces_id[0])
+  end
+
+  def test_interface_get_access_vlan_switchport_disabled
+    interface = Interface.new(interfaces[0])
+    interface.switchport_mode = :disabled
+    assert_equal(DEFAULT_IF_ACCESS_VLAN, interface.access_vlan)
+    interface_ethernet_default(interfaces_id[0])
+  end
+
+  def test_interface_get_access_vlan_switchport_trunk
+    interface = Interface.new(interfaces[0])
+    interface.switchport_mode = :disabled
+    interface.switchport_mode = :trunk
+    assert_equal(DEFAULT_IF_ACCESS_VLAN, interface.access_vlan)
+    interface_ethernet_default(interfaces_id[0])
+  end
+
   def test_switchport_vtp_disabled_feature_enabled
     vtp = Vtp.new(true)
     interface = Interface.new(interfaces[0])


### PR DESCRIPTION
First pass at interface support for XR/gRPC.

Rubocop:

```
Inspecting 65 files
.................................................................

65 files inspected, no offenses detected
```

Minitest (XR):

```
$ NODE="192.168.122.222:12222 admin admin" ruby tests/test_interface.rb 
Run options: --seed 16659

# Running:


Node under test:
  - name  - ios
  - type  - R-IOSXRV9000-RP
.S....................S..........

Finished in 154.526646s, 0.2136 runs/s, 1.1519 assertions/s.

33 runs, 178 assertions, 0 failures, 0 errors, 2 skips

You have skipped tests. Run with --verbose for details.
Coverage report generated for MiniTest to /home/glmatthe/cisco-network-node-utils/coverage. 532 / 745 LOC (71.41%) covered.
```

Minitest (NXOS, with one intermittent baseline error):

```
$ NODE="n9k-108 admin admin" ruby tests/test_interface.rb 
Run options: --seed 17513

# Running:


Node under test:
  - name  - switch
  - type  - N9K-C9396PX
..............E..................

Finished in 143.293068s, 0.2303 runs/s, 2.3030 assertions/s.

  1) Error:
TestInterface#test_interface_mtu_valid:
RuntimeError: [ethernet1/1] ' mtu 1490' : ERROR: MTU must be greater than all sub interface mtus
    /home/glmatthe/cisco-network-node-utils/lib/cisco_node_utils/interface.rb:263:in `rescue in mtu='
    /home/glmatthe/cisco-network-node-utils/lib/cisco_node_utils/interface.rb:260:in `mtu='
    tests/test_interface.rb:519:in `test_interface_mtu_valid'

33 runs, 330 assertions, 0 failures, 1 errors, 0 skips
Coverage report generated for MiniTest to /home/glmatthe/cisco-network-node-utils/coverage. 542 / 745 LOC (72.75%) covered.
```

Caveats:
- No support for Bundle-Ether interfaces in this class (XR version of portchannel) yet - XR requires that we actually map one or more Ethernet interfaces into the bundle-group before accepting the config, unlike NXOS.
- XR doesn't appear to have interface-vlan support
- No switchport interface support yet for XR
- Lots of hard-coded checks for 'grpc' vs 'nxapi' - we ought to be able to handle this in the YAML more.
