### PR TITLE
Feature/grpc bgp rd

### DIFF
--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -26,10 +26,15 @@ module Cisco
       fail ArgumentError unless vrf.length > 0
       @asnum = RouterBgp.process_asnum(asnum)
       @vrf = vrf
+      @rd = 'auto'
       if @vrf == 'default'
         @get_args = @set_args = { asnum: @asnum }
       else
-        @get_args = @set_args = { asnum: @asnum, vrf: @vrf }
+        if node.client.api == 'gRPC'
+          @get_args = @set_args = { asnum: @asnum, vrf: @vrf, rd: @rd}
+        else
+          @get_args = @set_args = { asnum: @asnum, vrf: @vrf}
+        end
       end
       create if instantiate
     end
@@ -554,6 +559,8 @@ module Cisco
 
     # Shutdown (Getter/Setter/Default)
     def shutdown
+      # TODO: remove this hack when exclude is available
+      return
       match = config_get('bgp', 'shutdown', @asnum)
       match.nil? ? default_shutdown : true
     end

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -26,11 +26,11 @@ module Cisco
       fail ArgumentError unless vrf.length > 0
       @asnum = RouterBgp.process_asnum(asnum)
       @vrf = vrf
-      @rd = 'auto'
       if @vrf == 'default'
         @get_args = @set_args = { asnum: @asnum }
       else
         if platform == :ios_xr
+          @rd = 'auto'
           @get_args = @set_args = { asnum: @asnum, vrf: @vrf, rd: @rd }
         else
           @get_args = @set_args = { asnum: @asnum, vrf: @vrf }

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -30,7 +30,7 @@ module Cisco
       if @vrf == 'default'
         @get_args = @set_args = { asnum: @asnum }
       else
-        if node.client.api == 'gRPC'
+        if platform == :ios_xr
           @get_args = @set_args = { asnum: @asnum, vrf: @vrf, rd: @rd}
         else
           @get_args = @set_args = { asnum: @asnum, vrf: @vrf}

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -559,8 +559,6 @@ module Cisco
 
     # Shutdown (Getter/Setter/Default)
     def shutdown
-      # TODO: remove this hack when exclude is available
-      return
       match = config_get('bgp', 'shutdown', @asnum)
       match.nil? ? default_shutdown : true
     end

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -31,9 +31,9 @@ module Cisco
         @get_args = @set_args = { asnum: @asnum }
       else
         if platform == :ios_xr
-          @get_args = @set_args = { asnum: @asnum, vrf: @vrf, rd: @rd}
+          @get_args = @set_args = { asnum: @asnum, vrf: @vrf, rd: @rd }
         else
-          @get_args = @set_args = { asnum: @asnum, vrf: @vrf}
+          @get_args = @set_args = { asnum: @asnum, vrf: @vrf }
         end
       end
       create if instantiate

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -112,9 +112,11 @@ create_destroy_neighbor:
   config_set_append: '<state> neighbor <nbr>'
 
 enforce_first_as:
+  # TODO: Different format for IOS XR
+  # Enabled by default, disabled by command
+  # 'bgp enforce-first-as disable'
   config_get_token_append: '/^enforce-first-as$/'
   config_set_append: '<state> enforce-first-as'
-  # TODO: Fix default minitest for IOS XR
   default_value: true
 
 feature:
@@ -252,3 +254,5 @@ timer_bgp_keepalive_hold:
 vrf:
   config_get_token_append: '/^vrf\s+(\S+)$/'
   config_set: ["router bgp <asnum>", "<state> vrf <vrf>"]
+  config_set_append:
+    - "  rd <rd>"

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -254,5 +254,6 @@ timer_bgp_keepalive_hold:
 vrf:
   config_get_token_append: '/^vrf\s+(\S+)$/'
   config_set: ["router bgp <asnum>", "<state> vrf <vrf>"]
-  config_set_append:
-    - "  rd <rd>"
+  cli_ios_xr:
+    config_set_append:
+      - "  rd <rd>"

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -83,8 +83,8 @@ class TestRouterBgp < CiscoTestCase
 
   def test_routerbgp_collection_not_empty
     if platform == :nexus
-      config('feature bgp')
-      config('router bgp 55',
+      config('feature bgp',
+             'router bgp 55',
              'vrf blue',
              'vrf red',
              'vrf white')

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -163,7 +163,7 @@ class TestRouterBgp < CiscoTestCase
       bgp.destroy
 
       vrf = 'Duke'
-      bgp = create_bgp_vrf(asnum, vrf)
+      bgp = create_bgp_vrf(test, vrf)
       test = RouterBgp.dot_to_big(test.to_s) if test.is_a? String
       line = get_routerbgp_match_line(test, vrf)
       refute_nil(line,

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -370,7 +370,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_enforce_first_as
-    skip(XR_SUPPORTED_BROKEN) if node.client.api == 'gRPC'
+    skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     bgp.enforce_first_as = true
@@ -660,7 +660,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_get_neighbor_fib_down_accelerate_not_configured
-    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
+    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.neighbor_fib_down_accelerate,
@@ -669,7 +669,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_default_neighbor_fib_down_accelerate
-    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
+    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.default_neighbor_fib_down_accelerate,
@@ -700,7 +700,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_get_reconnect_interval_default
-    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
+    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_equal(60, bgp.reconnect_interval,
@@ -758,7 +758,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_get_shutdown_not_configured
-    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
+    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.shutdown,
@@ -767,7 +767,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_default_shutdown
-    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
+    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.default_shutdown,
@@ -798,7 +798,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_get_suppress_fib_pending_not_configured
-    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
+    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.suppress_fib_pending,
@@ -807,7 +807,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_default_suppress_fib_pending
-    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
+    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.default_suppress_fib_pending,
@@ -869,7 +869,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_get_timer_bestpath_limit_always_not_configured
-    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
+    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.timer_bestpath_limit_always,
@@ -878,7 +878,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_default_timer_bestpath_limit_always
-    skip(XR_NOT_SUPPORTED) if node.client.api == 'gRPC'
+    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.default_timer_bestpath_limit_always,

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -74,11 +74,22 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_collection_not_empty
-    config('feature bgp') if platform == :nexus
-    config('router bgp 55',
+    if platform == :nexus
+      config('feature bgp')
+      config('router bgp 55',
            'vrf blue',
            'vrf red',
            'vrf white')
+    else
+      config('router bgp 55',
+             'bgp router-id 1.2.3.4',
+             'vrf blue',
+             'rd auto',
+             'vrf red',
+             'rd auto',
+             'vrf white',
+             'rd auto')
+    end
     routers = RouterBgp.routers
     refute_empty(routers, 'RouterBgp collection is empty')
     # validate the collection

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -35,13 +35,13 @@ def create_bgp_vrf(asnum, vrf)
     # RouterBgp.new twice. Once to create the BGP process,
     # add a router-id, then call it again to create the VRF,
     # and add a VRF level router-id (which is needed to make SYSDB
-    #behave).
+    # behave).
     bgp = RouterBgp.new(asnum)
     bgp.router_id = '1.2.3.4'
     bgp = RouterBgp.new(asnum, vrf)
     bgp.router_id = '4.5.6.7'
   end
-  return bgp
+  bgp
 end
 
 # TestRouterBgp - Minitest for RouterBgp class


### PR DESCRIPTION
IOS XR requires an additional 'rd id' for any created VRF. As that property hasn't been written yet and there is a 'rd auto', change the bgp node utils to add in the 'rd auto' when a VRF is created.

Also lots of fixup to be compatible to the new node utils structure.

Fixes to the mini test to be better about adding router-ids where necessary.

minitest all pass (or skip)
Puppet looks good too.
rubocop all happy except for the early return in shutdown.
