### PR TITLE
Implementation of node-utils for vxlan_global type. Includes yaml fil…

### DIFF
--- a/lib/cisco_node_utils/command_reference_common.yaml
+++ b/lib/cisco_node_utils/command_reference_common.yaml
@@ -1074,7 +1074,7 @@ vxlan_global:
   anycast_gateway_mac:
    config_get: 'show running fabric forwarding all'
    config_get_token: '/^fabric forwarding anycast-gateway-mac (\S+)$/'
-   config_set: "%s fabric forwarding anycast-gateway-mac %s"
+   config_set: "<state> fabric forwarding anycast-gateway-mac <mac_addr>"
 
   dup_host_mac_detection:
     config_get: 'show running | i l2rib'
@@ -1086,26 +1086,5 @@ vxlan_global:
 
   dup_host_mac_detection_host_moves:
     default_value: 5
-
   dup_host_mac_detection_timeout:
     default_value: 180
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/lib/cisco_node_utils/command_reference_common.yaml
+++ b/lib/cisco_node_utils/command_reference_common.yaml
@@ -1054,3 +1054,58 @@ yum:
   remove:
     config_set: "install deactivate %s"
 
+vxlan_global:
+  feature:
+    config_get: "show running | i ^feature"
+    config_get_token: '/^feature fabric forwarding$/'
+    config_set: "<state> feature fabric forwarding"
+
+  dup_host_ip_addr_detection:
+    config_get: 'show running fabric forwarding all'
+    config_get_token: '/^fabric forwarding dup-host-ip-addr-detection (\d+) (\d+)$/'
+    config_set: "<state> fabric forwarding dup-host-ip-addr-detection <host_moves> <timeout>"
+
+  dup_host_ip_addr_detection_host_moves:
+    default_value: 5
+
+  dup_host_ip_addr_detection_timeout:
+    default_value: 180
+
+  anycast_gateway_mac:
+   config_get: 'show running fabric forwarding all'
+   config_get_token: '/^fabric forwarding anycast-gateway-mac (\S+)$/'
+   config_set: "%s fabric forwarding anycast-gateway-mac %s"
+
+  dup_host_mac_detection:
+    config_get: 'show running | i l2rib'
+    config_get_token: '/^l2rib dup-host-mac-detection (\d+) (\d+)$/'
+    config_set: "l2rib dup-host-mac-detection <host_moves> <timeout>"
+
+  dup_host_mac_detection_default:
+    config_set: "l2rib dup-host-mac-detection default"
+
+  dup_host_mac_detection_host_moves:
+    default_value: 5
+
+  dup_host_mac_detection_timeout:
+    default_value: 180
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/lib/cisco_node_utils/command_reference_common.yaml
+++ b/lib/cisco_node_utils/command_reference_common.yaml
@@ -1086,5 +1086,6 @@ vxlan_global:
 
   dup_host_mac_detection_host_moves:
     default_value: 5
+
   dup_host_mac_detection_timeout:
     default_value: 180

--- a/lib/cisco_node_utils/vxlan_global.rb
+++ b/lib/cisco_node_utils/vxlan_global.rb
@@ -1,0 +1,158 @@
+# VXLAN global provider class
+# Provides configuration of anycast gateways and duplicate host IP and
+# mac detection
+#
+# Alok Aggarwal, October 2015
+#
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require File.join(File.dirname(__FILE__), 'node_util')
+
+module Cisco
+  # node_utils class for vxlan_global
+  class VxlanGlobal < NodeUtil
+    def feature_enable
+      config_set('vxlan_global', 'feature', state: '')
+    end
+
+    def feature_disable
+      config_set('vxlan_global', 'feature', state: 'no')
+    end
+
+    # Check current state of the configuration
+    def self.feature_enabled
+      feat = config_get('vxlan_global', 'feature')
+      return !(feat.nil? || feat.empty?)
+    rescue Cisco::CliError => e
+      # This cmd will syntax reject if feature is not
+      # enabled. Just catch the reject and return false.
+      return false if e.clierror =~ /Syntax error/
+      raise
+    end
+
+    # ----------
+    # PROPERTIES
+    # ----------
+
+    # dup-host-ip-addr-detection
+    def dup_host_ip_addr_detection
+      get_args = {}
+      match = config_get('vxlan_global', 'dup_host_ip_addr_detection', get_args)
+      if match.nil? || match.first.nil?
+        default_dup_host_ip_addr_detection
+      else
+        match.first.collect(&:to_i)
+      end
+    end
+
+    def dup_host_ip_addr_detection_host_moves
+      host_moves, _timeout = dup_host_ip_addr_detection
+      return default_dup_host_ip_addr_detection_host_moves if host_moves.nil?
+      host_moves
+    end
+
+    def dup_host_ip_addr_detection_timeout
+      _host_moves, timeout = dup_host_ip_addr_detection
+      return default_dup_host_ip_addr_detection_timeout if timeout.nil?
+      timeout
+    end
+
+    def dup_host_ip_addr_detection_set(state, host_moves, timeout)
+      set_args = {}
+      set_args[:state] = state
+      set_args[:host_moves] = host_moves
+      set_args[:timeout] = timeout
+
+      config_set('vxlan_global', 'dup_host_ip_addr_detection', set_args)
+    end
+
+    def default_dup_host_ip_addr_detection
+      [default_dup_host_ip_addr_detection_host_moves,
+       default_dup_host_ip_addr_detection_timeout]
+    end
+
+    def default_dup_host_ip_addr_detection_host_moves
+      config_get_default('vxlan_global',
+                         'dup_host_ip_addr_detection_host_moves')
+    end
+
+    def default_dup_host_ip_addr_detection_timeout
+      config_get_default('vxlan_global', 'dup_host_ip_addr_detection_timeout')
+    end
+
+    # dup-host-mac-detection
+    def dup_host_mac_detection
+      get_args = {}
+      match = config_get('vxlan_global', 'dup_host_mac_detection', get_args)
+      if match.nil? || match.first.nil?
+        default_dup_host_mac_detection
+      else
+        match.first.collect(&:to_i)
+      end
+    end
+
+    def dup_host_mac_detection_host_moves
+      host_moves, _timeout = dup_host_mac_detection
+      return default_dup_host_mac_detection_host_moves if host_moves.nil?
+      host_moves
+    end
+
+    def dup_host_mac_detection_timeout
+      _host_moves, timeout = dup_host_mac_detection
+      return default_dup_host_mac_detection_timeout if timeout.nil?
+      timeout
+    end
+
+    def dup_host_mac_detection_set(host_moves, timeout)
+      set_args = {}
+      set_args[:host_moves] = host_moves
+      set_args[:timeout] = timeout
+
+      config_set('vxlan_global', 'dup_host_mac_detection', set_args)
+    end
+
+    def dup_host_mac_detection_default
+      config_set('vxlan_global', 'dup_host_mac_detection_default')
+    end
+
+    def default_dup_host_mac_detection
+      [default_dup_host_mac_detection_host_moves,
+       default_dup_host_mac_detection_timeout]
+    end
+
+    def default_dup_host_mac_detection_host_moves
+      config_get_default('vxlan_global', 'dup_host_mac_detection_host_moves')
+    end
+
+    def default_dup_host_mac_detection_timeout
+      config_get_default('vxlan_global', 'dup_host_mac_detection_timeout')
+    end
+
+    # anycast-gateway-mac
+    def anycast_gateway_mac
+      mac_addr = config_get('vxlan_global', 'anycast_gateway_mac')
+      mac_addr.nil? ? ' ' : mac_addr.first
+    end
+
+    def anycast_gateway_mac_set(state, mac_addr)
+      fail TypeError unless mac_addr.is_a?(String)
+      if state == 'no'
+        config_set('vxlan_global', 'anycast_gateway_mac', 'no', ' ')
+      else
+        config_set('vxlan_global', 'anycast_gateway_mac', ' ', mac_addr)
+      end
+    end
+  end # class
+end # module

--- a/lib/cisco_node_utils/vxlan_global.rb
+++ b/lib/cisco_node_utils/vxlan_global.rb
@@ -18,21 +18,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.join(File.dirname(__FILE__), 'node_util')
+require_relative 'node_util'
 
 module Cisco
   # node_utils class for vxlan_global
   class VxlanGlobal < NodeUtil
-    def feature_enable
+    def enable
       config_set('vxlan_global', 'feature', state: '')
     end
 
-    def feature_disable
+    def disable
       config_set('vxlan_global', 'feature', state: 'no')
     end
 
     # Check current state of the configuration
-    def self.feature_enabled
+    def self.enabled
       feat = config_get('vxlan_global', 'feature')
       return !(feat.nil? || feat.empty?)
     rescue Cisco::CliError => e
@@ -57,24 +57,13 @@ module Cisco
       end
     end
 
-    def dup_host_ip_addr_detection_host_moves
-      host_moves, _timeout = dup_host_ip_addr_detection
-      return default_dup_host_ip_addr_detection_host_moves if host_moves.nil?
-      host_moves
-    end
-
-    def dup_host_ip_addr_detection_timeout
-      _host_moves, timeout = dup_host_ip_addr_detection
-      return default_dup_host_ip_addr_detection_timeout if timeout.nil?
-      timeout
-    end
-
-    def dup_host_ip_addr_detection_set(state, host_moves, timeout)
-      set_args = {}
-      set_args[:state] = state
-      set_args[:host_moves] = host_moves
-      set_args[:timeout] = timeout
-
+    def dup_host_ip_addr_detection_set(configure, host_moves, timeout)
+      if configure == 'True'
+        state = ''
+      else
+        state = 'no'
+      end
+      set_args = {state: state, host_moves: host_moves, timeout: timeout}
       config_set('vxlan_global', 'dup_host_ip_addr_detection', set_args)
     end
 
@@ -103,23 +92,8 @@ module Cisco
       end
     end
 
-    def dup_host_mac_detection_host_moves
-      host_moves, _timeout = dup_host_mac_detection
-      return default_dup_host_mac_detection_host_moves if host_moves.nil?
-      host_moves
-    end
-
-    def dup_host_mac_detection_timeout
-      _host_moves, timeout = dup_host_mac_detection
-      return default_dup_host_mac_detection_timeout if timeout.nil?
-      timeout
-    end
-
     def dup_host_mac_detection_set(host_moves, timeout)
-      set_args = {}
-      set_args[:host_moves] = host_moves
-      set_args[:timeout] = timeout
-
+      set_args = {host_moves: host_moves, timeout: timeout}
       config_set('vxlan_global', 'dup_host_mac_detection', set_args)
     end
 
@@ -143,15 +117,15 @@ module Cisco
     # anycast-gateway-mac
     def anycast_gateway_mac
       mac_addr = config_get('vxlan_global', 'anycast_gateway_mac')
-      mac_addr.nil? ? ' ' : mac_addr.first
+      mac_addr.nil? ? '' : mac_addr.first
     end
 
-    def anycast_gateway_mac_set(state, mac_addr)
+    def anycast_gateway_mac_set(configure, mac_addr)
       fail TypeError unless mac_addr.is_a?(String)
-      if state == 'no'
-        config_set('vxlan_global', 'anycast_gateway_mac', 'no', ' ')
+      if configure == 'True'
+        config_set('vxlan_global', 'anycast_gateway_mac', state: '', mac_addr: mac_addr)
       else
-        config_set('vxlan_global', 'anycast_gateway_mac', ' ', mac_addr)
+        config_set('vxlan_global', 'anycast_gateway_mac', state: 'no', mac_addr: '')
       end
     end
   end # class

--- a/tests/test_vxlan_global.rb
+++ b/tests/test_vxlan_global.rb
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.expand_path('../ciscotest', __FILE__)
-require File.expand_path('../../lib/cisco_node_utils/vxlan_global', __FILE__)
+require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/vxlan_global'
 
 include Cisco
 
@@ -21,32 +21,32 @@ include Cisco
 class TestVxlanGlobal < CiscoTestCase
   def setup
     super
-    no_feature_vxlan_global
+    no_vxlan_global
   end
 
   def teardown
-    no_feature_vxlan_global
+    no_vxlan_global
     super
   end
 
-  def no_feature_vxlan_global
+  def no_vxlan_global
     config('no feature fabric forwarding')
   end
 
-  def test_feature_on_off
+  def test_on_off
     feat = VxlanGlobal.new
-    feat.feature_enable
-    assert(VxlanGlobal.feature_enabled)
+    feat.enable
+    assert(VxlanGlobal.enabled)
 
-    feat.feature_disable
-    refute(VxlanGlobal.feature_enabled)
+    feat.disable
+    refute(VxlanGlobal.enabled)
   end
 
   def test_dup_host_ip_addr_detection_set
     vxlan_global = VxlanGlobal.new
     val = [200, 20]
-    vxlan_global.feature_enable
-    vxlan_global.dup_host_ip_addr_detection_set(' ', val[0], val[1])
+    vxlan_global.enable
+    vxlan_global.dup_host_ip_addr_detection_set('True', val[0], val[1])
     assert_equal(val, vxlan_global.dup_host_ip_addr_detection,
                  'Error: fabric forwarding dup_host_ip_addr_detection ' \
                  'get values mismatch')
@@ -57,9 +57,10 @@ class TestVxlanGlobal < CiscoTestCase
     val = [200, 20]
     # After the config is cleared, the get method should return
     # the default values
-    default = [5, 180]
-    vxlan_global.feature_enable
-    vxlan_global.dup_host_ip_addr_detection_set('no', val[0], val[1])
+    default = [vxlan_global.default_dup_host_ip_addr_detection_host_moves,
+               vxlan_global.default_dup_host_ip_addr_detection_timeout]
+    vxlan_global.enable
+    vxlan_global.dup_host_ip_addr_detection_set('False', val[0], val[1])
     assert_equal(default, vxlan_global.dup_host_ip_addr_detection,
                  'Error: fabric forwarding dup_host_ip_addr_detection ' \
                  'get values mismatch')
@@ -78,7 +79,8 @@ class TestVxlanGlobal < CiscoTestCase
     vxlan_global = VxlanGlobal.new
     # After the config is cleared, the get method should return
     # the default values
-    default = [5, 180]
+    default = [vxlan_global.default_dup_host_mac_detection_host_moves,
+               vxlan_global.default_dup_host_mac_detection_timeout]
     vxlan_global.dup_host_mac_detection_default
     assert_equal(default, vxlan_global.dup_host_mac_detection,
                  'Error: l2rib dup_host_mac_detection ' \
@@ -88,17 +90,17 @@ class TestVxlanGlobal < CiscoTestCase
   def test_anycast_gateway_mac_set
     vxlan_global = VxlanGlobal.new
     mac_addr = '1223.3445.5668'
-    vxlan_global.feature_enable
-    vxlan_global.anycast_gateway_mac_set(' ', mac_addr)
+    vxlan_global.enable
+    vxlan_global.anycast_gateway_mac_set('True', mac_addr)
     assert_equal(mac_addr, vxlan_global.anycast_gateway_mac,
                  'Error: anycast-gateway-mac mismatch')
   end
 
   def test_anycast_gateway_mac_clear
     vxlan_global = VxlanGlobal.new
-    vxlan_global.feature_enable
-    vxlan_global.anycast_gateway_mac_set('no', '')
-    assert_equal(' ', vxlan_global.anycast_gateway_mac,
+    vxlan_global.enable
+    vxlan_global.anycast_gateway_mac_set('False', '')
+    assert_equal('', vxlan_global.anycast_gateway_mac,
                  'Error: anycast-gateway-mac mismatch')
   end
 end

--- a/tests/test_vxlan_global.rb
+++ b/tests/test_vxlan_global.rb
@@ -1,0 +1,104 @@
+# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require File.expand_path('../ciscotest', __FILE__)
+require File.expand_path('../../lib/cisco_node_utils/vxlan_global', __FILE__)
+
+include Cisco
+
+# TestVxlanGlobal - Minitest for VxlanGlobal node utility
+class TestVxlanGlobal < CiscoTestCase
+  def setup
+    super
+    no_feature_vxlan_global
+  end
+
+  def teardown
+    no_feature_vxlan_global
+    super
+  end
+
+  def no_feature_vxlan_global
+    config('no feature fabric forwarding')
+  end
+
+  def test_feature_on_off
+    feat = VxlanGlobal.new
+    feat.feature_enable
+    assert(VxlanGlobal.feature_enabled)
+
+    feat.feature_disable
+    refute(VxlanGlobal.feature_enabled)
+  end
+
+  def test_dup_host_ip_addr_detection_set
+    vxlan_global = VxlanGlobal.new
+    val = [200, 20]
+    vxlan_global.feature_enable
+    vxlan_global.dup_host_ip_addr_detection_set(' ', val[0], val[1])
+    assert_equal(val, vxlan_global.dup_host_ip_addr_detection,
+                 'Error: fabric forwarding dup_host_ip_addr_detection ' \
+                 'get values mismatch')
+  end
+
+  def test_dup_host_ip_addr_detection_clear
+    vxlan_global = VxlanGlobal.new
+    val = [200, 20]
+    # After the config is cleared, the get method should return
+    # the default values
+    default = [5, 180]
+    vxlan_global.feature_enable
+    vxlan_global.dup_host_ip_addr_detection_set('no', val[0], val[1])
+    assert_equal(default, vxlan_global.dup_host_ip_addr_detection,
+                 'Error: fabric forwarding dup_host_ip_addr_detection ' \
+                 'get values mismatch')
+  end
+
+  def test_dup_host_mac_detection_set
+    vxlan_global = VxlanGlobal.new
+    val = [200, 20]
+    vxlan_global.dup_host_mac_detection_set(val[0], val[1])
+    assert_equal(val, vxlan_global.dup_host_mac_detection,
+                 'Error: l2rib dup_host_mac_detection ' \
+                 'get values mismatch')
+  end
+
+  def test_dup_host_mac_detection_default
+    vxlan_global = VxlanGlobal.new
+    # After the config is cleared, the get method should return
+    # the default values
+    default = [5, 180]
+    vxlan_global.dup_host_mac_detection_default
+    assert_equal(default, vxlan_global.dup_host_mac_detection,
+                 'Error: l2rib dup_host_mac_detection ' \
+                 'get values mismatch')
+  end
+
+  def test_anycast_gateway_mac_set
+    vxlan_global = VxlanGlobal.new
+    mac_addr = '1223.3445.5668'
+    vxlan_global.feature_enable
+    vxlan_global.anycast_gateway_mac_set(' ', mac_addr)
+    assert_equal(mac_addr, vxlan_global.anycast_gateway_mac,
+                 'Error: anycast-gateway-mac mismatch')
+  end
+
+  def test_anycast_gateway_mac_clear
+    vxlan_global = VxlanGlobal.new
+    vxlan_global.feature_enable
+    vxlan_global.anycast_gateway_mac_set('no', '')
+    assert_equal(' ', vxlan_global.anycast_gateway_mac,
+                 'Error: anycast-gateway-mac mismatch')
+  end
+end


### PR DESCRIPTION
Minitest output:
sjc-ads-1546:221> ruby-2.1.1 tests/test_vxlan_global.rb -v -- 10.122.197.174 admin admin
Run options: -v -- --seed 56091
# Running:

Node under test:
- name  - agent-lab1-nx
- type  - N9K-NXOSV
- image - bootflash:///nxos.7.0.3.I2.1.bin

TestVxlanGlobal#test_dup_host_mac_detection_set = 3.86 s = .
TestVxlanGlobal#test_dup_host_ip_addr_detection_clear = 4.29 s = .
TestVxlanGlobal#test_anycast_gateway_mac_set = 4.73 s = .
TestVxlanGlobal#test_feature_on_off = 4.58 s = .
TestVxlanGlobal#test_dup_host_ip_addr_detection_set = 4.07 s = .
TestVxlanGlobal#test_dup_host_mac_detection_default = 2.17 s = .
TestVxlanGlobal#test_anycast_gateway_mac_clear = 4.31 s = .

Finished in 28.010111s, 0.2499 runs/s, 0.2856 assertions/s.

7 runs, 8 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/aloaggar/pnc/cisco-network-node-utils/coverage. 379 / 505 LOC (75.05%) covered.
