### PR TITLE
Update vrf.rb to use config()

### DIFF
--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -26,9 +26,7 @@ class TestVrf < CiscoTestCase
     vrfs = Vrf.vrfs
     vrfs.each_value do |vrf|
       next unless vrf.name =~ /^test_vrf/
-      @device.cmd('conf t')
-      @device.cmd("no vrf context #{vrf.name}")
-      node.cache_flush
+      config("no vrf context #{vrf.name}")
     end
   end
 


### PR DESCRIPTION
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release_1.1.0/cisco-network-node-utils/tests> ruby test_vrf.rb -v -- 10.122.84.101 admin admin
Run options: -v -- --seed 41317
# Running:

Node under test:
- name  - n31x-101
- type  - N3K-C3132Q-40GX
- image - bootflash:///nxos.7.0.3.I2.1.bin

TestVrf#test_vrf_name_too_long = 2.07 s = .
TestVrf#test_vrf_name_type_invalid = 1.12 s = .
TestVrf#test_vrf_name_zero_length = 0.91 s = .
TestVrf#test_vrf_collection_not_empty = 1.12 s = .
TestVrf#test_vrf_description = 1.47 s = .
TestVrf#test_vrf_shutdown_valid = 3.07 s = .
TestVrf#test_vrf_create_and_destroy = 1.61 s = .

Finished in 11.370602s, 0.6156 runs/s, 1.6710 assertions/s.

7 runs, 19 assertions, 0 failures, 0 errors, 0 skips
