### PR TITLE
Add Cisco::UnsupportedError class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/*
 coverage
 Gemfile.lock
 *.gem
+*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,15 @@ Changelog
 
 ## [Unreleased]
 
+### Added
+
+* `Cisco::UnsupportedError` exception class, raised when a command is explicitly marked as unsupported on a particular class of nodes.
+
 ### Changed
 
-* Major refactor of `CommandReference` YAML files.
+* Major refactor and enhancement of `CommandReference` YAML files:
+  - Added support for `auto_default`, `default_only`, `kind`, and `multiple`
+  - Added filtering by product ID (`/N7K/`) and by client type (`cli_nexus`)
 
 ## [v1.1.0]
 

--- a/docs/README-develop-best-practices.md
+++ b/docs/README-develop-best-practices.md
@@ -21,6 +21,7 @@ This document is intended to assist in developing cisco_node_utils API's that ar
 * [Y7](#yaml7): When possible, use the same `config_get` show command for all properties and document any anomalies.
 * [Y8](#yaml8): Use Key-value wildcards instead of Printf-style wildcards.
 * [Y9](#yaml9): Selection of `show` commands for `config_get`.
+* [Y10](#yaml10): Use `true` and `false` for boolean values.
 
 
 
@@ -201,6 +202,9 @@ The following commands should be preferred over `show [feature]` commands since 
 * `show running [feature] all` if available.
 * `show running all` if `show running [feature] all` is *not* available.
 
+### <a name="yaml10">Y10: Use `true` and `false` for boolean values.
+
+YAML allows various synonyms for `true` and `false` such as `yes` and `no`, but for consistency and readability (especially to users more familiar with Ruby than with YAML), we recommend using `true` and `false` rather than any of their synonyms.
 
 ## Common Object Best Practices:
 

--- a/lib/cisco_node_utils/cmd_ref/README_YAML.md
+++ b/lib/cisco_node_utils/cmd_ref/README_YAML.md
@@ -474,17 +474,17 @@ By convention, a `default_value` of `''` (empty string) represents a configurabl
 
 ### `default_only`
 
-Some attributes may be hard-coded on certain platforms in such a way that they have a meaningful `default_value` but no relevant `config_get_token` or `config_set` behavior. On such platforms, the key `default_only: true` can be set, which causes the `config_get()` API to always return the default value and `config_set()` to raise a `Cisco::UnsupportedError`.
+Some attributes may be hard-coded in such a way that they have a meaningful default value but no relevant `config_get_token` or `config_set` behavior. For such attributes, the key `default_only` should be used as an alternative to `default_value`. The benefit of using this key is that it causes the `config_get()` API to always return the default value and `config_set()` to raise a `Cisco::UnsupportedError`.
 
 ```yaml
 negotiate_auto_ethernet:
   kind: boolean
   cli_nexus:
     /(N7K|C3064)/:
-      default_value: false
-      default_only: true
+      # this feature is always off on these platforms and cannot be changed
+      default_only: false
     else:
-      config_get_token_append: '/^negotiate auto$/'
+      config_get_token_append: '/^(no )?negotiate auto$/'
       config_set_append: "%s negotiate auto"
       default_value: true
 ```
@@ -521,13 +521,13 @@ feature_lacp:
 
 ### `multiple`
 
-By default, `config_get_token` should uniquely identify a single configuration entry, and `config_get()` will raise an error if more than one match is found. For a small number of attributes, it may be desirable to permit multiple matches (in particular, '`all_*`' attributes that are used up to look up all interfaces, all VRFs, etc.). For such attributes, you must specifyg `multiple: true`. When this value is `true`, `config_get()` will permit multiple matches and will return an array of matches (even if there is only a single match).
+By default, `config_get_token` should uniquely identify a single configuration entry, and `config_get()` will raise an error if more than one match is found. For a small number of attributes, it may be desirable to permit multiple matches (in particular, '`all_*`' attributes that are used up to look up all interfaces, all VRFs, etc.). For such attributes, you must specify the key `multiple:`. When this key is present, `config_get()` will permit multiple matches and will return an array of matches (even if there is only a single match).
 
 ```yaml
 # interface.yaml
 ---
 all_interfaces:
-  multiple: true
+  multiple:
   config_get_token: '/^interface (.*)/'
 ```
 

--- a/lib/cisco_node_utils/cmd_ref/README_YAML.md
+++ b/lib/cisco_node_utils/cmd_ref/README_YAML.md
@@ -25,6 +25,7 @@ This document describes the structure and semantics of these files.
   * [`config_set`](#config_set)
   * [`config_set_append`](#config_set_append)
   * [`default_value`](#default_value)
+  * [`default_only`](#default_only)
   * [`kind`](#kind)
   * [`multiple`](#multiple)
   * [`auto_default`](#auto_default)
@@ -236,6 +237,8 @@ attribute:
   config_get: 'show attribute'
   config_set: 'attribute'
 ```
+
+When a feature or attribute is excluded in this way, attempting to call `config_get`, `config_set`, or `config_get_default` on an excluded node will result in a `Cisco::UnsupportedError` being raised.
 
 ### Combinations of these
 
@@ -468,6 +471,23 @@ ipv4_address:
 By convention, a `default_value` of `''` (empty string) represents a configurable property that defaults to absent, while a default of `nil` (Ruby) or `~` (YAML) represents a property that has no meaningful default at all.
 
 `config_get()` will return the defined `default_value` if the defined `config_get_token` does not match anything on the node. Normally this is desirable behavior, but you can use [`auto_default`](#auto_default) to change this behavior if needed.
+
+### `default_only`
+
+Some attributes may be hard-coded on certain platforms in such a way that they have a meaningful `default_value` but no relevant `config_get_token` or `config_set` behavior. On such platforms, the key `default_only: true` can be set, which causes the `config_get()` API to always return the default value and `config_set()` to raise a `Cisco::UnsupportedError`.
+
+```yaml
+negotiate_auto_ethernet:
+  kind: boolean
+  cli_nexus:
+    /(N7K|C3064)/:
+      default_value: false
+      default_only: true
+    else:
+      config_get_token_append: '/^negotiate auto$/'
+      config_set_append: "%s negotiate auto"
+      default_value: true
+```
 
 ### `kind`
 

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -19,7 +19,7 @@ admin_state_ethernet_noswitchport_shutdown:
       default_value: "shutdown"
 
 all_interfaces:
-  multiple: true
+  multiple:
   config_get_token: '/^interface (.*)/'
 
 create:
@@ -62,7 +62,7 @@ feature_vlan:
 
 ipv4_addr_mask:
   # This handles both primary and secondary addresses
-  multiple: true
+  multiple:
   cli_nexus:
     config_get_token_append: '/^ip address ([0-9\.]+)[\s\/](.*)/'
     config_set_append: "%s ip address %s"
@@ -83,8 +83,7 @@ ipv4_proxy_arp:
 ipv4_redirects_loopback:
   kind: boolean
   cli_nexus:
-    default_value: false
-    default_only: true
+    default_only: false
 
 ipv4_redirects_other_interfaces:
   kind: boolean
@@ -114,8 +113,7 @@ negotiate_auto_ethernet:
     '/^\s+negotiate auto/'
     ]
     /(N7K|C3064)/:
-      default_value: false
-      default_only: true
+      default_only: false
     else:
       config_get_token_append: '/^negotiate auto$/'
       config_set_append: "%s negotiate auto"
@@ -123,8 +121,7 @@ negotiate_auto_ethernet:
 
 negotiate_auto_other_interfaces:
   kind: boolean
-  default_value: false
-  default_only: yes
+  default_only: false
 
 negotiate_auto_portchannel:
   kind: boolean
@@ -134,8 +131,7 @@ negotiate_auto_portchannel:
     '/^\s+negotiate auto/'
     ]
     /N7K/:
-      default_value: false
-      default_only: true
+      default_only: false
     else:
       config_get_token_append: '/^negotiate auto$/'
       config_set_append: "%s negotiate auto"
@@ -215,8 +211,7 @@ switchport_mode_ethernet:
   default_value: "access"
 
 switchport_mode_other_interfaces:
-  default_value: ""
-  default_only: true
+  default_only: ""
 
 switchport_mode_port_channel:
   config_get_token_append: '/^switchport mode (.*)$/'

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -82,14 +82,9 @@ ipv4_proxy_arp:
 
 ipv4_redirects_loopback:
   kind: boolean
-  test_config_result:
-    false: RuntimeError
-    true: RuntimeError
   cli_nexus:
     default_value: false
-    config_set: ~
-    config_get: ~
-    config_get_token: ~
+    default_only: true
 
 ipv4_redirects_other_interfaces:
   kind: boolean
@@ -119,10 +114,8 @@ negotiate_auto_ethernet:
     '/^\s+negotiate auto/'
     ]
     /(N7K|C3064)/:
-      config_get: ~
-      config_set: ~
-      config_get_token: ~
       default_value: false
+      default_only: true
     else:
       config_get_token_append: '/^negotiate auto$/'
       config_set_append: "%s negotiate auto"
@@ -130,12 +123,8 @@ negotiate_auto_ethernet:
 
 negotiate_auto_other_interfaces:
   kind: boolean
-  config_get: ~
-  config_set: ~
   default_value: false
-  test_config_result:
-    false: RuntimeError
-    true: RuntimeError
+  default_only: yes
 
 negotiate_auto_portchannel:
   kind: boolean
@@ -145,10 +134,8 @@ negotiate_auto_portchannel:
     '/^\s+negotiate auto/'
     ]
     /N7K/:
-      config_get: ~
-      config_get_token: ~
-      config_set: ~
       default_value: false
+      default_only: true
     else:
       config_get_token_append: '/^negotiate auto$/'
       config_set_append: "%s negotiate auto"
@@ -228,8 +215,8 @@ switchport_mode_ethernet:
   default_value: "access"
 
 switchport_mode_other_interfaces:
-  config_get: ~
   default_value: ""
+  default_only: true
 
 switchport_mode_port_channel:
   config_get_token_append: '/^switchport mode (.*)$/'

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -19,9 +19,10 @@ require 'yaml'
 module Cisco
   # Control a reference for an attribute.
   class CmdRef
-    attr_reader :feature, :name, :hash, :auto_default, :multiple, :kind
+    attr_reader :feature, :name, :hash
+    attr_reader :auto_default, :multiple, :kind, :default_only
 
-    KEYS = %w(default_value
+    KEYS = %w(default_value default_only
               config_set config_set_append
               config_get config_get_token config_get_token_append
               auto_default multiple kind
@@ -43,6 +44,7 @@ module Cisco
       @name = name
       @hash = {}
       @auto_default = true
+      @default_only = false
       @multiple = false
       @kind = nil
 
@@ -50,11 +52,7 @@ module Cisco
         unless KEYS.include?(key)
           fail "Unrecognized key #{key} for #{feature}, #{name} in #{file}"
         end
-        if value.nil?
-          # Some attributes can store an explicit nil.
-          # Others treat this as unset (allowing a platform to override common).
-          @hash[key] = value if key == 'default_value'
-        elsif key == 'config_get_token' || key == 'config_set'
+        if key == 'config_get_token' || key == 'config_set'
           # For simplicity, these are ALWAYS arrays
           value = [value] unless value.is_a?(Array)
           define_getter(key, value)
@@ -62,6 +60,8 @@ module Cisco
           @hash[key] = preprocess_value(value)
         elsif key == 'auto_default'
           @auto_default = value ? true : false
+        elsif key == 'default_only'
+          @default_only = value ? true : false
         elsif key == 'multiple'
           @multiple = value ? true : false
         elsif key == 'kind'
@@ -70,6 +70,15 @@ module Cisco
         else
           @hash[key] = preprocess_value(value)
         end
+      end
+
+      if @default_only # rubocop:disable Style/GuardClause
+        fail "default_only but no default_value for #{feature}, " \
+          "#{name} in #{file}" unless @hash.key?('default_value')
+        %w(config_get_token config_set).each do |key|
+          instance_eval "undef #{key}" if @hash.key?(key)
+        end
+        @hash.delete_if { |key, _| key != 'default_value' }
       end
     end
 
@@ -162,6 +171,9 @@ module Cisco
         # ref.foo -> return @hash[foo] or fail IndexError
         method_name = method_name.to_s
         unless @hash.include?(method_name)
+          if @default_only
+            fail UnsupportedError.new(@feature, @name, method_name)
+          end
           fail IndexError, "No #{method_name} defined for #{@feature}, #{@name}"
         end
         # puts("get #{method_name}: '#{@hash[method_name]}'")
@@ -188,6 +200,45 @@ module Cisco
     def valid?
       return false unless @feature && @name
       true
+    end
+  end
+
+  # Exception class raised when a particular feature/attribute
+  # is explicitly excluded on the given node.
+  class UnsupportedError < RuntimeError
+    def initialize(feature, name, oper=nil, msg=nil)
+      @feature = feature
+      @name = name
+      @oper = oper
+      message = "Feature '#{feature}'"
+      message += ", attribute '#{name}'" unless name.nil?
+      message += ", operation '#{oper}'" unless oper.nil?
+      message += ' is unsupported on this node'
+      message += ": #{msg}" unless msg.nil?
+      super(message)
+    end
+  end
+
+  # Placeholder for known but explicitly excluded entry
+  class UnsupportedCmdRef < CmdRef
+    def initialize(feature, name, file)
+      super(feature, name, {}, file)
+    end
+
+    def valid?
+      true
+    end
+
+    def method_missing(method_name, *args, &block)
+      if KEYS.include?(method_name.to_s)
+        fail UnsupportedError.new(@feature, @name)
+      elsif method_name.to_s[-1] == '?' && \
+            KEYS.include?(method_name.to_s[0..-2])
+        # ref.foo? -> return true if @hash[foo], else false
+        false
+      else
+        super(method_name, *args, &block)
+      end
     end
   end
 
@@ -237,9 +288,14 @@ module Cisco
         feature = File.basename(file).split('.')[0]
         debug "Processing file '#{file}' as feature '#{feature}'"
         feature_hash = load_yaml(file)
-        feature_hash = filter_hash(feature_hash)
         if feature_hash.empty?
           debug "Feature #{feature} is empty"
+          next
+        end
+        feature_hash = filter_hash(feature_hash)
+        if feature_hash.empty?
+          debug "Feature #{feature} is excluded"
+          @hash[feature] = UnsupportedCmdRef.new(feature, nil, file)
           next
         end
 
@@ -250,10 +306,13 @@ module Cisco
 
         feature_hash.each do |name, value|
           fail "No entries under '#{name}' in '#{file}'" if value.nil?
-          next if value.empty? # filtered out by exclusions, etc
           @hash[feature] ||= {}
-          values = CommandReference.hash_merge(value, base_hash.clone)
-          @hash[feature][name] = CmdRef.new(feature, name, values, file)
+          if value.empty?
+            @hash[feature][name] = UnsupportedCmdRef.new(feature, name, file)
+          else
+            values = CommandReference.hash_merge(value, base_hash.clone)
+            @hash[feature][name] = CmdRef.new(feature, name, values, file)
+          end
         end
       end
 
@@ -262,12 +321,8 @@ module Cisco
 
     # Get the command reference
     def lookup(feature, name)
-      begin
-        value = @hash[feature][name]
-      rescue NoMethodError
-        # happens if @hash[feature] doesn't exist
-        value = nil
-      end
+      value = @hash[feature]
+      value = value[name] if value.is_a? Hash
       fail IndexError, "No CmdRef defined for #{feature}, #{name}" if value.nil?
       value
     end
@@ -524,10 +579,15 @@ module Cisco
     def valid?
       complete_status = true
       @hash.each_value do |names|
-        names.each_value do |ref|
-          status = ref.valid?
-          debug('Reference does not contain all supported values:' \
-                "\n#{ref}") unless status
+        if names.is_a? Hash
+          names.each_value do |ref|
+            status = ref.valid?
+            debug("Reference is invalid: \n#{ref}") unless status
+            complete_status = (status && complete_status)
+          end
+        else
+          status = names.valid?
+          debug("Reference is invalid: \n#{names}") unless status
           complete_status = (status && complete_status)
         end
       end

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -204,16 +204,12 @@ module Cisco
 
     def ipv4_redirects
       config_get('interface', ipv4_redirects_lookup_string, @name)
-    rescue IndexError
-      default_ipv4_redirects
     end
 
     def ipv4_redirects=(redirects)
       check_switchport_disabled
       no_cmd = (redirects ? '' : 'no')
       config_set('interface', ipv4_redirects_lookup_string, @name, no_cmd)
-    rescue IndexError
-      raise "ipv4 redirects not supported on #{@name}"
     end
 
     def default_ipv4_redirects
@@ -291,12 +287,6 @@ module Cisco
 
     def negotiate_auto
       config_get('interface', negotiate_auto_lookup_string, @name)
-    rescue IndexError
-      # We return default state even if the config_get is not supported
-      # for this platform / interface type. This is done so that we can set
-      # the manifest to 'default' so there is a 'workaround' for the
-      # unsupported attribute
-      default_negotiate_auto
     end
 
     def negotiate_auto=(negotiate_auto)
@@ -306,8 +296,6 @@ module Cisco
         config_set('interface', lookup, @name, no_cmd)
       rescue Cisco::CliError => e
         raise "[#{@name}] '#{e.command}' : #{e.clierror}"
-      rescue IndexError
-        raise "[#{@name}] negotiate_auto is not supported on this interface"
       end
     end
 

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -70,7 +70,7 @@ module Cisco
       fail 'lazy_connect specified but did not request connect' unless @cmd_ref
       ref = @cmd_ref.lookup(feature, name)
 
-      return ref.default_value if ref.default_only
+      return ref.default_value if ref.default_only?
 
       begin
         token = ref.config_get_token(*args)

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -70,6 +70,8 @@ module Cisco
       fail 'lazy_connect specified but did not request connect' unless @cmd_ref
       ref = @cmd_ref.lookup(feature, name)
 
+      return ref.default_value if ref.default_only
+
       begin
         token = ref.config_get_token(*args)
       rescue IndexError

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -94,6 +94,17 @@ class TestCase < Minitest::Test
     GC.start
   end
 
+  # Extend standard Minitest error handling to report UnsupportedError as skip
+  def capture_exceptions
+    super do
+      begin
+        yield
+      rescue Cisco::UnsupportedError => e
+        skip(e.to_s)
+      end
+    end
+  end
+
   def config(*args)
     # Send the entire config as one string but be sure not to return until
     # we are safely back out of config mode, i.e. prompt is

--- a/tests/test_command_reference.rb
+++ b/tests/test_command_reference.rb
@@ -23,7 +23,7 @@ require 'tempfile'
 require_relative '../lib/cisco_node_utils/command_reference'
 
 # TestCmdRef - Minitest for CommandReference and CmdRef classes.
-class TestCmdRef < MiniTest::Test
+class TestCmdRef < Minitest::Test
   include Cisco
 
   def setup
@@ -32,6 +32,17 @@ class TestCmdRef < MiniTest::Test
 
   def teardown
     @input_file.close!
+  end
+
+  # Extend standard Minitest error handling to report UnsupportedError as skip
+  def capture_exceptions
+    super do
+      begin
+        yield
+      rescue Cisco::UnsupportedError => e
+        skip(e.to_s)
+      end
+    end
   end
 
   def load_file(**args)

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -320,10 +320,10 @@ class TestInterface < CiscoTestCase
                      'ipv4 redirects default incorrect')
 
         # Make sure setter fails
-        assert_raises(ref.test_config_result(true)) do
+        assert_raises(Cisco::UnsupportedError) do
           interface.ipv4_redirects = true
         end
-        assert_raises(ref.test_config_result(false)) do
+        assert_raises(Cisco::UnsupportedError) do
           interface.ipv4_redirects = false
         end
       end
@@ -713,10 +713,10 @@ class TestInterface < CiscoTestCase
     assert_equal(interface.negotiate_auto, ref.default_value,
                  "Error: #{inf_name} negotiate auto value mismatch")
 
-    assert_raises(ref.test_config_result(true)) do
+    assert_raises(Cisco::UnsupportedError) do
       interface.negotiate_auto = true
     end
-    assert_raises(ref.test_config_result(false)) do
+    assert_raises(Cisco::UnsupportedError) do
       interface.negotiate_auto = false
     end
 


### PR DESCRIPTION
Features and attributes explicitly excluded by a platform will now
raise a Cisco::UnsupportedError instead of an IndexError.
(IndexError is still raised for flat-out missing data)

Added 'default_only' YAML flag to mark an attribute that has a
default_value but no config_get_token or config_set (such as
several 'interface' attributes). config_get() automatically returns
the default_value for a flagged default_only attribute, and
config_set() will raise a Cisco::UnsupportedError.

Added tests to test_command_reference.rb to cover these new features.
Refactored interface.yaml, interface.rb, and test_interface.rb to take advantage of `default_only`.

test_command_reference and test_interface are passing.
