### PR TITLE
replace tacacs group with modified compatible version from AAA

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/tacacs_server_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/tacacs_server_group.yaml
@@ -1,5 +1,11 @@
 # tacacs_server_group
 ---
+deadtime:
+  config_get: "show run tacacs all"
+  config_get_token: ['/^aaa group server tacacs\+ %s/', '/^deadtime (\d+)/']
+  config_set: ["aaa group server tacacs <name>", "<state> deadtime <deadtime>"]
+  default_value: 0
+
 group:
   multiple: true
   config_get: "show running-config tacacs all"
@@ -10,6 +16,18 @@ group:
 servers:
   multiple: true
   config_get: "show running-config tacacs all"
-  config_get_token: ['/^aaa group server tacacs\+ %s $/i', '/server ((?:[0-9]{1,3}\.){3}[0-9]{1,3})/']
-  config_set: ['aaa group server tacacs <group>', '<state> server <ip>']
+  config_get_token: ['/^aaa group server tacacs\+ %s/i', '/^server (\S+)/']
+  config_set: ['aaa group server tacacs <name>', '<state> server <server>']
   default_value: []
+
+source_interface:
+  config_get: "show run tacacs all"
+  config_get_token: ['/^aaa group server tacacs\+ %s/', '/^source-interface (\S+)/']
+  config_set: ["aaa group server tacacs <name>", "<state> source-interface <interface>"]
+  default_value: ""
+
+vrf:
+  config_get: "show run tacacs all"
+  config_get_token: ['/^aaa group server tacacs\+ %s/', '/^use-vrf (\S+)/']
+  config_set: ["aaa group server tacacs <name>", "<state> use-vrf <vrf>"]
+  default_value: "default"

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -83,7 +83,8 @@ module Cisco
         return massage(show(ref.config_get, :structured), ref)
       elsif token[0].kind_of?(Regexp)
         return massage(find_ascii(show(ref.config_get, :ascii),
-                                  token[-1], *token[0..-2]), ref)
+                                  token[-1],
+                                  *token[0..-2]), ref)
       else
         return massage(
           config_get_handle_structured(token,

--- a/lib/cisco_node_utils/tacacs_server_group.rb
+++ b/lib/cisco_node_utils/tacacs_server_group.rb
@@ -32,16 +32,15 @@ module Cisco
       return unless create
 
       TacacsServer.new.enable unless TacacsServer.enabled
-      config_set('aaa_server_group', 'tacacs_group', '', name)
+      config_set('tacacs_server_group', 'group', state: '', name: name)
     end
 
     def destroy
-      config_set('aaa_server_group', 'tacacs_group', 'no', @name)
+      config_set('tacacs_server_group', 'group', state: 'no', name: @name)
     end
 
     def servers
-      tacservers = config_get('aaa_server_group',
-                              'tacacs_servers', @name)
+      tacservers = config_get('tacacs_server_group', 'servers', @name)
       servs = {}
       unless tacservers.nil?
         tacservers.each { |s| servs[s] = TacacsServerHost.new(s, false) }
@@ -56,17 +55,17 @@ module Cisco
       new_servs.each do |s|
         # add any servers not yet configured
         next if current_servs.include? s
-        config_set('aaa_server_group', 'tacacs_server', @name, '', s)
+        config_set('tacacs_server_group', 'servers', name: @name, state: '', server: s)
       end
       current_servs.each do |s|
         # remove any undesired existing servers
         next if new_servs.include? s
-        config_set('aaa_server_group', 'tacacs_server', @name, 'no', s)
+        config_set('tacacs_server_group', 'servers', name: @name, state: 'no', server: s)
       end
     end
 
     def default_servers
-      config_get_default('aaa_server_group', 'servers')
+      config_get_default('tacacs_server_group', 'servers')
     end
 
     def ==(other)
@@ -80,7 +79,7 @@ module Cisco
 
     def self.groups
       grps = {}
-      tacgroups = config_get('aaa_server_group', 'tacacs_groups') if
+      tacgroups = config_get('tacacs_server_group', 'group') if
         TacacsServer.enabled
       unless tacgroups.nil?
         tacgroups.each { |s| grps[s] = TacacsServerGroup.new(s, false) }
@@ -90,49 +89,47 @@ module Cisco
 
     def vrf
       # vrf is always present in running config
-      v = config_get('aaa_server_group', 'tacacs_vrf', @name)
-      v.nil? ? default_vrf : v.first
+      v = config_get('tacacs_server_group', 'vrf', @name)
+      v.nil? ? default_vrf : v
     end
 
     def vrf=(v)
       fail TypeError unless v.is_a? String
       # vrf = "default" is equivalent to unconfiguring vrf
-      config_set('aaa_server_group', 'tacacs_vrf', @name, '', v)
+      config_set('tacacs_server_group', 'vrf', name: @name, state: '', vrf: v)
     end
 
     def default_vrf
-      config_get_default('aaa_server_group', 'vrf')
+      config_get_default('tacacs_server_group', 'vrf')
     end
 
     def deadtime
-      d = config_get('aaa_server_group', 'tacacs_deadtime', @name)
-      d.nil? ? default_deadtime : d.first.to_i
+      d = config_get('tacacs_server_group', 'deadtime', @name)
+      d.nil? ? default_deadtime : d.to_i
     end
 
     def deadtime=(t)
       no_cmd = t == default_deadtime ? 'no' : ''
-      config_set('aaa_server_group', 'tacacs_deadtime', @name, no_cmd, t)
+      config_set('tacacs_server_group', 'deadtime', name: @name, state: no_cmd, deadtime: t)
     end
 
     def default_deadtime
-      config_get_default('aaa_server_group', 'deadtime')
+      config_get_default('tacacs_server_group', 'deadtime')
     end
 
     def source_interface
-      i = config_get('aaa_server_group',
-                     'tacacs_source_interface', @name)
-      i.nil? ? default_source_interface : i.first
+      i = config_get('tacacs_server_group', 'source_interface', @name)
+      i.nil? ? default_source_interface : i
     end
 
     def source_interface=(s)
       fail TypeError unless s.is_a? String
       no_cmd = s == default_source_interface ? 'no' : ''
-      config_set('aaa_server_group', 'tacacs_source_interface',
-                 @name, no_cmd, s)
+      config_set('tacacs_server_group', 'source_interface', name: @name, state: no_cmd, interface: s)
     end
 
     def default_source_interface
-      config_get_default('aaa_server_group', 'source_interface')
+      config_get_default('tacacs_server_group', 'source_interface')
     end
   end
 end

--- a/lib/cisco_node_utils/tacacs_server_group.rb
+++ b/lib/cisco_node_utils/tacacs_server_group.rb
@@ -1,15 +1,16 @@
-# Tacacs Server Group provider class
-
-# Jonathan Tripathy et al., October 2015
-
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
-
+#
+# NXAPI implementation of TacacsServerGroup class
+#
+# April 2015, Alex Hunsberger
+#
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,91 +18,121 @@
 # limitations under the License.
 
 require_relative 'node_util'
+require_relative 'tacacs_server'
 
 module Cisco
-  # TacacsServerGroup - node utility class for
-  # Raidus Server configuration management
+  # NXAPI implementation of AAA Server Group class
   class TacacsServerGroup < NodeUtil
     attr_reader :name
 
-    def initialize(name, instantiate=true)
-      unless name.is_a?(String)
-        fail ArgumentError, 'Invalid value (Name is not a String)'
-      end
-
+    def initialize(name, create=true)
+      fail TypeError unless name.is_a? String
       @name = name
 
-      create if instantiate
-    end
+      return unless create
 
-    def self.tacacs_server_groups
-      hash = {}
-      group_list = config_get('tacacs_server_group', 'group')
-      return hash if group_list.nil?
-
-      group_list.each do |id|
-        hash[id] = TacacsServerGroup.new(id, false)
-      end
-
-      hash
-    end
-
-    def create
-      config_set('tacacs_server_group',
-                 'group',
-                 state: '',
-                 name:  @name)
+      TacacsServer.new.enable unless TacacsServer.enabled
+      config_set('aaa_server_group', 'tacacs_group', '', name)
     end
 
     def destroy
-      config_set('tacacs_server_group',
-                 'group',
-                 state: 'no',
-                 name:  @name)
+      config_set('aaa_server_group', 'tacacs_group', 'no', @name)
+    end
+
+    def servers
+      tacservers = config_get('aaa_server_group',
+                              'tacacs_servers', @name)
+      servs = {}
+      unless tacservers.nil?
+        tacservers.each { |s| servs[s] = TacacsServerHost.new(s, false) }
+      end
+      servs
+    end
+
+    def servers=(new_servs)
+      fail TypeError unless new_servs.is_a? Array
+      # just need the names of the current servers for comparison
+      current_servs = servers.keys
+      new_servs.each do |s|
+        # add any servers not yet configured
+        next if current_servs.include? s
+        config_set('aaa_server_group', 'tacacs_server', @name, '', s)
+      end
+      current_servs.each do |s|
+        # remove any undesired existing servers
+        next if new_servs.include? s
+        config_set('aaa_server_group', 'tacacs_server', @name, 'no', s)
+      end
+    end
+
+    def default_servers
+      config_get_default('aaa_server_group', 'servers')
     end
 
     def ==(other)
       name == other.name
     end
 
-    def default_servers
-      config_get_default('tacacs_server_group', 'servers')
+    # for netdev compatibility
+    def self.tacacs_server_groups
+      groups
     end
 
-    def servers
-      val = config_get('tacacs_server_group', 'servers', @name)
-      val = default_servers if val.nil?
-      val
-    end
-
-    def servers=(val)
-      fail ArgumentError, 'Servers must be an array of valid IP addresses' \
-        unless val.is_a?(Array)
-
-      current = servers
-
-      # Remove IPs that are no longer required
-      current.each do |old_ip|
-        next if val.include?(old_ip)
-        config_set('tacacs_server_group',
-                   'servers',
-                   group: @name,
-                   state: 'no',
-                   ip:    old_ip)
+    def self.groups
+      grps = {}
+      tacgroups = config_get('aaa_server_group', 'tacacs_groups') if
+        TacacsServer.enabled
+      unless tacgroups.nil?
+        tacgroups.each { |s| grps[s] = TacacsServerGroup.new(s, false) }
       end
-
-      # Add new IPs that aren't already on the device
-      val.each do |new_ip|
-        fail ArgumentError, 'Servers must be an array of valid IP addresses' \
-          unless new_ip[/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/]
-
-        next unless current.nil? || !current.include?(new_ip)
-        config_set('tacacs_server_group',
-                   'servers',
-                   group: @name,
-                   state: '',
-                   ip:    new_ip)
-      end
+      grps
     end
-  end # class
-end # module
+
+    def vrf
+      # vrf is always present in running config
+      v = config_get('aaa_server_group', 'tacacs_vrf', @name)
+      v.nil? ? default_vrf : v.first
+    end
+
+    def vrf=(v)
+      fail TypeError unless v.is_a? String
+      # vrf = "default" is equivalent to unconfiguring vrf
+      config_set('aaa_server_group', 'tacacs_vrf', @name, '', v)
+    end
+
+    def default_vrf
+      config_get_default('aaa_server_group', 'vrf')
+    end
+
+    def deadtime
+      d = config_get('aaa_server_group', 'tacacs_deadtime', @name)
+      d.nil? ? default_deadtime : d.first.to_i
+    end
+
+    def deadtime=(t)
+      no_cmd = t == default_deadtime ? 'no' : ''
+      config_set('aaa_server_group', 'tacacs_deadtime', @name, no_cmd, t)
+    end
+
+    def default_deadtime
+      config_get_default('aaa_server_group', 'deadtime')
+    end
+
+    def source_interface
+      i = config_get('aaa_server_group',
+                     'tacacs_source_interface', @name)
+      i.nil? ? default_source_interface : i.first
+    end
+
+    def source_interface=(s)
+      fail TypeError unless s.is_a? String
+      no_cmd = s == default_source_interface ? 'no' : ''
+      config_set('aaa_server_group', 'tacacs_source_interface',
+                 @name, no_cmd, s)
+    end
+
+    def default_source_interface
+      config_get_default('aaa_server_group', 'source_interface')
+    end
+  end
+end

--- a/lib/cisco_node_utils/tacacs_server_group.rb
+++ b/lib/cisco_node_utils/tacacs_server_group.rb
@@ -55,12 +55,20 @@ module Cisco
       new_servs.each do |s|
         # add any servers not yet configured
         next if current_servs.include? s
-        config_set('tacacs_server_group', 'servers', name: @name, state: '', server: s)
+        config_set('tacacs_server_group',
+                   'servers',
+                   name:   @name,
+                   state:  '',
+                   server: s)
       end
       current_servs.each do |s|
         # remove any undesired existing servers
         next if new_servs.include? s
-        config_set('tacacs_server_group', 'servers', name: @name, state: 'no', server: s)
+        config_set('tacacs_server_group',
+                   'servers',
+                   name:   @name,
+                   state:  'no',
+                   server: s)
       end
     end
 
@@ -110,7 +118,11 @@ module Cisco
 
     def deadtime=(t)
       no_cmd = t == default_deadtime ? 'no' : ''
-      config_set('tacacs_server_group', 'deadtime', name: @name, state: no_cmd, deadtime: t)
+      config_set('tacacs_server_group',
+                 'deadtime',
+                 name:     @name,
+                 state:    no_cmd,
+                 deadtime: t)
     end
 
     def default_deadtime
@@ -125,7 +137,11 @@ module Cisco
     def source_interface=(s)
       fail TypeError unless s.is_a? String
       no_cmd = s == default_source_interface ? 'no' : ''
-      config_set('tacacs_server_group', 'source_interface', name: @name, state: no_cmd, interface: s)
+      config_set('tacacs_server_group',
+                 'source_interface',
+                 name:      @name,
+                 state:     no_cmd,
+                 interface: s)
     end
 
     def default_source_interface

--- a/tests/test_tacacs_server_group.rb
+++ b/tests/test_tacacs_server_group.rb
@@ -16,10 +16,6 @@ require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/tacacs_server_group'
 require_relative '../lib/cisco_node_utils/tacacs_server_host'
 
-DEFAULT_AAA_SERVER_GROUP_VRF = 'default'
-DEFAULT_AAA_SERVER_GROUP_DEADTIME = 0
-DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE = ''
-
 # Test class for Tacacs Server Group
 class TestTacacsServerGroup < CiscoTestCase
   def clean_tacacs_config
@@ -70,7 +66,7 @@ class TestTacacsServerGroup < CiscoTestCase
     group_name = 'Group1'
     aaa_group = TacacsServerGroup.new(group_name)
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /Group1/)
+                      pattern: /#{group_name}/)
 
     detach_aaaservergroup(aaa_group)
   end
@@ -82,9 +78,9 @@ class TestTacacsServerGroup < CiscoTestCase
     aaa_group2 = TacacsServerGroup.new(group_name2)
 
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /Group1/)
+                      pattern: /#{group_name1}/)
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /Group2/)
+                      pattern: /#{group_name2}/)
 
     detach_aaaservergroup(aaa_group1)
     detach_aaaservergroup(aaa_group2)
@@ -97,7 +93,7 @@ class TestTacacsServerGroup < CiscoTestCase
                  'Error: TacacsServerGroup collection is not empty')
   end
 
-  def test_collection_single_tacacs
+  def test_collection_multi_tacacs
     clean_tacacs_config
     group_name1 = 'Group1'
     group_name2 = 'Group2'
@@ -105,7 +101,6 @@ class TestTacacsServerGroup < CiscoTestCase
     aaa_group1 = TacacsServerGroup.new(group_name1)
 
     groups = TacacsServerGroup.groups
-    refute_empty(groups, 'Error: TacacsServerGroup collection is not filled')
     assert_equal(1, groups.size,
                  'Error: TacacsServerGroup collection reporting incorrect size')
     assert(groups.key?(group_name1),
@@ -125,33 +120,6 @@ class TestTacacsServerGroup < CiscoTestCase
 
     destroy_aaa_group(group_name2, 'tacacs+')
     destroy_aaa_group(group_name3, 'tacacs+')
-  end
-
-  def test_collection_multi_tacacs
-    clean_tacacs_config
-    group_name1 = 'Group1'
-    group_name2 = 'Group2'
-    group_name3 = 'Group3'
-    aaa_group1 = TacacsServerGroup.new(group_name1)
-
-    aaa_group2 = TacacsServerGroup.new(group_name2)
-
-    aaa_group3 = TacacsServerGroup.new(group_name3)
-
-    groups = TacacsServerGroup.groups
-    refute_empty(groups, 'Error: TacacsServerGroup collection is not filled')
-    assert_equal(3, groups.size,
-                 'Error: TacacsServerGroup collection reporting incorrect size')
-    assert(groups.key?(group_name1),
-           "Error: TacacsServerGroup collection does contain #{group_name1}")
-    assert(groups.key?(group_name2),
-           "Error: TacacsServerGroup collection does contain #{group_name2}")
-    assert(groups.key?(group_name3),
-           "Error: TacacsServerGroup collection does contain #{group_name3}")
-
-    detach_aaaservergroup(aaa_group1)
-    detach_aaaservergroup(aaa_group2)
-    detach_aaaservergroup(aaa_group3)
   end
 
   def test_servers_tacacs
@@ -193,36 +161,9 @@ class TestTacacsServerGroup < CiscoTestCase
     aaa_group.servers = [server_name1, server_name2]
 
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server1/)
+                      pattern: /server #{server_name1}/)
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server2/)
-
-    detach_aaaservergroup(aaa_group)
-    detach_tacacsserverhost(server1)
-    detach_tacacsserverhost(server2)
-  end
-
-  def test_add_server_twice_tacacs
-    clean_tacacs_config
-    server_name1 = 'server1'
-    server_name2 = 'server2'
-    server1 = create_tacacsserverhost(server_name1)
-    server2 = create_tacacsserverhost(server_name2)
-
-    aaa_group = TacacsServerGroup.new('Group1')
-    # aaa_group.servers = [server_name1, server_name2, server_name2]
-    # this behavior is different on n9k vs n3k, so comment out for now
-    # n3k throws a CLIError and n9k silently ignores
-    aaa_group.servers = [server_name1, server_name2]
-
-    servers = aaa_group.servers
-    assert_equal(2, servers.size,
-                 'Error: Collection is not two servers')
-
-    assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server1/)
-    assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server2/)
+                      pattern: /server #{server_name2}/)
 
     detach_aaaservergroup(aaa_group)
     detach_tacacsserverhost(server1)
@@ -247,11 +188,11 @@ class TestTacacsServerGroup < CiscoTestCase
     # Now remove them and then check again
     aaa_group.servers = [server_name2]
     refute_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server1/)
+                      pattern: /server #{server_name1}/)
 
     aaa_group.servers = []
     refute_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server2/)
+                      pattern: /server #{server_name2}/)
 
     detach_aaaservergroup(aaa_group)
     detach_tacacsserverhost(server1)
@@ -273,15 +214,15 @@ class TestTacacsServerGroup < CiscoTestCase
     assert_equal(2, servers.size,
                  'Error: Collection is not two servers')
 
-    # Now remove them and then check again
+    # Remove server 1
     aaa_group.servers = [server_name2]
     refute_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server1/)
+                      pattern: /server #{server_name1}/)
 
-    # Now remove server 1 again
+    # Now remove server 2
     aaa_group.servers = []
     refute_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server2/)
+                      pattern: /server #{server_name2}/)
 
     # Check collection size
     servers = aaa_group.servers
@@ -296,7 +237,7 @@ class TestTacacsServerGroup < CiscoTestCase
     group_name1 = 'Group1'
     aaa_group = TacacsServerGroup.new(group_name1)
 
-    vrf = DEFAULT_AAA_SERVER_GROUP_VRF
+    vrf = cmd_ref.lookup('tacacs_server_group', 'vrf').default_value
     assert_equal(vrf, aaa_group.vrf,
                  'Error: TacacsServerGroup, vrf not default')
 
@@ -305,7 +246,7 @@ class TestTacacsServerGroup < CiscoTestCase
     assert_equal(vrf, aaa_group.vrf,
                  'Error: TacacsServerGroup, vrf not configured')
 
-    vrf = DEFAULT_AAA_SERVER_GROUP_VRF
+    vrf = cmd_ref.lookup('tacacs_server_group', 'vrf').default_value
     aaa_group.vrf = vrf
     assert_equal(vrf, aaa_group.vrf,
                  'Error: TacacsServerGroup, vrf not restored to default')
@@ -315,7 +256,7 @@ class TestTacacsServerGroup < CiscoTestCase
 
   def test_get_default_vrf_tacacs
     aaa_group = TacacsServerGroup.new('Group1')
-    assert_equal(DEFAULT_AAA_SERVER_GROUP_VRF,
+    assert_equal(cmd_ref.lookup('tacacs_server_group', 'vrf').default_value,
                  aaa_group.default_vrf,
                  'Error: TacacsServerGroup, default vrf incorrect')
     detach_aaaservergroup(aaa_group)
@@ -326,12 +267,11 @@ class TestTacacsServerGroup < CiscoTestCase
     aaa_group = TacacsServerGroup.new('Group1')
     aaa_group.vrf = vrf
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /use-vrf management-123/)
+                      pattern: /use-vrf #{vrf}/)
 
     # Invalid case
-    vrf = 2450
     assert_raises(TypeError) do
-      aaa_group.vrf = vrf
+      aaa_group.vrf = 2450
     end
     detach_aaaservergroup(aaa_group)
   end
@@ -340,7 +280,7 @@ class TestTacacsServerGroup < CiscoTestCase
     group_name = 'Group1'
     aaa_group = TacacsServerGroup.new(group_name)
 
-    deadtime = DEFAULT_AAA_SERVER_GROUP_DEADTIME
+    deadtime = cmd_ref.lookup('tacacs_server_group', 'deadtime').default_value
     assert_equal(deadtime, aaa_group.deadtime,
                  'Error: TacacsServerGroup, deadtime not default')
 
@@ -349,7 +289,7 @@ class TestTacacsServerGroup < CiscoTestCase
     assert_equal(deadtime, aaa_group.deadtime,
                  'Error: TacacsServerGroup, deadtime not configured')
 
-    deadtime = DEFAULT_AAA_SERVER_GROUP_DEADTIME
+    deadtime = cmd_ref.lookup('tacacs_server_group', 'deadtime').default_value
     aaa_group.deadtime = deadtime
     assert_equal(deadtime, aaa_group.deadtime,
                  'Error: TacacsServerGroup, deadtime not restored to default')
@@ -359,9 +299,10 @@ class TestTacacsServerGroup < CiscoTestCase
 
   def test_get_default_deadtime_tacacs
     aaa_group = TacacsServerGroup.new('Group1')
-    assert_equal(DEFAULT_AAA_SERVER_GROUP_DEADTIME,
-                 aaa_group.default_deadtime,
-                 'Error: TacacsServerGroup, default deadtime incorrect')
+    assert_equal(
+      cmd_ref.lookup('tacacs_server_group', 'deadtime').default_value,
+      aaa_group.default_deadtime,
+      'Error: TacacsServerGroup, default deadtime incorrect')
     detach_aaaservergroup(aaa_group)
   end
 
@@ -370,7 +311,7 @@ class TestTacacsServerGroup < CiscoTestCase
     aaa_group = TacacsServerGroup.new('Group1')
     aaa_group.deadtime = deadtime
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /deadtime 1250/,
+                      pattern: /deadtime #{deadtime}/,
                       msg:     'Error: deadtime not configured')
     # Invalid case
     deadtime = 2450
@@ -383,7 +324,8 @@ class TestTacacsServerGroup < CiscoTestCase
   def test_get_source_interface_tacacs
     group_name = 'Group1'
     aaa_group = TacacsServerGroup.new(group_name)
-    intf = DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE
+    intf =
+      cmd_ref.lookup('tacacs_server_group', 'source_interface').default_value
     assert_equal(intf, aaa_group.source_interface,
                  'Error: TacacsServerGroup, source-interface set')
 
@@ -402,14 +344,16 @@ class TestTacacsServerGroup < CiscoTestCase
 
   def test_get_default_source_interface_tacacs
     aaa_group = TacacsServerGroup.new('Group1')
-    assert_equal(DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE,
-                 aaa_group.default_source_interface,
-                 'Error: Aaa_Group Server, default source-interface incorrect')
+    assert_equal(
+      cmd_ref.lookup('tacacs_server_group', 'source_interface').default_value,
+      aaa_group.default_source_interface,
+      'Error: Aaa_Group Server, default source-interface incorrect')
     detach_aaaservergroup(aaa_group)
   end
 
   def test_set_source_interface_tacacs
-    intf = DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE
+    intf =
+      cmd_ref.lookup('tacacs_server_group', 'source_interface').default_value
     aaa_group = TacacsServerGroup.new('Group1')
     assert_equal(intf, aaa_group.source_interface,
                  'Error: Aaa_Group Server, source-interface not default')
@@ -419,7 +363,8 @@ class TestTacacsServerGroup < CiscoTestCase
                       pattern: /source-interface loopback1/,
                       msg:     'Error: source-interface not correct')
 
-    aaa_group.source_interface = DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE
+    aaa_group.source_interface =
+      cmd_ref.lookup('tacacs_server_group', 'source_interface').default_value
     refute_show_match(command: 'show run tacacs+ all | no-more',
                       pattern: /source-interface loopback1/)
 
@@ -455,6 +400,6 @@ class TestTacacsServerGroup < CiscoTestCase
 
     detach_aaaservergroup(aaa_group)
     refute_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /Group1/)
+                      pattern: /#{group_name}/)
   end
 end

--- a/tests/test_tacacs_server_group.rb
+++ b/tests/test_tacacs_server_group.rb
@@ -193,9 +193,9 @@ class TestTacacsServerGroup < CiscoTestCase
     aaa_group.servers = [server_name1, server_name2]
 
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server1/)
+                      pattern: /server server1/)
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server2/)
+                      pattern: /server server2/)
 
     detach_aaaservergroup(aaa_group)
     detach_tacacsserverhost(server1)

--- a/tests/test_tacacs_server_group.rb
+++ b/tests/test_tacacs_server_group.rb
@@ -1,6 +1,3 @@
-#
-# Minitest for TacacsServerGroup class
-#
 # Copyright (c) 2014-2015 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,98 +14,447 @@
 
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/tacacs_server_group'
+require_relative '../lib/cisco_node_utils/tacacs_server_host'
 
-# TestTacacsServerGroup - Minitest for TacacsServerGroup node utility.
+DEFAULT_AAA_SERVER_GROUP_VRF = 'default'
+DEFAULT_AAA_SERVER_GROUP_DEADTIME = 0
+DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE = ''
+
+# Test class for Tacacs Server Group
 class TestTacacsServerGroup < CiscoTestCase
-  def setup
-    # setup runs at the beginning of each test
-    super
-    config('no feature tacacs+', 'feature tacacs+',
-           'tacacs-server host 8.8.8.8',
-           'tacacs-server host 9.9.9.9',
-           'tacacs-server host 10.10.10.10',
-           'tacacs-server host 11.11.11.11',
-           'tacacs-server host 12.12.12.12',
-           'tacacs-server host 13.13.13.13')
-    no_tacacsserver
+  def clean_tacacs_config
+    config('no feature tacacs',
+           'feature tacacs')
   end
 
-  def teardown
-    # teardown runs at the end of each test
-    config('no feature tacacs+')
-    no_tacacsserver
-    super
+  def create_tacacsserverhost(name='defaulttest')
+    TacacsServerHost.new(name)
   end
 
-  def no_tacacsserver
-    # Turn the feature off for a clean test.
-    config('no aaa group server tacacs+ red',
-           'no aaa group server tacacs+ blue')
+  def detach_tacacsserverhost(host)
+    host.destroy
   end
 
-  # TESTS
-
-  def test_create_destroy_single
-    id = 'red'
-    refute_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id)
-
-    group = Cisco::TacacsServerGroup.new(id, true)
-    assert_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id)
-    assert_equal(Cisco::TacacsServerGroup.tacacs_server_groups[id], group)
-
-    group.servers = ['8.8.8.8', '9.9.9.9']
-    assert_equal(['8.8.8.8', '9.9.9.9'],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id].servers)
-
-    group.servers = ['8.8.8.8', '10.10.10.10']
-    assert_equal(['8.8.8.8', '10.10.10.10'],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id].servers)
-
-    group.servers = []
-    assert_equal([],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id].servers)
-
-    group.destroy
-    refute_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id)
+  def detach_aaaservergroup(aaa_server_group)
+    aaa_server_group.destroy
   end
 
-  def test_create_destroy_multiple
-    id = 'red'
-    id2 = 'blue'
-    refute_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id)
-    refute_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id2)
+  def create_aaa_group(group_name, server)
+    config("aaa group server #{server} #{group_name}")
+  end
 
-    group = Cisco::TacacsServerGroup.new(id, true)
-    group2 = Cisco::TacacsServerGroup.new(id2, true)
-    assert_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id)
-    assert_equal(Cisco::TacacsServerGroup.tacacs_server_groups[id], group)
-    assert_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id2)
-    assert_equal(Cisco::TacacsServerGroup.tacacs_server_groups[id2], group2)
+  def destroy_aaa_group(group_name, server)
+    config("no aaa group server #{server} #{group_name}")
+  end
 
-    group.servers = ['8.8.8.8', '9.9.9.9']
-    assert_equal(['8.8.8.8', '9.9.9.9'],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id].servers)
-    group2.servers = ['11.11.11.11', '12.12.12.12']
-    assert_equal(['11.11.11.11', '12.12.12.12'],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id2].servers)
+  def create_vrf(group_name, server, vrf_name)
+    config("aaa group server #{server} #{group_name} ; use-vrf #{vrf_name}")
+  end
 
-    group.servers = ['8.8.8.8', '10.10.10.10']
-    assert_equal(['8.8.8.8', '10.10.10.10'],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id].servers)
-    group2.servers = ['11.11.11.11', '13.13.13.13']
-    assert_equal(['11.11.11.11', '13.13.13.13'],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id2].servers)
+  def create_deadtime(group_name, server, deadtime)
+    config("aaa group server #{server} #{group_name} ; deadtime #{deadtime}")
+  end
 
-    group.servers = []
-    assert_equal([],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id].servers)
-    group2.servers = []
-    assert_equal([],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id2].servers)
+  def create_source_interface(group_name, server, interface)
+    config("aaa group server #{server} #{group_name} ; " \
+           "source-interface #{interface}")
+  end
 
-    group.destroy
-    group2.destroy
-    refute_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id)
-    refute_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id2)
+  def test_create_invalid_name_tacacs
+    assert_raises(TypeError) do
+      TacacsServerGroup.new(nil)
+    end
+  end
+
+  def test_create_valid_tacacs
+    group_name = 'Group1'
+    aaa_group = TacacsServerGroup.new(group_name)
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /Group1/)
+
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_create_valid_multiple_tacacs
+    group_name1 = 'Group1'
+    group_name2 = 'Group2'
+    aaa_group1 = TacacsServerGroup.new(group_name1)
+    aaa_group2 = TacacsServerGroup.new(group_name2)
+
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /Group1/)
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /Group2/)
+
+    detach_aaaservergroup(aaa_group1)
+    detach_aaaservergroup(aaa_group2)
+  end
+
+  def test_collection_empty_tacacs
+    clean_tacacs_config
+    aaa_group_list = TacacsServerGroup.groups
+    assert_empty(aaa_group_list,
+                 'Error: TacacsServerGroup collection is not empty')
+  end
+
+  def test_collection_single_tacacs
+    clean_tacacs_config
+    group_name1 = 'Group1'
+    group_name2 = 'Group2'
+    group_name3 = 'Group3'
+    aaa_group1 = TacacsServerGroup.new(group_name1)
+
+    groups = TacacsServerGroup.groups
+    refute_empty(groups, 'Error: TacacsServerGroup collection is not filled')
+    assert_equal(1, groups.size,
+                 'Error: TacacsServerGroup collection reporting incorrect size')
+    assert(groups.key?(group_name1),
+           "Error: TacacsServerGroup collection does contain #{group_name1}")
+    detach_aaaservergroup(aaa_group1)
+
+    create_aaa_group(group_name2, 'tacacs+')
+    create_aaa_group(group_name3, 'tacacs+')
+    groups = TacacsServerGroup.groups
+    refute_empty(groups, 'Error: TacacsServerGroup collection is not filled')
+    assert_equal(2, groups.size,
+                 'Error: TacacsServerGroup collection reporting incorrect size')
+    assert(groups.key?(group_name2),
+           "Error: TacacsServerGroup collection does contain #{group_name2}")
+    assert(groups.key?(group_name3),
+           "Error: TacacsServerGroup collection does contain #{group_name3}")
+
+    destroy_aaa_group(group_name2, 'tacacs+')
+    destroy_aaa_group(group_name3, 'tacacs+')
+  end
+
+  def test_collection_multi_tacacs
+    clean_tacacs_config
+    group_name1 = 'Group1'
+    group_name2 = 'Group2'
+    group_name3 = 'Group3'
+    aaa_group1 = TacacsServerGroup.new(group_name1)
+
+    aaa_group2 = TacacsServerGroup.new(group_name2)
+
+    aaa_group3 = TacacsServerGroup.new(group_name3)
+
+    groups = TacacsServerGroup.groups
+    refute_empty(groups, 'Error: TacacsServerGroup collection is not filled')
+    assert_equal(3, groups.size,
+                 'Error: TacacsServerGroup collection reporting incorrect size')
+    assert(groups.key?(group_name1),
+           "Error: TacacsServerGroup collection does contain #{group_name1}")
+    assert(groups.key?(group_name2),
+           "Error: TacacsServerGroup collection does contain #{group_name2}")
+    assert(groups.key?(group_name3),
+           "Error: TacacsServerGroup collection does contain #{group_name3}")
+
+    detach_aaaservergroup(aaa_group1)
+    detach_aaaservergroup(aaa_group2)
+    detach_aaaservergroup(aaa_group3)
+  end
+
+  def test_servers_tacacs
+    clean_tacacs_config
+    server_name1 = 'server1'
+    server_name2 = 'server2'
+    server1 = create_tacacsserverhost(server_name1)
+    server2 = create_tacacsserverhost(server_name2)
+
+    aaa_group = TacacsServerGroup.new('Group1')
+
+    # pre check that default servers are empty
+    default_server = aaa_group.default_servers
+    assert_empty(default_server, 'Error: Default Servers are not empty')
+
+    aaa_group.servers = [server_name1, server_name2]
+
+    # Check collection size
+    servers = aaa_group.servers.keys
+    assert_equal(2, servers.size,
+                 'Error: Collection is not two servers')
+    assert(servers.include?('server1'),
+           "Error: Collection does not contain #{server_name1}")
+    assert(servers.include?('server2'),
+           "Error: Collection does not contain #{server_name2}")
+
+    detach_aaaservergroup(aaa_group)
+    detach_tacacsserverhost(server1)
+    detach_tacacsserverhost(server2)
+  end
+
+  def test_add_server_tacacs
+    server_name1 = 'server1'
+    server_name2 = 'server2'
+    server1 = create_tacacsserverhost(server_name1)
+    server2 = create_tacacsserverhost(server_name2)
+
+    aaa_group = TacacsServerGroup.new('Group1')
+    aaa_group.servers = [server_name1, server_name2]
+
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server1/)
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server2/)
+
+    detach_aaaservergroup(aaa_group)
+    detach_tacacsserverhost(server1)
+    detach_tacacsserverhost(server2)
+  end
+
+  def test_add_server_twice_tacacs
+    clean_tacacs_config
+    server_name1 = 'server1'
+    server_name2 = 'server2'
+    server1 = create_tacacsserverhost(server_name1)
+    server2 = create_tacacsserverhost(server_name2)
+
+    aaa_group = TacacsServerGroup.new('Group1')
+    # aaa_group.servers = [server_name1, server_name2, server_name2]
+    # this behavior is different on n9k vs n3k, so comment out for now
+    # n3k throws a CLIError and n9k silently ignores
+    aaa_group.servers = [server_name1, server_name2]
+
+    servers = aaa_group.servers
+    assert_equal(2, servers.size,
+                 'Error: Collection is not two servers')
+
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server server1/)
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server server2/)
+
+    detach_aaaservergroup(aaa_group)
+    detach_tacacsserverhost(server1)
+    detach_tacacsserverhost(server2)
+  end
+
+  def test_remove_server_tacacs
+    clean_tacacs_config
+    server_name1 = 'server1'
+    server_name2 = 'server2'
+    server1 = create_tacacsserverhost(server_name1)
+    server2 = create_tacacsserverhost(server_name2)
+
+    aaa_group = TacacsServerGroup.new('Group1')
+    aaa_group.servers = [server_name1, server_name2]
+
+    # Check collection size
+    servers = aaa_group.servers
+    assert_equal(2, servers.size,
+                 'Error: Collection is not two servers')
+
+    # Now remove them and then check again
+    aaa_group.servers = [server_name2]
+    refute_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server server1/)
+
+    aaa_group.servers = []
+    refute_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server server2/)
+
+    detach_aaaservergroup(aaa_group)
+    detach_tacacsserverhost(server1)
+    detach_tacacsserverhost(server2)
+  end
+
+  def test_remove_server_twice_tacacs
+    clean_tacacs_config
+    server_name1 = 'server1'
+    server_name2 = 'server2'
+    server1 = create_tacacsserverhost(server_name1)
+    server2 = create_tacacsserverhost(server_name2)
+
+    aaa_group = TacacsServerGroup.new('Group1')
+    aaa_group.servers = [server_name1, server_name2]
+
+    # Check collection size
+    servers = aaa_group.servers
+    assert_equal(2, servers.size,
+                 'Error: Collection is not two servers')
+
+    # Now remove them and then check again
+    aaa_group.servers = [server_name2]
+    refute_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server server1/)
+
+    # Now remove server 1 again
+    aaa_group.servers = []
+    refute_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server server2/)
+
+    # Check collection size
+    servers = aaa_group.servers
+    assert_empty(servers, 'Error: Collection not empty')
+
+    detach_aaaservergroup(aaa_group)
+    detach_tacacsserverhost(server1)
+    detach_tacacsserverhost(server2)
+  end
+
+  def test_get_vrf_tacacs
+    group_name1 = 'Group1'
+    aaa_group = TacacsServerGroup.new(group_name1)
+
+    vrf = DEFAULT_AAA_SERVER_GROUP_VRF
+    assert_equal(vrf, aaa_group.vrf,
+                 'Error: TacacsServerGroup, vrf not default')
+
+    vrf = 'TESTME'
+    create_vrf(group_name1, 'tacacs+', vrf)
+    assert_equal(vrf, aaa_group.vrf,
+                 'Error: TacacsServerGroup, vrf not configured')
+
+    vrf = DEFAULT_AAA_SERVER_GROUP_VRF
+    aaa_group.vrf = vrf
+    assert_equal(vrf, aaa_group.vrf,
+                 'Error: TacacsServerGroup, vrf not restored to default')
+
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_get_default_vrf_tacacs
+    aaa_group = TacacsServerGroup.new('Group1')
+    assert_equal(DEFAULT_AAA_SERVER_GROUP_VRF,
+                 aaa_group.default_vrf,
+                 'Error: TacacsServerGroup, default vrf incorrect')
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_set_vrf_tacacs
+    vrf = 'management-123'
+    aaa_group = TacacsServerGroup.new('Group1')
+    aaa_group.vrf = vrf
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /use-vrf management-123/)
+
+    # Invalid case
+    vrf = 2450
+    assert_raises(TypeError) do
+      aaa_group.vrf = vrf
+    end
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_get_deadtime_tacacs
+    group_name = 'Group1'
+    aaa_group = TacacsServerGroup.new(group_name)
+
+    deadtime = DEFAULT_AAA_SERVER_GROUP_DEADTIME
+    assert_equal(deadtime, aaa_group.deadtime,
+                 'Error: TacacsServerGroup, deadtime not default')
+
+    deadtime = 850
+    create_deadtime(group_name, 'tacacs+', deadtime)
+    assert_equal(deadtime, aaa_group.deadtime,
+                 'Error: TacacsServerGroup, deadtime not configured')
+
+    deadtime = DEFAULT_AAA_SERVER_GROUP_DEADTIME
+    aaa_group.deadtime = deadtime
+    assert_equal(deadtime, aaa_group.deadtime,
+                 'Error: TacacsServerGroup, deadtime not restored to default')
+
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_get_default_deadtime_tacacs
+    aaa_group = TacacsServerGroup.new('Group1')
+    assert_equal(DEFAULT_AAA_SERVER_GROUP_DEADTIME,
+                 aaa_group.default_deadtime,
+                 'Error: TacacsServerGroup, default deadtime incorrect')
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_set_deadtime_tacacs
+    deadtime = 1250
+    aaa_group = TacacsServerGroup.new('Group1')
+    aaa_group.deadtime = deadtime
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /deadtime 1250/,
+                      msg:     'Error: deadtime not configured')
+    # Invalid case
+    deadtime = 2450
+    assert_raises(CliError) do
+      aaa_group.deadtime = deadtime
+    end
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_get_source_interface_tacacs
+    group_name = 'Group1'
+    aaa_group = TacacsServerGroup.new(group_name)
+    intf = DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE
+    assert_equal(intf, aaa_group.source_interface,
+                 'Error: TacacsServerGroup, source-interface set')
+
+    intf = 'Ethernet1/1'
+    create_source_interface(group_name, 'tacacs+', intf)
+    assert_equal(intf, aaa_group.source_interface,
+                 'Error: TacacsServerGroup, source-interface not correct')
+
+    intf = 'Ethernet1/32'
+    create_source_interface(group_name, 'tacacs+', intf)
+    assert_equal(intf, aaa_group.source_interface,
+                 'Error: TacacsServerGroup, source-interface not correct')
+
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_get_default_source_interface_tacacs
+    aaa_group = TacacsServerGroup.new('Group1')
+    assert_equal(DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE,
+                 aaa_group.default_source_interface,
+                 'Error: Aaa_Group Server, default source-interface incorrect')
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_set_source_interface_tacacs
+    intf = DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE
+    aaa_group = TacacsServerGroup.new('Group1')
+    assert_equal(intf, aaa_group.source_interface,
+                 'Error: Aaa_Group Server, source-interface not default')
+
+    aaa_group.source_interface = 'loopback1'
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /source-interface loopback1/,
+                      msg:     'Error: source-interface not correct')
+
+    aaa_group.source_interface = DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE
+    refute_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /source-interface loopback1/)
+
+    # Invalid case
+    state = true
+    assert_raises(TypeError) do
+      aaa_group.source_interface = state
+    end
+
+    detach_aaaservergroup(aaa_group)
+  end
+
+  # tacacs_server_groups method is the same as groups, added for netdev
+  # compatibility, make sure output is the same
+  def test_groups_methods_equality
+    aaagroup1 = TacacsServerGroup.new('test1')
+    aaagroup2 = TacacsServerGroup.new('test2')
+    aaagroup3 = TacacsServerGroup.new('test3')
+
+    groups1 = TacacsServerGroup.groups.sort
+    groups2 = TacacsServerGroup.tacacs_server_groups.sort
+
+    assert_equal(groups1, groups2)
+
+    detach_aaaservergroup(aaagroup1)
+    detach_aaaservergroup(aaagroup2)
+    detach_aaaservergroup(aaagroup3)
+  end
+
+  def test_destroy_tacacs
+    group_name = 'Group1'
+    aaa_group = TacacsServerGroup.new(group_name)
+
+    detach_aaaservergroup(aaa_group)
+    refute_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /Group1/)
   end
 end


### PR DESCRIPTION
Pulling these changes off of develop instead of AAA now, since these changes can't wait for AAA to collapse. This replaces the tacacs group node utils class and test compatible with both Cisco and NetDev puppet providers. The diffs show as file changes, but it's just 2 file replacements.
