### PR TITLE
Feature/grpc confed

### DIFF
--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -343,10 +343,9 @@ module Cisco
       # XR: retrieved as an array.
       # So make it an array in the NX case.
       # Sort the end results to make it consistent across both platforms.
-      # And if peers is an empty list - make it an empty array.
       peers = config_get('bgp', 'confederation_peers', @get_args)
       peers = peers.split(' ') if peers.is_a?(String)
-      peers.empty? ? [] : peers.sort
+      peers.sort
     end
 
     def confederation_peers=(should)

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -62,7 +62,7 @@ module Cisco
       hash_final = {}
       asnum = asnum.to_i unless /\d+.\d+/.match(asnum)
       hash_tmp = { asnum =>
-        { 'default' => RouterBgp.new(asnum, 'default', false) } }
+                   { 'default' => RouterBgp.new(asnum, 'default', false) } }
       vrf_ids = config_get('bgp', 'vrf', asnum: asnum)
       unless vrf_ids.nil?
         vrf_ids.each do |vrf|
@@ -358,7 +358,7 @@ module Cisco
       delta_hash = Utils.delta_add_remove(should, is)
       return if delta_hash.values.flatten.empty?
       [:add, :remove].each do |action|
-        CiscoLogger.debug("confederation_peers delta " \
+        CiscoLogger.debug('confederation_peers delta ' \
                           "#{@get_args}\n #{action}: " \
                           "#{delta_hash[action]}")
         delta_hash[action].each do |peer|

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -61,8 +61,9 @@ module Cisco
 
       hash_final = {}
       asnum = asnum.to_i unless /\d+.\d+/.match(asnum)
-      hash_tmp = { asnum =>
-                   { 'default' => RouterBgp.new(asnum, 'default', false) } }
+      hash_tmp = {
+        asnum => { 'default' => RouterBgp.new(asnum, 'default', false) }
+      }
       vrf_ids = config_get('bgp', 'vrf', asnum: asnum)
       unless vrf_ids.nil?
         vrf_ids.each do |vrf|
@@ -340,8 +341,9 @@ module Cisco
     # Confederation Peers (Getter/Setter/Default)
     def confederation_peers
       cmds = config_get('bgp', 'confederation_peers', @get_args)
-      # For XR convert array of peers to a string
-      cmds.to_s.empty? ? default_confederation_peers : cmds.join(' ')
+      return default_confederation_peers if cmds.to_s.empty?
+      cmds = cmds.split(' ') if cmds.instance_of? String
+      cmds.sort.join(' ')
     end
 
     def confederation_peers=(should)
@@ -349,9 +351,9 @@ module Cisco
       # and only apply the changes
       # Convert strings (1 2 3) to an array
       # Or FixedNum (1) to a string then an array
-      should = should.to_s.nil? ? [] : should.to_s.split(' ')
+      should = should.to_s.empty? ? [] : should.to_s.split(' ')
       is = confederation_peers
-      is = is.nil? ? [] : is.split(' ')
+      is = is.empty? ? [] : is.split(' ')
 
       delta_hash = Utils.delta_add_remove(should, is)
       return if delta_hash.values.flatten.empty?

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -355,9 +355,7 @@ module Cisco
       is = confederation_peers
       is = is.nil? ? [] : is.split(' ')
 
-      puts "is: #{is.class}, should: #{should.class}"
       delta_hash = Utils.delta_add_remove(should, is)
-      puts "delta hash=#{delta_hash}"
       return if delta_hash.values.flatten.empty?
       [:add, :remove].each do |action|
         CiscoLogger.debug("confederation_peers delta " \

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -347,11 +347,9 @@ module Cisco
     def confederation_peers=(should)
       # confederation peers are additive. So create a delta hash of entries
       # and only apply the changes
-      if should.instance_of? String
-        should = should.nil? ? [] : should.split(' ')
-      else
-        should = Array(should)
-      end
+      # Convert strings (1 2 3) to an array
+      # Or FixedNum (1) to a string then an array
+      should = should.to_s.nil? ? [] : should.to_s.split(' ')
       is = confederation_peers
       is = is.nil? ? [] : is.split(' ')
 

--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -121,8 +121,8 @@ module Cisco
       should.each(&:compact!) unless should.empty? if depth(should) > 1
       delta = { add: should - current, remove: current - should }
 
-      # To allow this method to handle comparing nested and unnested arrays
-      # the depth checks differentiate between the two cases.
+      # Differentiate between comparing nested and unnested arrays by
+      # checking the depth of the array.
       if depth(should) == 1
         # Delete entries from :remove if f1 is an update to an existing command
         delta[:add].each do |id|

--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -121,6 +121,8 @@ module Cisco
       should.each(&:compact!) unless should.empty? if depth(should) > 1
       delta = { add: should - current, remove: current - should }
 
+      # To allow this method to handle comparing nested and unnested arrays
+      # the depth checks differentiate between the two cases.
       if depth(should) == 1
         # Delete entries from :remove if f1 is an update to an existing command
         delta[:add].each do |id|

--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -125,7 +125,7 @@ module Cisco
 
       if depth(should) == 1
         # Delete entries from :remove if f1 is an update to an existing command
-        delta[:add].each do |id, _| #todo remove _
+        delta[:add].each do |id|
           delta[:remove].delete_if { |f1| [f1] if f1.to_s == id.to_s }
         end
       else

--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -107,9 +107,9 @@ module Cisco
       network
     end
 
-    def self.depth (a)
+    def self.depth(a)
       return 0 unless a.is_a?(Array)
-      return 1 + depth(a[0])
+      1 + depth(a[0])
     end
 
     # Helper to build a hash of add/remove commands for a nested array.
@@ -118,9 +118,7 @@ module Cisco
     #  current: an array of existing cmds on the device
     def self.delta_add_remove(should, current=[])
       # Remove nil entries from array
-      if depth(should) > 1
-        should.each(&:compact!) unless should.empty?
-      end
+      should.each(&:compact!) unless should.empty? if depth(should) > 1
       delta = { add: should - current, remove: current - should }
 
       if depth(should) == 1

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -109,14 +109,14 @@ confederation_id:
     config_set_append: '<state> confederation identifier <id>'
 
 confederation_peers:
-  # TODO: Supported in XR but broken as identifier is nvgened on a seperate line.
   default_value: ""
   cli_ios_xr:
-    config_get_token_append: '/^bgp confederation peers (.*)$/'
-    config_set_append: ' <state> bgp confederation peers <peer_list>'
+    multiple: true
+    config_get_token_append: ['/^bgp confederation peers$/', '/(\S+)/']
+    config_set_append: ' <state> bgp confederation peers <peer>'
   cli_nexus:
     config_get_token_append: '/^confederation peers (.*)$/'
-    config_set_append: '<state> confederation peers <peer_list>'
+    config_set_append: '<state> confederation peers <peer>'
 
 create_destroy_neighbor:
   config_set_append: '<state> neighbor <nbr>'

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -109,7 +109,7 @@ confederation_id:
     config_set_append: '<state> confederation identifier <id>'
 
 confederation_peers:
-  default_value: ""
+  default_value: []
   cli_ios_xr:
     multiple: true
     config_get_token_append: ['/^bgp confederation peers$/', '/(\S+)/']

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -82,8 +82,8 @@ module Cisco
         # Just get the whole output
         return massage(show(ref.config_get, :structured), ref)
       elsif token[0].kind_of?(Regexp)
-        return massage(find_ascii(show(ref.config_get, :ascii),
-                                  token[-1], *token[0..-2]), ref)
+        return massage(Cisco.find_ascii(show(ref.config_get, :ascii),
+                                        token[-1], *token[0..-2]), ref)
       else
         return massage(
           config_get_handle_structured(token,

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -352,7 +352,7 @@ class TestRouterBgp < CiscoTestCase
              'default value for bestpath_med_non_deterministic should be false')
     else
       assert_raises(Cisco::UnsupportedError) do
-        bgp.bestpath_med_non_deterministic
+        bgp.default_bestpath_med_non_deterministic
       end
     end
     bgp.destroy

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -44,15 +44,13 @@ def create_bgp_vrf(asnum, vrf)
 end
 
 def setup_default
-  asnum = 55
   @vrf = 'default'
-  RouterBgp.new(asnum)
+  RouterBgp.new(55)
 end
 
 def setup_vrf
-  asnum = 99
   @vrf = 'yamllll'
-  create_bgp_vrf(asnum, @vrf)
+  create_bgp_vrf(99, @vrf)
 end
 
 # TestRouterBgp - Minitest for RouterBgp class
@@ -256,9 +254,7 @@ class TestRouterBgp < CiscoTestCase
     assert(bgp.bestpath_cost_community_ignore, "vrf #{@vrf}: "\
            'bgp bestpath_cost_community_ignore should be enabled')
     bgp.bestpath_med_confed = true
-    if platform == :nexus ||
-       (platform == :ios_xr && @vrf == 'default')
-      # TODO: This property only works on IOS XR at the global level.
+    unless platform == :ios_xr && !@vrf == 'default'
       assert(bgp.bestpath_med_confed, "vrf #{@vrf}: "\
              'bgp bestpath_med_confed should be enabled')
     end
@@ -266,7 +262,6 @@ class TestRouterBgp < CiscoTestCase
     assert(bgp.bestpath_med_missing_as_worst, "vrf #{@vrf}: "\
            'bgp bestpath_med_missing_as_worst should be enabled')
     if platform == :nexus
-      # TODO: only applies to :nexus
       bgp.bestpath_med_non_deterministic = true
       assert(bgp.bestpath_med_non_deterministic, "vrf #{@vrf}: "\
              'bgp bestpath_med_non_deterministic should be enabled')
@@ -290,7 +285,6 @@ class TestRouterBgp < CiscoTestCase
     refute(bgp.bestpath_med_missing_as_worst, "vrf #{@vrf}: "\
            'bgp bestpath_med_missing_as_worst should be disabled')
     if platform == :nexus
-      # TODO: Only applies to :nexus
       bgp.bestpath_med_non_deterministic = false
       refute(bgp.bestpath_med_non_deterministic, "vrf #{@vrf}: "\
            'bgp bestpath_med_non_deterministic should be disabled')
@@ -320,7 +314,6 @@ class TestRouterBgp < CiscoTestCase
     refute(bgp.bestpath_med_missing_as_worst, "vrf #{@vrf}: "\
            'bgp bestpath_med_missing_as_worst should *NOT* be enabled')
     if platform == :nexus
-      # TODO: Only applies to :nexus
       refute(bgp.bestpath_med_non_deterministic, "vrf #{@vrf}: "\
            'bgp bestpath_med_non_deterministic should *NOT* be enabled')
     end
@@ -343,7 +336,6 @@ class TestRouterBgp < CiscoTestCase
     refute(bgp.default_bestpath_med_missing_as_worst,
            'default value for bestpath_med_missing_as_worst should be false')
     if platform == :nexus
-      # TODO: Only applies to :nexus
       refute(bgp.default_bestpath_med_non_deterministic,
              'default value for bestpath_med_non_deterministic should be false')
     end
@@ -432,7 +424,6 @@ class TestRouterBgp < CiscoTestCase
                  "vrf #{@vrf}: bgp graceful restart timers stalepath time" \
                  "should be set to '77'")
     if platform == :nexus
-      # TODO: Only applies to :nexus
       bgp.graceful_restart_helper = true
       assert(bgp.graceful_restart_helper,
              "vrf #{@vrf}: bgp graceful restart helper should be enabled")
@@ -449,7 +440,6 @@ class TestRouterBgp < CiscoTestCase
                  "vrf #{@vrf}: bgp graceful restart timers stalepath time" \
                  "should be set to default value of '300'")
     if platform == :nexus
-      # TODO: Only applies to :nexus
       bgp.graceful_restart_helper = false
       refute(bgp.graceful_restart_helper,
              "vrf #{@vrf}: bgp graceful restart helper should be disabled")

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -552,10 +552,10 @@ class TestRouterBgp < CiscoTestCase
                    "vrf #{vrf}: bgp confederation_peers list should be " \
                    "'55.77'")
       bgp.confederation_peers = ('15 16 55.77 18 555 299')
-      assert_equal('15 16 18 299 555 55.77',
+      assert_equal('15 16 18 299 55.77 555',
                    bgp.confederation_peers,
                    "vrf #{vrf}: bgp confederation_peers list should be " \
-                   "'15 16 18 299 555 55.77'")
+                   "'15 16 18 299 55.77 555'")
       bgp.confederation_peers = ('')
       assert_empty(bgp.confederation_peers,
                    "vrf #{vrf}: bgp confederation_peers list should be empty")
@@ -563,7 +563,7 @@ class TestRouterBgp < CiscoTestCase
     end
   end
 
-  def test_routerbgp_get_confederation_peers_not_configured
+  def test_get_confederation_peers_not_configured
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_empty(bgp.confederation_peers,
@@ -571,7 +571,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_default_confederation_peers
+  def test_default_confederation_peers
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_empty(bgp.default_confederation_peers,
@@ -579,7 +579,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_set_get_log_neighbor_changes
+  def test_set_get_log_neighbor_changes
     skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
@@ -601,7 +601,7 @@ class TestRouterBgp < CiscoTestCase
     end
   end
 
-  def test_routerbgp_get_log_neighbor_changes_not_configured
+  def test_get_log_neighbor_changes_not_configured
     skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
@@ -610,7 +610,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_default_log_neighbor_changes
+  def test_default_log_neighbor_changes
     skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
@@ -619,7 +619,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_set_get_maxas_limit
+  def test_set_get_maxas_limit
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -640,7 +640,7 @@ class TestRouterBgp < CiscoTestCase
     end
   end
 
-  def test_routerbgp_default_maxas_limit
+  def test_default_maxas_limit
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_equal(bgp.default_maxas_limit, bgp.maxas_limit,
@@ -648,7 +648,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_set_get_neighbor_fib_down_accelerate
+  def test_set_get_neighbor_fib_down_accelerate
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -669,7 +669,7 @@ class TestRouterBgp < CiscoTestCase
     end
   end
 
-  def test_routerbgp_get_neighbor_fib_down_accelerate_not_configured
+  def test_get_neighbor_fib_down_accelerate_not_configured
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.neighbor_fib_down_accelerate,
@@ -677,7 +677,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_default_neighbor_fib_down_accelerate
+  def test_default_neighbor_fib_down_accelerate
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.default_neighbor_fib_down_accelerate,
@@ -685,7 +685,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_set_get_reconnect_interval
+  def test_set_get_reconnect_interval
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -706,7 +706,7 @@ class TestRouterBgp < CiscoTestCase
     end
   end
 
-  def test_routerbgp_get_reconnect_interval_default
+  def test_get_reconnect_interval_default
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_equal(60, bgp.reconnect_interval,
@@ -714,7 +714,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_set_get_router_id
+  def test_set_get_router_id
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -735,7 +735,7 @@ class TestRouterBgp < CiscoTestCase
     end
   end
 
-  def test_routerbgp_get_router_id_not_configured
+  def test_get_router_id_not_configured
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_empty(bgp.router_id,
@@ -743,7 +743,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_default_router_id
+  def test_default_router_id
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_empty(bgp.default_router_id,
@@ -751,7 +751,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_set_get_shutdown
+  def test_set_get_shutdown
     asnum = 55
     bgp = RouterBgp.new(asnum)
     bgp.shutdown = true
@@ -761,7 +761,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_get_shutdown_not_configured
+  def test_get_shutdown_not_configured
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.shutdown,
@@ -769,7 +769,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_default_shutdown
+  def test_default_shutdown
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.default_shutdown,
@@ -777,7 +777,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_set_get_suppress_fib_pending
+  def test_set_get_suppress_fib_pending
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -798,7 +798,7 @@ class TestRouterBgp < CiscoTestCase
     end
   end
 
-  def test_routerbgp_get_suppress_fib_pending_not_configured
+  def test_get_suppress_fib_pending_not_configured
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.suppress_fib_pending,
@@ -806,7 +806,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_default_suppress_fib_pending
+  def test_default_suppress_fib_pending
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.default_suppress_fib_pending,
@@ -814,7 +814,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_set_get_timer_bestpath_limit
+  def test_set_get_timer_bestpath_limit
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -835,7 +835,7 @@ class TestRouterBgp < CiscoTestCase
     end
   end
 
-  def test_routerbgp_get_timer_bestpath_limit_default
+  def test_get_timer_bestpath_limit_default
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_equal(300, bgp.timer_bestpath_limit,
@@ -843,7 +843,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_set_get_timer_bestpath_limit_always
+  def test_set_get_timer_bestpath_limit_always
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -864,7 +864,7 @@ class TestRouterBgp < CiscoTestCase
     end
   end
 
-  def test_routerbgp_get_timer_bestpath_limit_always_not_configured
+  def test_get_timer_bestpath_limit_always_not_configured
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.timer_bestpath_limit_always,
@@ -872,7 +872,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_default_timer_bestpath_limit_always
+  def test_default_timer_bestpath_limit_always
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.default_timer_bestpath_limit_always,
@@ -880,7 +880,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_set_get_timer_bgp_keepalive_hold
+  def test_set_get_timer_bgp_keepalive_hold
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -912,7 +912,7 @@ class TestRouterBgp < CiscoTestCase
     end
   end
 
-  def test_routerbgp_default_timer_keepalive_hold_default
+  def test_default_timer_keepalive_hold_default
     skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -20,7 +20,7 @@
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/bgp'
 
-XR_SUPPORTED_BROKEN  = 'Supported in IOS XR - needs further work'
+XR_SUPPORTED_BROKEN = 'Supported in IOS XR - needs further work'
 
 def create_bgp_vrf(asnum, vrf)
   if platform == :nexus
@@ -542,7 +542,7 @@ class TestRouterBgp < CiscoTestCase
       assert_empty(bgp.confederation_peers,
                    "vrf #{vrf}: bgp confederation_peers list should be empty")
       bgp.confederation_peers = (15)
-      assert_equal("15", bgp.confederation_peers,
+      assert_equal('15', bgp.confederation_peers,
                    "vrf #{vrf}: bgp confederation_peers list should be '15'")
       bgp.confederation_peers = (16)
       assert_equal('16', bgp.confederation_peers,

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -20,8 +20,6 @@
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/bgp'
 
-XR_NOT_SUPPORTED     = 'Not supported in IOS XR'
-XR_NO_VRF_SUPPORT    = 'Feature not supported in a vrf in IOS XR'
 XR_SUPPORTED_BROKEN  = 'Supported in IOS XR - needs further work'
 
 def create_bgp_vrf(asnum, vrf)
@@ -525,9 +523,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_confederation_peers
-    puts "RICHAA:"
-
-    # skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -625,7 +620,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_maxas_limit
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -647,7 +641,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_default_maxas_limit
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_equal(bgp.default_maxas_limit, bgp.maxas_limit,
@@ -656,7 +649,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_neighbor_fib_down_accelerate
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -678,7 +670,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_get_neighbor_fib_down_accelerate_not_configured
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.neighbor_fib_down_accelerate,
@@ -687,7 +678,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_default_neighbor_fib_down_accelerate
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.default_neighbor_fib_down_accelerate,
@@ -696,7 +686,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_reconnect_interval
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -718,7 +707,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_get_reconnect_interval_default
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_equal(60, bgp.reconnect_interval,
@@ -764,7 +752,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_shutdown
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     bgp.shutdown = true
@@ -775,7 +762,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_get_shutdown_not_configured
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.shutdown,
@@ -784,7 +770,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_default_shutdown
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.default_shutdown,
@@ -793,7 +778,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_suppress_fib_pending
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -815,7 +799,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_get_suppress_fib_pending_not_configured
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.suppress_fib_pending,
@@ -824,7 +807,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_default_suppress_fib_pending
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.default_suppress_fib_pending,
@@ -833,7 +815,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_timer_bestpath_limit
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -855,7 +836,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_get_timer_bestpath_limit_default
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_equal(300, bgp.timer_bestpath_limit,
@@ -864,7 +844,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_timer_bestpath_limit_always
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
@@ -886,7 +865,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_get_timer_bestpath_limit_always_not_configured
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.timer_bestpath_limit_always,
@@ -895,7 +873,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_default_timer_bestpath_limit_always
-    skip(XR_NOT_SUPPORTED) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.default_timer_bestpath_limit_always,

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -525,13 +525,16 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_routerbgp_set_get_confederation_peers
-    skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
+    puts "RICHAA:"
+
+    # skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         asnum = 55
         vrf = 'default'
         bgp = RouterBgp.new(asnum)
       else
+        next if platform == :ios_xr
         asnum = 99
         vrf = 'yamllll'
         bgp = create_bgp_vrf(asnum, vrf)
@@ -540,24 +543,25 @@ class TestRouterBgp < CiscoTestCase
       # confederation id be configured first so the expectation
       # in the next test is an empty peer list
       bgp.confederation_id = 55
+
       assert_empty(bgp.confederation_peers,
                    "vrf #{vrf}: bgp confederation_peers list should be empty")
-      bgp.confederation_peers_set(15)
-      assert_equal('15', bgp.confederation_peers,
+      bgp.confederation_peers = (15)
+      assert_equal("15", bgp.confederation_peers,
                    "vrf #{vrf}: bgp confederation_peers list should be '15'")
-      bgp.confederation_peers_set(16)
+      bgp.confederation_peers = (16)
       assert_equal('16', bgp.confederation_peers,
                    "vrf #{vrf}: bgp confederation_peers list should be '16'")
-      bgp.confederation_peers_set(55.77)
+      bgp.confederation_peers = (55.77)
       assert_equal('55.77', bgp.confederation_peers,
-                   "vrf #{vrf}: bgp confederation_peers list should be" \
+                   "vrf #{vrf}: bgp confederation_peers list should be " \
                    "'55.77'")
-      bgp.confederation_peers_set('15 16 55.77 18 555 299')
-      assert_equal('15 16 55.77 18 555 299',
+      bgp.confederation_peers = ('15 16 55.77 18 555 299')
+      assert_equal('15 16 18 299 555 55.77',
                    bgp.confederation_peers,
-                   "vrf #{vrf}: bgp confederation_peers list should be" \
-                   "'15 16 55.77 18 555 299'")
-      bgp.confederation_peers_set('')
+                   "vrf #{vrf}: bgp confederation_peers list should be " \
+                   "'15 16 18 299 555 55.77'")
+      bgp.confederation_peers = ('')
       assert_empty(bgp.confederation_peers,
                    "vrf #{vrf}: bgp confederation_peers list should be empty")
       bgp.destroy

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -242,52 +242,60 @@ class TestRouterBgp < CiscoTestCase
 
   def bestpath(bgp)
     bgp.bestpath_always_compare_med = true
-    assert(bgp.bestpath_always_compare_med, "vrf #{@vrf}: "\
+    assert(bgp.bestpath_always_compare_med,
            'bgp bestpath_always_compare_med should be enabled')
     bgp.bestpath_aspath_multipath_relax = true
-    assert(bgp.bestpath_aspath_multipath_relax, "vrf #{@vrf}: "\
+    assert(bgp.bestpath_aspath_multipath_relax,
            'bgp bestpath_aspath_multipath_relax should be enabled')
     bgp.bestpath_compare_routerid = true
-    assert(bgp.bestpath_compare_routerid, "vrf #{@vrf}: "\
+    assert(bgp.bestpath_compare_routerid,
            'bgp bestpath_compare_routerid should be enabled')
     bgp.bestpath_cost_community_ignore = true
-    assert(bgp.bestpath_cost_community_ignore, "vrf #{@vrf}: "\
+    assert(bgp.bestpath_cost_community_ignore,
            'bgp bestpath_cost_community_ignore should be enabled')
     bgp.bestpath_med_confed = true
-    unless platform == :ios_xr && !@vrf == 'default'
-      assert(bgp.bestpath_med_confed, "vrf #{@vrf}: "\
+    unless platform == :ios_xr && !@vrf[/default/]
+      assert(bgp.bestpath_med_confed,
              'bgp bestpath_med_confed should be enabled')
     end
     bgp.bestpath_med_missing_as_worst = true
-    assert(bgp.bestpath_med_missing_as_worst, "vrf #{@vrf}: "\
+    assert(bgp.bestpath_med_missing_as_worst,
            'bgp bestpath_med_missing_as_worst should be enabled')
     if platform == :nexus
       bgp.bestpath_med_non_deterministic = true
-      assert(bgp.bestpath_med_non_deterministic, "vrf #{@vrf}: "\
+      assert(bgp.bestpath_med_non_deterministic,
              'bgp bestpath_med_non_deterministic should be enabled')
+    else
+      assert_raises(Cisco::UnsupportedError) do
+        bgp.bestpath_med_non_deterministic = true
+      end
     end
     bgp.bestpath_always_compare_med = false
-    refute(bgp.bestpath_always_compare_med, "vrf #{@vrf}: "\
+    refute(bgp.bestpath_always_compare_med,
            'bgp bestpath_always_compare_med should be disabled')
     bgp.bestpath_aspath_multipath_relax = false
-    refute(bgp.bestpath_aspath_multipath_relax, "vrf #{@vrf}: "\
+    refute(bgp.bestpath_aspath_multipath_relax,
            'bgp bestpath_aspath_multipath_relax should be disabled')
     bgp.bestpath_compare_routerid = false
-    refute(bgp.bestpath_compare_routerid, "vrf #{@vrf}: "\
+    refute(bgp.bestpath_compare_routerid,
            'bgp bestpath_compare_routerid should be disabled')
     bgp.bestpath_cost_community_ignore = false
-    refute(bgp.bestpath_cost_community_ignore, "vrf #{@vrf}: "\
+    refute(bgp.bestpath_cost_community_ignore,
            'bgp bestpath_cost_community_ignore should be disabled')
     bgp.bestpath_med_confed = false
-    refute(bgp.bestpath_med_confed, "vrf #{@vrf}: "\
+    refute(bgp.bestpath_med_confed,
            'bgp bestpath_med_confed should be disabled')
     bgp.bestpath_med_missing_as_worst = false
-    refute(bgp.bestpath_med_missing_as_worst, "vrf #{@vrf}: "\
+    refute(bgp.bestpath_med_missing_as_worst,
            'bgp bestpath_med_missing_as_worst should be disabled')
     if platform == :nexus
       bgp.bestpath_med_non_deterministic = false
-      refute(bgp.bestpath_med_non_deterministic, "vrf #{@vrf}: "\
-           'bgp bestpath_med_non_deterministic should be disabled')
+      refute(bgp.bestpath_med_non_deterministic,
+             'bgp bestpath_med_non_deterministic should be disabled')
+    else
+      assert_raises(Cisco::UnsupportedError) do
+        bgp.bestpath_med_non_deterministic = false
+      end
     end
     bgp.destroy
   end
@@ -301,21 +309,25 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def bestpath_not_configured(bgp)
-    refute(bgp.bestpath_always_compare_med, "vrf #{@vrf}: "\
-             'bgp bestpath_always_compare_med should *NOT* be enabled')
-    refute(bgp.bestpath_aspath_multipath_relax, "vrf #{@vrf}: "\
+    refute(bgp.bestpath_always_compare_med,
+           'bgp bestpath_always_compare_med should *NOT* be enabled')
+    refute(bgp.bestpath_aspath_multipath_relax,
            'bgp bestpath_aspath_multipath_relax should *NOT* be enabled')
-    refute(bgp.bestpath_compare_routerid, "vrf #{@vrf}: "\
+    refute(bgp.bestpath_compare_routerid,
            'bgp bestpath_compare_routerid should be *NOT* enabled')
-    refute(bgp.bestpath_cost_community_ignore, "vrf #{@vrf}: "\
+    refute(bgp.bestpath_cost_community_ignore,
            'bgp bestpath_cost_community_ignore should *NOT* be enabled')
-    refute(bgp.bestpath_med_confed, "vrf #{@vrf}: "\
+    refute(bgp.bestpath_med_confed,
            'bgp bestpath_med_confed should *NOT* be enabled')
-    refute(bgp.bestpath_med_missing_as_worst, "vrf #{@vrf}: "\
+    refute(bgp.bestpath_med_missing_as_worst,
            'bgp bestpath_med_missing_as_worst should *NOT* be enabled')
     if platform == :nexus
-      refute(bgp.bestpath_med_non_deterministic, "vrf #{@vrf}: "\
-           'bgp bestpath_med_non_deterministic should *NOT* be enabled')
+      refute(bgp.bestpath_med_non_deterministic,
+             'bgp bestpath_med_non_deterministic should *NOT* be enabled')
+    else
+      assert_raises(Cisco::UnsupportedError) do
+        bgp.bestpath_med_non_deterministic
+      end
     end
     bgp.destroy
   end
@@ -338,6 +350,10 @@ class TestRouterBgp < CiscoTestCase
     if platform == :nexus
       refute(bgp.default_bestpath_med_non_deterministic,
              'default value for bestpath_med_non_deterministic should be false')
+    else
+      assert_raises(Cisco::UnsupportedError) do
+        bgp.bestpath_med_non_deterministic
+      end
     end
     bgp.destroy
   end
@@ -354,13 +370,13 @@ class TestRouterBgp < CiscoTestCase
   def cluster_id(bgp)
     bgp.cluster_id = 34
     assert_equal('34', bgp.cluster_id,
-                 "vrf #{@vrf}: bgp cluster_id should be set to '34'")
+                 "bgp cluster_id should be set to '34'")
     bgp.cluster_id = '1.2.3.4'
     assert_equal('1.2.3.4', bgp.cluster_id,
-                 "vrf #{@vrf}: bgp cluster_id should be set to '1.2.3.4'")
+                 "bgp cluster_id should be set to '1.2.3.4'")
     bgp.cluster_id = ''
     assert_empty(bgp.cluster_id,
-                 "vrf #{@vrf}: bgp cluster_id should *NOT* be configured")
+                 'bgp cluster_id should *NOT* be configured')
     bgp.destroy
   end
 
@@ -414,35 +430,43 @@ class TestRouterBgp < CiscoTestCase
   def graceful_restart(bgp)
     bgp.graceful_restart = true
     assert(bgp.graceful_restart,
-           "vrf #{@vrf}: bgp graceful restart should be enabled")
+           'bgp graceful restart should be enabled')
     bgp.graceful_restart_timers_restart = 55
     assert_equal(55, bgp.graceful_restart_timers_restart,
-                 "vrf #{@vrf}: bgp graceful restart timers restart" \
+                 'bgp graceful restart timers restart' \
                  "should be set to '55'")
     bgp.graceful_restart_timers_stalepath_time = 77
     assert_equal(77, bgp.graceful_restart_timers_stalepath_time,
-                 "vrf #{@vrf}: bgp graceful restart timers stalepath time" \
+                 'bgp graceful restart timers stalepath time' \
                  "should be set to '77'")
     if platform == :nexus
       bgp.graceful_restart_helper = true
       assert(bgp.graceful_restart_helper,
-             "vrf #{@vrf}: bgp graceful restart helper should be enabled")
+             'bgp graceful restart helper should be enabled')
+    else
+      assert_raises(Cisco::UnsupportedError) do
+        bgp.graceful_restart_helper = true
+      end
     end
     bgp.graceful_restart = false
     refute(bgp.graceful_restart,
-           "vrf #{@vrf}: bgp graceful_restart should be disabled")
+           'bgp graceful_restart should be disabled')
     bgp.graceful_restart_timers_restart = 120
     assert_equal(120, bgp.graceful_restart_timers_restart,
-                 "vrf #{@vrf}: bgp graceful restart timers restart" \
+                 'bgp graceful restart timers restart' \
                  "should be set to default value of '120'")
     bgp.graceful_restart_timers_stalepath_time = 300
     assert_equal(300, bgp.graceful_restart_timers_stalepath_time,
-                 "vrf #{@vrf}: bgp graceful restart timers stalepath time" \
+                 'bgp graceful restart timers stalepath time' \
                  "should be set to default value of '300'")
     if platform == :nexus
       bgp.graceful_restart_helper = false
       refute(bgp.graceful_restart_helper,
-             "vrf #{@vrf}: bgp graceful restart helper should be disabled")
+             'bgp graceful restart helper should be disabled')
+    else
+      assert_raises(Cisco::UnsupportedError) do
+        bgp.graceful_restart_helper = false
+      end
     end
     bgp.destroy
   end
@@ -456,11 +480,14 @@ class TestRouterBgp < CiscoTestCase
                  "bgp graceful restart default timer value should be '120'")
     assert_equal(300, bgp.default_graceful_restart_timers_stalepath_time,
                  "bgp graceful restart default timer value should be '300'")
-    # rubocop:disable Style/GuardClause
     if platform == :nexus
       refute(bgp.default_graceful_restart_helper,
              'graceful restart helper default value ' \
              'should be enabled = false')
+    else
+      assert_raises(Cisco::UnsupportedError) do
+        bgp.default_graceful_restart_helper
+      end
     end
     # rubocop:enable Style/GuardClause
   end
@@ -477,9 +504,9 @@ class TestRouterBgp < CiscoTestCase
   def confederation_id(bgp)
     bgp.confederation_id = 77
     assert_equal('77', bgp.confederation_id,
-                 "vrf #{@vrf}: bgp confederation_id should be set to '77'")
+                 "bgp confederation_id should be set to '77'")
     bgp.confederation_id = ''
-    assert_empty(bgp.confederation_id, "vrf #{@vrf}: " \
+    assert_empty(bgp.confederation_id, '' \
                  'bgp confederation_id should *NOT* be configured')
     bgp.destroy
   end
@@ -524,25 +551,25 @@ class TestRouterBgp < CiscoTestCase
     bgp.confederation_id = 55
 
     assert_empty(bgp.confederation_peers,
-                 "vrf #{@vrf}: bgp confederation_peers list should be empty")
+                 'bgp confederation_peers list should be empty')
     bgp.confederation_peers = [15]
     assert_equal(['15'], bgp.confederation_peers,
-                 "vrf #{@vrf}: bgp confederation_peers list should be ['15']")
+                 "bgp confederation_peers list should be ['15']")
     bgp.confederation_peers = [16]
     assert_equal(['16'], bgp.confederation_peers,
-                 "vrf #{@vrf}: bgp confederation_peers list should be ['16']")
+                 "bgp confederation_peers list should be ['16']")
     bgp.confederation_peers = [55.77]
     assert_equal(['55.77'], bgp.confederation_peers,
-                 "vrf #{@vrf}: bgp confederation_peers list should be " \
+                 'bgp confederation_peers list should be ' \
                  "['55.77']")
     bgp.confederation_peers = ['15', '55.77', '16', '18', '555', '299']
     assert_equal(['15', '16', '18', '299', '55.77', '555'],
                  bgp.confederation_peers,
-                 "vrf #{@vrf}: bgp confederation_peers list should be " \
+                 'bgp confederation_peers list should be ' \
                  "'['15', '16', '18', '299', '55.77', '555']'")
     bgp.confederation_peers = []
     assert_empty(bgp.confederation_peers,
-                 "vrf #{@vrf}: bgp confederation_peers list should be empty")
+                 'bgp confederation_peers list should be empty')
     bgp.destroy
   end
 
@@ -609,10 +636,10 @@ class TestRouterBgp < CiscoTestCase
   def maxas_limit(bgp)
     bgp.maxas_limit = 50
     assert_equal(50, bgp.maxas_limit,
-                 "vrf #{@vrf}: bgp maxas-limit should be set to '50'")
+                 "bgp maxas-limit should be set to '50'")
     bgp.maxas_limit = bgp.default_maxas_limit
     assert_equal(bgp.default_maxas_limit, bgp.maxas_limit,
-                 "vrf #{@vrf}: bgp maxas-limit should be set to default value")
+                 'bgp maxas-limit should be set to default value')
     bgp.destroy
   end
 


### PR DESCRIPTION
Note: there is an associated puppet change that is needed to run this manifest and that's going to be a separate review.

Changes to make bgp confederation peers work on XR.

Change the setter to use the delta functionality introduced recently.

Mini test on both platforms:

Xrv9k:

```
Finished in 478.095544s, 0.1129 runs/s, 0.2886 assertions/s.
54 runs, 138 assertions, 0 failures, 0 errors, 24 skips
```

Nexus:

```
Finished in 595.645666s, 0.0907 runs/s, 0.3693 assertions/s.
54 runs, 220 assertions, 0 failures, 0 errors, 0 skips
```

Adding confed peers to my bgp manifest:

root@rtp-puppetserver228:~/cisco-network-puppet-module# cat /etc/puppetlabs/code/environments/production/manifests/site.pp

``` puppet
class ciscopuppet::demo_bgp {
  cisco_bgp { 'default_vrf_global':
    ensure                                 => present,
    asn                                    => 55.77,
    vrf                                    => 'default',
    router_id                              => '1.1.1.1',

    # Graceful Restart Properties
    graceful_restart                       => true,

    # Inherited Properties - applied to VRF but configured globally
    confederation_id                       => '33',
    confederation_peers                    => '999',
    cluster_id                             => '55',
    graceful_restart_timers_restart        => '131',
    graceful_restart_timers_stalepath_time => '311',
    bestpath_med_confed                    => true,
  } 
}
```

Results in:

```
Info: Loading facts
Info: Caching catalog for sunstoneabc.cisco.com
Info: Applying configuration version '1447352626'
Notice: Applied catalog in 2.18 seconds

RP/0/RP0/CPU0:ios#sh run router bgp
Thu Nov 12 18:35:16.666 UTC
router bgp 3604557
 bgp confederation peers
  999
 !
 bgp confederation identifier 33
 bgp router-id 1.1.1.1
 bgp cluster-id 55
 bgp graceful-restart restart-time 131
 bgp graceful-restart stalepath-time 311
 bgp graceful-restart
 bgp bestpath med confed
 vrf blue
  rd auto
  timers bgp 46 111
  bgp router-id 192.168.0.66
  bgp bestpath cost-community ignore
  bgp bestpath med always
  bgp bestpath compare-routerid
  bgp bestpath as-path multipath-relax
 !
!
```

Changing the peer to a list and expecting a CLI error:

``` puppet
    confederation_peers                    => '999 44 55.77 22 1001 1003 88',
```

```
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp[default_vrf_global]/confederation_peers: confederation_peers changed '999' to '999 44 55.77 22 1001 1003 88'
Error: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp[default_vrf_global]: Could not evaluate: CliError: 'input TODO' rejected with message:
'["'BGP' detected the 'warning' condition 'Local member-AS not allowed in confed peer list'"]'
Notice: Applied catalog in 3.93 seconds
```

Change it to a working range of peers:

``` puppet
    confederation_peers                    => '999 44 55.77 22 1001 1003 88',
```

```
Notice: /Stage[main]/Ciscopuppet::Demo_bgp/Cisco_bgp[default_vrf_global]/confederation_peers: confederation_peers changed '1001 1003 22 44 88 999' to '999 44 22 1001 1003 88'
```

```
RP/0/RP0/CPU0:ios#sh run router bgp 3604557 bgp confederation peers
Thu Nov 12 19:15:18.091 UTC
router bgp 3604557
 bgp confederation peers
  22
  44
  88
  999
  1001
  1003
 !
!
```
