### PR TITLE
Fixed broken regexp

### DIFF
--- a/lib/cisco_node_utils/command_reference_common_bgp.yaml
+++ b/lib/cisco_node_utils/command_reference_common_bgp.yaml
@@ -58,7 +58,7 @@ bgp:
     default_value: ""
 
   confederation_id:
-    config_get_token_append: '/^confederation identifier (\d+.?\d+?)$/'
+    config_get_token_append: '/^confederation identifier (\d+|\d+.\d+)$/'
     config_set_append: '<state> confederation identifier <id>'
     default_value: ""
 


### PR DESCRIPTION
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release_1.1.0/cisco-network-node-utils/tests> /router/bin/ruby-2.1.1 test_router_bgp.rb -v -- dt-n9k5-1 admin admin
Run options: -v -- --seed 23742
# Running:

Node under test:
- name  - dt-n9k5-1
- type  - N9K-C9396PX
- image - bootflash:///nxos.7.0.3.I2.1.74.bin

TestRouterBgp#test_routerbgp_get_confederation_id_not_configured = 10.46 s = .
TestRouterBgp#test_routerbgp_create_vrf_invalid = 1.66 s = .
TestRouterBgp#test_routerbgp_set_get_suppress_fib_pending = 12.31 s = .
TestRouterBgp#test_routerbgp_create_asnum_invalid = 1.68 s = .
TestRouterBgp#test_routerbgp_set_get_graceful_restart = 18.11 s = .
TestRouterBgp#test_routerbgp_get_timer_bestpath_limit_default = 6.49 s = .
TestRouterBgp#test_routerbgp_default_shutdown = 6.45 s = .
TestRouterBgp#test_routerbgp_set_get_router_id = 12.39 s = .
TestRouterBgp#test_routerbgp_get_confederation_peers_not_configured = 6.59 s = .
TestRouterBgp#test_routerbgp_get_bestpath_not_configured = 11.25 s = .
TestRouterBgp#test_routerbgp_get_log_neighbor_changes_not_configured = 6.39 s = .
TestRouterBgp#test_routerbgp_default_enforce_first_as = 6.53 s = .
TestRouterBgp#test_routerbgp_set_get_timer_bestpath_limit = 12.32 s = .
TestRouterBgp#test_routerbgp_set_get_maxas_limit = 11.86 s = .
TestRouterBgp#test_routerbgp_get_suppress_fib_pending_not_configured = 6.48 s = .
TestRouterBgp#test_routerbgp_default_timer_keepalive_hold_default = 6.48 s = .
TestRouterBgp#test_routerbgp_collection_not_empty = 5.83 s = .
TestRouterBgp#test_routerbgp_default_graceful_restart = 5.95 s = .
TestRouterBgp#test_routerbgp_get_asnum = 7.93 s = .
TestRouterBgp#test_routerbgp_default_confederation_id = 6.59 s = .
TestRouterBgp#test_routerbgp_create_invalid_multiple = 6.87 s = .
TestRouterBgp#test_routerbgp_default_bestpath = 6.45 s = .
TestRouterBgp#test_routerbgp_set_get_log_neighbor_changes = 12.59 s = .
TestRouterBgp#test_routerbgp_default_confederation_peers = 6.44 s = .
TestRouterBgp#test_routerbgp_get_shutdown_not_configured = 6.58 s = .
TestRouterBgp#test_routerbgp_create_vrfname_zero_length = 1.69 s = .
TestRouterBgp#test_routerbgp_create_valid = 11.62 s = .
TestRouterBgp#test_routerbgp_set_get_timer_bgp_keepalive_hold = 13.19 s = .
TestRouterBgp#test_routerbgp_default_log_neighbor_changes = 6.44 s = .
TestRouterBgp#test_routerbgp_default_cluster_id = 6.39 s = .
TestRouterBgp#test_routerbgp_default_timer_bestpath_limit_always = 6.55 s = .
TestRouterBgp#test_routerbgp_collection_empty = 1.79 s = .
TestRouterBgp#test_routerbgp_set_get_confederation_peers = 16.64 s = .
TestRouterBgp#test_routerbgp_get_cluster_id_not_configured = 6.57 s = .
TestRouterBgp#test_routerbgp_set_get_shutdown = 7.01 s = .
TestRouterBgp#test_routerbgp_get_router_id_not_configured = 6.44 s = .
TestRouterBgp#test_routerbgp_default_router_id = 6.50 s = .
TestRouterBgp#test_routerbgp_set_get_bestpath = 23.28 s = .
TestRouterBgp#test_routerbgp_get_timer_bestpath_limit_always_not_configured = 6.50 s = .
TestRouterBgp#test_routerbgp_default_neighbor_fib_down_accelerate = 6.39 s = .
TestRouterBgp#test_routerbgp_create_valid_asn = 71.48 s = .
TestRouterBgp#test_routerbgp_destroy = 6.59 s = .
TestRouterBgp#test_routerbgp_set_get_timer_bestpath_limit_always = 12.51 s = .
TestRouterBgp#test_routerbgp_default_maxas_limit = 6.51 s = .
TestRouterBgp#test_routerbgp_create_valid_no_feature = 7.17 s = .
TestRouterBgp#test_routerbgp_set_get_confederation_id = 12.35 s = .
TestRouterBgp#test_routerbgp_set_get_reconnect_interval = 12.43 s = .
TestRouterBgp#test_routerbgp_set_get_enforce_first_as = 6.95 s = .
TestRouterBgp#test_routerbgp_default_suppress_fib_pending = 6.56 s = .
TestRouterBgp#test_routerbgp_set_get_confed_id_uu76828 = 5.25 s = .
TestRouterBgp#test_routerbgp_get_reconnect_interval_default = 8.21 s = .
TestRouterBgp#test_routerbgp_set_get_cluster_id = 13.26 s = .
TestRouterBgp#test_routerbgp_get_neighbor_fib_down_accelerate_not_configured = 6.51 s = .
TestRouterBgp#test_routerbgp_set_get_neighbor_fib_down_accelerate = 12.38 s = .

Finished in 517.865573s, 0.1043 runs/s, 0.4248 assertions/s.

54 runs, 220 assertions, 0 failures, 0 errors, 0 skips

```
  Test Suite: tests @ 2015-11-03 08:29:42 -0500

  - Host Configuration Summary -


          - Test Case Summary for suite 'tests' -
   Total Suite Time: 389.71 seconds
  Average Test Time: 97.43 seconds
          Attempted: 4
             Passed: 4
             Failed: 0
            Errored: 0
            Skipped: 0
            Pending: 0
              Total: 4

  - Specific Test Case Status -
```
