### PR TITLE
minitest fixes for negotiate auto and virtual-services

### DIFF
--- a/docs/template-test_router.rb
+++ b/docs/template-test_router.rb
@@ -60,9 +60,11 @@ class TestX__CLASS_NAME__X < CiscoTestCase
 
     @default_show_command = "show runn | i 'router X__RESOURCE_NAME__X'"
 
-    s = @device.cmd("show runn | i 'router X__RESOURCE_NAME__X'")
-    assert_match(s, /^router X__RESOURCE_NAME__X #{id1}$/)
-    assert_match(s, /^router X__RESOURCE_NAME__X #{id2}$/)
+    assert_show_match(pattern: /^router X__RESOURCE_NAME__X #{id1}$/,
+                      msg:     "failed to create router X__RESOURCE_NAME__X #{id1}")
+
+    assert_show_match(pattern: /^router X__RESOURCE_NAME__X #{id2}$/,
+                      msg:     "failed to create router X__RESOURCE_NAME__X #{id2}")
 
     rtr1.destroy
     refute_show_match(pattern: /^router X__RESOURCE_NAME__X #{id1}$/,

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -559,7 +559,10 @@ class TestInterface < CiscoTestCase
     assert_equal(default, interface.default_negotiate_auto,
                  "Error: #{inf_name} negotiate auto default value mismatch")
 
-    assert_equal(interface.negotiate_auto, default,
+    interface.negotiate_auto = default
+    # Delay as this change is sometimes too quick for some interfaces
+    sleep 1 unless default == interface.negotiate_auto
+    assert_equal(default, interface.negotiate_auto,
                  "Error: #{inf_name} negotiate auto value " \
                  'should be same as default')
 
@@ -598,7 +601,7 @@ class TestInterface < CiscoTestCase
     assert_equal(interface.negotiate_auto, non_default,
                  "Error: #{inf_name} negotiate auto value not #{non_default}")
 
-    pattern = cmd_ref.test_config_get_regex[non_default ? 0 : 1]
+    pattern = cmd_ref.test_config_get_regex[non_default ? 1 : 0]
     assert_show_match(pattern: pattern)
 
     # Clean up after ourselves
@@ -642,6 +645,15 @@ class TestInterface < CiscoTestCase
 
     inf_name = interfaces[0]
     interface = Interface.new(inf_name)
+
+    # Some platforms/interfaces/versions do not support negotiation changes
+    begin
+      interface.negotiate_auto = false
+    rescue => e
+      skip('Skip test: Interface type does not allow config change') if
+        e.message[/requested config change not allowed/]
+    end
+
     default = ref.default_value
     @default_show_command = show_cmd(inf_name)
 

--- a/tests/test_platform.rb
+++ b/tests/test_platform.rb
@@ -171,6 +171,9 @@ class TestPlatform < CiscoTestCase
   end
 
   def test_virtual_services
+    skip('Skip test: No virtual-services installed') unless
+      @device.cmd('show virtual-service list')[/Name\s+Status\s+Package Name/]
+
     # this would be beyond ugly to parse from ascii, utilize config_get
     vir_arr = node.config_get('virtual_service', 'services')
     vir_arr = [vir_arr] if vir_arr.is_a? Hash


### PR DESCRIPTION
Skip tests for unsupported interfaces and inactivate virt svcs.

rubocop: clean
minitest: tested against n30k, n31k, n9k, n9kv
