### PR TITLE
Support for cisco_os_shim refactor

### DIFF
--- a/cisco_node_utils.gemspec
+++ b/cisco_node_utils.gemspec
@@ -32,5 +32,6 @@ Currently supports NX-OS nodes.
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.34'
   spec.add_development_dependency 'simplecov', '~> 0.9'
-  spec.add_runtime_dependency 'cisco_os_shim', '~> 1.0'
+  spec.add_runtime_dependency 'cisco_os_shim', '> 0'
+  # spec.add_runtime_dependency 'cisco_os_shim', '~> 1.0'
 end

--- a/cisco_node_utils.gemspec
+++ b/cisco_node_utils.gemspec
@@ -32,6 +32,6 @@ Currently supports NX-OS nodes.
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.34'
   spec.add_development_dependency 'simplecov', '~> 0.9'
-  spec.add_runtime_dependency 'cisco_os_shim', '> 0'
+  spec.add_runtime_dependency 'cisco_os_shim', '~> 1.0.pre.dev'
   # spec.add_runtime_dependency 'cisco_os_shim', '~> 1.0'
 end

--- a/lib/cisco_node_utils/cmd_ref/dnsclient.yaml
+++ b/lib/cisco_node_utils/cmd_ref/dnsclient.yaml
@@ -15,10 +15,10 @@ domain_list_vrf:
 domain_name:
   config_get: 'show running-config all'
   default_value: ''
-  nxapi:
+  cli_nexus:
     config_set: '<state> ip domain-name <name>'
     config_get_token: '/^ip domain-name (\S+)$/'
-  grpc:
+  cli_ios_xr:
     config_set: '<state> domain name <name>'
     config_get_token: '/^domain name (\S+)$/'
 

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -3,9 +3,9 @@
 _template:
   config_set: ["interface %s"]
   config_get_token: '/^interface %s$/i'
-  grpc:
+  cli_ios_xr:
     config_get: "show running interface"
-  nxapi:
+  cli_nexus:
     config_get: "show running interface all"
 
 access_vlan:
@@ -15,7 +15,7 @@ access_vlan:
 
 admin_state_ethernet_noswitchport_shutdown:
   # TODO: is this actually used?
-  nxapi:
+  cli_nexus:
     /N7K/:
       default_value: "shutdown"
 
@@ -44,19 +44,19 @@ feature_lacp:
   config_set: "%s feature lacp"
 
 feature_vlan:
-  grpc:
+  cli_ios_xr:
     config_get: ~
     config_set: ~
-  nxapi:
+  cli_nexus:
     config_get: "show running | i ^feature"
     config_get_token: '/^feature interface-vlan$/'
     config_set: "%s feature interface-vlan"
 
 ipv4_addr_mask:
-  nxapi:
+  cli_nexus:
     config_get_token_append: '/^ip address ([0-9\.]+)[\s\/](.*)/'
     config_set_append: "%s ip address %s"
-  grpc:
+  cli_ios_xr:
     config_get_token_append: '/^ipv4 address ([0-9\.]+) (.*)/'
     config_set_append: '%s ipv4 address %s'
 
@@ -68,10 +68,10 @@ ipv4_netmask_length:
 
 ipv4_proxy_arp:
   default_value: false
-  nxapi:
+  cli_nexus:
     config_get_token_append: '/^ip proxy-arp$/'
     config_set_append: "%s ip proxy-arp"
-  grpc:
+  cli_ios_xr:
     config_get_token_append: '/^proxy-arp$/'
     config_set_append: "%s proxy-arp"
 
@@ -79,7 +79,7 @@ ipv4_redirects_loopback:
   test_config_result:
     false: RuntimeError
     true: RuntimeError
-  nxapi:
+  cli_nexus:
     /N7K/:
       default_value: false
       config_set: ~
@@ -93,7 +93,7 @@ ipv4_redirects_loopback:
       '/^\s+ip redirects/',
       '/^\s+no ip redirects/'
       ]
-  grpc:
+  cli_ios_xr:
     config_get_token_append: '/^((?:no )?ipv4 redirects)$/'
     config_set_append: "%s ipv4 redirects"
     default_value: false
@@ -106,7 +106,7 @@ ipv4_redirects_other_interfaces:
   test_config_result:
     false: false
     true: true
-  nxapi:
+  cli_nexus:
     config_get_token_append: '/^((?:no )?ip redirects)$/'
     config_set_append: "%s ip redirects"
     default_value: true
@@ -114,7 +114,7 @@ ipv4_redirects_other_interfaces:
     '/^\s+ip redirects/',
     '/^\s+no ip redirects/'
     ]
-  grpc:
+  cli_ios_xr:
     config_get_token_append: '/^((?:no )?ipv4 redirects)$/'
     config_set_append: "%s ipv4 redirects"
     default_value: false
@@ -129,7 +129,7 @@ mtu:
   default_value: 1500
 
 negotiate_auto_ethernet:
-  nxapi:
+  cli_nexus:
     test_config_get_regex: [
     '/^\s+no negotiate auto/',
     '/^\s+negotiate auto/'
@@ -143,7 +143,7 @@ negotiate_auto_ethernet:
       config_get_token_append: '/^negotiate auto$/'
       config_set_append: "%s negotiate auto"
       default_value: true
-  grpc:
+  cli_ios_xr:
     # TODO: which XR platforms *do* support this?
     /XRV/:
       config_get: ~
@@ -164,7 +164,7 @@ negotiate_auto_other_interfaces:
     true: RuntimeError
 
 negotiate_auto_portchannel:
-  nxapi:
+  cli_nexus:
     test_config_get_regex: [
     '/^\s+no negotiate auto/',
     '/^\s+negotiate auto/'
@@ -178,7 +178,7 @@ negotiate_auto_portchannel:
       config_get_token_append: '/^negotiate auto$/'
       config_set_append: "%s negotiate auto"
       default_value: true
-  grpc:
+  cli_ios_xr:
     config_get_token_append: '^/negotiation auto$/'
     config_set_append: "%s negotiation auto"
     default_value: true
@@ -209,7 +209,7 @@ shutdown_unknown:
   default_value: true
 
 shutdown_vlan:
-  nxapi:
+  cli_nexus:
     default_value: true
 
 svi_autostate:
@@ -280,10 +280,10 @@ system_default_switchport_shutdown:
 
 vrf:
   default_value: ""
-  nxapi:
+  cli_nexus:
     config_get_token_append: '/^vrf member (.*)/'
     config_set_append: "%s vrf member %s"
-  grpc:
+  cli_ios_xr:
     config_get_token_append: '/^vrf (.*)/'
     config_set_append: "%s vrf %s"
 

--- a/lib/cisco_node_utils/cmd_ref/inventory.yaml
+++ b/lib/cisco_node_utils/cmd_ref/inventory.yaml
@@ -1,21 +1,21 @@
 # inventory
 ---
 _template:
-  grpc:
+  cli_ios_xr:
     # TODO: this doesn't work quite right,
     # as it seems that 'head' ignores 'begin'... :-(
     config_get: 'show inventory | begin "Rack 0" | utility head count 2'
     test_config_get: 'show inventory'
-  nxapi:
+  cli_nexus:
     config_get: 'show inventory'
     test_config_get: 'show inventory | no-more'
 
 all:
-  nxapi:
+  cli_nexus:
     config_get_token: ["TABLE_inv", "ROW_inv"]
 
 chassis:
-  nxapi:
+  cli_nexus:
     config_get_token: ["TABLE_inv", "ROW_inv", {'name': '"Chassis"'}]
 
 inventory:
@@ -37,19 +37,19 @@ inventory:
     ]
 
 productid:
-  grpc:
+  cli_ios_xr:
     config_get_token: '/PID: ([^ ,]+)/'
-  nxapi:
+  cli_nexus:
     config_get_token: ["TABLE_inv", "ROW_inv", 0, "productid"]
 
 serialnum:
-  grpc:
+  cli_ios_xr:
     config_get_token: '/SN: ([^ ,]+)/'
-  nxapi:
+  cli_nexus:
     config_get_token: ["TABLE_inv", "ROW_inv", 0, "serialnum"]
 
 versionid:
-  grpc:
+  cli_ios_xr:
     config_get_token: '/VID: ([^ ,]+)/'
-  nxapi:
+  cli_nexus:
     config_get_token: ["TABLE_inv", "ROW_inv", 0, "vendorid"]

--- a/lib/cisco_node_utils/cmd_ref/show_version.yaml
+++ b/lib/cisco_node_utils/cmd_ref/show_version.yaml
@@ -2,9 +2,9 @@
 ---
 _template:
   config_get: 'sh version'
-  nxapi:
+  cli_nexus:
     test_config_get: "sh version | no-more"
-  grpc:
+  cli_ios_xr:
     test_config_get: "sh version"
 
 board:
@@ -19,7 +19,7 @@ cpu:
 
 description:
   config_get_token: "chassis_id"
-  nxapi:
+  cli_nexus:
     /N7K/:
       test_config_get_regex: '/.*Hardware\n  cisco (\w+ \w+ \(\w+ \w+\) \w+).*/'
     else:
@@ -32,7 +32,7 @@ description:
       #   cisco Nexus3000 C3132Q Chassis
       #   cisco N3K-C3048TP-1GE
       test_config_get_regex: '/Hardware\n  cisco (([^(\n]+|\(\d+ Slot\))+\w+)/'
-  grpc:
+  cli_ios_xr:
     config_get: 'show inventory | inc "Rack 0"'
     config_get_token: '/DESCR: "(.*)"/'
     test_config_get: 'show inventory | inc "Rack 0"'
@@ -45,9 +45,9 @@ header:
   config_get_token: "header_str"
 
 host_name:
-  nxapi:
+  cli_nexus:
     config_get_token: "host_name"
-  grpc:
+  cli_ios_xr:
     # not displayed in 'show version' on IOS XR
     config_get: "show running | i hostname"
     config_get_token: '/^hostname (.*)$/'
@@ -61,7 +61,7 @@ last_reset_time:
   test_config_get_regex: '/.*\nLast reset at \d+ usecs after  (.*)\n/'
 
 system_image:
-  nxapi:
+  cli_nexus:
     /N7K/:
       config_get_token: "isan_file_name"
       test_config_get_regex: '/.*system image file is:    (.*)$.*/'
@@ -73,13 +73,13 @@ uptime:
   config_get_token: '/uptime is (.*)/'
 
 version:
-  nxapi:
+  cli_nexus:
     config_get_token: "kickstart_ver_str"
     test_config_get_regex: [
     /\nkickstart_ver_str\s+(.+)\n/,
     '/.*NXOS:\s+version (.*)\n/'
     ]
-  grpc:
+  cli_ios_xr:
     config_get_token: '/IOS XR.*Version (.*)$/'
     test_config_get_regex: [
     ~,

--- a/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
@@ -1,7 +1,7 @@
 # snmp_server
 ---
 aaa_user_cache_timeout:
-  nxapi:
+  cli_nexus:
     config_get: "show snmp internal globals"
     config_get_token: '/AAA Cache Timeout :(\d+)/'
     config_set: "%s snmp-server aaa-user cache-timeout %d"

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -189,7 +189,7 @@ module Cisco
       @@debug = value # rubocop:disable Style/ClassVars
     end
 
-    attr_reader :api, :files, :product_id
+    attr_reader :cli, :files, :platform, :product_id
 
     # Constructor.
     # Normal usage is to pass product_id only, in which case all usual YAML
@@ -197,9 +197,13 @@ module Cisco
     # matching the given product_id.
     # For testing purposes (only!) you can pass an explicit list of files to
     # load instead. This list will NOT be filtered further by product_id.
-    def initialize(api, product_id, files=nil)
-      @api = api.downcase
-      @product_id = product_id
+    def initialize(product:  nil,
+                   platform: nil,
+                   cli:      false,
+                   files:    nil)
+      @product_id = product
+      @platform = platform
+      @cli = cli
       @hash = {}
       if files
         @files = files
@@ -224,15 +228,13 @@ module Cisco
 
         base_hash = {}
         if feature_hash.key?('_template')
-          base_hash = CommandReference.hash_merge(feature_hash['_template'],
-                                                  @api, @product_id)
+          base_hash = hash_merge(feature_hash['_template'])
         end
 
         feature_hash.each do |name, value|
           fail "No entries under '#{name}' in '#{file}'" if value.nil?
           @hash[feature] ||= {}
-          values = CommandReference.hash_merge(value, @api, @product_id,
-                                               base_hash.clone)
+          values = hash_merge(value, base_hash.clone)
           @hash[feature][name] = CmdRef.new(feature, name, values, file)
         end
       end
@@ -261,17 +263,17 @@ module Cisco
       puts "DEBUG: #{text}" if @@debug
     end
 
-    KNOWN_APIS = %w(nxapi grpc)
+    KNOWN_FILTERS = %w(cli_nexus cli_ios_xr)
 
     # Helper method
     # Given a Hash of command reference data (as read from YAML), does:
-    # - Filter any API-specific data according to the given api string
-    # - Filter any platform-specific data according to the given product_id
+    # - Filter any API-specific data
+    # - Filter any platform-specific data
     # - Inherit data from the given base_hash (if any) and extend/override it
     #   with the given input data.
     # - Append 'config_set_append' data to any existing 'config_set' data
     # - Append 'config_get_token_append' data to 'config_get_token', ditto
-    def self.hash_merge(input_hash, api, product_id, base_hash=nil)
+    def hash_merge(input_hash, base_hash=nil)
       result = base_hash
       result ||= {}
       # to_inspect: sub-hashes we want to recurse into
@@ -295,8 +297,9 @@ module Cisco
           regexp_match = true
           # Platform match - we want to descend into this sub-hash
           to_inspect << value
-        elsif KNOWN_APIS.include?(key)
-          next unless key == api
+        elsif KNOWN_FILTERS.include?(key)
+          next if key.match(/cli/) && !cli
+          next unless key.match(platform.to_s)
           # API match - we want to descend into this sub-hash
           to_inspect << value
         elsif key == 'else'
@@ -313,7 +316,7 @@ module Cisco
       end
       # Recurse! Sub-hashes can override the base hash
       to_inspect.each do |hash|
-        result = hash_merge(hash, api, product_id, result)
+        result = hash_merge(hash, result)
       end
       result
     end
@@ -323,12 +326,12 @@ module Cisco
     # into a single combined array
     # value_append('foo', 'bar') ==> ['foo', 'bar']
     # value_append('foo', ['bar', 'baz']) ==> ['foo', 'bar', 'baz']
-    def self.value_append(base_value, new_value)
+    def value_append(base_value, new_value)
       base_value = [base_value] unless base_value.is_a?(Array)
       new_value = [new_value] unless new_value.is_a?(Array)
       base_value + new_value
     end
-    private_class_method :value_append
+    private :value_append
 
     def mapping?(node)
       node.class.ancestors.any? { |name| /Map/ =~ name.to_s }

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -150,8 +150,8 @@ module Cisco
 
     def ipv4_addr_mask
       val = config_get('interface', 'ipv4_addr_mask', @name)
-      if val && client.api == 'gRPC'
-        # gRPC reports address as <address> <bitmask> but we
+      if val && platform == :ios_xr
+        # IOS XR reports address as <address> <bitmask> but we
         # want <address>/<length>
         val[0][1] = Utils.bitmask_to_length(val[0][1])
       end

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -161,7 +161,9 @@ module Cisco
     # "hidden" API - used for UT but shouldn't be used elsewhere
     def connect(*args)
       @client = Cisco::Shim::Client.create(*args)
-      @cmd_ref = CommandReference.new(@client.api, product_id)
+      @cmd_ref = CommandReference.new(product:  product_id,
+                                      platform: @client.platform,
+                                      cli:      @client.supports?(:cli))
       cache_flush
     end
 
@@ -271,10 +273,10 @@ module Cisco
         val
       else
         # We use this function to *find* the appropriate CommandReference
-        if @client.api == 'NXAPI'
+        if @client.platform == :nexus
           entries = show('show inventory', :structured)
           return entries['TABLE_inv']['ROW_inv'][0]['productid']
-        elsif @client.api == 'gRPC'
+        elsif @client.platform == :ios_xr
           # No support for structured output for this command yet
           output = show('show inventory', :ascii)
           return /NAME: "Rack 0".*\nPID: (\S+)/.match(output)[0]

--- a/lib/cisco_node_utils/node_util.rb
+++ b/lib/cisco_node_utils/node_util.rb
@@ -65,5 +65,21 @@ module Cisco
     def config_set(*args)
       node.config_set(*args)
     end
+
+    def self.supports?(api)
+      client.supports?(api)
+    end
+
+    def supports?(api)
+      client.supports?(api)
+    end
+
+    def self.platform
+      client.platform
+    end
+
+    def platform
+      client.platform
+    end
   end
 end

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -55,8 +55,12 @@ class CiscoTestCase < TestCase
     node.cmd_ref
   end
 
+  def platform
+    node.client.platform
+  end
+
   def config(*args)
-    if node.client.api == 'gRPC'
+    if node.client.platform == :ios_xr
       result = super(*args, 'commit best-effort')
     else
       result = super
@@ -69,7 +73,7 @@ class CiscoTestCase < TestCase
     unless @@interfaces
       # Build the platform_info, used for interface lookup
       # rubocop:disable Style/ClassVars
-      platform_info = PlatformInfo.new(node.host_name, node.client.api)
+      platform_info = PlatformInfo.new(node.host_name, platform)
       @@interfaces = platform_info.get_value_from_key('interfaces')
       # rubocop:enable Style/ClassVars
     end

--- a/tests/cmd_config.yaml
+++ b/tests/cmd_config.yaml
@@ -1,6 +1,6 @@
 # test command config yaml file
 ---
-nxapi:
+nexus:
   feature-enable:
     command: |
             feature tacacs+
@@ -51,7 +51,7 @@ nxapi:
             interface port-channel100
               description test-portchannel
 
-grpc:
+ios_xr:
   name-server:
     command: |
             domain name-server 10.10.10.10

--- a/tests/platform_info.rb
+++ b/tests/platform_info.rb
@@ -27,7 +27,7 @@ class PlatformInfo
   # @param[in] device_name      hostname of device on which
   #                             UTs are to be run
   #
-  def initialize(device_name, api_name)
+  def initialize(device_name, platform)
     if device_name.nil? || device_name.empty?
       fail 'device name must be specified in PlatformInfo constructor.'
     end
@@ -41,7 +41,7 @@ class PlatformInfo
     end
 
     @platform_info_hash = project_info_hash[device_name]
-    @platform_info_hash ||= project_info_hash['default'][api_name.downcase]
+    @platform_info_hash ||= project_info_hash['default'][platform.to_s]
     fail "Error - could not find #{device_name} device specific information " \
          'in platform_info.yaml' if @platform_info_hash.nil?
   end

--- a/tests/platform_info.yaml
+++ b/tests/platform_info.yaml
@@ -7,8 +7,8 @@
 # attributes can be added in future.
 
 default:
-  nxapi:
+  nexus:
     interfaces: [Ethernet1/1, Ethernet1/2, Ethernet1/3]
 
-  grpc:
+  ios_xr:
     interfaces: [GigabitEthernet0/0/0/1, GigabitEthernet0/0/0/2, GigabitEthernet0/0/0/3]

--- a/tests/test_command_config.rb
+++ b/tests/test_command_config.rb
@@ -84,7 +84,7 @@ class TestCommandConfig < CiscoTestCase
   end
 
   def loopback
-    (node.client.api == 'gRPC') ? 'Loopback' : 'loopback'
+    (platform == :ios_xr) ? 'Loopback' : 'loopback'
   end
 
   def build_int_scale_config(add=true)
@@ -105,7 +105,7 @@ class TestCommandConfig < CiscoTestCase
   # ---------------------------------------------------------------------------
 
   def test_valid_config
-    cfg_hash = load_yaml[node.client.api.downcase]
+    cfg_hash = load_yaml[platform.to_s]
     begin
       send_device_config(cfg_hash)
     end

--- a/tests/test_node_ext.rb
+++ b/tests/test_node_ext.rb
@@ -18,8 +18,8 @@ require_relative 'ciscotest'
 class TestNodeExt < CiscoTestCase
   def setup
     super
-    @chassis = (node.client.api == 'NXAPI') ? 'Chassis' : 'Rack 0'
-    @domain = (node.client.api == 'NXAPI') ? 'ip domain-name' : 'domain name'
+    @chassis = (platform == :nexus) ? 'Chassis' : 'Rack 0'
+    @domain = (platform == :nexus) ? 'ip domain-name' : 'domain name'
   end
 
   def assert_output_check(command: nil, pattern: nil, msg: nil, check: nil)
@@ -103,7 +103,7 @@ vrf blue",
   end
 
   def test_node_config_get_default
-    skip 'TODO: needs rework' if node.client.api == 'gRPC'
+    skip 'TODO: needs rework' if platform == :ios_xr
     result = node.config_get_default('snmp_server', 'aaa_user_cache_timeout')
     assert_equal(result, 3600)
   end
@@ -121,7 +121,7 @@ vrf blue",
   end
 
   def test_node_config_set
-    skip 'TODO: needs rework' if node.client.api == 'gRPC'
+    skip 'TODO: needs rework' if platform == :ios_xr
     node.config_set('snmp_server', 'aaa_user_cache_timeout', '', 100)
     run = node.client.show('show run all | inc snmp')
     val = find_one_ascii(run, /snmp-server aaa-user cache-timeout (\d+)/)
@@ -152,12 +152,12 @@ vrf blue",
     # don't use config() here because we are testing caching and flushing
     @device.cmd('conf t')
     @device.cmd("#{@domain} minitest")
-    @device.cmd('commit') if node.client.api == 'gRPC'
+    @device.cmd('commit') if platform == :ios_xr
     @device.cmd('end')
     dom1 = node.domain_name
     @device.cmd('conf t')
     @device.cmd("no #{@domain} minitest")
-    @device.cmd('commit') if node.client.api == 'gRPC'
+    @device.cmd('commit') if platform == :ios_xr
     @device.cmd('end')
     dom2 = node.domain_name
     assert_equal(dom1, dom2) # cached output was used for dom2
@@ -220,7 +220,7 @@ vrf blue",
   end
 
   def test_node_get_host_name_when_not_set
-    if node.client.api == 'NXAPI'
+    if platform == :nexus
       s = @device.cmd('show running-config all | no-more')
     else
       s = @device.cmd('show running-config all')
@@ -245,7 +245,7 @@ vrf blue",
     switchname ? config('no switchname') : config('no hostname')
 
     name = node.host_name
-    if node.client.api == 'NXAPI'
+    if platform == :nexus
       assert_equal('switch', name)
     else
       assert_equal('ios', name)
@@ -257,7 +257,7 @@ vrf blue",
   end
 
   def test_node_get_host_name_when_set
-    if node.client.api == 'NXAPI'
+    if platform == :nexus
       s = @device.cmd('show running-config all | no-more')
     else
       s = @device.cmd('show running-config all')
@@ -339,7 +339,7 @@ vrf blue",
   end
 
   def test_node_get_system_uptime
-    skip 'not yet supported' if node.client.api == 'gRPC'
+    skip 'not yet supported' if platform == :ios_xr
     node.cache_flush
     # rubocop:disable Metrics/LineLength
     pattern = /.*System uptime:\s+(\d+) days, (\d+) hours, (\d+) minutes, (\d+) seconds/
@@ -361,7 +361,7 @@ vrf blue",
   end
 
   def test_node_get_last_reset_time
-    skip 'not yet supported' if node.client.api == 'gRPC'
+    skip 'not yet supported' if platform == :ios_xr
     last_reset_time = node.last_reset_time
     ref = cmd_ref.lookup('show_version', 'last_reset_time')
     assert(ref, 'Error, reference not found')
@@ -379,7 +379,7 @@ vrf blue",
   end
 
   def test_node_get_last_reset_reason
-    skip 'not yet supported' if node.client.api == 'gRPC'
+    skip 'not yet supported' if platform == :ios_xr
     ref = cmd_ref.lookup('show_version', 'last_reset_reason')
     assert(ref, 'Error, reference not found')
     assert_output_check(command: ref.test_config_get,
@@ -389,7 +389,7 @@ vrf blue",
   end
 
   def test_node_get_system_cpu_utilization
-    skip 'not yet supported' if node.client.api == 'gRPC'
+    skip 'not yet supported' if platform == :ios_xr
     cpu_utilization = node.system_cpu_utilization
     ref = cmd_ref.lookup('system', 'resources')
     assert(ref, 'Error, reference not found')
@@ -402,7 +402,7 @@ vrf blue",
   end
 
   def test_node_get_boot
-    skip 'not yet supported' if node.client.api == 'gRPC'
+    skip 'not yet supported' if platform == :ios_xr
     ref = cmd_ref.lookup('show_version', 'boot_image')
     assert(ref, 'Error, reference not found')
     assert_output_check(command: ref.test_config_get,
@@ -412,7 +412,7 @@ vrf blue",
   end
 
   def test_node_get_system
-    skip 'not yet supported' if node.client.api == 'gRPC'
+    skip 'not yet supported' if platform == :ios_xr
     ref = cmd_ref.lookup('show_version', 'system_image')
     assert(ref, 'Error, reference not found')
     assert_output_check(command: ref.test_config_get,


### PR DESCRIPTION
Companion to cisco/cisco-nxapi/pull/3.
- Use `cli_nexus` and `cli_ios_xr` as YAML keywords instead of `nxapi` and `grpc`
- Platform variants now check `platform` (alias of `node.client.platform`) for `:nexus` or `:ios_xr` instead of checking `node.client.api` for `'gRPC'` or `'NXAPI'`

Ran test_command_reference, test_interface, test_command_config against both NXOS and IOS XR and they are passing.
