### PR TITLE
Default_value is now nil for unsupported nodes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/README_YAML.md
+++ b/lib/cisco_node_utils/cmd_ref/README_YAML.md
@@ -238,7 +238,7 @@ attribute:
   config_set: 'attribute'
 ```
 
-When a feature or attribute is excluded in this way, attempting to call `config_get`, `config_set`, or `config_get_default` on an excluded node will result in a `Cisco::UnsupportedError` being raised.
+When a feature or attribute is excluded in this way, attempting to call `config_get` or `config_set` on an excluded node will result in a `Cisco::UnsupportedError` being raised. Calling `config_get_default` on such a node will always return `nil`.
 
 ### Combinations of these
 

--- a/tests/test_command_reference.rb
+++ b/tests/test_command_reference.rb
@@ -151,6 +151,7 @@ name:
   test_config_result:
     false: RuntimeError
     32: "Long VLAN name knob is not enabled"
+    nil: ~
 ))
     reference = load_file
     ref = reference.lookup('test', 'name')
@@ -163,6 +164,7 @@ name:
     assert_raises(IndexError) { ref.test_config_get }
     type_check(ref.test_config_result(false), RuntimeError.class)
     type_check(ref.test_config_result(32), String)
+    type_check(ref.test_config_result('nil'), NilClass)
 
     assert(ref.default_value?)
     assert(ref.config_get?)
@@ -177,7 +179,7 @@ name:
   cli_nexus:
     default_value: 'NXAPI base'
     /N7K/:
-      default_value: 'NXAPI N7K'
+      default_value: ~
     /N9K/:
       default_value: 'NXAPI N9K'
 ")
@@ -198,7 +200,7 @@ name:
   def test_load_n7k
     write_variants
     reference = load_file(platform: :nexus, product: 'N7K-C7010', cli: true)
-    assert_equal('NXAPI N7K', reference.lookup('test', 'name').default_value)
+    assert_equal(nil, reference.lookup('test', 'name').default_value)
   end
 
   def test_load_n3k_3064
@@ -227,14 +229,17 @@ rank:
     reference = load_file(product: 'N9K-C9396PX')
 
     ref = reference.lookup('test', 'name')
-    refute(ref.default_value?)
-    assert_raises(Cisco::UnsupportedError) { ref.default_value }
+    # default_value is nil for an unsupported property
+    assert(ref.default_value?, 'default_value? returned false')
+    assert_nil(ref.default_value)
     refute(ref.config_get?)
     assert_raises(Cisco::UnsupportedError) { ref.config_get }
 
+    # Because the whole file is excluded, we don't know which
+    # attributes are 'valid' - so any attribute name is permitted:
     ref = reference.lookup('test', 'foobar')
-    refute(ref.default_value?)
-    assert_raises(Cisco::UnsupportedError) { ref.default_value }
+    assert(ref.default_value?)
+    assert_nil(ref.default_value)
     refute(ref.config_get?)
     assert_raises(Cisco::UnsupportedError) { ref.config_get }
   end
@@ -245,8 +250,8 @@ rank:
     assert_equal(27, reference.lookup('test', 'rank').default_value)
 
     ref = reference.lookup('test', 'name')
-    refute(ref.default_value?)
-    assert_raises(Cisco::UnsupportedError) { ref.default_value }
+    assert(ref.default_value?)
+    assert_nil(ref.default_value)
     refute(ref.config_get?)
     assert_raises(Cisco::UnsupportedError) { ref.config_get }
   end
@@ -266,8 +271,8 @@ name:
 ")
     reference = load_file(platform: 'nexus', cli: false)
     ref = reference.lookup('test', 'name')
-    refute(ref.default_value?)
-    assert_raises(Cisco::UnsupportedError) { ref.default_value }
+    assert(ref.default_value?)
+    assert_nil(ref.default_value)
   end
 
   def test_default_only


### PR DESCRIPTION
As discussed by email, this changes the behavior for excluded attributes such that unsupported attributes are equivalent to an explicitly specified `default_only: ~` - they now return `nil` for `config_get_default` and `config_get`, but still raise `Cisco::UnsupportedError` on `config_set`.

``` bash
ruby tests/test_command_reference.rb 
Run options: --seed 6709

# Running:

........................

Finished in 0.872312s, 27.5131 runs/s, 88.2712 assertions/s.

24 runs, 77 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /home/glmatthe/cisco-network-node-utils/coverage. 256 / 266 LOC (96.24%) covered.
```
