### PR TITLE
Add rescue for unsupported speed values in minitest

### DIFF
--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -469,11 +469,15 @@ class TestInterface < CiscoTestCase
 
   def test_interface_speed_change
     interface = Interface.new(interfaces[0])
-    interface.speed = 100
-    assert_equal('100', interface.speed)
-    interface.speed = 1000
-    assert_equal('1000', interface.speed)
-    interface_ethernet_default(interfaces_id[0])
+    begin
+      interface.speed = 100
+      assert_equal('100', interface.speed)
+      interface.speed = 1000
+      assert_equal('1000', interface.speed)
+      interface_ethernet_default(interfaces_id[0])
+    rescue RuntimeError => e
+      assert_match(/port doesn t support this speed/, e.message)
+    end
   end
 
   def test_interface_speed_invalid


### PR DESCRIPTION
% rubocop test_interface.rb
Inspecting 1 file
.

1 file inspected, no offenses detected

Test with n3k/n9k/n9kv & n9k that discovered this problem:

ruby-2.1.1 test_interface.rb -v -n test_interface_speed_change --
1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/cvanheuv/git.nu.dev.cvh/cisco-network-node-utils/tests/coverage. 0.0 / 0.0 LOC (100.0%) covered.
