### PR TITLE
Fix remaining failures in interface support on XR

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -1,79 +1,74 @@
 # interface
 ---
 _template:
-  config_set: ["interface %s"]
-  config_get_token: '/^interface %s$/i'
+  config_set: ["interface <name>"]
+  config_get_token: '/^interface <name>$/i'
   cli_ios_xr:
     config_get: "show running interface"
   cli_nexus:
     config_get: "show running interface all"
 
 access_vlan:
-  config_get_token_append: '/^switchport access vlan (.*)$/'
-  config_set_append: "switchport access vlan %s"
+  _exclude: [cli_ios_xr]
   kind: int
+  config_get_token_append: '/^switchport access vlan (.*)$/'
+  config_set_append: "switchport access vlan <vlan>"
   default_value: 1
-
-admin_state_ethernet_noswitchport_shutdown:
-  # TODO: is this actually used?
-  cli_nexus:
-    /N7K/:
-      default_value: "shutdown"
 
 all_interfaces:
   multiple:
   config_get_token: '/^interface (.*)/'
 
 create:
-  config_set: "interface %s"
+  config_set: "interface <name>"
 
 description:
   kind: string
   config_get_token_append: '/^description (.*)/'
-  config_set_append: "%s description %s"
+  config_set_append: "<state> description <desc>"
   default_value: ""
 
 destroy:
-  config_set: "no interface %s"
+  config_set: "no interface <name>"
 
 duplex:
+  _exclude: [cli_ios_xr]
   kind: string
-  config_get: "show running interface all"
-  config_get_token: ['/^interface %s$/i', '/^duplex (.*)$/']
-  config_set: ["interface %s", "duplex %s"]
+  config_get_token_append: '/^duplex (.*)$/'
+  config_set_append: "duplex <duplex>"
   default_value: "auto"
 
 encapsulation_dot1q:
+  _exclude: [cli_ios_xr]
   kind: int
-  config_get_token_append: '/^encapsulation dot1q (.*)/'
-  config_set_append: "%s encapsulation dot1q %s"
   default_value: ""
+  config_get_token_append: '/^encapsulation dot1q (.*)/'
+  config_set_append: "<state> encapsulation dot1q <vlan>"
 
 feature_lacp:
+  _exclude: [cli_ios_xr]
   kind: boolean
   config_get: "show running | i ^feature"
   config_get_token: '/^feature lacp$/'
-  config_set: "%s feature lacp"
+  config_set: "<state> feature lacp"
 
 feature_vlan:
-  cli_ios_xr:
-    config_get: ~
-    config_set: ~
+  _exclude: [cli_ios_xr]
   cli_nexus:
     kind: boolean
     config_get: "show running | i ^feature"
     config_get_token: '/^feature interface-vlan$/'
-    config_set: "%s feature interface-vlan"
+    config_set: "<state> feature interface-vlan"
 
 ipv4_addr_mask:
   # This handles both primary and secondary addresses
   multiple:
   cli_nexus:
     config_get_token_append: '/^ip address ([0-9\.]+)[\s\/](.*)/'
-    config_set_append: "%s ip address %s"
+    config_set_append: "<state> ip address <addr>"
   cli_ios_xr:
     config_get_token_append: '/^ipv4 address ([0-9\.]+) (.*)/'
-    config_set_append: '%s ipv4 address %s'
+    config_set_append: '<state> ipv4 address <addr>'
 
 ipv4_address:
   default_value: ~
@@ -86,10 +81,10 @@ ipv4_proxy_arp:
   default_value: false
   cli_nexus:
     config_get_token_append: '/^ip proxy-arp$/'
-    config_set_append: "%s ip proxy-arp"
+    config_set_append: "<state> ip proxy-arp"
   cli_ios_xr:
     config_get_token_append: '/^proxy-arp$/'
-    config_set_append: "%s proxy-arp"
+    config_set_append: "<state> proxy-arp"
 
 ipv4_redirects_loopback:
   kind: boolean
@@ -97,7 +92,7 @@ ipv4_redirects_loopback:
     default_only: false
   cli_ios_xr:
     config_get_token_append: '/^((?:no )?ipv4 redirects)$/'
-    config_set_append: "%s ipv4 redirects"
+    config_set_append: "<state> ipv4 redirects"
     default_value: false
     test_config_get_regex: [
     '/^\s+ipv4 redirects/',
@@ -111,7 +106,7 @@ ipv4_redirects_other_interfaces:
     true: true
   cli_nexus:
     config_get_token_append: '/^((?:no )?ip redirects)$/'
-    config_set_append: "%s ip redirects"
+    config_set_append: "<state> ip redirects"
     default_value: true
     test_config_get_regex: [
     '/^\s+ip redirects/',
@@ -119,7 +114,7 @@ ipv4_redirects_other_interfaces:
     ]
   cli_ios_xr:
     config_get_token_append: '/^((?:no )?ipv4 redirects)$/'
-    config_set_append: "%s ipv4 redirects"
+    config_set_append: "<state> ipv4 redirects"
     default_value: false
     test_config_get_regex: [
     '/^\s+ipv4 redirects/',
@@ -129,30 +124,25 @@ ipv4_redirects_other_interfaces:
 mtu:
   kind: int
   config_get_token_append: '/^mtu (.*)$/'
-  config_set_append: "%s mtu %s"
-  default_value: 1500
+  config_set_append: "<state> mtu <mtu>"
+  cli_nexus:
+    default_value: 1500
+  cli_ios_xr:
+    default_value: 1514
 
 negotiate_auto_ethernet:
   kind: boolean
-  cli_nexus:
-    test_config_get_regex: [
-    '/^\s+no negotiate auto/',
-    '/^\s+negotiate auto/'
-    ]
-    /(N7K|C3064)/:
-      default_only: false
-    else:
-      config_get_token_append: '/^(no )?negotiate auto$/'
-      config_set_append: "%s negotiate auto"
-      default_value: true
-  cli_ios_xr:
-    # TODO: which XR platforms *do* support this?
-    /XRV/:
-      default_only: false
-    else:
-      config_get_token_append: '^/negotiation auto$/'
-      config_set_append: "%s negotiation auto"
-      default_value: true
+  _exclude: [cli_ios_xr]
+  test_config_get_regex: [
+  '/^\s+no negotiate auto/',
+  '/^\s+negotiate auto/'
+  ]
+  /(N7K|C3064)/:
+    default_only: false
+  else:
+    config_get_token_append: '/^(no )?negotiate auto$/'
+    config_set_append: "<state> negotiate auto"
+    default_value: true
 
 negotiate_auto_other_interfaces:
   kind: boolean
@@ -169,17 +159,17 @@ negotiate_auto_portchannel:
       default_only: false
     else:
       config_get_token_append: '/^(no )?negotiate auto$/'
-      config_set_append: "%s negotiate auto"
+      config_set_append: "<state> negotiate auto"
       default_value: true
   cli_ios_xr:
-    config_get_token_append: '^/negotiation auto$/'
-    config_set_append: "%s negotiation auto"
+    config_get_token_append: '/^negotiation auto$/'
+    config_set_append: "<state> negotiation auto"
     default_value: true
 
 shutdown:
   kind: boolean
   config_get_token_append: '/^shutdown$/'
-  config_set_append: "%s shutdown"
+  config_set_append: "<state> shutdown"
 
 shutdown_ether_channel:
   default_value: false
@@ -207,96 +197,112 @@ shutdown_vlan:
     default_value: true
 
 speed:
-  config_get: "show running interface all"
-  config_get_token: ['/^interface %s$/i', '/^speed (.*)$/']
-  config_set: ["interface %s", "speed %s"]
+  _exclude: [cli_ios_xr]
+  config_get_token_append: '/^speed (.*)$/'
+  config_set_append: "speed <speed>"
   default_value: "auto"
 
 svi_autostate:
+  _exclude: [cli_ios_xr]
   kind: boolean
   config_get_token_append: '/^(?:no )?autostate$/'
-  config_set_append: "%s autostate"
+  config_set_append: "<state> autostate"
   default_value: true
-  test_config_result:
-    false: false
-    true: true
 
 svi_management:
+  _exclude: [cli_ios_xr]
   kind: boolean
   config_get_token_append: '/^management$/'
-  config_set_append: "%s management"
+  config_set_append: "<state> management"
   default_value: false
 
 switchport:
+  _exclude: [cli_ios_xr]
   kind: boolean
   config_get_token_append: '/^switchport$/'
-  config_set_append: "%s switchport"
+  config_set_append: "<state> switchport"
   # default_value: n/a. This is derived from system_default_switchport
 
 switchport_autostate_exclude:
+  _exclude: [cli_ios_xr]
   kind: boolean
   config_get_token_append: '/(^switchport autostate exclude)/'
-  config_set_append: "%s switchport autostate exclude"
+  config_set_append: "<state> switchport autostate exclude"
   default_value: false
 
 switchport_mode_dot1q_tunnel:
-  test_config_result:
-    false: RuntimeError
+  default_only: ""
 
 switchport_mode_ethernet:
-  auto_default: false
-  config_get_token_append: '/^(?:no )?switchport mode ?(.*)$/'
-  config_set_append: "%s switchport mode %s"
-  default_value: "access"
+  cli_nexus:
+    auto_default: false
+    config_get_token_append: '/^(?:no )?switchport mode ?(.*)$/'
+    config_set_append: "<state> switchport mode <mode>"
+    default_value: "access"
+  cli_ios_xr:
+    default_only: ""
 
 switchport_mode_other_interfaces:
   default_only: ""
 
 switchport_mode_port_channel:
-  config_get_token_append: '/^switchport mode (.*)$/'
-  config_set_append: "%s switchport mode %s"
-  default_value: ""
+  cli_nexus:
+    config_get_token_append: '/^switchport mode (.*)$/'
+    config_set_append: "<state> switchport mode <mode>"
+    default_value: ""
+  cli_ios_xr:
+    default_only: ""
 
 switchport_trunk_allowed_vlan:
   config_get_token_append: '/^switchport trunk allowed vlan (.*)$/'
-  config_set_append: "%s switchport trunk allowed vlan %s"
+  config_set_append: "<state> switchport trunk allowed vlan <vlan>"
   default_value: "all"
 
 switchport_trunk_native_vlan:
   kind: int
   config_get_token_append: '/^switchport trunk native vlan (.*)$/'
-  config_set_append: "%s switchport trunk native vlan %s"
+  config_set_append: "<state> switchport trunk native vlan <vlan>"
   default_value: 1
 
 system_default_svi_autostate:
   kind: boolean
-  config_get: "show running all | include 'system default'"
-  config_get_token: ['/^system default interface-vlan autostate$/']
-  # default_value: n/a. This is a user-configurable system default.
+  cli_nexus:
+    config_get: "show running all | include 'system default'"
+    config_get_token: ['/^system default interface-vlan autostate$/']
+    # default_value: n/a. This is a user-configurable system default.
+  cli_ios_xr:
+    default_only: false
 
 system_default_switchport:
   kind: boolean
-  config_get: "show running all | include 'system default'"
-  config_get_token: ['/^no system default switchport$/']
-  default_value: true
+  cli_nexus:
+    config_get: "show running all | include 'system default'"
+    config_get_token: ['/^no system default switchport$/']
+    default_value: true
+  cli_ios_xr:
+    default_only: false
 
 system_default_switchport_shutdown:
   kind: boolean
-  config_get: "show running all | include 'system default'"
-  config_get_token: ['/^system default switchport shutdown$/']
-  # default_value: n/a. This is a user-configurable system default.
+  cli_nexus:
+    config_get: "show running all | include 'system default'"
+    config_get_token: ['/^system default switchport shutdown$/']
+    # default_value: n/a. This is a user-configurable system default.
+  cli_ios_xr:
+    default_only: true
 
 vrf:
   default_value: ""
   cli_nexus:
     config_get_token_append: '/^vrf member (.*)/'
-    config_set_append: "%s vrf member %s"
+    config_set_append: "<state> vrf member <vrf>"
   cli_ios_xr:
     config_get_token_append: '/^vrf (.*)/'
-    config_set_append: "%s vrf %s"
+    config_set_append: "<state> vrf <vrf>"
 
 vtp:
+  _exclude: [cli_ios_xr]
   kind: boolean
   config_get_token_append: '/^vtp *$/'
-  config_set_append: "%s vtp"
+  config_set_append: "<state> vtp"
   default_value: false

--- a/lib/cisco_node_utils/cmd_ref/show_version.yaml
+++ b/lib/cisco_node_utils/cmd_ref/show_version.yaml
@@ -51,6 +51,7 @@ host_name:
     # not displayed in 'show version' on IOS XR
     config_get: "show running | i hostname"
     config_get_token: '/^hostname (.*)$/'
+    default_value: 'ios'
 
 last_reset_reason:
   config_get_token: "rr_reason"

--- a/lib/cisco_node_utils/cmd_ref/vtp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vtp.yaml
@@ -1,5 +1,7 @@
 # vtp
 ---
+_exclude: [cli_ios_xr]
+
 domain:
   config_get: "show vtp status"
   config_get_token: "domain_name"

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -92,6 +92,7 @@ class TestCase < Minitest::Test
                     'LoginPrompt' => /(?:[Ll]ogin|[Uu]sername)[: ]*\z/n,
                    )
     rescue Errno::ECONNRESET
+      @device.close
       # TODO
       puts 'Connection reset by peer? Try again'
       sleep 1

--- a/tests/test_interface_svi.rb
+++ b/tests/test_interface_svi.rb
@@ -19,27 +19,14 @@ include Cisco
 
 # TestSvi - Minitest for Interface configuration of SVI interfaces.
 class TestSvi < CiscoTestCase
-  def cmd_ref_autostate
-    ref = cmd_ref.lookup('interface', 'svi_autostate')
-    assert(ref, 'Error, reference not found for autostate')
-    ref
-  end
-
-  # Decides whether to check for a raised Exception or an equal value.
-  def assert_result(expected_result, err_msg, &block)
-    if expected_result.is_a? Class
-      assert_raises(expected_result, &block)
-    else
-      value = block.call
-      assert_equal(expected_result, value, err_msg)
+  def system_default_svi_autostate(state='')
+    s = config("#{state}system default interface-vlan autostate")
+    if s[/Invalid input/] # rubocop:disable Style/GuardClause
+      skip("'system default interface-vlan autostate' is not supported")
     end
   end
 
-  def system_default_svi_autostate(state='')
-    config("#{state}system default interface-vlan autostate")
-  end
-
-  def test_svi_prop_nil_when_ethernet
+  def test_prop_nil_when_ethernet
     intf = Interface.new(interfaces[0])
     assert_nil(intf.svi_autostate,
                'Error: svi_autostate should be nil when interface is ethernet')
@@ -47,97 +34,69 @@ class TestSvi < CiscoTestCase
                'Error: svi_management should be nil when interface is ethernet')
   end
 
-  def test_svi_create_valid
+  def test_create_valid
     svi = Interface.new('Vlan23')
-    s = @device.cmd('show run interface all | inc Vlan')
-    cmd = 'interface Vlan1'
-    assert(s.include?(cmd), 'Error: Failed to create svi Vlan1')
+    @default_show_command = 'show run interface all | inc Vlan'
+    assert_show_match(pattern: /interface Vlan1/,
+                      msg:     'Error: Failed to create svi Vlan1')
 
-    cmd = 'interface Vlan23'
-    assert(s.include?(cmd), 'Error: Failed to create svi Vlan23')
+    assert_show_match(pattern: /interface Vlan23/,
+                      msg:     'Error: Failed to create svi Vlan23')
+
     svi.destroy
 
     # Verify that svi23 got removed now that we invoked svi.destroy
-    s = @device.cmd('show run interface all | inc Vlan')
-    cmd = 'interface Vlan23'
-    refute(s.include?(cmd), 'Error: svi Vlan23 still configured')
+    refute_show_match(pattern: /interface Vlan23/,
+                      msg:     'Error: svi Vlan23 still configured')
   end
 
-  def test_svi_create_vlan_invalid
+  def test_create_invalid
     assert_raises(CliError) { Interface.new('10.1.1.1') }
-  end
-
-  def test_svi_create_vlan_invalid_value
-    assert_raises(CliError) { Interface.new('Vlan0') }
-  end
-
-  def test_svi_create_vlan_nil
+    assert_raises(CliError, Cisco::UnsupportedError) { Interface.new('Vlan0') }
     assert_raises(TypeError) { Interface.new(nil) }
   end
 
-  def test_svi_name
+  def test_name
     svi = Interface.new('Vlan23')
     assert_equal('vlan23', svi.name, 'Error: svi vlan name is wrong')
     svi.destroy
   end
 
-  def test_svi_assignment
+  def test_assignment
     svi = Interface.new('Vlan23')
     svi.svi_management = true
     assert(svi.svi_management, 'Error: svi svi_management, false')
-    svi_extra = svi
+    svi_extra = Interface.new('Vlan23')
     assert(svi_extra.svi_management, 'Error: new svi svi_management, false')
     svi.destroy
   end
 
-  def test_svi_get_autostate_false
+  def test_get_autostate
     svi = Interface.new('Vlan23')
 
     config('interface vlan 23', 'no autostate')
     refute(svi.svi_autostate, 'Error: svi autostate not correct.')
-    svi.destroy
-  end
-
-  def test_svi_get_autostate_true
-    svi = Interface.new('Vlan23')
 
     config('interface vlan 23', 'autostate')
     assert(svi.svi_autostate, 'Error: svi autostate not correct.')
     svi.destroy
   end
 
-  def test_svi_set_autostate_false
-    ref = cmd_ref_autostate
+  def test_set_autostate
     svi = Interface.new('Vlan23')
-    assert_result(ref.test_config_result(false),
-                  'Error: svi autostate not set to false') do
-      svi.svi_autostate = false
-    end
+    svi.svi_autostate = false
+    refute(svi.svi_autostate, 'Error: svi autostate not set to false')
+
+    svi.svi_autostate = true
+    assert(svi.svi_autostate, 'Error: svi autostate not set to true')
+
+    svi.svi_autostate = svi.default_svi_autostate
+    assert_equal(svi.default_svi_autostate, svi.svi_autostate,
+                 'Error: svi autostate not set to default')
     svi.destroy
   end
 
-  def test_svi_set_autostate_true
-    svi = Interface.new('Vlan23')
-    ref = cmd_ref_autostate
-    assert_result(ref.test_config_result(true),
-                  'Error: svi autostate not set to true') do
-      svi.svi_autostate = true
-    end
-    svi.destroy
-  end
-
-  def test_svi_set_autostate_default
-    svi = Interface.new('Vlan23')
-    ref = cmd_ref_autostate
-    default_value = ref.default_value
-    assert_result(ref.test_config_result(default_value),
-                  'Error: svi autostate not set to default') do
-      svi.svi_autostate = default_value
-    end
-    svi.destroy
-  end
-
-  def test_svi_get_management_true
+  def test_get_management
     svi = Interface.new('Vlan23')
 
     config('interface vlan 23', 'management')
@@ -146,22 +105,14 @@ class TestSvi < CiscoTestCase
     svi.destroy
   end
 
-  def test_svi_set_management_false
+  def test_set_management
     svi = Interface.new('Vlan23')
     svi.svi_management = false
     refute(svi.svi_management)
-    svi.destroy
-  end
 
-  def test_svi_set_management_true
-    svi = Interface.new('Vlan23')
     svi.svi_management = true
     assert(svi.svi_management)
-    svi.destroy
-  end
 
-  def test_svi_set_management_default
-    svi = Interface.new('Vlan23')
     svi.svi_management = true
     assert(svi.svi_management)
 
@@ -170,38 +121,31 @@ class TestSvi < CiscoTestCase
     svi.destroy
   end
 
-  def test_svi_get_svis
+  def test_get_svis
     count = 5
 
-    ref = cmd_ref_autostate
     # Have to account for interface Vlan1 why we add 1 to count
     (2..count + 1).each do |i|
       str = 'Vlan' + i.to_s
       svi = Interface.new(str)
-      assert_result(ref.test_config_result(false),
-                    'Error: svi autostate not set to false') do
-        svi.svi_autostate = false
-      end
+      svi.svi_autostate = false
+      refute(svi.svi_autostate, 'Error: svi autostate not set to false')
       svi.svi_management = true
     end
 
     svis = Interface.interfaces
-    ref = cmd_ref_autostate
-    result = ref.default_value
     svis.each do |id, svi|
       case id
       when /^vlan1$/
-        result = true if ref.config_set?
-        assert_equal(result, svi.svi_autostate,
+        assert_equal(svi.default_svi_autostate, svi.svi_autostate,
                      'Error: svis collection, Vlan1, incorrect autostate')
         refute(svi.svi_management,
                'Error: svis collection, Vlan1, incorrect management')
       when /^vlan/
-        result = false if ref.config_set?
-        assert_equal(result, svi.svi_autostate,
-                     "Error: svis collection, Vlan#{id}, incorrect autostate")
+        refute(svi.svi_autostate,
+               "Error: svis collection, #{id}, incorrect autostate")
         assert(svi.svi_management,
-               "Error: svis collection, Vlan#{id}, incorrect management")
+               "Error: svis collection, #{id}, incorrect management")
       end
     end
 
@@ -210,7 +154,7 @@ class TestSvi < CiscoTestCase
     end
   end
 
-  def test_svi_create_interface_description
+  def test_create_interface_description
     svi = Interface.new('Vlan23')
 
     description = 'Test description'
@@ -221,7 +165,7 @@ class TestSvi < CiscoTestCase
   end
 
   def test_system_default_svi_autostate_on_off
-    interface = Interface.new('Eth1/1')
+    interface = Interface.new(interfaces[0])
 
     system_default_svi_autostate('no ')
     refute(interface.system_default_svi_autostate,

--- a/tests/test_interface_switchport.rb
+++ b/tests/test_interface_switchport.rb
@@ -24,9 +24,24 @@ class TestInterfaceSwitchport < CiscoTestCase
   DEFAULT_IF_SWITCHPORT_ALLOWED_VLAN = '1-4094'
   DEFAULT_IF_SWITCHPORT_NATIVE_VLAN = 1
 
+  attr_reader :interface
+
   def setup
     super
     config('no feature vtp', 'no feature interface-vlan')
+    @interface = Interface.new(interfaces[0])
+  end
+
+  def teardown
+    interface_ethernet_default(interfaces_id[0])
+  end
+
+  def mgmt_intf
+    if platform == :nexus
+      'mgmt0'
+    elsif platform == :ios_xr
+      'MgmtEth0/RP0/CPU0/0'
+    end
   end
 
   def interface_ethernet_default(ethernet_id)
@@ -59,120 +74,96 @@ class TestInterfaceSwitchport < CiscoTestCase
   end
 
   def test_interface_get_access_vlan
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :disabled
     interface.switchport_mode = :access
     assert_equal(DEFAULT_IF_ACCESS_VLAN, interface.access_vlan)
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_interface_get_access_vlan_switchport_disabled
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :disabled
     assert_equal(DEFAULT_IF_ACCESS_VLAN, interface.access_vlan)
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_interface_get_access_vlan_switchport_trunk
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :disabled
     interface.switchport_mode = :trunk
     assert_equal(DEFAULT_IF_ACCESS_VLAN, interface.access_vlan)
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_switchport_vtp_disabled_feature_enabled
     vtp = Vtp.new(true)
-    interface = Interface.new(interfaces[0])
     refute(interface.switchport_vtp,
            'Error: interface, access, vtp not disabled')
     vtp.destroy
   end
 
   def test_switchport_vtp_disabled_feature_disabled_eth1_1
-    interface = Interface.new(interfaces[0])
     refute(interface.switchport_vtp,
            'Error: interface, access, vtp not disabled')
   end
 
-  def test_switchport_vtp_disabled_feature_disabled_mgmt0
-    interface = Interface.new('mgmt0')
+  def test_switchport_vtp_disabled_feature_disabled_mgmt_intf
+    interface = Interface.new(mgmt_intf)
     refute(interface.switchport_vtp,
            'Error: interface, access, vtp not disabled')
   end
 
   def test_switchport_vtp_disabled_unsupported_mode_disabled
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :disabled
     refute(interface.switchport_vtp,
            'Error: interface, access, vtp not disabled')
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_switchport_vtp_disabled_unsupported_mode_fex
-    begin
-      interface = Interface.new(interfaces[0])
-      interface.switchport_mode = :fex_fabric
-      refute(interface.switchport_vtp,
-             'Error: interface, access, vtp not disabled')
-    rescue RuntimeError => e
-      msg = "[#{interfaces[0]}] switchport_mode is not supported " \
-            'on this interface'
-      assert_equal(msg.downcase, e.message)
-    end
-    interface_ethernet_default(interfaces_id[0])
+    interface.switchport_mode = :fex_fabric
+    refute(interface.switchport_vtp,
+           'Error: interface, access, vtp not disabled')
+  rescue Cisco::CliError => e
+    msg = "[#{interfaces[0]}] switchport_mode is not supported " \
+          'on this interface'
+    assert_equal(msg.downcase, e.message)
   end
 
   def test_switchport_vtp_enabled_access
     vtp = Vtp.new(true)
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :access
     config("interface ethernet #{interfaces_id[0]}", 'vtp')
 
     assert(interface.switchport_vtp,
            'Error: interface, access, vtp not enabled')
     vtp.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_switchport_vtp_disabled_access
     vtp = Vtp.new(true)
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :access
     config("interface ethernet #{interfaces_id[0]}", 'no vtp')
 
     refute(interface.switchport_vtp,
            'Error: interface, access, vtp not disabled')
     vtp.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_switchport_vtp_enabled_trunk
     vtp = Vtp.new(true)
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :trunk
     config("interface ethernet #{interfaces_id[0]}", 'vtp')
 
     assert(interface.switchport_vtp,
            'Error: interface, trunk, vtp not enabled')
     vtp.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_switchport_vtp_disabled_trunk
     vtp = Vtp.new(true)
-    interface = Interface.new(interfaces[0])
-
     interface.switchport_mode = :trunk
     refute(interface.switchport_vtp,
            'Error: interface, trunk, vtp not disabled')
     vtp.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_set_switchport_vtp_default_access
     vtp = Vtp.new(true)
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :access
 
     interface.switchport_vtp = interface.default_switchport_vtp
@@ -188,13 +179,10 @@ class TestInterfaceSwitchport < CiscoTestCase
            'Error:(3) mode :access, vtp should be default (false)')
 
     vtp.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_set_switchport_vtp_default_trunk
     vtp = Vtp.new(true)
-    interface = Interface.new(interfaces[0])
-
     interface.switchport_mode = :trunk
     interface.switchport_vtp = interface.default_switchport_vtp
     refute(interface.switchport_vtp,
@@ -208,47 +196,37 @@ class TestInterfaceSwitchport < CiscoTestCase
     refute(interface.switchport_vtp,
            'Error:(3) mode :trunk, vtp should be default (false)')
     vtp.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_set_switchport_vtp_true_access
     vtp = Vtp.new(true)
-    interface = Interface.new(interfaces[0])
-
     interface.switchport_mode = :access
     interface.switchport_vtp = true
     assert(interface.switchport_vtp,
            'Error: interface, access, vtp not enabled')
     vtp.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_set_switchport_vtp_true_trunk
     vtp = Vtp.new(true)
-    interface = Interface.new(interfaces[0])
-
     interface.switchport_mode = :trunk
     interface.switchport_vtp = true
     assert(interface.switchport_vtp,
            'Error: interface, access, vtp not enabled')
     vtp.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_set_switchport_vtp_true_unsupported_mode_disabled
     vtp = Vtp.new(true)
-    interface = Interface.new(interfaces[0])
-
     interface.switchport_mode = :disabled
     refute(interface.switchport_vtp,
            'Error: interface, access, vtp is enabled')
     vtp.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
-  def test_set_switchport_vtp_true_unsupported_mgmt0
+  def test_set_switchport_vtp_true_unsupported_mgmt_intf
     vtp = Vtp.new(true)
-    interface = Interface.new('mgmt0')
+    interface = Interface.new(mgmt_intf)
 
     interface.switchport_vtp = true
     refute(interface.switchport_vtp,
@@ -258,71 +236,57 @@ class TestInterfaceSwitchport < CiscoTestCase
 
   def test_set_switchport_vtp_false_access
     vtp = Vtp.new(true)
-    interface = Interface.new(interfaces[0])
-
     interface.switchport_mode = :access
     interface.switchport_vtp = false
     refute(interface.switchport_vtp,
            'Error: interface, access, vtp not disabled')
     vtp.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_set_switchport_vtp_false_trunk
     vtp = Vtp.new(true)
-    interface = Interface.new(interfaces[0])
-
     interface.switchport_mode = :trunk
     interface.switchport_vtp = false
     refute(interface.switchport_vtp,
            'Error: interface, access, vtp not disabled')
     vtp.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_set_switchport_vtp_false_unsupported_mode_disabled
     vtp = Vtp.new(true)
-    interface = Interface.new(interfaces[0])
-
     interface.switchport_mode = :disabled
     interface.switchport_vtp = false
     refute(interface.switchport_vtp,
            'Error: mode :disabled, vtp should be false')
     vtp.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_switchport_autostate_disabled_feature_enabled
     svi = Interface.new('Vlan23')
-    interface = Interface.new(interfaces[0])
     refute(interface.switchport_autostate_exclude,
            'Error: interface, access, autostate exclude not disabled')
     svi.destroy
   end
 
   def test_switchport_autostate_disabled_feature_disabled_eth1_1
-    interface = Interface.new(interfaces[0])
     refute(interface.switchport_autostate_exclude,
            'Error: interface, access, autostate exclude not disabled')
   end
 
-  def test_switchport_autostate_disabled_feature_disabled_mgmt0
-    interface = Interface.new('mgmt0')
+  def test_switchport_autostate_disabled_feature_disabled_mgmt_intf
+    interface = Interface.new(mgmt_intf)
     refute(interface.switchport_autostate_exclude,
            'Error: interface, access, autostate exclude not disabled')
   end
 
   def test_switchport_autostate_disabled_unsupported_mode
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :disabled
     refute(interface.switchport_autostate_exclude,
            'Error: interface, access, autostate exclude not disabled')
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_switchport_autostate_enabled_access
     svi = Interface.new('Vlan23')
-    interface = Interface.new(interfaces[0])
     config("interface ethernet #{interfaces_id[0]}",
            'switchport',
            'switchport autostate exclude')
@@ -336,14 +300,11 @@ class TestInterfaceSwitchport < CiscoTestCase
                    interface.switchport_autostate_exclude,
                    'Error: interface, access, autostate exclude not disabled')
     end
-
     svi.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_switchport_autostate_disabled_access
     svi = Interface.new('Vlan23')
-    interface = Interface.new(interfaces[0])
     refute(interface.switchport_autostate_exclude,
            'Error: interface, access, autostate exclude not disabled')
     svi.destroy
@@ -351,7 +312,6 @@ class TestInterfaceSwitchport < CiscoTestCase
 
   def test_switchport_autostate_enabled_trunk
     svi = Interface.new('Vlan23')
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :trunk
     config("interface ethernet #{interfaces_id[0]}",
            'switchport autostate exclude')
@@ -365,14 +325,11 @@ class TestInterfaceSwitchport < CiscoTestCase
                    interface.switchport_autostate_exclude,
                    'Error: interface, access, autostate exclude not disabled')
     end
-
     svi.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_switchport_autostate_disabled_trunk
     svi = Interface.new('Vlan23')
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :trunk
     config("interface ethernet #{interfaces_id[0]}",
            'no switchport autostate exclude')
@@ -380,13 +337,10 @@ class TestInterfaceSwitchport < CiscoTestCase
     refute(interface.switchport_autostate_exclude,
            'Error: interface, access, autostate exclude not disabled')
     svi.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_raise_error_switchport_not_enabled
-    interface = Interface.new(interfaces[0])
-
-    config("interface #{interfaces[0]}", 'no switchport')
+    interface.switchport_enable(false)
 
     assert_raises(RuntimeError) do
       interface.switchport_autostate_exclude = true
@@ -395,10 +349,8 @@ class TestInterfaceSwitchport < CiscoTestCase
 
   def test_set_switchport_autostate_default_access
     svi = Interface.new('Vlan23')
-    interface = Interface.new(interfaces[0])
-
     # switchport must be enabled to configure autostate
-    config("interface #{interfaces[0]}", 'switchport')
+    interface.switchport_enable(true)
 
     result = interface.default_switchport_autostate_exclude
     assert_result(result,
@@ -406,16 +358,14 @@ class TestInterfaceSwitchport < CiscoTestCase
       interface.switchport_autostate_exclude = result
     end
     svi.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_set_switchport_autostate_default_trunk
     svi = Interface.new('Vlan23')
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :trunk
 
     # switchport must be enabled to configure autostate
-    config("interface #{interfaces[0]}", 'switchport')
+    interface.switchport_enable(true)
 
     result = false
     assert_result(result,
@@ -423,15 +373,12 @@ class TestInterfaceSwitchport < CiscoTestCase
       interface.switchport_autostate_exclude = result
     end
     svi.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_set_switchport_autostate_true_access
     svi = Interface.new('Vlan23')
-    interface = Interface.new(interfaces[0])
-
     # switchport must be enabled to configure autostate
-    config("interface #{interfaces[0]}", 'switchport')
+    interface.switchport_enable(true)
 
     result = true
     assert_result(result,
@@ -439,16 +386,14 @@ class TestInterfaceSwitchport < CiscoTestCase
       interface.switchport_autostate_exclude = result
     end
     svi.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_set_switchport_autostate_true_trunk
     svi = Interface.new('Vlan23')
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :trunk
 
     # switchport must be enabled to configure autostate
-    config("interface #{interfaces[0]}", 'switchport')
+    interface.switchport_enable(true)
 
     result = true
     assert_result(result,
@@ -456,24 +401,21 @@ class TestInterfaceSwitchport < CiscoTestCase
       interface.switchport_autostate_exclude = result
     end
     svi.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_set_switchport_autostate_true_unsupported_mode_disabled
     svi = Interface.new('Vlan23')
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :disabled
 
     assert_raises RuntimeError do
       interface.switchport_autostate_exclude = true
     end
     svi.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
-  def test_set_switchport_autostate_true_unsupported_mgmt0
+  def test_set_switchport_autostate_true_unsupported_mgmt_intf
     svi = Interface.new('Vlan23')
-    interface = Interface.new('mgmt0')
+    interface = Interface.new(mgmt_intf)
     assert_raises RuntimeError do
       interface.switchport_autostate_exclude = true
     end
@@ -482,10 +424,8 @@ class TestInterfaceSwitchport < CiscoTestCase
 
   def test_set_switchport_autostate_false_access
     svi = Interface.new('Vlan23')
-    interface = Interface.new(interfaces[0])
-
     # switchport must be enabled to configure autostate
-    config("interface #{interfaces[0]}", 'switchport')
+    interface.switchport_enable(true)
 
     result = false
     assert_result(result,
@@ -493,16 +433,14 @@ class TestInterfaceSwitchport < CiscoTestCase
       interface.switchport_autostate_exclude = result
     end
     svi.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_set_switchport_autostate_false_trunk
     svi = Interface.new('Vlan23')
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :trunk
 
     # switchport must be enabled to configure autostate
-    config("interface #{interfaces[0]}", 'switchport')
+    interface.switchport_enable(true)
 
     result = false
     assert_result(result,
@@ -510,35 +448,26 @@ class TestInterfaceSwitchport < CiscoTestCase
       interface.switchport_autostate_exclude = result
     end
     svi.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_set_switchport_autostate_false_unsupported_mode_disabled
     svi = Interface.new('Vlan23')
-    interface = Interface.new(interfaces[0])
     interface.switchport_mode = :disabled
 
     assert_raises RuntimeError do
       interface.switchport_autostate_exclude = false
     end
     svi.destroy
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_interface_switchport_mode_invalid
-    interface = Interface.new(interfaces[0])
     assert_raises(ArgumentError) { interface.switchport_mode = :unknown }
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_interface_switchport_mode_not_supported
-    interface = Interface.new('mgmt0')
-    assert_raises(RuntimeError) { interface.switchport_mode = :access }
-    begin
+    interface = Interface.new(mgmt_intf)
+    assert_raises(Cisco::CliError, Cisco::UnsupportedError) do
       interface.switchport_mode = :access
-    rescue RuntimeError => e
-      msg = '[mgmt0] switchport_mode is not supported on this interface'
-      assert_equal(msg, e.message)
     end
   end
 
@@ -552,8 +481,6 @@ class TestInterfaceSwitchport < CiscoTestCase
       :tunnel,
     ]
 
-    interface = Interface.new(interfaces[0])
-
     switchport_modes.each do |start|
       switchport_modes.each do |finish|
         next if start == :unknown || finish == :unknown
@@ -566,14 +493,11 @@ class TestInterfaceSwitchport < CiscoTestCase
           interface.switchport_mode = finish
           assert_equal(finish, interface.switchport_mode,
                        "Error: Switchport mode, #{finish}, not as expected")
-        rescue RuntimeError => e
-          msg = "[#{interfaces[0]}] switchport_mode is not supported " \
-                'on this interface'
-          assert_equal(msg.downcase, e.message)
+        rescue Cisco::CliError
+          next
         end
       end
     end
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_interface_switchport_mode_valid_fex
@@ -582,7 +506,6 @@ class TestInterfaceSwitchport < CiscoTestCase
       :fex_fabric,
     ]
 
-    interface = Interface.new(interfaces[0])
     switchport_modes.each do |start|
       switchport_modes.each do |finish|
         next if start == :unknown || finish == :unknown
@@ -594,108 +517,87 @@ class TestInterfaceSwitchport < CiscoTestCase
           interface.switchport_mode = finish
           assert_equal(finish, interface.switchport_mode,
                        "Error: Switchport mode, #{finish}, not as expected")
-        rescue RuntimeError => e
+        rescue Cisco::CliError => e
           msg = "[#{interfaces[0]}] switchport_mode is not supported " \
                 'on this interface'
           assert_equal(msg.downcase, e.message)
         end
       end
     end
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_interface_switchport_trunk_allowed_vlan_all
-    interface = Interface.new(interfaces[0])
     interface.switchport_enable
     interface.switchport_trunk_allowed_vlan = 'all'
     assert_equal(
       DEFAULT_IF_SWITCHPORT_ALLOWED_VLAN,
       interface.switchport_trunk_allowed_vlan)
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_interface_switchport_trunk_allowed_vlan_change
-    interface = Interface.new(interfaces[0])
     interface.switchport_enable
     interface.switchport_trunk_allowed_vlan = '20'
     assert_equal('20', interface.switchport_trunk_allowed_vlan)
     interface.switchport_trunk_allowed_vlan = '30'
     assert_equal('30', interface.switchport_trunk_allowed_vlan)
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_interface_switchport_trunk_allowed_vlan_default
-    interface = Interface.new(interfaces[0])
     interface.switchport_enable
     interface.switchport_trunk_allowed_vlan =
       interface.default_switchport_trunk_allowed_vlan
     assert_equal(
       DEFAULT_IF_SWITCHPORT_ALLOWED_VLAN,
       interface.switchport_trunk_allowed_vlan)
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_interface_switchport_trunk_allowed_vlan_invalid
-    interface = Interface.new(interfaces[0])
     interface.switchport_enable
     assert_raises(RuntimeError) do
       interface.switchport_trunk_allowed_vlan = 'hello'
     end
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_interface_switchport_trunk_allowed_vlan_none
-    interface = Interface.new(interfaces[0])
     interface.switchport_enable
     interface.switchport_trunk_allowed_vlan = 'none'
     assert_equal('none', interface.switchport_trunk_allowed_vlan)
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_interface_switchport_trunk_allowed_vlan_valid
-    interface = Interface.new(interfaces[0])
     interface.switchport_enable
     interface.switchport_trunk_allowed_vlan = '20, 30'
     assert_equal('20,30', interface.switchport_trunk_allowed_vlan)
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_interface_switchport_trunk_native_vlan_change
-    interface = Interface.new(interfaces[0])
     interface.switchport_enable
     interface.switchport_trunk_native_vlan = 20
     assert_equal(20, interface.switchport_trunk_native_vlan)
     interface.switchport_trunk_native_vlan = 30
     assert_equal(30, interface.switchport_trunk_native_vlan)
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_interface_switchport_trunk_native_vlan_default
-    interface = Interface.new(interfaces[0])
     interface.switchport_enable
     interface.switchport_trunk_native_vlan =
       interface.default_switchport_trunk_native_vlan
     assert_equal(
       DEFAULT_IF_SWITCHPORT_NATIVE_VLAN,
       interface.switchport_trunk_native_vlan)
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_interface_switchport_trunk_native_vlan_invalid
-    interface = Interface.new(interfaces[0])
     interface.switchport_enable
     assert_raises(RuntimeError) do
       interface.switchport_trunk_native_vlan = '20, 30'
     end
-    interface_ethernet_default(interfaces_id[0])
   end
 
   def test_interface_switchport_trunk_native_vlan_valid
-    interface = Interface.new(interfaces[0])
     interface.switchport_enable
     interface.switchport_trunk_native_vlan = 20
     assert_equal(20, interface.switchport_trunk_native_vlan)
-    interface_ethernet_default(interfaces_id[0])
   end
 
   # TODO: Run this test at your peril as it can cause timeouts for this test and
@@ -739,14 +641,14 @@ class TestInterfaceSwitchport < CiscoTestCase
   #   end
 
   def test_system_default_switchport_on_off
-    interface = Interface.new('Eth1/1')
+    if platform == :nexus
+      system_default_switchport('')
+      assert(interface.system_default_switchport,
+             'Test for enabled - failed')
 
-    system_default_switchport('')
-    assert(interface.system_default_switchport,
-           'Test for enabled - failed')
-
-    # common default is "no switch"
-    system_default_switchport('no ')
+      # common default is "no switch"
+      system_default_switchport('no ')
+    end
     refute(interface.system_default_switchport,
            'Test for disabled - failed')
   rescue RuntimeError => e
@@ -756,22 +658,20 @@ class TestInterfaceSwitchport < CiscoTestCase
   end
 
   def test_system_default_switchport_shutdown_on_off
-    interface = Interface.new('Eth1/1')
+    if platform == :nexus
+      system_default_switchport_shutdown('no ')
+      refute(interface.system_default_switchport_shutdown,
+             'Test for disabled - failed')
 
-    system_default_switchport_shutdown('no ')
-    refute(interface.system_default_switchport_shutdown,
-           'Test for disabled - failed')
-
-    # common default is "shutdown"
-    system_default_switchport_shutdown('')
+      # common default is "shutdown"
+      system_default_switchport_shutdown('')
+    end
     assert(interface.system_default_switchport_shutdown,
            'Test for enabled - failed')
   end
 
   def test_interface_svi_command_on_non_vlan
-    interface = Interface.new(interfaces[0])
     assert_raises(RuntimeError) { interface.svi_autostate = true }
     assert_raises(RuntimeError) { interface.svi_management = true }
-    interface_ethernet_default(interfaces_id[0])
   end
 end


### PR DESCRIPTION
# Tests passing on XR

TestInterface#test_interface_create_does_not_exist
TestInterface#test_interface_create_name_invalid
TestInterface#test_interface_create_name_nil
TestInterface#test_interface_create_valid
TestInterface#test_interface_description_nil
TestInterface#test_interface_description_valid
TestInterface#test_interface_description_zero_length
TestInterface#test_interface_encapsulation_dot1q_invalid
TestInterface#test_interface_ipv4_addr_mask_set_address_invalid
TestInterface#test_interface_ipv4_addr_mask_set_netmask_invalid
TestInterface#test_interface_ipv4_address
TestInterface#test_interface_ipv4_address_getter_with_preconfig
TestInterface#test_interface_ipv4_address_getter_with_preconfig_secondary
TestInterface#test_interface_ipv4_all_interfaces
TestInterface#test_interface_ipv4_proxy_arp
TestInterface#test_interface_ipv4_redirects
TestInterface#test_interface_mtu_change
TestInterface#test_interface_mtu_invalid
TestInterface#test_interface_mtu_valid
TestInterface#test_interface_shutdown_valid
TestInterface#test_interface_vrf_default
TestInterface#test_interface_vrf_empty
TestInterface#test_interface_vrf_exceeds_max_length
TestInterface#test_interface_vrf_invalid_type
TestInterface#test_interface_vrf_override
TestInterface#test_interface_vrf_valid
TestInterface#test_interfaces_not_empty
TestInterface#test_negotiate_auto_loopback
TestInterfaceSwitchport#test_interface_switchport_mode_invalid
TestInterfaceSwitchport#test_interface_switchport_mode_not_supported
TestInterfaceSwitchport#test_interface_svi_command_on_non_vlan
TestInterfaceSwitchport#test_switchport_vtp_disabled_feature_disabled_mgmt_intf
TestInterfaceSwitchport#test_switchport_vtp_disabled_feature_disabled_eth1_1
TestInterfaceSwitchport#test_system_default_switchport_shutdown_on_off
TestSvi#test_create_invalid
TestSvi#test_prop_nil_when_ethernet
# Tests Skipped on XR
## No bundle-ether support yet

TestInterface#test_negotiate_auto_portchannel
## XR doesn't limit interface description length

TestInterface#test_interface_description_too_long
## duplex is unsupported

TestInterface#test_interface_duplex_change
TestInterface#test_interface_duplex_invalid
TestInterface#test_interface_duplex_valid
## encapsulation dot1q is unsupported

TestInterface#test_interface_encapsulation_dot1q_change
TestInterface#test_interface_encapsulation_dot1q_valid
## negotiation is unsupported

TestInterface#test_negotiate_auto_ethernet
## speed is unsupported

TestInterface#test_interface_speed_change
TestInterface#test_interface_speed_invalid
TestInterface#test_interface_speed_valid
## switchport is unsupported

TestInterfaceSwitchport#test_interface_get_access_vlan
TestInterfaceSwitchport#test_interface_get_access_vlan_switchport_disabled
TestInterfaceSwitchport#test_interface_get_access_vlan_switchport_trunk
TestInterfaceSwitchport#test_interface_switchport_mode_valid
TestInterfaceSwitchport#test_interface_switchport_mode_valid_fex
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_all
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_change
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_default
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_invalid
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_none
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_valid
TestInterfaceSwitchport#test_interface_switchport_trunk_native_vlan_change
TestInterfaceSwitchport#test_interface_switchport_trunk_native_vlan_default
TestInterfaceSwitchport#test_interface_switchport_trunk_native_vlan_invalid
TestInterfaceSwitchport#test_interface_switchport_trunk_native_vlan_valid
TestInterfaceSwitchport#test_raise_error_switchport_not_enabled
TestInterfaceSwitchport#test_switchport_autostate_disabled_unsupported_mode
TestInterfaceSwitchport#test_switchport_vtp_disabled_unsupported_mode_disabled
TestInterfaceSwitchport#test_switchport_vtp_disabled_unsupported_mode_fex
## switchport_autostate_exclude is unsupported

TestInterfaceSwitchport#test_switchport_autostate_disabled_feature_disabled_eth1_1
TestInterfaceSwitchport#test_switchport_autostate_disabled_feature_disabled_mgmt_intf
## vtp is unsupported

TestInterfaceSwitchport#test_set_switchport_vtp_default_access
TestInterfaceSwitchport#test_set_switchport_vtp_default_trunk
TestInterfaceSwitchport#test_set_switchport_vtp_false_access
TestInterfaceSwitchport#test_set_switchport_vtp_false_trunk
TestInterfaceSwitchport#test_set_switchport_vtp_false_unsupported_mode_disabled
TestInterfaceSwitchport#test_set_switchport_vtp_true_access
TestInterfaceSwitchport#test_set_switchport_vtp_true_trunk
TestInterfaceSwitchport#test_set_switchport_vtp_true_unsupported_mgmt_intf
TestInterfaceSwitchport#test_set_switchport_vtp_true_unsupported_mode_disabled
TestInterfaceSwitchport#test_switchport_vtp_disabled_access
TestInterfaceSwitchport#test_switchport_vtp_disabled_feature_enabled
TestInterfaceSwitchport#test_switchport_vtp_disabled_trunk
TestInterfaceSwitchport#test_switchport_vtp_enabled_access
TestInterfaceSwitchport#test_switchport_vtp_enabled_trunk
## feature_vlan is unsupported

TestInterfaceSwitchport#test_set_switchport_autostate_default_access
TestInterfaceSwitchport#test_set_switchport_autostate_default_trunk
TestInterfaceSwitchport#test_set_switchport_autostate_false_access
TestInterfaceSwitchport#test_set_switchport_autostate_false_trunk
TestInterfaceSwitchport#test_set_switchport_autostate_false_unsupported_mode_disabled
TestInterfaceSwitchport#test_set_switchport_autostate_true_access
TestInterfaceSwitchport#test_set_switchport_autostate_true_unsupported_mgmt_intf
TestInterfaceSwitchport#test_set_switchport_autostate_true_unsupported_mode_disabled
TestInterfaceSwitchport#test_set_switchport_autostate_true_trunk
TestInterfaceSwitchport#test_switchport_autostate_disabled_access
TestInterfaceSwitchport#test_switchport_autostate_disabled_feature_enabled
TestInterfaceSwitchport#test_switchport_autostate_disabled_trunk
TestInterfaceSwitchport#test_switchport_autostate_enabled_access
TestInterfaceSwitchport#test_switchport_autostate_enabled_trunk
TestSvi#test_assignment
TestSvi#test_create_valid
TestSvi#test_create_interface_description
TestSvi#test_get_autostate
TestSvi#test_get_management
TestSvi#test_get_svis
TestSvi#test_name
TestSvi#test_set_autostate
TestSvi#test_set_management
## system default interface-vlan autostate is not supported

TestSvi#test_system_default_svi_autostate_on_off
