### PR TITLE
Feature/grpc bgp demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/*
 coverage
 Gemfile.lock
 *.gem
+TAGS

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -84,7 +84,9 @@ module Cisco
     end
 
     def self.enable(state='')
-      config_set('bgp', 'feature', state: state)
+      # IOS XR has no '[no] feature xyz'.
+      config_set('bgp', 'feature', state: state) if
+        node.client.api == 'NXAPI' || state == 'no'
     end
 
     # Convert BGP ASN ASDOT+ to ASPLAIN
@@ -139,6 +141,7 @@ module Cisco
     def destroy
       vrf_ids = config_get('bgp', 'vrf', asnum: @asnum)
       vrf_ids = ['default'] if vrf_ids.nil?
+      router_bgp(asnum, @vrf, 'no')
       if vrf_ids.size == 1 || @vrf == 'default'
         RouterBgp.enable('no')
       else

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -1,109 +1,197 @@
 # bgp.yaml
 ---
 _template:
-  config_get: "show running bgp all"
-  config_get_token: '/^router bgp <asnum>$/'
-  config_get_token_append:
-    - '/^vrf <vrf>$/'
-  config_set: "router bgp <asnum>"
-  config_set_append:
-    - "vrf <vrf>"
+  grpc:
+    config_get: "show running-config router bgp"
+    config_get_token: '/^router bgp <asnum>$/'
+    config_get_token_append:
+      - '/^vrf <vrf>$/'
+    config_set: "router bgp <asnum>"
+    # Note the space before 'vrf' - seems like grpc
+    # is currently indentation sensitive.
+    config_set_append:
+      - " vrf <vrf>"
+  nxapi:
+    config_get: "show running bgp all"
+    config_get_token: '/^router bgp <asnum>$/'
+    config_get_token_append:
+      - '/^vrf <vrf>$/'
+    config_set: "router bgp <asnum>"
+    config_set_append:
+      - "vrf <vrf>"
 
 address_family:
   config_set_append: '<state> address-family <afi> <safi>'
 
 bestpath_always_compare_med:
-  config_get_token_append: '/^bestpath always-compare-med$/'
-  config_set_append: '<state> bestpath always-compare-med'
-  default_value: false
+  grpc:
+    config_get_token_append: '/^bgp bestpath med always$/'
+    config_set_append: ' <state> bgp bestpath med always'
+    default_value: false
+  nxapi:
+    config_get_token_append: '/^bestpath always-compare-med$/'
+    config_set_append: '<state> bestpath always-compare-med'
+    default_value: false
 
 bestpath_aspath_multipath_relax:
-  config_get_token_append: '/^bestpath as-path multipath-relax$/'
-  config_set_append: '<state> bestpath as-path multipath-relax'
-  default_value: false
+  grpc:
+    config_get_token_append: '/^bgp bestpath as-path multipath-relax$/'
+    config_set_append: ' <state> bgp bestpath as-path multipath-relax'
+    default_value: false
+  nxapi:
+    config_get_token_append: '/^bestpath as-path multipath-relax$/'
+    config_set_append: '<state> bestpath as-path multipath-relax'
+    default_value: false
 
 bestpath_compare_routerid:
-  config_get_token_append: '/^bestpath compare-routerid$/'
-  config_set_append: '<state> bestpath compare-routerid'
-  default_value: false
+  grpc:
+    config_get_token_append: '/^bgp bestpath compare-routerid$/'
+    config_set_append: ' <state> bgp bestpath compare-routerid'
+    default_value: false
+  nxapi:
+    config_get_token_append: '/^bestpath compare-routerid$/'
+    config_set_append: '<state> bestpath compare-routerid'
+    default_value: false
 
 bestpath_cost_community_ignore:
-  config_get_token_append: '/^bestpath cost-community ignore$/'
-  config_set_append: '<state> bestpath cost-community ignore'
-  default_value: false
+  grpc:
+    config_get_token_append: '/^bgp bestpath cost-community ignore$/'
+    config_set_append: ' <state> bgp bestpath cost-community ignore'
+    default_value: false
+  nxapi:
+    config_get_token_append: '/^bestpath cost-community ignore$/'
+    config_set_append: '<state> bestpath cost-community ignore'
+    default_value: false
 
 bestpath_med_confed:
-  config_get_token_append: '/^bestpath med confed$/'
-  config_set_append: '<state> bestpath med confed'
-  default_value: false
+  grpc:
+    config_get_token_append: '/^bgp bestpath med confed$/'
+    config_set_append: ' <state> bgp bestpath med confed'
+    default_value: false
+  nxapi:
+    config_get_token_append: '/^bestpath med confed$/'
+    config_set_append: '<state> bestpath med confed'
+    default_value: false
 
 bestpath_med_missing_as_worst:
-  config_get_token_append: '/^bestpath med missing-as-worst$/'
-  config_set_append: '<state> bestpath med missing-as-worst'
-  default_value: false
+  grpc:
+    config_get_token_append: '/^bgp bestpath med missing-as-worst$/'
+    config_set_append: ' <state> bgp bestpath med missing-as-worst'
+    default_value: false
+  nxapi:
+    config_get_token_append: '/^bestpath med missing-as-worst$/'
+    config_set_append: '<state> bestpath med missing-as-worst'
+    default_value: false
 
 bestpath_med_non_deterministic:
-  config_get_token_append: '/^bestpath med non-deterministic$/'
-  config_set_append: '<state> bestpath med non-deterministic'
-  default_value: false
+  nxapi:
+    config_get_token_append: '/^bestpath med non-deterministic$/'
+    config_set_append: '<state> bestpath med non-deterministic'
+    default_value: false
 
 cluster_id:
-  config_get_token_append: '/^cluster-id (\S+)$/'
-  config_set_append: '<state> cluster-id <id>'
-  default_value: ""
+  grpc:
+    config_get_token_append: '/^bgp cluster-id (\S+)$/'
+    config_set_append: ' <state> bgp cluster-id <id>'
+    default_value: ""
+  nxapi:
+    config_get_token_append: '/^cluster-id (\S+)$/'
+    config_set_append: '<state> cluster-id <id>'
+    default_value: ""
 
 confederation_id:
-  config_get_token_append: '/^confederation identifier (\d+.?\d+?)$/'
-  config_set_append: '<state> confederation identifier <id>'
-  default_value: ""
+  grpc:
+    config_get_token_append: '/^bgp confederation identifier (\d+.?\d+?)$/'
+    config_set_append: ' <state> bgp confederation identifier <id>'
+    default_value: ""
+  nxapi:
+    config_get_token_append: '/^confederation identifier (\d+.?\d+?)$/'
+    config_set_append: '<state> confederation identifier <id>'
+    default_value: ""
 
+#TODO regexp is broken
 confederation_peers:
-  config_get_token_append: '/^confederation peers (.*)$/'
-  config_set_append: '<state> confederation peers <peer_list>'
-  default_value: ""
+  grpc:
+    config_get_token_append: '/^bgp confederation peers (.*)$/'
+    config_set_append: ' <state> bgp confederation peers <peer_list>'
+    default_value: ""
+  nxapi:
+    config_get_token_append: '/^confederation peers (.*)$/'
+    config_set_append: '<state> confederation peers <peer_list>'
+    default_value: ""
 
 create_destroy_neighbor:
   config_set_append: '<state> neighbor <nbr>'
 
 enforce_first_as:
-  config_get_token_append: '/^enforce-first-as$/'
-  config_set_append: '<state> enforce-first-as'
-  default_value: true
+  grpc:
+    config_get_token_append: '/^bgp enforce-first-as disable$/'
+    config_set_append: ' <state> bgp enforce-first-as disable'
+    default_value: true
+  nxapi:
+    config_get_token_append: '/^enforce-first-as$/'
+    config_set_append: '<state> enforce-first-as'
+    default_value: true
 
 feature:
-  config_get: "show running bgp"
-  config_get_token: '/^feature bgp$/'
-  config_set: "<state> feature bgp"
+  grpc:
+    config_get: "show running-config router bgp"
+    config_get_token: '/^router bgp$/'
+    config_set: "<state> router bgp"
+  nxapi:
+    config_get: "show running bgp all"
+    config_get_token: '/^feature bgp$/'
+    config_set: "<state> feature bgp"
 
 graceful_restart:
-  config_get_token_append: '/^graceful-restart$/'
-  config_set_append: '<state> graceful-restart'
-  default_value: true
+  grpc:
+    config_get_token_append: '/^bgp graceful-restart$/'
+    config_set_append: ' <state> bgp graceful-restart'
+    default_value: true
+  nxapi:
+    config_get_token_append: '/^graceful-restart$/'
+    config_set_append: '<state> graceful-restart'
+    default_value: true
 
+#Does not exist in IOS XR
 graceful_restart_helper:
-  config_get_token_append: '/^graceful-restart-helper$/'
-  config_set_append: '<state> graceful-restart-helper'
-  default_value: false
+  nxapi:
+    config_get_token_append: '/^graceful-restart-helper$/'
+    config_set_append: '<state> graceful-restart-helper'
+    default_value: false
 
 graceful_restart_timers_restart:
-  config_get_token_append: '/^graceful-restart restart-time (\d+)$/'
-  config_set_append: '<state> graceful-restart restart-time <seconds>'
-  default_value: 120
+  grpc:
+    config_get_token_append: '/^bgp graceful-restart restart-time (\d+)$/'
+    config_set_append: ' <state> bgp graceful-restart restart-time <seconds>'
+    default_value: 120
+  nxapi:
+    config_get_token_append: '/^graceful-restart restart-time (\d+)$/'
+    config_set_append: '<state> graceful-restart restart-time <seconds>'
+    default_value: 120
 
 graceful_restart_timers_stalepath_time:
-  config_get_token_append: '/^graceful-restart stalepath-time (\d+)$/'
-  config_set_append: '<state> graceful-restart stalepath-time <seconds>'
-  default_value: 300
+  grpc:
+    config_get_token_append: '/^bgp graceful-restart stalepath-time (\d+)$/'
+    config_set_append: ' <state> bgp graceful-restart stalepath-time <seconds>'
+    default_value: 300
+  nxapi:
+    config_get_token_append: '/^graceful-restart stalepath-time (\d+)$/'
+    config_set_append: '<state> graceful-restart stalepath-time <seconds>'
+    default_value: 300
 
 log_neighbor_changes:
-  config_get_token_append: '/^log-neighbor-changes$/'
-  config_set_append: '<state> log-neighbor-changes'
-  default_value: false
+  #Equivalent for bgp is 'bgp log'
+  nxapi:
+    config_get_token_append: '/^log-neighbor-changes$/'
+    config_set_append: '<state> log-neighbor-changes'
+    default_value: false
 
 maxas_limit:
-  config_get_token_append: '/^maxas-limit (\d+)$/'
-  config_set_append: '<state> maxas-limit <limit>'
-  default_value: false
+  nxapi:
+    config_get_token_append: '/^maxas-limit (\d+)$/'
+    config_set_append: '<state> maxas-limit <limit>'
+    default_value: false
 
 neighbor_fib_down_accelerate:
   config_get_token_append: '/^neighbor-down fib-accelerate$/'
@@ -111,30 +199,57 @@ neighbor_fib_down_accelerate:
   default_value: false
 
 reconnect_interval:
-  config_get_token_append: '/^reconnect-interval (\d+)$/'
-  config_set_append: '<state> reconnect-interval <seconds>'
-  default_value: 60
+  grpc:
+    config_get_token_append: '/^bgp reconnect-interval (\d+)$/'
+    config_set_append: ' <state> bgp reconnect-interval <seconds>'
+    default_value: 60
+  nxapi:
+    config_get_token_append: '/^reconnect-interval (\d+)$/'
+    config_set_append: '<state> reconnect-interval <seconds>'
+    default_value: 60
 
 router:
-  config_get: "show running bgp"
-  config_get_token: '/^router bgp (\d+)$/'
-  config_set: "<state> router bgp <asnum>"
+  grpc:
+    config_get: "show running router bgp"
+    config_get_token: '/^router bgp (\d+)$/'
+    config_set: "<state> router bgp <asnum>"
+  nxapi:
+    config_get: "show running bgp"
+    config_get_token: '/^router bgp (\d+)$/'
+    config_set: "<state> router bgp <asnum>"
 
 router_id:
-  config_get_token_append: '/^router-id (\S+)$/'
-  config_set_append: '<state> router-id <id>'
-  default_value: ""
+  grpc:
+    config_get_token_append: '/^bgp router-id (\S+)$/'
+    config_set_append: ' <state> bgp router-id <id>'
+    default_value: ""
+  nxapi:
+    config_get_token_append: '/^router-id (\S+)$/'
+    config_set_append: '<state> router-id <id>'
+    default_value: ""
 
 shutdown:
   # Shutdown only applies to global bgp
-  config_get: "show running bgp"
-  config_get_token: ['/^router bgp %s$/i', '/^shutdown$/']
-  config_set: ["router bgp <asnum>", "<state> shutdown"]
-  default_value: false
+  grpc:
+    config_get: "show running router bgp"
+    config_get_token: ['/^router bgp %s$/i', '/^shutdown$/']
+    config_set: ["router bgp <asnum>", "<state> shutdown"]
+    default_value: false
+  nxapi:
+    config_get: "show running bgp"
+    config_get_token: ['/^router bgp %s$/i', '/^shutdown$/']
+    config_set: ["router bgp <asnum>", "<state> shutdown"]
+    default_value: false
+
 suppress_fib_pending:
-  config_get_token_append: '/^suppress-fib-pending$/'
-  config_set_append: '<state> suppress-fib-pending'
-  default_value: false
+  grpc:
+    config_get_token_append: '/^bgp suppress-fib-pending$/'
+    config_set_append: ' <state> bgp suppress-fib-pending'
+    default_value: false
+  nxapi:
+    config_get_token_append: '/^suppress-fib-pending$/'
+    config_set_append: '<state> suppress-fib-pending'
+    default_value: false
 
 timer_bestpath_limit:
   config_get_token_append: '/^timers bestpath-limit (\d+)(?: always)?$/'
@@ -153,9 +268,14 @@ timer_bgp_keepalive:
   default_value: 60
 
 timer_bgp_keepalive_hold:
-  config_get_token_append: '/^timers bgp (\d+) (\d+)$/'
-  config_set_append: '<state> timers bgp <keepalive> <hold>'
+  #Looks the same
+  grpc:
+    config_get_token_append: '/^timers bgp (\d+) (\d+)$/'
+    config_set_append: ' <state> timers bgp <keepalive> <hold>'
+  nxapi:
+    config_get_token_append: '/^timers bgp (\d+) (\d+)$/'
+    config_set_append: '<state> timers bgp <keepalive> <hold>'
 
 vrf:
   config_get_token_append: '/^vrf\s+(\S+)$/'
-  config_set: ["router bgp <asnum>", "<state> vrf <vrf>", "end"]
+  config_set: ["router bgp <asnum>", "<state> vrf <vrf>"]

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -1,22 +1,18 @@
 # bgp.yaml
 ---
 _template:
+  config_get_token: '/^router bgp <asnum>$/'
+  config_get_token_append:
+    - '/^vrf <vrf>$/'
+  config_set: "router bgp <asnum>"
   grpc:
     config_get: "show running-config router bgp"
-    config_get_token: '/^router bgp <asnum>$/'
-    config_get_token_append:
-      - '/^vrf <vrf>$/'
-    config_set: "router bgp <asnum>"
     # Note the space before 'vrf' - seems like grpc
     # is currently indentation sensitive.
     config_set_append:
       - " vrf <vrf>"
   nxapi:
     config_get: "show running bgp all"
-    config_get_token: '/^router bgp <asnum>$/'
-    config_get_token_append:
-      - '/^vrf <vrf>$/'
-    config_set: "router bgp <asnum>"
     config_set_append:
       - "vrf <vrf>"
 
@@ -24,114 +20,102 @@ address_family:
   config_set_append: '<state> address-family <afi> <safi>'
 
 bestpath_always_compare_med:
+  default_value: false
   grpc:
     config_get_token_append: '/^bgp bestpath med always$/'
     config_set_append: ' <state> bgp bestpath med always'
-    default_value: false
   nxapi:
     config_get_token_append: '/^bestpath always-compare-med$/'
     config_set_append: '<state> bestpath always-compare-med'
-    default_value: false
 
 bestpath_aspath_multipath_relax:
+  default_value: false
   grpc:
     config_get_token_append: '/^bgp bestpath as-path multipath-relax$/'
     config_set_append: ' <state> bgp bestpath as-path multipath-relax'
-    default_value: false
   nxapi:
     config_get_token_append: '/^bestpath as-path multipath-relax$/'
     config_set_append: '<state> bestpath as-path multipath-relax'
-    default_value: false
 
 bestpath_compare_routerid:
+  default_value: false
   grpc:
     config_get_token_append: '/^bgp bestpath compare-routerid$/'
     config_set_append: ' <state> bgp bestpath compare-routerid'
-    default_value: false
   nxapi:
     config_get_token_append: '/^bestpath compare-routerid$/'
     config_set_append: '<state> bestpath compare-routerid'
-    default_value: false
 
 bestpath_cost_community_ignore:
+  default_value: false
   grpc:
     config_get_token_append: '/^bgp bestpath cost-community ignore$/'
     config_set_append: ' <state> bgp bestpath cost-community ignore'
-    default_value: false
   nxapi:
     config_get_token_append: '/^bestpath cost-community ignore$/'
     config_set_append: '<state> bestpath cost-community ignore'
-    default_value: false
 
 bestpath_med_confed:
+  default_value: false
   grpc:
     config_get_token_append: '/^bgp bestpath med confed$/'
     config_set_append: ' <state> bgp bestpath med confed'
-    default_value: false
   nxapi:
     config_get_token_append: '/^bestpath med confed$/'
     config_set_append: '<state> bestpath med confed'
-    default_value: false
 
 bestpath_med_missing_as_worst:
+  default_value: false
   grpc:
     config_get_token_append: '/^bgp bestpath med missing-as-worst$/'
     config_set_append: ' <state> bgp bestpath med missing-as-worst'
-    default_value: false
   nxapi:
     config_get_token_append: '/^bestpath med missing-as-worst$/'
     config_set_append: '<state> bestpath med missing-as-worst'
-    default_value: false
 
 bestpath_med_non_deterministic:
+  # Does not exist in IOS XR
   nxapi:
     config_get_token_append: '/^bestpath med non-deterministic$/'
     config_set_append: '<state> bestpath med non-deterministic'
     default_value: false
 
 cluster_id:
+  default_value: ""
   grpc:
     config_get_token_append: '/^bgp cluster-id (\S+)$/'
     config_set_append: ' <state> bgp cluster-id <id>'
-    default_value: ""
   nxapi:
     config_get_token_append: '/^cluster-id (\S+)$/'
     config_set_append: '<state> cluster-id <id>'
-    default_value: ""
 
 confederation_id:
+  default_value: ""
   grpc:
-    config_get_token_append: '/^bgp confederation identifier (\d+.?\d+?)$/'
+    config_get_token_append: '/^bgp confederation identifier (\d+|\d+.\d+)$/'
     config_set_append: ' <state> bgp confederation identifier <id>'
-    default_value: ""
   nxapi:
-    config_get_token_append: '/^confederation identifier (\d+.?\d+?)$/'
+    config_get_token_append: '/^confederation identifier (\d+|\d+.\d+)$/'
     config_set_append: '<state> confederation identifier <id>'
-    default_value: ""
 
-#TODO regexp is broken
 confederation_peers:
+  # TODO: Supported in XR but broken as identifier is nvgened on a seperate line.
+  default_value: ""
   grpc:
     config_get_token_append: '/^bgp confederation peers (.*)$/'
     config_set_append: ' <state> bgp confederation peers <peer_list>'
-    default_value: ""
   nxapi:
     config_get_token_append: '/^confederation peers (.*)$/'
     config_set_append: '<state> confederation peers <peer_list>'
-    default_value: ""
 
 create_destroy_neighbor:
   config_set_append: '<state> neighbor <nbr>'
 
 enforce_first_as:
-  grpc:
-    config_get_token_append: '/^bgp enforce-first-as disable$/'
-    config_set_append: ' <state> bgp enforce-first-as disable'
-    default_value: true
-  nxapi:
-    config_get_token_append: '/^enforce-first-as$/'
-    config_set_append: '<state> enforce-first-as'
-    default_value: true
+  config_get_token_append: '/^enforce-first-as$/'
+  config_set_append: '<state> enforce-first-as'
+  # TODO: Fix default minitest for IOS XR
+  default_value: true
 
 feature:
   grpc:
@@ -144,16 +128,15 @@ feature:
     config_set: "<state> feature bgp"
 
 graceful_restart:
+  default_value: true
   grpc:
     config_get_token_append: '/^bgp graceful-restart$/'
     config_set_append: ' <state> bgp graceful-restart'
-    default_value: true
   nxapi:
     config_get_token_append: '/^graceful-restart$/'
     config_set_append: '<state> graceful-restart'
-    default_value: true
 
-#Does not exist in IOS XR
+# TODO: Does not exist in IOS XR
 graceful_restart_helper:
   nxapi:
     config_get_token_append: '/^graceful-restart-helper$/'
@@ -161,80 +144,71 @@ graceful_restart_helper:
     default_value: false
 
 graceful_restart_timers_restart:
+  default_value: 120
   grpc:
     config_get_token_append: '/^bgp graceful-restart restart-time (\d+)$/'
     config_set_append: ' <state> bgp graceful-restart restart-time <seconds>'
-    default_value: 120
   nxapi:
     config_get_token_append: '/^graceful-restart restart-time (\d+)$/'
     config_set_append: '<state> graceful-restart restart-time <seconds>'
-    default_value: 120
 
 graceful_restart_timers_stalepath_time:
+  default_value: 300
   grpc:
     config_get_token_append: '/^bgp graceful-restart stalepath-time (\d+)$/'
     config_set_append: ' <state> bgp graceful-restart stalepath-time <seconds>'
-    default_value: 300
   nxapi:
     config_get_token_append: '/^graceful-restart stalepath-time (\d+)$/'
     config_set_append: '<state> graceful-restart stalepath-time <seconds>'
-    default_value: 300
 
 log_neighbor_changes:
-  #Equivalent for bgp is 'bgp log'
+  #TODO: Equivalent for bgp is 'bgp log'
+  # Currently supported but broken in IOS XR
   nxapi:
     config_get_token_append: '/^log-neighbor-changes$/'
     config_set_append: '<state> log-neighbor-changes'
     default_value: false
 
 maxas_limit:
+  # Does not exist in IOS XR
   nxapi:
     config_get_token_append: '/^maxas-limit (\d+)$/'
     config_set_append: '<state> maxas-limit <limit>'
     default_value: false
 
 neighbor_fib_down_accelerate:
-  config_get_token_append: '/^neighbor-down fib-accelerate$/'
-  config_set_append: '<state> neighbor-down fib-accelerate'
-  default_value: false
+  # Does not exist in IOS XR
+  nxapi:
+    config_get_token_append: '/^neighbor-down fib-accelerate$/'
+    config_set_append: '<state> neighbor-down fib-accelerate'
+    default_value: false
 
 reconnect_interval:
-  grpc:
-    config_get_token_append: '/^bgp reconnect-interval (\d+)$/'
-    config_set_append: ' <state> bgp reconnect-interval <seconds>'
-    default_value: 60
+  # Does not exist in IOS XR
   nxapi:
     config_get_token_append: '/^reconnect-interval (\d+)$/'
     config_set_append: '<state> reconnect-interval <seconds>'
     default_value: 60
 
 router:
+  config_get_token: '/^router bgp (\d+)$/'
+  config_set: "<state> router bgp <asnum>"
   grpc:
     config_get: "show running router bgp"
-    config_get_token: '/^router bgp (\d+)$/'
-    config_set: "<state> router bgp <asnum>"
   nxapi:
     config_get: "show running bgp"
-    config_get_token: '/^router bgp (\d+)$/'
-    config_set: "<state> router bgp <asnum>"
 
 router_id:
+  default_value: ""
   grpc:
     config_get_token_append: '/^bgp router-id (\S+)$/'
     config_set_append: ' <state> bgp router-id <id>'
-    default_value: ""
   nxapi:
     config_get_token_append: '/^router-id (\S+)$/'
     config_set_append: '<state> router-id <id>'
-    default_value: ""
 
 shutdown:
-  # Shutdown only applies to global bgp
-  grpc:
-    config_get: "show running router bgp"
-    config_get_token: ['/^router bgp %s$/i', '/^shutdown$/']
-    config_set: ["router bgp <asnum>", "<state> shutdown"]
-    default_value: false
+  # Does not exist in IOS XR
   nxapi:
     config_get: "show running bgp"
     config_get_token: ['/^router bgp %s$/i', '/^shutdown$/']
@@ -242,24 +216,25 @@ shutdown:
     default_value: false
 
 suppress_fib_pending:
-  grpc:
-    config_get_token_append: '/^bgp suppress-fib-pending$/'
-    config_set_append: ' <state> bgp suppress-fib-pending'
-    default_value: false
+  # Does not exist in IOS XR
   nxapi:
     config_get_token_append: '/^suppress-fib-pending$/'
     config_set_append: '<state> suppress-fib-pending'
     default_value: false
 
 timer_bestpath_limit:
-  config_get_token_append: '/^timers bestpath-limit (\d+)(?: always)?$/'
-  config_set_append: '<state> timers bestpath-limit <seconds>'
-  default_value: 300
+  # Does not exist in IOS XR
+  nxapi:
+    config_get_token_append: '/^timers bestpath-limit (\d+)(?: always)?$/'
+    config_set_append: '<state> timers bestpath-limit <seconds>'
+    default_value: 300
 
 timer_bestpath_limit_always:
-  config_get_token_append: '/^timers bestpath-limit \d+ always$/'
-  config_set_append: '<state> timers bestpath-limit <seconds> always'
-  default_value: false
+  # Does not exist in IOS XR
+  nxapi:
+    config_get_token_append: '/^timers bestpath-limit \d+ always$/'
+    config_set_append: '<state> timers bestpath-limit <seconds> always'
+    default_value: false
 
 timer_bgp_hold:
   default_value: 180
@@ -268,12 +243,10 @@ timer_bgp_keepalive:
   default_value: 60
 
 timer_bgp_keepalive_hold:
-  #Looks the same
+  config_get_token_append: '/^timers bgp (\d+) (\d+)$/'
   grpc:
-    config_get_token_append: '/^timers bgp (\d+) (\d+)$/'
     config_set_append: ' <state> timers bgp <keepalive> <hold>'
   nxapi:
-    config_get_token_append: '/^timers bgp (\d+) (\d+)$/'
     config_set_append: '<state> timers bgp <keepalive> <hold>'
 
 vrf:

--- a/lib/cisco_node_utils/cmd_ref/vrf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vrf.yaml
@@ -1,4 +1,5 @@
 # vrf.yaml
+---
 all_vrfs:
   config_get: "show running | section 'vrf context'"
   config_get_token: '/^vrf context (.*)/'

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -213,7 +213,6 @@ module Cisco
     # Build complete reference hash.
     def build_cmd_ref
       # Example id's: N3K-C3048TP-1GE, N3K-C3064PQ-10GE, N7K-C7009, N7K-C7009
-
       debug "Product: #{@product_id}"
       debug "Files being used: #{@files.join(', ')}"
 
@@ -272,6 +271,8 @@ module Cisco
     # - Append 'config_set_append' data to any existing 'config_set' data
     # - Append 'config_get_token_append' data to 'config_get_token', ditto
     def self.hash_merge(input_hash, api, product_id, base_hash=nil)
+      return base_hash if input_hash.nil?
+
       result = base_hash
       result ||= {}
       # to_inspect: sub-hashes we want to recurse into

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -219,7 +219,8 @@ module Cisco
     #
     # @raise [Cisco::CliError] if any command is rejected by the device.
     def config(commands)
-      CiscoLogger.debug("CLI Sent to device: #{commands}")
+      CiscoLogger.debug('CLI sent to device:')
+      commands.each { |cli| CiscoLogger.debug("#{cli}") }
       @client.config(commands)
     rescue Cisco::Shim::RequestFailed => e
       raise Cisco::CliError.new(
@@ -234,6 +235,7 @@ module Cisco
     #
     # @raise [Cisco::CliError] if any command is rejected by the device.
     def show(command, type=:ascii)
+      CiscoLogger.debug("Show command sent to device: '#{command}'")
       @client.show(command, type)
     rescue Cisco::Shim::RequestFailed => e
       raise Cisco::CliError.new(

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -24,7 +24,7 @@ XR_NOT_SUPPORTED     = 'Not supported in IOS XR'
 XR_NO_VRF_SUPPORT    = 'Feature not supported in a vrf in IOS XR'
 XR_SUPPORTED_BROKEN  = 'Supported in IOS XR - needs further work'
 
-def test_add_routerid_rdauto(asnum, vrf)
+def iosxr_add_routerid_rdauto(asnum, vrf)
   return if node.client.api != 'gRPC'
   # If IOS XR - vrf requires a router id and a rd
   # bgp.routerid = '1.1.1.1'
@@ -155,7 +155,6 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
 
     if node.client.api == 'gRPC'
-      config('term len 0')
       s = config('show run router bgp')
       line = /"router bgp"/.match(s)
       assert_nil(line, "Error: 'router bgp' still configured")
@@ -209,7 +208,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
-        test_add_routerid_rdauto(asnum, vrf)
+        iosxr_add_routerid_rdauto(asnum, vrf)
       end
       bgp.bestpath_always_compare_med = true
       assert(bgp.bestpath_always_compare_med, "vrf #{vrf}: "\
@@ -226,6 +225,7 @@ class TestRouterBgp < CiscoTestCase
       bgp.bestpath_med_confed = true
       if node.client.api == 'NXAPI' ||
          (node.client.api == 'gRPC' && vrf == 'default')
+        # TODO: This property only works on IOS XR at the global level.
         assert(bgp.bestpath_med_confed, "vrf #{vrf}: "\
                'bgp bestpath_med_confed should be enabled')
       end
@@ -233,6 +233,7 @@ class TestRouterBgp < CiscoTestCase
       assert(bgp.bestpath_med_missing_as_worst, "vrf #{vrf}: "\
              'bgp bestpath_med_missing_as_worst should be enabled')
       if node.client.api == 'NXAPI'
+        # TODO: only applies to NXAPI
         bgp.bestpath_med_non_deterministic = true
         assert(bgp.bestpath_med_non_deterministic, "vrf #{vrf}: "\
                'bgp bestpath_med_non_deterministic should be enabled')
@@ -256,6 +257,7 @@ class TestRouterBgp < CiscoTestCase
       refute(bgp.bestpath_med_missing_as_worst, "vrf #{vrf}: "\
              'bgp bestpath_med_missing_as_worst should be disabled')
       if node.client.api == 'NXAPI'
+        # TODO: Only applies to NXAPI
         bgp.bestpath_med_non_deterministic = false
         refute(bgp.bestpath_med_non_deterministic, "vrf #{vrf}: "\
              'bgp bestpath_med_non_deterministic should be disabled')
@@ -274,7 +276,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
-        test_add_routerid_rdauto(asnum, vrf)
+        iosxr_add_routerid_rdauto(asnum, vrf)
       end
       refute(bgp.bestpath_always_compare_med, "vrf #{vrf}: "\
              'bgp bestpath_always_compare_med should *NOT* be enabled')
@@ -289,6 +291,7 @@ class TestRouterBgp < CiscoTestCase
       refute(bgp.bestpath_med_missing_as_worst, "vrf #{vrf}: "\
              'bgp bestpath_med_missing_as_worst should *NOT* be enabled')
       if node.client.api == 'NXAPI'
+        # TODO: Only applies to NXAPI
         refute(bgp.bestpath_med_non_deterministic, "vrf #{vrf}: "\
              'bgp bestpath_med_non_deterministic should *NOT* be enabled')
       end
@@ -312,6 +315,7 @@ class TestRouterBgp < CiscoTestCase
     refute(bgp.default_bestpath_med_missing_as_worst,
            'default value for bestpath_med_missing_as_worst should be false')
     if node.client.api == 'NXAPI'
+      # TODO: Only applies to NXAPI
       refute(bgp.default_bestpath_med_non_deterministic,
              'default value for bestpath_med_non_deterministic should be false')
     end
@@ -325,11 +329,11 @@ class TestRouterBgp < CiscoTestCase
         vrf = 'default'
         bgp = RouterBgp.new(asnum)
       else
-        skip(XR_NO_VRF_SUPPORT) if node.client.api == 'gRPC'
+        next if node.client.api == 'gRPC'
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
-        test_add_routerid_rdauto(asnum, vrf)
+        iosxr_add_routerid_rdauto(asnum, vrf)
       end
       bgp.cluster_id = 34
       assert_equal('34', bgp.cluster_id,
@@ -388,11 +392,12 @@ class TestRouterBgp < CiscoTestCase
         vrf = 'default'
         bgp = RouterBgp.new(asnum)
       else
-        skip(XR_NO_VRF_SUPPORT) if node.client.api == 'gRPC'
+        # Non-default VRF does not apply to IOS XR
+        next if node.client.api == 'gRPC'
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
-        test_add_routerid_rdauto(asnum, vrf)
+        iosxr_add_routerid_rdauto(asnum, vrf)
       end
       bgp.graceful_restart = true
       assert(bgp.graceful_restart,
@@ -406,6 +411,7 @@ class TestRouterBgp < CiscoTestCase
                    "vrf #{vrf}: bgp graceful restart timers stalepath time" \
                    "should be set to '77'")
       if node.client.api == 'NXAPI'
+        # TODO: Only applies to NXAPI
         bgp.graceful_restart_helper = true
         assert(bgp.graceful_restart_helper,
                "vrf #{vrf}: bgp graceful restart helper should be enabled")
@@ -422,6 +428,7 @@ class TestRouterBgp < CiscoTestCase
                    "vrf #{vrf}: bgp graceful restart timers stalepath time" \
                    "should be set to default value of '300'")
       if node.client.api == 'NXAPI'
+        # TODO: Only applies to NXAPI
         bgp.graceful_restart_helper = false
         refute(bgp.graceful_restart_helper,
                "vrf #{vrf}: bgp graceful restart helper should be disabled")
@@ -439,10 +446,11 @@ class TestRouterBgp < CiscoTestCase
                  "bgp graceful restart default timer value should be '120'")
     assert_equal(300, bgp.default_graceful_restart_timers_stalepath_time,
                  "bgp graceful restart default timer value should be '300'")
-    refute(bgp.default_graceful_restart_helper,
-           'graceful restart helper default value ' \
-           'should be enabled = false') if
-      node.client.api == 'NXAPI'
+    if node.client.api == 'NXAPI'
+      refute(bgp.default_graceful_restart_helper,
+             'graceful restart helper default value ' \
+             'should be enabled = false')
+    end
   end
 
   def test_routerbgp_set_get_confederation_id
@@ -452,11 +460,12 @@ class TestRouterBgp < CiscoTestCase
         vrf = 'default'
         bgp = RouterBgp.new(asnum)
       else
-        skip(XR_NO_VRF_SUPPORT) if node.client.api == 'gRPC'
+        # Non-default VRF does not apply to IOS XR
+        next if node.client.api == 'gRPC'
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
-        test_add_routerid_rdauto(asnum, vrf)
+        iosxr_add_routerid_rdauto(asnum, vrf)
       end
       bgp.confederation_id = 77
       assert_equal('77', bgp.confederation_id,
@@ -504,7 +513,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
-        test_add_routerid_rdauto(asnum, vrf)
+        iosxr_add_routerid_rdauto(asnum, vrf)
       end
       # Confederation peer configuration requires that a
       # confederation id be configured first so the expectation
@@ -551,7 +560,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_log_neighbor_changes
-    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
+    skip(XR_SUPPORTED_BROKEN) if node.client.api == 'gRPC'
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -561,7 +570,6 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
-        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.log_neighbor_changes = true
       assert(bgp.log_neighbor_changes,
@@ -574,7 +582,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_get_log_neighbor_changes_not_configured
-    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
+    skip(XR_SUPPORTED_BROKEN) if node.client.api == 'gRPC'
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.log_neighbor_changes,
@@ -602,7 +610,6 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
-        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.maxas_limit = 50
       assert_equal(50, bgp.maxas_limit,
@@ -634,7 +641,6 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
-        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.neighbor_fib_down_accelerate = true
       assert(bgp.neighbor_fib_down_accelerate,
@@ -673,7 +679,6 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
-        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.reconnect_interval = 34
       assert_equal(34, bgp.reconnect_interval,
@@ -703,7 +708,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
-        test_add_routerid_rdauto(asnum, vrf)
+        iosxr_add_routerid_rdauto(asnum, vrf)
       end
       bgp.router_id = '1.2.3.4'
       assert_equal('1.2.3.4', bgp.router_id,
@@ -733,8 +738,6 @@ class TestRouterBgp < CiscoTestCase
 
   def test_routerbgp_set_get_shutdown
     skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
-    # NOTE: Shutdown command only applies under
-    # default vrf
     asnum = 55
     bgp = RouterBgp.new(asnum)
     bgp.shutdown = true
@@ -771,7 +774,6 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
-        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.suppress_fib_pending = true
       assert(bgp.suppress_fib_pending,
@@ -810,7 +812,6 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
-        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.timer_bestpath_limit_set(34)
       assert_equal(34, bgp.timer_bestpath_limit, "vrf #{vrf}: " \
@@ -842,7 +843,6 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
-        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.timer_bestpath_limit_set(34, true)
       assert(bgp.timer_bestpath_limit_always,
@@ -880,7 +880,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
-        test_add_routerid_rdauto(asnum, vrf)
+        iosxr_add_routerid_rdauto(asnum, vrf)
       end
       bgp.timer_bgp_keepalive_hold_set(25, 45)
       assert_equal(%w(25 45), bgp.timer_bgp_keepalive_hold, "vrf #{vrf}: " \

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -20,17 +20,38 @@
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/bgp'
 
+XR_NOT_SUPPORTED     = 'Not supported in IOS XR'
+XR_NO_VRF_SUPPORT    = 'Feature not supported in a vrf in IOS XR'
+XR_SUPPORTED_BROKEN  = 'Supported in IOS XR - needs further work'
+
+def test_add_routerid_rdauto(asnum, vrf)
+  return if node.client.api != 'gRPC'
+  # If IOS XR - vrf requires a router id and a rd
+  # bgp.routerid = '1.1.1.1'
+  # Yes the indents appear to be needed
+  config("router bgp #{asnum}", 'bgp router-id 1.2.3.4',
+         " vrf #{vrf}", ' rd auto')
+end
+
 # TestRouterBgp - Minitest for RouterBgp class
 class TestRouterBgp < CiscoTestCase
   def setup
     # Disable feature bgp before each test to ensure we
     # are starting with a clean slate for each test.
     super
-    config('no feature bgp')
+    if node.client.api == 'gRPC'
+      config('no router bgp')
+    else
+      config('no feature bgp')
+    end
   end
 
   def get_routerbgp_match_line(as_number, vrf='default')
-    s = @device.cmd("show run | section '^router bgp .*'")
+    if node.client.api == 'gRPC'
+      s = @device.cmd('show running-config router bgp')
+    else
+      s = @device.cmd("show run | section '^router bgp .*'")
+    end
     if vrf == 'default'
       line = /router bgp\s#{as_number}/.match(s)
     else
@@ -40,15 +61,18 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_collection_empty
-    config('no feature bgp')
-    node.cache_flush
+    if node.client.api == 'gRPC'
+      config('no router bgp')
+    else
+      config('no feature bgp')
+    end
     routers = RouterBgp.routers
     assert_empty(routers, 'RouterBgp collection is not empty')
   end
 
   def test_routerbgp_collection_not_empty
-    config('feature bgp',
-           'router bgp 55',
+    config('feature bgp') if node.client.api == 'NXAPI'
+    config('router bgp 55',
            'vrf blue',
            'vrf red',
            'vrf white')
@@ -130,9 +154,16 @@ class TestRouterBgp < CiscoTestCase
     refute_nil(line, "Error: 'router bgp #{asnum}' not configured")
     bgp.destroy
 
-    s = @device.cmd('show run all | no-more')
-    line = /"feature bgp"/.match(s)
-    assert_nil(line, "Error: 'feature bgp' still configured")
+    if node.client.api == 'gRPC'
+      config('term len 0')
+      s = config('show run router bgp')
+      line = /"router bgp"/.match(s)
+      assert_nil(line, "Error: 'router bgp' still configured")
+    else
+      s = config('show run all | no-more')
+      line = /"feature bgp"/.match(s)
+      assert_nil(line, "Error: 'feature bgp' still configured")
+    end
   end
 
   def test_routerbgp_create_invalid_multiple
@@ -178,6 +209,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
+        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.bestpath_always_compare_med = true
       assert(bgp.bestpath_always_compare_med, "vrf #{vrf}: "\
@@ -192,15 +224,19 @@ class TestRouterBgp < CiscoTestCase
       assert(bgp.bestpath_cost_community_ignore, "vrf #{vrf}: "\
              'bgp bestpath_cost_community_ignore should be enabled')
       bgp.bestpath_med_confed = true
-      assert(bgp.bestpath_med_confed, "vrf #{vrf}: "\
-             'bgp bestpath_med_confed should be enabled')
+      if node.client.api == 'NXAPI' ||
+         (node.client.api == 'gRPC' && vrf == 'default')
+        assert(bgp.bestpath_med_confed, "vrf #{vrf}: "\
+               'bgp bestpath_med_confed should be enabled')
+      end
       bgp.bestpath_med_missing_as_worst = true
       assert(bgp.bestpath_med_missing_as_worst, "vrf #{vrf}: "\
              'bgp bestpath_med_missing_as_worst should be enabled')
-      bgp.bestpath_med_non_deterministic = true
-      assert(bgp.bestpath_med_non_deterministic, "vrf #{vrf}: "\
-             'bgp bestpath_med_non_deterministic should be enabled')
-
+      if node.client.api == 'NXAPI'
+        bgp.bestpath_med_non_deterministic = true
+        assert(bgp.bestpath_med_non_deterministic, "vrf #{vrf}: "\
+               'bgp bestpath_med_non_deterministic should be enabled')
+      end
       bgp.bestpath_always_compare_med = false
       refute(bgp.bestpath_always_compare_med, "vrf #{vrf}: "\
              'bgp bestpath_always_compare_med should be disabled')
@@ -219,9 +255,11 @@ class TestRouterBgp < CiscoTestCase
       bgp.bestpath_med_missing_as_worst = false
       refute(bgp.bestpath_med_missing_as_worst, "vrf #{vrf}: "\
              'bgp bestpath_med_missing_as_worst should be disabled')
-      bgp.bestpath_med_non_deterministic = false
-      refute(bgp.bestpath_med_non_deterministic, "vrf #{vrf}: "\
+      if node.client.api == 'NXAPI'
+        bgp.bestpath_med_non_deterministic = false
+        refute(bgp.bestpath_med_non_deterministic, "vrf #{vrf}: "\
              'bgp bestpath_med_non_deterministic should be disabled')
+      end
       bgp.destroy
     end
   end
@@ -236,6 +274,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
+        test_add_routerid_rdauto(asnum, vrf)
       end
       refute(bgp.bestpath_always_compare_med, "vrf #{vrf}: "\
              'bgp bestpath_always_compare_med should *NOT* be enabled')
@@ -249,8 +288,10 @@ class TestRouterBgp < CiscoTestCase
              'bgp bestpath_med_confed should *NOT* be enabled')
       refute(bgp.bestpath_med_missing_as_worst, "vrf #{vrf}: "\
              'bgp bestpath_med_missing_as_worst should *NOT* be enabled')
-      refute(bgp.bestpath_med_non_deterministic, "vrf #{vrf}: "\
+      if node.client.api == 'NXAPI'
+        refute(bgp.bestpath_med_non_deterministic, "vrf #{vrf}: "\
              'bgp bestpath_med_non_deterministic should *NOT* be enabled')
+      end
       bgp.destroy
     end
   end
@@ -270,8 +311,10 @@ class TestRouterBgp < CiscoTestCase
            'default value for bestpath_med_confed should be false')
     refute(bgp.default_bestpath_med_missing_as_worst,
            'default value for bestpath_med_missing_as_worst should be false')
-    refute(bgp.default_bestpath_med_non_deterministic,
-           'default value for bestpath_med_non_deterministic should be false')
+    if node.client.api == 'NXAPI'
+      refute(bgp.default_bestpath_med_non_deterministic,
+             'default value for bestpath_med_non_deterministic should be false')
+    end
     bgp.destroy
   end
 
@@ -282,9 +325,11 @@ class TestRouterBgp < CiscoTestCase
         vrf = 'default'
         bgp = RouterBgp.new(asnum)
       else
+        skip(XR_NO_VRF_SUPPORT) if node.client.api == 'gRPC'
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
+        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.cluster_id = 34
       assert_equal('34', bgp.cluster_id,
@@ -328,6 +373,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_default_enforce_first_as
+    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert(bgp.enforce_first_as,
@@ -342,9 +388,11 @@ class TestRouterBgp < CiscoTestCase
         vrf = 'default'
         bgp = RouterBgp.new(asnum)
       else
+        skip(XR_NO_VRF_SUPPORT) if node.client.api == 'gRPC'
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
+        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.graceful_restart = true
       assert(bgp.graceful_restart,
@@ -357,10 +405,11 @@ class TestRouterBgp < CiscoTestCase
       assert_equal(77, bgp.graceful_restart_timers_stalepath_time,
                    "vrf #{vrf}: bgp graceful restart timers stalepath time" \
                    "should be set to '77'")
-      bgp.graceful_restart_helper = true
-      assert(bgp.graceful_restart_helper,
-             "vrf #{vrf}: bgp graceful restart helper should be enabled")
-
+      if node.client.api == 'NXAPI'
+        bgp.graceful_restart_helper = true
+        assert(bgp.graceful_restart_helper,
+               "vrf #{vrf}: bgp graceful restart helper should be enabled")
+      end
       bgp.graceful_restart = false
       refute(bgp.graceful_restart,
              "vrf #{vrf}: bgp graceful_restart should be disabled")
@@ -372,9 +421,11 @@ class TestRouterBgp < CiscoTestCase
       assert_equal(300, bgp.graceful_restart_timers_stalepath_time,
                    "vrf #{vrf}: bgp graceful restart timers stalepath time" \
                    "should be set to default value of '300'")
-      bgp.graceful_restart_helper = false
-      refute(bgp.graceful_restart_helper,
-             "vrf #{vrf}: bgp graceful restart helper should be disabled")
+      if node.client.api == 'NXAPI'
+        bgp.graceful_restart_helper = false
+        refute(bgp.graceful_restart_helper,
+               "vrf #{vrf}: bgp graceful restart helper should be disabled")
+      end
       bgp.destroy
     end
   end
@@ -389,7 +440,9 @@ class TestRouterBgp < CiscoTestCase
     assert_equal(300, bgp.default_graceful_restart_timers_stalepath_time,
                  "bgp graceful restart default timer value should be '300'")
     refute(bgp.default_graceful_restart_helper,
-           'graceful restart helper default value should be enabled = false')
+           'graceful restart helper default value ' \
+           'should be enabled = false') if
+      node.client.api == 'NXAPI'
   end
 
   def test_routerbgp_set_get_confederation_id
@@ -399,9 +452,11 @@ class TestRouterBgp < CiscoTestCase
         vrf = 'default'
         bgp = RouterBgp.new(asnum)
       else
+        skip(XR_NO_VRF_SUPPORT) if node.client.api == 'gRPC'
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
+        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.confederation_id = 77
       assert_equal('77', bgp.confederation_id,
@@ -438,6 +493,8 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_confederation_peers
+    skip(XR_SUPPORTED_BROKEN) if
+      node.client.api == 'gRPC'
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -447,6 +504,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
+        test_add_routerid_rdauto(asnum, vrf)
       end
       # Confederation peer configuration requires that a
       # confederation id be configured first so the expectation
@@ -493,6 +551,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_log_neighbor_changes
+    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -502,6 +561,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
+        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.log_neighbor_changes = true
       assert(bgp.log_neighbor_changes,
@@ -514,6 +574,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_get_log_neighbor_changes_not_configured
+    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.log_neighbor_changes,
@@ -522,6 +583,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_default_log_neighbor_changes
+    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.default_log_neighbor_changes,
@@ -530,6 +592,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_maxas_limit
+    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -539,6 +602,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
+        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.maxas_limit = 50
       assert_equal(50, bgp.maxas_limit,
@@ -551,6 +615,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_default_maxas_limit
+    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_equal(bgp.default_maxas_limit, bgp.maxas_limit,
@@ -559,6 +624,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_neighbor_fib_down_accelerate
+    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -568,6 +634,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
+        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.neighbor_fib_down_accelerate = true
       assert(bgp.neighbor_fib_down_accelerate,
@@ -596,6 +663,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_reconnect_interval
+    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -605,6 +673,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
+        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.reconnect_interval = 34
       assert_equal(34, bgp.reconnect_interval,
@@ -634,6 +703,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
+        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.router_id = '1.2.3.4'
       assert_equal('1.2.3.4', bgp.router_id,
@@ -662,6 +732,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_shutdown
+    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
     # NOTE: Shutdown command only applies under
     # default vrf
     asnum = 55
@@ -690,6 +761,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_suppress_fib_pending
+    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -699,6 +771,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
+        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.suppress_fib_pending = true
       assert(bgp.suppress_fib_pending,
@@ -727,6 +800,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_timer_bestpath_limit
+    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -736,6 +810,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
+        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.timer_bestpath_limit_set(34)
       assert_equal(34, bgp.timer_bestpath_limit, "vrf #{vrf}: " \
@@ -748,6 +823,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_get_timer_bestpath_limit_default
+    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_equal(300, bgp.timer_bestpath_limit,
@@ -756,6 +832,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_timer_bestpath_limit_always
+    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -765,6 +842,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
+        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.timer_bestpath_limit_set(34, true)
       assert(bgp.timer_bestpath_limit_always,
@@ -802,6 +880,7 @@ class TestRouterBgp < CiscoTestCase
         asnum = 99
         vrf = 'yamllll'
         bgp = RouterBgp.new(asnum, vrf)
+        test_add_routerid_rdauto(asnum, vrf)
       end
       bgp.timer_bgp_keepalive_hold_set(25, 45)
       assert_equal(%w(25 45), bgp.timer_bgp_keepalive_hold, "vrf #{vrf}: " \
@@ -825,6 +904,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_default_timer_keepalive_hold_default
+    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_equal(%w(60 180), bgp.default_timer_bgp_keepalive_hold,

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -446,11 +446,13 @@ class TestRouterBgp < CiscoTestCase
                  "bgp graceful restart default timer value should be '120'")
     assert_equal(300, bgp.default_graceful_restart_timers_stalepath_time,
                  "bgp graceful restart default timer value should be '300'")
+    # rubocop:disable Style/GuardClause
     if node.client.api == 'NXAPI'
       refute(bgp.default_graceful_restart_helper,
              'graceful restart helper default value ' \
              'should be enabled = false')
     end
+    # rubocop:enable Style/GuardClause
   end
 
   def test_routerbgp_set_get_confederation_id


### PR DESCRIPTION
Minitest happy:

54 runs, 141 assertions, 0 failures, 0 errors, 18 skips
Coverage report generated for MiniTest to /ws/rwellum-rtp/github/cisco-network-node-utils/tests/coverage. 0.0 / 0.0 LOC (100.0%) covered.

Rubocop clean on modified files.

-_\- mode: compilation; default-directory: "/ws/rwellum-rtp/github/cisco-network-node-utils/lib/cisco_node_utils/" -_-
Compilation started at Tue Nov  3 15:25:11

rubocop --format emacs /ws/rwellum-rtp/github/cisco-network-node-utils/

Compilation finished at Tue Nov  3 15:25:39
