### PR TITLE
speed_change_disallowed missed one error message

### DIFF
--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -78,7 +78,8 @@ class TestInterface < CiscoTestCase
   # Helper to check for misc speed change disallowed error messages.
   def speed_change_disallowed(message)
     pattern = Regexp.new('(port doesn t support this speed|' \
-                         'Changing interface speed is not permitted)')
+                         'Changing interface speed is not permitted|' \
+                         'requested config change not allowed)')
     skip('Skip test: Interface type does not allow config change') if
          message[pattern]
     flunk(message)

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -714,7 +714,9 @@ class TestInterface < CiscoTestCase
     begin
       interface.negotiate_auto = false
     rescue RuntimeError => e
-      speed_change_disallowed(e.message)
+      skip('Skip test: Interface type does not allow config change') if
+        e.message[/requested config change not allowed/]
+      flunk(e.message)
     end
 
     default = ref.default_value


### PR DESCRIPTION
Follow-up fix for:   https://github.com/cisco/cisco-network-node-utils/pull/74

speed_change_disallowed doesn't match the /requested config change not allowed/ pattern, which breaks test_negotiate_auto_ethernet.

n9k: 42 runs, 108 assertions, 0 failures, 0 errors, 2 skips
n31k: 42 runs, 338 assertions, 0 failures, 0 errors, 5 skips
n30k: 42 runs, 317 assertions, 0 failures, 0 errors, 1 skips

1 file inspected, no offenses detected
