### PR TITLE
Cleaned up command_config minitest

### DIFF
--- a/tests/cmd_config.yaml
+++ b/tests/cmd_config.yaml
@@ -1,56 +1,75 @@
 # test command config yaml file
 ---
-# TODO: support NX as well as XR configs
-#feature-enable:
-#  command: |
-#          feature tacacs+
-#          feature ospf
-#          feature bgp
-#          feature pim
-#          feature msdp
-#          feature private-vlan
-#          feature udld
-#          feature interface-vlan
-#          feature hsrp
-#          feature lacp
-#          feature dhcp
-#          feature vtp
-#
-#feature-disable:
-#  command: |
-#          no feature tacacs+
-#          no feature ospf
-#          no feature bgp
-#          no feature pim
-#          no feature msdp
-#          no feature private-vlan
-#          no feature udld
-#          no feature interface-vlan
-#          no feature hsrp
-#          no feature lacp
-#          no feature dhcp
-#          no feature vtp
-#
-#feature-snmp-comm-acl-ro:
-#  command: |
-#           snmp-server community networkopercom group network-operator
-#           snmp-server community networkopercom use-acl SNMP_RO
-#
-#feature-snmp-comm-acl-rw:
-#  command: |
-#           snmp-server community admincom group network-admin
-#           snmp-server community admincom use-acl SNMP_RW
-#
-#feature-int-loopback:
-#  command: >
-#          interface loopback0
-#            description testloopback
-#
-#feature-int-portchannel:
-#  command: >
-#          interface port-channel100
-#            description test-portchannel
+nxapi:
+  feature-enable:
+    command: |
+            feature tacacs+
+            feature ospf
+            feature bgp
+            feature pim
+            feature msdp
+            feature private-vlan
+            feature udld
+            feature interface-vlan
+            feature hsrp
+            feature lacp
+            feature dhcp
+            feature vtp
 
-xr-name-server:
-  command: |
-          domain name-server 10.10.10.10
+  feature-disable:
+    command: |
+            no feature tacacs+
+            no feature ospf
+            no feature bgp
+            no feature pim
+            no feature msdp
+            no feature private-vlan
+            no feature udld
+            no feature interface-vlan
+            no feature hsrp
+            no feature lacp
+            no feature dhcp
+            no feature vtp
+
+  feature-snmp-comm-acl-ro:
+    command: |
+             snmp-server community networkopercom group network-operator
+             snmp-server community networkopercom use-acl SNMP_RO
+
+  feature-snmp-comm-acl-rw:
+    command: |
+             snmp-server community admincom group network-admin
+             snmp-server community admincom use-acl SNMP_RW
+
+  feature-int-loopback:
+    command: >
+            interface loopback0
+              description testloopback
+
+  feature-int-portchannel:
+    command: >
+            interface port-channel100
+              description test-portchannel
+
+grpc:
+  name-server:
+    command: |
+            domain name-server 10.10.10.10
+            domain name-server 10.10.10.11
+            domain name-server 10.10.10.12
+
+  no-name-server:
+    command: |
+            no domain name-server 10.10.10.10
+            no domain name-server 10.10.10.11
+            no domain name-server 10.10.10.12
+
+  lo-intf:
+    command: |
+            interface Loopback0
+              description test description
+              vrf red
+
+  no-lo-intf:
+    command: |
+            no interface Loopback0

--- a/tests/test_command_config.rb
+++ b/tests/test_command_config.rb
@@ -83,14 +83,18 @@ class TestCommandConfig < CiscoTestCase
     end
   end
 
+  def loopback
+    (node.client.api == "gRPC") ? 'Loopback' : 'loopback'
+  end
+
   def build_int_scale_config(add=true)
     add ? s = '' : s = 'no '
     current_interface = 0
     # num_interfaces = 1024
-    num_interfaces = 10
+    num_interfaces = 1024
     command_list = ''
     while current_interface < num_interfaces
-      command_list += "#{s}interface Loopback#{current_interface}\n"
+      command_list += "#{s}interface #{loopback}#{current_interface}\n"
       current_interface += 1
     end
     command_list
@@ -101,7 +105,7 @@ class TestCommandConfig < CiscoTestCase
   # ---------------------------------------------------------------------------
 
   def test_valid_config
-    cfg_hash = load_yaml
+    cfg_hash = load_yaml[node.client.api.downcase]
     begin
       send_device_config(cfg_hash)
     end

--- a/tests/test_command_config.rb
+++ b/tests/test_command_config.rb
@@ -84,7 +84,7 @@ class TestCommandConfig < CiscoTestCase
   end
 
   def loopback
-    (node.client.api == "gRPC") ? 'Loopback' : 'loopback'
+    (node.client.api == 'gRPC') ? 'Loopback' : 'loopback'
   end
 
   def build_int_scale_config(add=true)


### PR DESCRIPTION
#### Rubocop passes

```
Inspecting 79 files
...............................................................................

79 files inspected, no offenses detected
```
#### N3k passes

```
# Running:


Node under test:
  - name  - n3k-51
  - type  - N3K-C3048TP-1GE
TestCommandConfig#test_invalid_config = 2.57 s = .
TestCommandConfig#test_valid_config = 19.49 s = .
TestCommandConfig#test_build_min_config_hash = 0.92 s = .
TestCommandConfig#test_indent_with_tab = 0.94 s = .
TestCommandConfig#test_valid_scale = 65.56 s = .

Finished in 89.477643s, 0.0559 runs/s, 0.1453 assertions/s.

5 runs, 13 assertions, 0 failures, 0 errors, 0 skips
```
#### XR9kV passes

```
# Running:


Node under test:
  - name  - sunstone47
  - type  - R-IOSXRV9000-RP
TestCommandConfig#test_valid_config = 5.77 s = .
TestCommandConfig#test_invalid_config = 1.63 s = .
TestCommandConfig#test_build_min_config_hash = 1.23 s = .
TestCommandConfig#test_indent_with_tab = 1.21 s = .
TestCommandConfig#test_valid_scale = 25.59 s = .

Finished in 35.429724s, 0.1411 runs/s, 0.3105 assertions/s.

5 runs, 11 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /home/robgrie/forks/cisco-network-node-utils/coverage. 330 / 456 LOC (72.37%) covered.
```
