### PR TITLE
Validate rubygems version to avoid Gemfile error

### DIFF
--- a/cisco_node_utils.gemspec
+++ b/cisco_node_utils.gemspec
@@ -3,9 +3,15 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'cisco_node_utils/version'
 
+def valid_rubygems_version
+  gem_version = Gem::VERSION
+  return true if (gem_version.to_f >= 2.1)
+  fail 'Required rubygems version >= 2.1.0'
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'cisco_node_utils'
-  spec.version       = CiscoNodeUtils::VERSION
+  spec.version       = CiscoNodeUtils::VERSION if valid_rubygems_version
   spec.authors       = ['Alex Hunsberger', 'Glenn Matthews',
                         'Chris Van Heuveln', 'Mike Wiebe', 'Jie Yang']
   spec.email         = 'cisco_agent_gem@cisco.com'


### PR DESCRIPTION
This commit reports a more specific error when rubygems version requirement is not met.

The error is changed from:

```
robgrie@puppetmaster:~/forks/robert-w-gries/cisco-network-node-utils$ bundle install

[!] There was an error parsing `Gemfile`: There was a ArgumentError while loading cisco_node_utils.gemspec: 
Malformed version number string 1.0.2-dev from
  /home/robgrie/forks/robert-w-gries/cisco-network-node-utils/cisco_node_utils.gemspec:13
. Bundler cannot continue.

 #  from /home/robgrie/forks/robert-w-gries/cisco-network-node-utils/Gemfile:4
 #  -------------------------------------------
 #  # Specify your gem's dependencies in cisco_node_utils.gemspec
 >  gemspec
 #  -------------------------------------------
```

to

```
 robgrie@puppetmaster:~/forks/robert-w-gries/cisco-network-node-utils$ bundle install

[!] There was an error parsing `Gemfile`: There was a RuntimeError while loading cisco_node_utils.gemspec: 
Required rubygems version >= 2.1.0 from
  /home/robgrie/forks/robert-w-gries/cisco-network-node-utils/cisco_node_utils.gemspec:9:in `valid_rubygems_version'
. Bundler cannot continue.

 #  from /home/robgrie/forks/robert-w-gries/cisco-network-node-utils/Gemfile:4
 #  -------------------------------------------
 #  # Specify your gem's dependencies in cisco_node_utils.gemspec
 >  gemspec
 #  -------------------------------------------
```
