### PR TITLE
Minor change to flatten confed peers

### DIFF
--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -351,6 +351,7 @@ module Cisco
     def confederation_peers=(should)
       # confederation peers are additive. So create a delta hash of entries
       # and only apply the changes
+      should = should.flatten
       is = confederation_peers
 
       delta_hash = Utils.delta_add_remove(should, is)


### PR DESCRIPTION
While working on the provider and type for confederation_peers, discovered a nested array of peers was breaking the setter. Small fix to flatten the array.
