### PR TITLE
Feature/vxlan vtep

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/README_YAML.md
+++ b/lib/cisco_node_utils/cmd_ref/README_YAML.md
@@ -238,7 +238,7 @@ attribute:
   config_set: 'attribute'
 ```
 
-When a feature or attribute is excluded in this way, attempting to call `config_get`, `config_set`, or `config_get_default` on an excluded node will result in a `Cisco::UnsupportedError` being raised.
+When a feature or attribute is excluded in this way, attempting to call `config_get` or `config_set` on an excluded node will result in a `Cisco::UnsupportedError` being raised. Calling `config_get_default` on such a node will always return `nil`.
 
 ### Combinations of these
 

--- a/lib/cisco_node_utils/cmd_ref/limit_resource.yaml
+++ b/lib/cisco_node_utils/cmd_ref/limit_resource.yaml
@@ -1,0 +1,10 @@
+# limit_resource
+---
+vdc:
+  _exclude: [/N3K/, /N9K/]
+  config_get: "show vdc current-vdc"
+  config_get_token: '/^Current vdc is.*\-\s+(\S+)/'
+
+vxlan:
+  _exclude: [/N3K/, /N9K/]
+  config_set: ["terminal dont-ask", "vdc %s", "limit-resource module-type f3", "end"]

--- a/lib/cisco_node_utils/cmd_ref/limit_resource.yaml
+++ b/lib/cisco_node_utils/cmd_ref/limit_resource.yaml
@@ -7,4 +7,4 @@ vdc:
 
 vxlan:
   _exclude: [/N3K/, /N9K/]
-  config_set: ["terminal dont-ask", "vdc %s", "limit-resource module-type f3", "end"]
+  config_set: ["terminal dont-ask", "vdc %s", "limit-resource module-type f3"]

--- a/lib/cisco_node_utils/cmd_ref/tacacs_server_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/tacacs_server_group.yaml
@@ -1,5 +1,11 @@
 # tacacs_server_group
 ---
+deadtime:
+  config_get: "show run tacacs all"
+  config_get_token: ['/^aaa group server tacacs\+ %s/', '/^deadtime (\d+)/']
+  config_set: ["aaa group server tacacs <name>", "<state> deadtime <deadtime>"]
+  default_value: 0
+
 group:
   multiple: true
   config_get: "show running-config tacacs all"
@@ -10,6 +16,18 @@ group:
 servers:
   multiple: true
   config_get: "show running-config tacacs all"
-  config_get_token: ['/^aaa group server tacacs\+ %s $/i', '/server ((?:[0-9]{1,3}\.){3}[0-9]{1,3})/']
-  config_set: ['aaa group server tacacs <group>', '<state> server <ip>']
+  config_get_token: ['/^aaa group server tacacs\+ %s/i', '/^server (\S+)/']
+  config_set: ['aaa group server tacacs <name>', '<state> server <server>']
   default_value: []
+
+source_interface:
+  config_get: "show run tacacs all"
+  config_get_token: ['/^aaa group server tacacs\+ %s/', '/^source-interface (\S+)/']
+  config_set: ["aaa group server tacacs <name>", "<state> source-interface <interface>"]
+  default_value: ""
+
+vrf:
+  config_get: "show run tacacs all"
+  config_get_token: ['/^aaa group server tacacs\+ %s/', '/^use-vrf (\S+)/']
+  config_set: ["aaa group server tacacs <name>", "<state> use-vrf <vrf>"]
+  default_value: "default"

--- a/lib/cisco_node_utils/cmd_ref/vxlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan.yaml
@@ -1,6 +1,7 @@
 # vxlan
 ---
 feature:
-  config_get: 'show feature'
-  config_get_token: '/^nve\s+\d+\s+(\S+)/'
-  config_set: "%s feature nv overlay"
+  kind: boolean
+  config_get: 'show running nv overlay'
+  config_get_token: '/^feature nv overlay$/'
+  config_set: "<state> feature nv overlay"

--- a/lib/cisco_node_utils/cmd_ref/vxlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan.yaml
@@ -1,0 +1,6 @@
+# vxlan
+---
+feature:
+  config_get: 'show feature'
+  config_get_token: '/^nve\s+\d+\s+(\S+)/'
+  config_set: "%s feature nv overlay"

--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
@@ -8,7 +8,7 @@ all_interfaces:
 mac_distribution:
   config_get: 'show running-config interface all'
   config_get_token: ['/^interface <name>$/', '/^host-reachability protocol (\S+)/']
-  config_set: ['interface <name>', '<no_cmd> host-reachability protocol <proto>', 'end']
+  config_set: ['interface <name>', '<state> host-reachability protocol <proto>']
 
 #TODO: move to vxlan_vtp_vni.rb
 #member_vni_mgrp:
@@ -17,10 +17,10 @@ mac_distribution:
 #  config_set: ['interface <name>', '<no_cmd> member vni <vni>', 'mcast-group <mcast_grp>','end']
 
 member_vni_arp:
-  config_set: ['interface <name>', '<no_cmd> member vni <vni>', 'suppress-arp']
+  config_set: ['interface <name>', '<state> member vni <vni>', 'suppress-arp']
 
 source_intf:
   config_get: 'show running-config interface'
   config_get_token: ['/^interface <name>$/','/^source\-interface (\S+)$/']
-  config_set: ['interface <name>', '<no_cmd> source-interface <lpbk_intf>', 'end']
+  config_set: ['interface <name>', '<state> source-interface <lpbk_intf>']
   default_value: ''

--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
@@ -1,0 +1,26 @@
+# vxlan_vtep
+---
+all_interfaces:
+  multiple:
+  config_get: 'show running-config interface all'
+  config_get_token: '/^interface\s+(nve.*)$/'
+
+mac_distribution:
+  config_get: 'show running-config interface all'
+  config_get_token: ['/^interface <name>$/', '/^host-reachability protocol (\S+)/']
+  config_set: ['interface <name>', '<no_cmd> host-reachability protocol <proto>', 'end']
+
+#TODO: move to vxlan_vtp_vni.rb
+#member_vni_mgrp:
+#  config_get: 'show running-config interface all'
+#  config_get_token: ['/^interface <name>$/', '/^member vni (\S+)/', '/^mcast-group (\S+)$/']
+#  config_set: ['interface <name>', '<no_cmd> member vni <vni>', 'mcast-group <mcast_grp>','end']
+
+member_vni_arp:
+  config_set: ['interface <name>', '<no_cmd> member vni <vni>', 'suppress-arp']
+
+source_intf:
+  config_get: 'show running-config interface'
+  config_get_token: ['/^interface <name>$/','/^source\-interface (\S+)$/']
+  config_set: ['interface <name>', '<no_cmd> source-interface <lpbk_intf>', 'end']
+  default_value: ''

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -82,7 +82,7 @@ module Cisco
         # Just get the whole output
         return massage(show(ref.config_get, :structured), ref)
       elsif token[0].kind_of?(Regexp)
-        return massage(find_ascii(show(ref.config_get, :ascii),
+        return massage(Cisco::find_ascii(show(ref.config_get, :ascii),
                                   token[-1],
                                   *token[0..-2]), ref)
       else

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -83,7 +83,8 @@ module Cisco
         return massage(show(ref.config_get, :structured), ref)
       elsif token[0].kind_of?(Regexp)
         return massage(find_ascii(show(ref.config_get, :ascii),
-                                  token[-1], *token[0..-2]), ref)
+                                  token[-1],
+                                  *token[0..-2]), ref)
       else
         return massage(
           config_get_handle_structured(token,

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -82,9 +82,9 @@ module Cisco
         # Just get the whole output
         return massage(show(ref.config_get, :structured), ref)
       elsif token[0].kind_of?(Regexp)
-        return massage(Cisco::find_ascii(show(ref.config_get, :ascii),
-                                  token[-1],
-                                  *token[0..-2]), ref)
+        return massage(Cisco.find_ascii(show(ref.config_get, :ascii),
+                                        token[-1],
+                                        *token[0..-2]), ref)
       else
         return massage(
           config_get_handle_structured(token,

--- a/lib/cisco_node_utils/tacacs_server_group.rb
+++ b/lib/cisco_node_utils/tacacs_server_group.rb
@@ -32,16 +32,15 @@ module Cisco
       return unless create
 
       TacacsServer.new.enable unless TacacsServer.enabled
-      config_set('aaa_server_group', 'tacacs_group', '', name)
+      config_set('tacacs_server_group', 'group', state: '', name: name)
     end
 
     def destroy
-      config_set('aaa_server_group', 'tacacs_group', 'no', @name)
+      config_set('tacacs_server_group', 'group', state: 'no', name: @name)
     end
 
     def servers
-      tacservers = config_get('aaa_server_group',
-                              'tacacs_servers', @name)
+      tacservers = config_get('tacacs_server_group', 'servers', @name)
       servs = {}
       unless tacservers.nil?
         tacservers.each { |s| servs[s] = TacacsServerHost.new(s, false) }
@@ -56,17 +55,17 @@ module Cisco
       new_servs.each do |s|
         # add any servers not yet configured
         next if current_servs.include? s
-        config_set('aaa_server_group', 'tacacs_server', @name, '', s)
+        config_set('tacacs_server_group', 'servers', name: @name, state: '', server: s)
       end
       current_servs.each do |s|
         # remove any undesired existing servers
         next if new_servs.include? s
-        config_set('aaa_server_group', 'tacacs_server', @name, 'no', s)
+        config_set('tacacs_server_group', 'servers', name: @name, state: 'no', server: s)
       end
     end
 
     def default_servers
-      config_get_default('aaa_server_group', 'servers')
+      config_get_default('tacacs_server_group', 'servers')
     end
 
     def ==(other)
@@ -80,7 +79,7 @@ module Cisco
 
     def self.groups
       grps = {}
-      tacgroups = config_get('aaa_server_group', 'tacacs_groups') if
+      tacgroups = config_get('tacacs_server_group', 'group') if
         TacacsServer.enabled
       unless tacgroups.nil?
         tacgroups.each { |s| grps[s] = TacacsServerGroup.new(s, false) }
@@ -90,49 +89,47 @@ module Cisco
 
     def vrf
       # vrf is always present in running config
-      v = config_get('aaa_server_group', 'tacacs_vrf', @name)
-      v.nil? ? default_vrf : v.first
+      v = config_get('tacacs_server_group', 'vrf', @name)
+      v.nil? ? default_vrf : v
     end
 
     def vrf=(v)
       fail TypeError unless v.is_a? String
       # vrf = "default" is equivalent to unconfiguring vrf
-      config_set('aaa_server_group', 'tacacs_vrf', @name, '', v)
+      config_set('tacacs_server_group', 'vrf', name: @name, state: '', vrf: v)
     end
 
     def default_vrf
-      config_get_default('aaa_server_group', 'vrf')
+      config_get_default('tacacs_server_group', 'vrf')
     end
 
     def deadtime
-      d = config_get('aaa_server_group', 'tacacs_deadtime', @name)
-      d.nil? ? default_deadtime : d.first.to_i
+      d = config_get('tacacs_server_group', 'deadtime', @name)
+      d.nil? ? default_deadtime : d.to_i
     end
 
     def deadtime=(t)
       no_cmd = t == default_deadtime ? 'no' : ''
-      config_set('aaa_server_group', 'tacacs_deadtime', @name, no_cmd, t)
+      config_set('tacacs_server_group', 'deadtime', name: @name, state: no_cmd, deadtime: t)
     end
 
     def default_deadtime
-      config_get_default('aaa_server_group', 'deadtime')
+      config_get_default('tacacs_server_group', 'deadtime')
     end
 
     def source_interface
-      i = config_get('aaa_server_group',
-                     'tacacs_source_interface', @name)
-      i.nil? ? default_source_interface : i.first
+      i = config_get('tacacs_server_group', 'source_interface', @name)
+      i.nil? ? default_source_interface : i
     end
 
     def source_interface=(s)
       fail TypeError unless s.is_a? String
       no_cmd = s == default_source_interface ? 'no' : ''
-      config_set('aaa_server_group', 'tacacs_source_interface',
-                 @name, no_cmd, s)
+      config_set('tacacs_server_group', 'source_interface', name: @name, state: no_cmd, interface: s)
     end
 
     def default_source_interface
-      config_get_default('aaa_server_group', 'source_interface')
+      config_get_default('tacacs_server_group', 'source_interface')
     end
   end
 end

--- a/lib/cisco_node_utils/tacacs_server_group.rb
+++ b/lib/cisco_node_utils/tacacs_server_group.rb
@@ -1,15 +1,16 @@
-# Tacacs Server Group provider class
-
-# Jonathan Tripathy et al., October 2015
-
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
-
+#
+# NXAPI implementation of TacacsServerGroup class
+#
+# April 2015, Alex Hunsberger
+#
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,91 +18,121 @@
 # limitations under the License.
 
 require_relative 'node_util'
+require_relative 'tacacs_server'
 
 module Cisco
-  # TacacsServerGroup - node utility class for
-  # Raidus Server configuration management
+  # NXAPI implementation of AAA Server Group class
   class TacacsServerGroup < NodeUtil
     attr_reader :name
 
-    def initialize(name, instantiate=true)
-      unless name.is_a?(String)
-        fail ArgumentError, 'Invalid value (Name is not a String)'
-      end
-
+    def initialize(name, create=true)
+      fail TypeError unless name.is_a? String
       @name = name
 
-      create if instantiate
-    end
+      return unless create
 
-    def self.tacacs_server_groups
-      hash = {}
-      group_list = config_get('tacacs_server_group', 'group')
-      return hash if group_list.nil?
-
-      group_list.each do |id|
-        hash[id] = TacacsServerGroup.new(id, false)
-      end
-
-      hash
-    end
-
-    def create
-      config_set('tacacs_server_group',
-                 'group',
-                 state: '',
-                 name:  @name)
+      TacacsServer.new.enable unless TacacsServer.enabled
+      config_set('aaa_server_group', 'tacacs_group', '', name)
     end
 
     def destroy
-      config_set('tacacs_server_group',
-                 'group',
-                 state: 'no',
-                 name:  @name)
+      config_set('aaa_server_group', 'tacacs_group', 'no', @name)
+    end
+
+    def servers
+      tacservers = config_get('aaa_server_group',
+                              'tacacs_servers', @name)
+      servs = {}
+      unless tacservers.nil?
+        tacservers.each { |s| servs[s] = TacacsServerHost.new(s, false) }
+      end
+      servs
+    end
+
+    def servers=(new_servs)
+      fail TypeError unless new_servs.is_a? Array
+      # just need the names of the current servers for comparison
+      current_servs = servers.keys
+      new_servs.each do |s|
+        # add any servers not yet configured
+        next if current_servs.include? s
+        config_set('aaa_server_group', 'tacacs_server', @name, '', s)
+      end
+      current_servs.each do |s|
+        # remove any undesired existing servers
+        next if new_servs.include? s
+        config_set('aaa_server_group', 'tacacs_server', @name, 'no', s)
+      end
+    end
+
+    def default_servers
+      config_get_default('aaa_server_group', 'servers')
     end
 
     def ==(other)
       name == other.name
     end
 
-    def default_servers
-      config_get_default('tacacs_server_group', 'servers')
+    # for netdev compatibility
+    def self.tacacs_server_groups
+      groups
     end
 
-    def servers
-      val = config_get('tacacs_server_group', 'servers', @name)
-      val = default_servers if val.nil?
-      val
-    end
-
-    def servers=(val)
-      fail ArgumentError, 'Servers must be an array of valid IP addresses' \
-        unless val.is_a?(Array)
-
-      current = servers
-
-      # Remove IPs that are no longer required
-      current.each do |old_ip|
-        next if val.include?(old_ip)
-        config_set('tacacs_server_group',
-                   'servers',
-                   group: @name,
-                   state: 'no',
-                   ip:    old_ip)
+    def self.groups
+      grps = {}
+      tacgroups = config_get('aaa_server_group', 'tacacs_groups') if
+        TacacsServer.enabled
+      unless tacgroups.nil?
+        tacgroups.each { |s| grps[s] = TacacsServerGroup.new(s, false) }
       end
-
-      # Add new IPs that aren't already on the device
-      val.each do |new_ip|
-        fail ArgumentError, 'Servers must be an array of valid IP addresses' \
-          unless new_ip[/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/]
-
-        next unless current.nil? || !current.include?(new_ip)
-        config_set('tacacs_server_group',
-                   'servers',
-                   group: @name,
-                   state: '',
-                   ip:    new_ip)
-      end
+      grps
     end
-  end # class
-end # module
+
+    def vrf
+      # vrf is always present in running config
+      v = config_get('aaa_server_group', 'tacacs_vrf', @name)
+      v.nil? ? default_vrf : v.first
+    end
+
+    def vrf=(v)
+      fail TypeError unless v.is_a? String
+      # vrf = "default" is equivalent to unconfiguring vrf
+      config_set('aaa_server_group', 'tacacs_vrf', @name, '', v)
+    end
+
+    def default_vrf
+      config_get_default('aaa_server_group', 'vrf')
+    end
+
+    def deadtime
+      d = config_get('aaa_server_group', 'tacacs_deadtime', @name)
+      d.nil? ? default_deadtime : d.first.to_i
+    end
+
+    def deadtime=(t)
+      no_cmd = t == default_deadtime ? 'no' : ''
+      config_set('aaa_server_group', 'tacacs_deadtime', @name, no_cmd, t)
+    end
+
+    def default_deadtime
+      config_get_default('aaa_server_group', 'deadtime')
+    end
+
+    def source_interface
+      i = config_get('aaa_server_group',
+                     'tacacs_source_interface', @name)
+      i.nil? ? default_source_interface : i.first
+    end
+
+    def source_interface=(s)
+      fail TypeError unless s.is_a? String
+      no_cmd = s == default_source_interface ? 'no' : ''
+      config_set('aaa_server_group', 'tacacs_source_interface',
+                 @name, no_cmd, s)
+    end
+
+    def default_source_interface
+      config_get_default('aaa_server_group', 'source_interface')
+    end
+  end
+end

--- a/lib/cisco_node_utils/tacacs_server_group.rb
+++ b/lib/cisco_node_utils/tacacs_server_group.rb
@@ -55,12 +55,20 @@ module Cisco
       new_servs.each do |s|
         # add any servers not yet configured
         next if current_servs.include? s
-        config_set('tacacs_server_group', 'servers', name: @name, state: '', server: s)
+        config_set('tacacs_server_group',
+                   'servers',
+                   name:   @name,
+                   state:  '',
+                   server: s)
       end
       current_servs.each do |s|
         # remove any undesired existing servers
         next if new_servs.include? s
-        config_set('tacacs_server_group', 'servers', name: @name, state: 'no', server: s)
+        config_set('tacacs_server_group',
+                   'servers',
+                   name:   @name,
+                   state:  'no',
+                   server: s)
       end
     end
 
@@ -110,7 +118,11 @@ module Cisco
 
     def deadtime=(t)
       no_cmd = t == default_deadtime ? 'no' : ''
-      config_set('tacacs_server_group', 'deadtime', name: @name, state: no_cmd, deadtime: t)
+      config_set('tacacs_server_group',
+                 'deadtime',
+                 name:     @name,
+                 state:    no_cmd,
+                 deadtime: t)
     end
 
     def default_deadtime
@@ -125,7 +137,11 @@ module Cisco
     def source_interface=(s)
       fail TypeError unless s.is_a? String
       no_cmd = s == default_source_interface ? 'no' : ''
-      config_set('tacacs_server_group', 'source_interface', name: @name, state: no_cmd, interface: s)
+      config_set('tacacs_server_group',
+                 'source_interface',
+                 name:      @name,
+                 state:     no_cmd,
+                 interface: s)
     end
 
     def default_source_interface

--- a/lib/cisco_node_utils/vxlan_vtep.rb
+++ b/lib/cisco_node_utils/vxlan_vtep.rb
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require File.join(File.dirname(__FILE__), 'node_util')
+require_relative 'node_util'
 
 module Cisco
   # node_utils class for vxlan_vtep
@@ -35,7 +35,7 @@ module Cisco
     def self.vteps
       hash = {}
       is_vxlan_feature = config_get('vxlan', 'feature')
-      return hash if (:enabled != is_vxlan_feature.first.to_sym)
+      return hash if (:enabled != is_vxlan_feature.to_sym)
       vtep_list = config_get('vxlan_vtep', 'all_interfaces')
       return hash if vtep_list.nil?
 
@@ -50,7 +50,7 @@ module Cisco
       vxlan = config_get('vxlan', 'feature')
       fail 'vxlan/nv_overlay feature not found' if vxlan.nil?
       return :disabled if vxlan.nil?
-      vxlan.first.to_sym
+      vxlan.to_sym
     end
 
     def vxlan_feature_set(vxlan_set)
@@ -71,9 +71,12 @@ module Cisco
     def create
       unless (:enabled == vxlan_feature)
         vdc_name = config_get('limit_resource', 'vdc')
-        @apply_to = vdc_name.first
-        debug("###### VDC is #{@apply_to}")
-        config_set('limit_resource', 'vxlan', @apply_to)
+        # Only supported on n7k currently.
+        unless vdc_name.nil?
+          @apply_to = vdc_name
+          debug("###### VDC is #{@apply_to}")
+          config_set('limit_resource', 'vxlan', @apply_to)
+        end
         vxlan_feature_set(:enabled)
       end
       # re-use the "interface command ref hooks"
@@ -85,14 +88,18 @@ module Cisco
       config_set('interface', 'destroy', @name)
     end
 
+    def ==(other)
+      name == other.name
+    end
+
     ########################################################
     #                      PROPERTIES                      #
     ########################################################
 
     def description
       desc = config_get('interface', 'description', @name)
-      return '' if desc.nil?
-      desc.shift.strip
+      return default_description if desc.nil?
+      desc
     end
 
     def description=(desc)
@@ -110,72 +117,76 @@ module Cisco
       config_get_default('interface', 'description')
     end
 
-    def vni_mcast_grp_map
-      final_hash = {}
-      show = show("show running-config interface #{@name}")
-      debug("show class is #{show.class} and show op is #{show}")
-      return final_hash if show == {}
-      match_pat1 = /vni\s+(\S+).*mcast\-group\s+(\S+)/m
-      match_pat2 = /vni\s+(\S+).*(associate\-vrf)/m
-      split_pat = /member\s+/
-      pair_arr = show.split(split_pat)
-      pair_arr.each do |pair|
-        match_arr = match_pat1.match(pair)
-        match_arr ||= match_pat2.match(pair)
-        unless match_arr.nil?
-          debug "match arr 1 : #{match_arr[1]} 2: #{match_arr[2]}"
-          final_hash[match_arr[1]] = "#{match_arr[2]}"
-        end
-      end
-      final_hash
-    end
+    # TODO: Move vni_mcast_grp_map to vxlan_vtp_vni.rb object
+    #
+    # def vni_mcast_grp_map
+    #  final_hash = {}
+    #  show = show("show running-config interface #{@name}")
+    #  debug("show class is #{show.class} and show op is #{show}")
+    #  return final_hash if show == {}
+    #  match_pat1 = /vni\s+(\S+).*mcast\-group\s+(\S+)/m
+    #  match_pat2 = /vni\s+(\S+).*(associate\-vrf)/m
+    #  split_pat = /member\s+/
+    #  pair_arr = show.split(split_pat)
+    #  pair_arr.each do |pair|
+    #    match_arr = match_pat1.match(pair)
+    #    match_arr ||= match_pat2.match(pair)
+    #    unless match_arr.nil?
+    #      debug "match arr 1 : #{match_arr[1]} 2: #{match_arr[2]}"
+    #      final_hash[match_arr[1]] = "#{match_arr[2]}"
+    #    end
+    #  end
+    #  final_hash
+    # end
 
-    def vni_mcast_grp_map=(val, prev_val=nil)
-      debug "val is of class #{val.class} and is #{val} prev is #{prev_val}"
-      # When prev_val is nil, HashDiff doesn't do a `+' on each element, so this
-      debug "value of mac_dist = #{@mac_dist_proto}"
-      param_hash = {}
-      # supress_arp = (@mac_dist_proto == :evpn) ? "supress-arp" : ""
-      if prev_val.nil?
-        val.each do |fresh_vni, fresh_mgrp|
-          param_hash = { name: @name, no_cmd: '', vni: fresh_vni,
-                         mcast_grp: fresh_mgrp }
-          config_set('vxlan_vtep', 'member_vni_mgrp', param_hash)
-        end
-        return
-      end
-      require 'hashdiff'
-      hash_diff = HashDiff.diff(prev_val, val)
-      debug "hsh diff ; #{hash_diff}"
-      return if hash_diff == []
-      hash_diff.each do |diff|
-        case diff[0]
-        when /\+/
-          param_hash = { name: @name, no_cmd: '', vni: diff[1],
-                         mcast_grp: diff[2] }
-        when /\-/
-          param_hash = { name: @name, no_cmd: 'no', vni: diff[1],
-                         mcast_grp: diff[2] }
-        when /~/
-          param_hash = { name: @name, no_cmd: 'no', vni: diff[1],
-                         mcast_grp: diff[2] }
-          config_set('vxlan_vtep', 'member_vni_mgrp', param_hash)
-          param_hash = { name: @name, no_cmd: '', vni: diff[1],
-                         mcast_grp: diff[3] }
-        end
-        config_set('vxlan_vtep', 'member_vni_mgrp', param_hash)
-      end
-    rescue CliError => e
-      raise "[vxlan_vtep #{@name}] '#{e.command}' : #{e.clierror}"
-    end
+    # TODO: Move vni_mcast_grp_map to vxlan_vtp_vni.rb object
+    #
+    # def vni_mcast_grp_map=(val, prev_val=nil)
+    #  debug "val is of class #{val.class} and is #{val} prev is #{prev_val}"
+    #  # When prev_val is nil, HashDiff doesn't do a `+' on each element, so
+    #  # this
+    #  debug "value of mac_dist = #{@mac_dist_proto}"
+    #  param_hash = {}
+    #  # supress_arp = (@mac_dist_proto == :evpn) ? "supress-arp" : ""
+    #  if prev_val.nil?
+    #    val.each do |fresh_vni, fresh_mgrp|
+    #      param_hash = { name: @name, no_cmd: '', vni: fresh_vni,
+    #                     mcast_grp: fresh_mgrp }
+    #      config_set('vxlan_vtep', 'member_vni_mgrp', param_hash)
+    #    end
+    #    return
+    #  end
+    #  require 'hashdiff'
+    #  hash_diff = HashDiff.diff(prev_val, val)
+    #  debug "hsh diff ; #{hash_diff}"
+    #  return if hash_diff == []
+    #  hash_diff.each do |diff|
+    #    case diff[0]
+    #    when /\+/
+    #      param_hash = { name: @name, no_cmd: '', vni: diff[1],
+    #                     mcast_grp: diff[2] }
+    #    when /\-/
+    #      param_hash = { name: @name, no_cmd: 'no', vni: diff[1],
+    #                     mcast_grp: diff[2] }
+    #    when /~/
+    #      param_hash = { name: @name, no_cmd: 'no', vni: diff[1],
+    #                     mcast_grp: diff[2] }
+    #      config_set('vxlan_vtep', 'member_vni_mgrp', param_hash)
+    #      param_hash = { name: @name, no_cmd: '', vni: diff[1],
+    #                     mcast_grp: diff[3] }
+    #    end
+    #    config_set('vxlan_vtep', 'member_vni_mgrp', param_hash)
+    #  end
+    # rescue CliError => e
+    #  raise "[vxlan_vtep #{@name}] '#{e.command}' : #{e.clierror}"
+    # end
 
     def mac_distribution
       mac_dist = config_get('vxlan_vtep', 'mac_distribution', name: @name)
-      debug "mac_dist is #{mac_dist}"
       if mac_dist.nil?
         @mac_dist_proto = :flood
       else
-        @mac_dist_proto = (mac_dist.first.strip == 'bgp') ? :evpn : :flood
+        @mac_dist_proto = (mac_dist == 'bgp') ? :evpn : :flood
       end
       @mac_dist_proto.to_s
     end
@@ -200,8 +211,8 @@ module Cisco
     def source_interface
       src_intf = config_get('vxlan_vtep', 'source_intf', name: @name)
       debug "src_intf is #{src_intf}"
-      return '' if src_intf.nil?
-      src_intf.first.strip
+      return default_source_interface if src_intf.nil?
+      src_intf
     end
 
     def source_interface=(val)
@@ -215,6 +226,10 @@ module Cisco
       end
     rescue Cisco::CliError => e
       raise "[#{@name}] '#{e.command}' : #{e.clierror}"
+    end
+
+    def default_source_interface
+      config_get_default('vxlan_vtep', 'source_intf')
     end
 
     def shutdown

--- a/lib/cisco_node_utils/vxlan_vtep.rb
+++ b/lib/cisco_node_utils/vxlan_vtep.rb
@@ -54,16 +54,14 @@ module Cisco
     end
 
     def self.enable(state='')
+      # vdc only supported on n7k currently.
+      vdc_name = config_get('limit_resource', 'vdc')
+      config_set('limit_resource', 'vxlan', vdc_name) unless vdc_name.nil?
       config_set('vxlan', 'feature', state: state)
     end
 
     def create
-      unless VxlanVtep.feature_enabled
-        # Only supported on n7k currently.
-        vdc_name = config_get('limit_resource', 'vdc')
-        config_set('limit_resource', 'vxlan', vdc_name) unless vdc_name.nil?
-        VxlanVtep.enable
-      end
+      VxlanVtep.enable unless VxlanVtep.feature_enabled
       # re-use the "interface command ref hooks"
       config_set('interface', 'create', @name)
     end

--- a/tests/test_command_reference.rb
+++ b/tests/test_command_reference.rb
@@ -151,6 +151,7 @@ name:
   test_config_result:
     false: RuntimeError
     32: "Long VLAN name knob is not enabled"
+    nil: ~
 ))
     reference = load_file
     ref = reference.lookup('test', 'name')
@@ -163,6 +164,7 @@ name:
     assert_raises(IndexError) { ref.test_config_get }
     type_check(ref.test_config_result(false), RuntimeError.class)
     type_check(ref.test_config_result(32), String)
+    type_check(ref.test_config_result('nil'), NilClass)
 
     assert(ref.default_value?)
     assert(ref.config_get?)
@@ -177,7 +179,7 @@ name:
   cli_nexus:
     default_value: 'NXAPI base'
     /N7K/:
-      default_value: 'NXAPI N7K'
+      default_value: ~
     /N9K/:
       default_value: 'NXAPI N9K'
 ")
@@ -198,7 +200,7 @@ name:
   def test_load_n7k
     write_variants
     reference = load_file(platform: :nexus, product: 'N7K-C7010', cli: true)
-    assert_equal('NXAPI N7K', reference.lookup('test', 'name').default_value)
+    assert_equal(nil, reference.lookup('test', 'name').default_value)
   end
 
   def test_load_n3k_3064
@@ -227,14 +229,17 @@ rank:
     reference = load_file(product: 'N9K-C9396PX')
 
     ref = reference.lookup('test', 'name')
-    refute(ref.default_value?)
-    assert_raises(Cisco::UnsupportedError) { ref.default_value }
+    # default_value is nil for an unsupported property
+    assert(ref.default_value?, 'default_value? returned false')
+    assert_nil(ref.default_value)
     refute(ref.config_get?)
     assert_raises(Cisco::UnsupportedError) { ref.config_get }
 
+    # Because the whole file is excluded, we don't know which
+    # attributes are 'valid' - so any attribute name is permitted:
     ref = reference.lookup('test', 'foobar')
-    refute(ref.default_value?)
-    assert_raises(Cisco::UnsupportedError) { ref.default_value }
+    assert(ref.default_value?)
+    assert_nil(ref.default_value)
     refute(ref.config_get?)
     assert_raises(Cisco::UnsupportedError) { ref.config_get }
   end
@@ -245,8 +250,8 @@ rank:
     assert_equal(27, reference.lookup('test', 'rank').default_value)
 
     ref = reference.lookup('test', 'name')
-    refute(ref.default_value?)
-    assert_raises(Cisco::UnsupportedError) { ref.default_value }
+    assert(ref.default_value?)
+    assert_nil(ref.default_value)
     refute(ref.config_get?)
     assert_raises(Cisco::UnsupportedError) { ref.config_get }
   end
@@ -266,8 +271,8 @@ name:
 ")
     reference = load_file(platform: 'nexus', cli: false)
     ref = reference.lookup('test', 'name')
-    refute(ref.default_value?)
-    assert_raises(Cisco::UnsupportedError) { ref.default_value }
+    assert(ref.default_value?)
+    assert_nil(ref.default_value)
   end
 
   def test_default_only

--- a/tests/test_tacacs_server_group.rb
+++ b/tests/test_tacacs_server_group.rb
@@ -16,10 +16,6 @@ require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/tacacs_server_group'
 require_relative '../lib/cisco_node_utils/tacacs_server_host'
 
-DEFAULT_AAA_SERVER_GROUP_VRF = 'default'
-DEFAULT_AAA_SERVER_GROUP_DEADTIME = 0
-DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE = ''
-
 # Test class for Tacacs Server Group
 class TestTacacsServerGroup < CiscoTestCase
   def clean_tacacs_config
@@ -70,7 +66,7 @@ class TestTacacsServerGroup < CiscoTestCase
     group_name = 'Group1'
     aaa_group = TacacsServerGroup.new(group_name)
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /Group1/)
+                      pattern: /#{group_name}/)
 
     detach_aaaservergroup(aaa_group)
   end
@@ -82,9 +78,9 @@ class TestTacacsServerGroup < CiscoTestCase
     aaa_group2 = TacacsServerGroup.new(group_name2)
 
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /Group1/)
+                      pattern: /#{group_name1}/)
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /Group2/)
+                      pattern: /#{group_name2}/)
 
     detach_aaaservergroup(aaa_group1)
     detach_aaaservergroup(aaa_group2)
@@ -97,7 +93,7 @@ class TestTacacsServerGroup < CiscoTestCase
                  'Error: TacacsServerGroup collection is not empty')
   end
 
-  def test_collection_single_tacacs
+  def test_collection_multi_tacacs
     clean_tacacs_config
     group_name1 = 'Group1'
     group_name2 = 'Group2'
@@ -105,7 +101,6 @@ class TestTacacsServerGroup < CiscoTestCase
     aaa_group1 = TacacsServerGroup.new(group_name1)
 
     groups = TacacsServerGroup.groups
-    refute_empty(groups, 'Error: TacacsServerGroup collection is not filled')
     assert_equal(1, groups.size,
                  'Error: TacacsServerGroup collection reporting incorrect size')
     assert(groups.key?(group_name1),
@@ -125,33 +120,6 @@ class TestTacacsServerGroup < CiscoTestCase
 
     destroy_aaa_group(group_name2, 'tacacs+')
     destroy_aaa_group(group_name3, 'tacacs+')
-  end
-
-  def test_collection_multi_tacacs
-    clean_tacacs_config
-    group_name1 = 'Group1'
-    group_name2 = 'Group2'
-    group_name3 = 'Group3'
-    aaa_group1 = TacacsServerGroup.new(group_name1)
-
-    aaa_group2 = TacacsServerGroup.new(group_name2)
-
-    aaa_group3 = TacacsServerGroup.new(group_name3)
-
-    groups = TacacsServerGroup.groups
-    refute_empty(groups, 'Error: TacacsServerGroup collection is not filled')
-    assert_equal(3, groups.size,
-                 'Error: TacacsServerGroup collection reporting incorrect size')
-    assert(groups.key?(group_name1),
-           "Error: TacacsServerGroup collection does contain #{group_name1}")
-    assert(groups.key?(group_name2),
-           "Error: TacacsServerGroup collection does contain #{group_name2}")
-    assert(groups.key?(group_name3),
-           "Error: TacacsServerGroup collection does contain #{group_name3}")
-
-    detach_aaaservergroup(aaa_group1)
-    detach_aaaservergroup(aaa_group2)
-    detach_aaaservergroup(aaa_group3)
   end
 
   def test_servers_tacacs
@@ -193,36 +161,9 @@ class TestTacacsServerGroup < CiscoTestCase
     aaa_group.servers = [server_name1, server_name2]
 
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server1/)
+                      pattern: /server #{server_name1}/)
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server2/)
-
-    detach_aaaservergroup(aaa_group)
-    detach_tacacsserverhost(server1)
-    detach_tacacsserverhost(server2)
-  end
-
-  def test_add_server_twice_tacacs
-    clean_tacacs_config
-    server_name1 = 'server1'
-    server_name2 = 'server2'
-    server1 = create_tacacsserverhost(server_name1)
-    server2 = create_tacacsserverhost(server_name2)
-
-    aaa_group = TacacsServerGroup.new('Group1')
-    # aaa_group.servers = [server_name1, server_name2, server_name2]
-    # this behavior is different on n9k vs n3k, so comment out for now
-    # n3k throws a CLIError and n9k silently ignores
-    aaa_group.servers = [server_name1, server_name2]
-
-    servers = aaa_group.servers
-    assert_equal(2, servers.size,
-                 'Error: Collection is not two servers')
-
-    assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server1/)
-    assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server2/)
+                      pattern: /server #{server_name2}/)
 
     detach_aaaservergroup(aaa_group)
     detach_tacacsserverhost(server1)
@@ -247,11 +188,11 @@ class TestTacacsServerGroup < CiscoTestCase
     # Now remove them and then check again
     aaa_group.servers = [server_name2]
     refute_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server1/)
+                      pattern: /server #{server_name1}/)
 
     aaa_group.servers = []
     refute_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server2/)
+                      pattern: /server #{server_name2}/)
 
     detach_aaaservergroup(aaa_group)
     detach_tacacsserverhost(server1)
@@ -273,15 +214,15 @@ class TestTacacsServerGroup < CiscoTestCase
     assert_equal(2, servers.size,
                  'Error: Collection is not two servers')
 
-    # Now remove them and then check again
+    # Remove server 1
     aaa_group.servers = [server_name2]
     refute_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server1/)
+                      pattern: /server #{server_name1}/)
 
-    # Now remove server 1 again
+    # Now remove server 2
     aaa_group.servers = []
     refute_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server server2/)
+                      pattern: /server #{server_name2}/)
 
     # Check collection size
     servers = aaa_group.servers
@@ -296,7 +237,7 @@ class TestTacacsServerGroup < CiscoTestCase
     group_name1 = 'Group1'
     aaa_group = TacacsServerGroup.new(group_name1)
 
-    vrf = DEFAULT_AAA_SERVER_GROUP_VRF
+    vrf = cmd_ref.lookup('tacacs_server_group', 'vrf').default_value
     assert_equal(vrf, aaa_group.vrf,
                  'Error: TacacsServerGroup, vrf not default')
 
@@ -305,7 +246,7 @@ class TestTacacsServerGroup < CiscoTestCase
     assert_equal(vrf, aaa_group.vrf,
                  'Error: TacacsServerGroup, vrf not configured')
 
-    vrf = DEFAULT_AAA_SERVER_GROUP_VRF
+    vrf = cmd_ref.lookup('tacacs_server_group', 'vrf').default_value
     aaa_group.vrf = vrf
     assert_equal(vrf, aaa_group.vrf,
                  'Error: TacacsServerGroup, vrf not restored to default')
@@ -315,7 +256,7 @@ class TestTacacsServerGroup < CiscoTestCase
 
   def test_get_default_vrf_tacacs
     aaa_group = TacacsServerGroup.new('Group1')
-    assert_equal(DEFAULT_AAA_SERVER_GROUP_VRF,
+    assert_equal(cmd_ref.lookup('tacacs_server_group', 'vrf').default_value,
                  aaa_group.default_vrf,
                  'Error: TacacsServerGroup, default vrf incorrect')
     detach_aaaservergroup(aaa_group)
@@ -326,12 +267,11 @@ class TestTacacsServerGroup < CiscoTestCase
     aaa_group = TacacsServerGroup.new('Group1')
     aaa_group.vrf = vrf
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /use-vrf management-123/)
+                      pattern: /use-vrf #{vrf}/)
 
     # Invalid case
-    vrf = 2450
     assert_raises(TypeError) do
-      aaa_group.vrf = vrf
+      aaa_group.vrf = 2450
     end
     detach_aaaservergroup(aaa_group)
   end
@@ -340,7 +280,7 @@ class TestTacacsServerGroup < CiscoTestCase
     group_name = 'Group1'
     aaa_group = TacacsServerGroup.new(group_name)
 
-    deadtime = DEFAULT_AAA_SERVER_GROUP_DEADTIME
+    deadtime = cmd_ref.lookup('tacacs_server_group', 'deadtime').default_value
     assert_equal(deadtime, aaa_group.deadtime,
                  'Error: TacacsServerGroup, deadtime not default')
 
@@ -349,7 +289,7 @@ class TestTacacsServerGroup < CiscoTestCase
     assert_equal(deadtime, aaa_group.deadtime,
                  'Error: TacacsServerGroup, deadtime not configured')
 
-    deadtime = DEFAULT_AAA_SERVER_GROUP_DEADTIME
+    deadtime = cmd_ref.lookup('tacacs_server_group', 'deadtime').default_value
     aaa_group.deadtime = deadtime
     assert_equal(deadtime, aaa_group.deadtime,
                  'Error: TacacsServerGroup, deadtime not restored to default')
@@ -359,9 +299,10 @@ class TestTacacsServerGroup < CiscoTestCase
 
   def test_get_default_deadtime_tacacs
     aaa_group = TacacsServerGroup.new('Group1')
-    assert_equal(DEFAULT_AAA_SERVER_GROUP_DEADTIME,
-                 aaa_group.default_deadtime,
-                 'Error: TacacsServerGroup, default deadtime incorrect')
+    assert_equal(
+      cmd_ref.lookup('tacacs_server_group', 'deadtime').default_value,
+      aaa_group.default_deadtime,
+      'Error: TacacsServerGroup, default deadtime incorrect')
     detach_aaaservergroup(aaa_group)
   end
 
@@ -370,7 +311,7 @@ class TestTacacsServerGroup < CiscoTestCase
     aaa_group = TacacsServerGroup.new('Group1')
     aaa_group.deadtime = deadtime
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /deadtime 1250/,
+                      pattern: /deadtime #{deadtime}/,
                       msg:     'Error: deadtime not configured')
     # Invalid case
     deadtime = 2450
@@ -383,7 +324,8 @@ class TestTacacsServerGroup < CiscoTestCase
   def test_get_source_interface_tacacs
     group_name = 'Group1'
     aaa_group = TacacsServerGroup.new(group_name)
-    intf = DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE
+    intf =
+      cmd_ref.lookup('tacacs_server_group', 'source_interface').default_value
     assert_equal(intf, aaa_group.source_interface,
                  'Error: TacacsServerGroup, source-interface set')
 
@@ -402,14 +344,16 @@ class TestTacacsServerGroup < CiscoTestCase
 
   def test_get_default_source_interface_tacacs
     aaa_group = TacacsServerGroup.new('Group1')
-    assert_equal(DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE,
-                 aaa_group.default_source_interface,
-                 'Error: Aaa_Group Server, default source-interface incorrect')
+    assert_equal(
+      cmd_ref.lookup('tacacs_server_group', 'source_interface').default_value,
+      aaa_group.default_source_interface,
+      'Error: Aaa_Group Server, default source-interface incorrect')
     detach_aaaservergroup(aaa_group)
   end
 
   def test_set_source_interface_tacacs
-    intf = DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE
+    intf =
+      cmd_ref.lookup('tacacs_server_group', 'source_interface').default_value
     aaa_group = TacacsServerGroup.new('Group1')
     assert_equal(intf, aaa_group.source_interface,
                  'Error: Aaa_Group Server, source-interface not default')
@@ -419,7 +363,8 @@ class TestTacacsServerGroup < CiscoTestCase
                       pattern: /source-interface loopback1/,
                       msg:     'Error: source-interface not correct')
 
-    aaa_group.source_interface = DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE
+    aaa_group.source_interface =
+      cmd_ref.lookup('tacacs_server_group', 'source_interface').default_value
     refute_show_match(command: 'show run tacacs+ all | no-more',
                       pattern: /source-interface loopback1/)
 
@@ -455,6 +400,6 @@ class TestTacacsServerGroup < CiscoTestCase
 
     detach_aaaservergroup(aaa_group)
     refute_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /Group1/)
+                      pattern: /#{group_name}/)
   end
 end

--- a/tests/test_tacacs_server_group.rb
+++ b/tests/test_tacacs_server_group.rb
@@ -193,9 +193,9 @@ class TestTacacsServerGroup < CiscoTestCase
     aaa_group.servers = [server_name1, server_name2]
 
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server1/)
+                      pattern: /server server1/)
     assert_show_match(command: 'show run tacacs+ all | no-more',
-                      pattern: /server2/)
+                      pattern: /server server2/)
 
     detach_aaaservergroup(aaa_group)
     detach_tacacsserverhost(server1)

--- a/tests/test_tacacs_server_group.rb
+++ b/tests/test_tacacs_server_group.rb
@@ -1,6 +1,3 @@
-#
-# Minitest for TacacsServerGroup class
-#
 # Copyright (c) 2014-2015 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,98 +14,447 @@
 
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/tacacs_server_group'
+require_relative '../lib/cisco_node_utils/tacacs_server_host'
 
-# TestTacacsServerGroup - Minitest for TacacsServerGroup node utility.
+DEFAULT_AAA_SERVER_GROUP_VRF = 'default'
+DEFAULT_AAA_SERVER_GROUP_DEADTIME = 0
+DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE = ''
+
+# Test class for Tacacs Server Group
 class TestTacacsServerGroup < CiscoTestCase
-  def setup
-    # setup runs at the beginning of each test
-    super
-    config('no feature tacacs+', 'feature tacacs+',
-           'tacacs-server host 8.8.8.8',
-           'tacacs-server host 9.9.9.9',
-           'tacacs-server host 10.10.10.10',
-           'tacacs-server host 11.11.11.11',
-           'tacacs-server host 12.12.12.12',
-           'tacacs-server host 13.13.13.13')
-    no_tacacsserver
+  def clean_tacacs_config
+    config('no feature tacacs',
+           'feature tacacs')
   end
 
-  def teardown
-    # teardown runs at the end of each test
-    config('no feature tacacs+')
-    no_tacacsserver
-    super
+  def create_tacacsserverhost(name='defaulttest')
+    TacacsServerHost.new(name)
   end
 
-  def no_tacacsserver
-    # Turn the feature off for a clean test.
-    config('no aaa group server tacacs+ red',
-           'no aaa group server tacacs+ blue')
+  def detach_tacacsserverhost(host)
+    host.destroy
   end
 
-  # TESTS
-
-  def test_create_destroy_single
-    id = 'red'
-    refute_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id)
-
-    group = Cisco::TacacsServerGroup.new(id, true)
-    assert_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id)
-    assert_equal(Cisco::TacacsServerGroup.tacacs_server_groups[id], group)
-
-    group.servers = ['8.8.8.8', '9.9.9.9']
-    assert_equal(['8.8.8.8', '9.9.9.9'],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id].servers)
-
-    group.servers = ['8.8.8.8', '10.10.10.10']
-    assert_equal(['8.8.8.8', '10.10.10.10'],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id].servers)
-
-    group.servers = []
-    assert_equal([],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id].servers)
-
-    group.destroy
-    refute_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id)
+  def detach_aaaservergroup(aaa_server_group)
+    aaa_server_group.destroy
   end
 
-  def test_create_destroy_multiple
-    id = 'red'
-    id2 = 'blue'
-    refute_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id)
-    refute_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id2)
+  def create_aaa_group(group_name, server)
+    config("aaa group server #{server} #{group_name}")
+  end
 
-    group = Cisco::TacacsServerGroup.new(id, true)
-    group2 = Cisco::TacacsServerGroup.new(id2, true)
-    assert_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id)
-    assert_equal(Cisco::TacacsServerGroup.tacacs_server_groups[id], group)
-    assert_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id2)
-    assert_equal(Cisco::TacacsServerGroup.tacacs_server_groups[id2], group2)
+  def destroy_aaa_group(group_name, server)
+    config("no aaa group server #{server} #{group_name}")
+  end
 
-    group.servers = ['8.8.8.8', '9.9.9.9']
-    assert_equal(['8.8.8.8', '9.9.9.9'],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id].servers)
-    group2.servers = ['11.11.11.11', '12.12.12.12']
-    assert_equal(['11.11.11.11', '12.12.12.12'],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id2].servers)
+  def create_vrf(group_name, server, vrf_name)
+    config("aaa group server #{server} #{group_name} ; use-vrf #{vrf_name}")
+  end
 
-    group.servers = ['8.8.8.8', '10.10.10.10']
-    assert_equal(['8.8.8.8', '10.10.10.10'],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id].servers)
-    group2.servers = ['11.11.11.11', '13.13.13.13']
-    assert_equal(['11.11.11.11', '13.13.13.13'],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id2].servers)
+  def create_deadtime(group_name, server, deadtime)
+    config("aaa group server #{server} #{group_name} ; deadtime #{deadtime}")
+  end
 
-    group.servers = []
-    assert_equal([],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id].servers)
-    group2.servers = []
-    assert_equal([],
-                 Cisco::TacacsServerGroup.tacacs_server_groups[id2].servers)
+  def create_source_interface(group_name, server, interface)
+    config("aaa group server #{server} #{group_name} ; " \
+           "source-interface #{interface}")
+  end
 
-    group.destroy
-    group2.destroy
-    refute_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id)
-    refute_includes(Cisco::TacacsServerGroup.tacacs_server_groups, id2)
+  def test_create_invalid_name_tacacs
+    assert_raises(TypeError) do
+      TacacsServerGroup.new(nil)
+    end
+  end
+
+  def test_create_valid_tacacs
+    group_name = 'Group1'
+    aaa_group = TacacsServerGroup.new(group_name)
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /Group1/)
+
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_create_valid_multiple_tacacs
+    group_name1 = 'Group1'
+    group_name2 = 'Group2'
+    aaa_group1 = TacacsServerGroup.new(group_name1)
+    aaa_group2 = TacacsServerGroup.new(group_name2)
+
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /Group1/)
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /Group2/)
+
+    detach_aaaservergroup(aaa_group1)
+    detach_aaaservergroup(aaa_group2)
+  end
+
+  def test_collection_empty_tacacs
+    clean_tacacs_config
+    aaa_group_list = TacacsServerGroup.groups
+    assert_empty(aaa_group_list,
+                 'Error: TacacsServerGroup collection is not empty')
+  end
+
+  def test_collection_single_tacacs
+    clean_tacacs_config
+    group_name1 = 'Group1'
+    group_name2 = 'Group2'
+    group_name3 = 'Group3'
+    aaa_group1 = TacacsServerGroup.new(group_name1)
+
+    groups = TacacsServerGroup.groups
+    refute_empty(groups, 'Error: TacacsServerGroup collection is not filled')
+    assert_equal(1, groups.size,
+                 'Error: TacacsServerGroup collection reporting incorrect size')
+    assert(groups.key?(group_name1),
+           "Error: TacacsServerGroup collection does contain #{group_name1}")
+    detach_aaaservergroup(aaa_group1)
+
+    create_aaa_group(group_name2, 'tacacs+')
+    create_aaa_group(group_name3, 'tacacs+')
+    groups = TacacsServerGroup.groups
+    refute_empty(groups, 'Error: TacacsServerGroup collection is not filled')
+    assert_equal(2, groups.size,
+                 'Error: TacacsServerGroup collection reporting incorrect size')
+    assert(groups.key?(group_name2),
+           "Error: TacacsServerGroup collection does contain #{group_name2}")
+    assert(groups.key?(group_name3),
+           "Error: TacacsServerGroup collection does contain #{group_name3}")
+
+    destroy_aaa_group(group_name2, 'tacacs+')
+    destroy_aaa_group(group_name3, 'tacacs+')
+  end
+
+  def test_collection_multi_tacacs
+    clean_tacacs_config
+    group_name1 = 'Group1'
+    group_name2 = 'Group2'
+    group_name3 = 'Group3'
+    aaa_group1 = TacacsServerGroup.new(group_name1)
+
+    aaa_group2 = TacacsServerGroup.new(group_name2)
+
+    aaa_group3 = TacacsServerGroup.new(group_name3)
+
+    groups = TacacsServerGroup.groups
+    refute_empty(groups, 'Error: TacacsServerGroup collection is not filled')
+    assert_equal(3, groups.size,
+                 'Error: TacacsServerGroup collection reporting incorrect size')
+    assert(groups.key?(group_name1),
+           "Error: TacacsServerGroup collection does contain #{group_name1}")
+    assert(groups.key?(group_name2),
+           "Error: TacacsServerGroup collection does contain #{group_name2}")
+    assert(groups.key?(group_name3),
+           "Error: TacacsServerGroup collection does contain #{group_name3}")
+
+    detach_aaaservergroup(aaa_group1)
+    detach_aaaservergroup(aaa_group2)
+    detach_aaaservergroup(aaa_group3)
+  end
+
+  def test_servers_tacacs
+    clean_tacacs_config
+    server_name1 = 'server1'
+    server_name2 = 'server2'
+    server1 = create_tacacsserverhost(server_name1)
+    server2 = create_tacacsserverhost(server_name2)
+
+    aaa_group = TacacsServerGroup.new('Group1')
+
+    # pre check that default servers are empty
+    default_server = aaa_group.default_servers
+    assert_empty(default_server, 'Error: Default Servers are not empty')
+
+    aaa_group.servers = [server_name1, server_name2]
+
+    # Check collection size
+    servers = aaa_group.servers.keys
+    assert_equal(2, servers.size,
+                 'Error: Collection is not two servers')
+    assert(servers.include?('server1'),
+           "Error: Collection does not contain #{server_name1}")
+    assert(servers.include?('server2'),
+           "Error: Collection does not contain #{server_name2}")
+
+    detach_aaaservergroup(aaa_group)
+    detach_tacacsserverhost(server1)
+    detach_tacacsserverhost(server2)
+  end
+
+  def test_add_server_tacacs
+    server_name1 = 'server1'
+    server_name2 = 'server2'
+    server1 = create_tacacsserverhost(server_name1)
+    server2 = create_tacacsserverhost(server_name2)
+
+    aaa_group = TacacsServerGroup.new('Group1')
+    aaa_group.servers = [server_name1, server_name2]
+
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server1/)
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server2/)
+
+    detach_aaaservergroup(aaa_group)
+    detach_tacacsserverhost(server1)
+    detach_tacacsserverhost(server2)
+  end
+
+  def test_add_server_twice_tacacs
+    clean_tacacs_config
+    server_name1 = 'server1'
+    server_name2 = 'server2'
+    server1 = create_tacacsserverhost(server_name1)
+    server2 = create_tacacsserverhost(server_name2)
+
+    aaa_group = TacacsServerGroup.new('Group1')
+    # aaa_group.servers = [server_name1, server_name2, server_name2]
+    # this behavior is different on n9k vs n3k, so comment out for now
+    # n3k throws a CLIError and n9k silently ignores
+    aaa_group.servers = [server_name1, server_name2]
+
+    servers = aaa_group.servers
+    assert_equal(2, servers.size,
+                 'Error: Collection is not two servers')
+
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server server1/)
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server server2/)
+
+    detach_aaaservergroup(aaa_group)
+    detach_tacacsserverhost(server1)
+    detach_tacacsserverhost(server2)
+  end
+
+  def test_remove_server_tacacs
+    clean_tacacs_config
+    server_name1 = 'server1'
+    server_name2 = 'server2'
+    server1 = create_tacacsserverhost(server_name1)
+    server2 = create_tacacsserverhost(server_name2)
+
+    aaa_group = TacacsServerGroup.new('Group1')
+    aaa_group.servers = [server_name1, server_name2]
+
+    # Check collection size
+    servers = aaa_group.servers
+    assert_equal(2, servers.size,
+                 'Error: Collection is not two servers')
+
+    # Now remove them and then check again
+    aaa_group.servers = [server_name2]
+    refute_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server server1/)
+
+    aaa_group.servers = []
+    refute_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server server2/)
+
+    detach_aaaservergroup(aaa_group)
+    detach_tacacsserverhost(server1)
+    detach_tacacsserverhost(server2)
+  end
+
+  def test_remove_server_twice_tacacs
+    clean_tacacs_config
+    server_name1 = 'server1'
+    server_name2 = 'server2'
+    server1 = create_tacacsserverhost(server_name1)
+    server2 = create_tacacsserverhost(server_name2)
+
+    aaa_group = TacacsServerGroup.new('Group1')
+    aaa_group.servers = [server_name1, server_name2]
+
+    # Check collection size
+    servers = aaa_group.servers
+    assert_equal(2, servers.size,
+                 'Error: Collection is not two servers')
+
+    # Now remove them and then check again
+    aaa_group.servers = [server_name2]
+    refute_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server server1/)
+
+    # Now remove server 1 again
+    aaa_group.servers = []
+    refute_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /server server2/)
+
+    # Check collection size
+    servers = aaa_group.servers
+    assert_empty(servers, 'Error: Collection not empty')
+
+    detach_aaaservergroup(aaa_group)
+    detach_tacacsserverhost(server1)
+    detach_tacacsserverhost(server2)
+  end
+
+  def test_get_vrf_tacacs
+    group_name1 = 'Group1'
+    aaa_group = TacacsServerGroup.new(group_name1)
+
+    vrf = DEFAULT_AAA_SERVER_GROUP_VRF
+    assert_equal(vrf, aaa_group.vrf,
+                 'Error: TacacsServerGroup, vrf not default')
+
+    vrf = 'TESTME'
+    create_vrf(group_name1, 'tacacs+', vrf)
+    assert_equal(vrf, aaa_group.vrf,
+                 'Error: TacacsServerGroup, vrf not configured')
+
+    vrf = DEFAULT_AAA_SERVER_GROUP_VRF
+    aaa_group.vrf = vrf
+    assert_equal(vrf, aaa_group.vrf,
+                 'Error: TacacsServerGroup, vrf not restored to default')
+
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_get_default_vrf_tacacs
+    aaa_group = TacacsServerGroup.new('Group1')
+    assert_equal(DEFAULT_AAA_SERVER_GROUP_VRF,
+                 aaa_group.default_vrf,
+                 'Error: TacacsServerGroup, default vrf incorrect')
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_set_vrf_tacacs
+    vrf = 'management-123'
+    aaa_group = TacacsServerGroup.new('Group1')
+    aaa_group.vrf = vrf
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /use-vrf management-123/)
+
+    # Invalid case
+    vrf = 2450
+    assert_raises(TypeError) do
+      aaa_group.vrf = vrf
+    end
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_get_deadtime_tacacs
+    group_name = 'Group1'
+    aaa_group = TacacsServerGroup.new(group_name)
+
+    deadtime = DEFAULT_AAA_SERVER_GROUP_DEADTIME
+    assert_equal(deadtime, aaa_group.deadtime,
+                 'Error: TacacsServerGroup, deadtime not default')
+
+    deadtime = 850
+    create_deadtime(group_name, 'tacacs+', deadtime)
+    assert_equal(deadtime, aaa_group.deadtime,
+                 'Error: TacacsServerGroup, deadtime not configured')
+
+    deadtime = DEFAULT_AAA_SERVER_GROUP_DEADTIME
+    aaa_group.deadtime = deadtime
+    assert_equal(deadtime, aaa_group.deadtime,
+                 'Error: TacacsServerGroup, deadtime not restored to default')
+
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_get_default_deadtime_tacacs
+    aaa_group = TacacsServerGroup.new('Group1')
+    assert_equal(DEFAULT_AAA_SERVER_GROUP_DEADTIME,
+                 aaa_group.default_deadtime,
+                 'Error: TacacsServerGroup, default deadtime incorrect')
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_set_deadtime_tacacs
+    deadtime = 1250
+    aaa_group = TacacsServerGroup.new('Group1')
+    aaa_group.deadtime = deadtime
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /deadtime 1250/,
+                      msg:     'Error: deadtime not configured')
+    # Invalid case
+    deadtime = 2450
+    assert_raises(CliError) do
+      aaa_group.deadtime = deadtime
+    end
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_get_source_interface_tacacs
+    group_name = 'Group1'
+    aaa_group = TacacsServerGroup.new(group_name)
+    intf = DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE
+    assert_equal(intf, aaa_group.source_interface,
+                 'Error: TacacsServerGroup, source-interface set')
+
+    intf = 'Ethernet1/1'
+    create_source_interface(group_name, 'tacacs+', intf)
+    assert_equal(intf, aaa_group.source_interface,
+                 'Error: TacacsServerGroup, source-interface not correct')
+
+    intf = 'Ethernet1/32'
+    create_source_interface(group_name, 'tacacs+', intf)
+    assert_equal(intf, aaa_group.source_interface,
+                 'Error: TacacsServerGroup, source-interface not correct')
+
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_get_default_source_interface_tacacs
+    aaa_group = TacacsServerGroup.new('Group1')
+    assert_equal(DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE,
+                 aaa_group.default_source_interface,
+                 'Error: Aaa_Group Server, default source-interface incorrect')
+    detach_aaaservergroup(aaa_group)
+  end
+
+  def test_set_source_interface_tacacs
+    intf = DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE
+    aaa_group = TacacsServerGroup.new('Group1')
+    assert_equal(intf, aaa_group.source_interface,
+                 'Error: Aaa_Group Server, source-interface not default')
+
+    aaa_group.source_interface = 'loopback1'
+    assert_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /source-interface loopback1/,
+                      msg:     'Error: source-interface not correct')
+
+    aaa_group.source_interface = DEFAULT_AAA_SERVER_GROUP_SOURCE_INTERFACE
+    refute_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /source-interface loopback1/)
+
+    # Invalid case
+    state = true
+    assert_raises(TypeError) do
+      aaa_group.source_interface = state
+    end
+
+    detach_aaaservergroup(aaa_group)
+  end
+
+  # tacacs_server_groups method is the same as groups, added for netdev
+  # compatibility, make sure output is the same
+  def test_groups_methods_equality
+    aaagroup1 = TacacsServerGroup.new('test1')
+    aaagroup2 = TacacsServerGroup.new('test2')
+    aaagroup3 = TacacsServerGroup.new('test3')
+
+    groups1 = TacacsServerGroup.groups.sort
+    groups2 = TacacsServerGroup.tacacs_server_groups.sort
+
+    assert_equal(groups1, groups2)
+
+    detach_aaaservergroup(aaagroup1)
+    detach_aaaservergroup(aaagroup2)
+    detach_aaaservergroup(aaagroup3)
+  end
+
+  def test_destroy_tacacs
+    group_name = 'Group1'
+    aaa_group = TacacsServerGroup.new(group_name)
+
+    detach_aaaservergroup(aaa_group)
+    refute_show_match(command: 'show run tacacs+ all | no-more',
+                      pattern: /Group1/)
   end
 end

--- a/tests/test_vxlan_vtep.rb
+++ b/tests/test_vxlan_vtep.rb
@@ -1,0 +1,160 @@
+# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/vxlan_vtep'
+
+include Cisco
+
+# TestVxlanGlobal - Minitest for VxlanGlobal node utility
+class TestVxlanVtep < CiscoTestCase
+  def setup
+    super
+    no_vxlan_global
+  end
+
+  def teardown
+    no_vxlan_global
+    super
+  end
+
+  def no_vxlan_global
+    config('no feature nv overlay')
+  end
+
+  def test_create_destroy_one
+    id = 'nve1'
+    vtep = VxlanVtep.new(id)
+    @default_show_command = "show running | i 'interface #{id}'"
+
+    assert_show_match(pattern: /^interface #{id}$/,
+                      msg:     "failed to create interface #{id}")
+
+    assert_includes(Cisco::VxlanVtep.vteps, id)
+    assert_equal(Cisco::VxlanVtep.vteps[id], vtep)
+
+    vtep.destroy
+    refute_show_match(pattern: /^interface #{id}$/,
+                      msg:     "failed to destroy interface #{id}")
+  end
+
+  def test_create_destroy_multiple
+    skip('Only supported on n7k') if node.product_id =~ /N[3|5|9]K/
+
+    id1 = 'nve1'
+    id2 = 'nve2'
+    id3 = 'nve3'
+    id4 = 'nve4'
+    vtep1 = VxlanVtep.new(id1)
+    vtep2 = VxlanVtep.new(id2)
+    vtep3 = VxlanVtep.new(id3)
+    vtep4 = VxlanVtep.new(id4)
+
+    [id1, id2, id3, id4].each do |id|
+      assert_show_match(command: "show running | i 'interface #{id}'",
+                        pattern: /^interface #{id}$/,
+                        msg:     "failed to create interface #{id}")
+      assert_includes(Cisco::VxlanVtep.vteps, id)
+    end
+
+    vtep1.destroy
+    vtep2.destroy
+    vtep3.destroy
+    vtep4.destroy
+
+    [id1, id2, id3, id4].each do |id|
+      refute_show_match(command: "show running | i 'interface #{id}'",
+                        pattern: /^interface #{id}$/,
+                        msg:     "failed to create interface #{id}")
+    end
+  end
+
+  def test_create_multiple_negative
+    # N[3|9]K supports a single nve int, N7K supports 4.
+    case node.product_id
+    when /N[3|9]K/
+      VxlanVtep.new('nve1')
+      negative_id = 'nve2'
+    when /N7K/
+      (1..4).each { |n| VxlanVtep.new("nve#{n}") }
+      negative_id = 'nve5'
+    end
+
+    assert_raises(CliError) do
+      VxlanVtep.new(negative_id)
+    end
+  end
+
+  def test_description
+    id = 'nve1'
+    vtep = VxlanVtep.new(id)
+
+    # Set description to non-default value and verify
+    desc = 'vxlan interface'
+    vtep.description = desc
+    assert_equal(vtep.description, desc, "description is not #{desc}")
+
+    # Set description to default value and verfiy
+    desc = vtep.default_description
+    vtep.description = desc
+    assert_equal(vtep.description, desc, "description is not #{desc}")
+  end
+
+  def test_mac_distribution
+    id = 'nve1'
+    vtep = VxlanVtep.new(id)
+
+    val = :flood
+    vtep.mac_distribution = val
+    assert_equal(vtep.mac_distribution, val.to_s,
+                 "mac_distribution is not #{val}")
+
+    val = :evpn
+    vtep.mac_distribution = val
+    assert_equal(vtep.mac_distribution, val.to_s,
+                 "mac_distribution is not #{val}")
+
+    # Set value back to flood, currently evpn.
+    val = :flood
+    vtep.mac_distribution = val
+    assert_equal(vtep.mac_distribution, val.to_s,
+                 "mac_distribution is not #{val}")
+  end
+
+  def test_shutdown
+    id = 'nve1'
+    vtep = VxlanVtep.new(id)
+
+    vtep.shutdown = true
+    assert(vtep.shutdown, 'source_interface is not shutdown')
+
+    vtep.shutdown = false
+    refute(vtep.shutdown, 'source_interface is shutdown')
+  end
+
+  def test_source_interface
+    id = 'nve1'
+    vtep = VxlanVtep.new(id)
+
+    # Set source_interface to non-default value
+    val = 'loopback55'
+    vtep.source_interface = val
+    assert_equal(vtep.source_interface, val, "source_interface is not #{val}")
+
+    # Set source_interface to default value
+    val = vtep.default_source_interface
+    vtep.source_interface = val
+    assert_equal(vtep.source_interface, val, "source_interface is not #{val}")
+  end
+end

--- a/tests/test_vxlan_vtep.rb
+++ b/tests/test_vxlan_vtep.rb
@@ -97,23 +97,21 @@ class TestVxlanVtep < CiscoTestCase
   end
 
   def test_description
-    id = 'nve1'
-    vtep = VxlanVtep.new(id)
+    vtep = VxlanVtep.new('nve1')
 
     # Set description to non-default value and verify
     desc = 'vxlan interface'
     vtep.description = desc
     assert_equal(vtep.description, desc, "description is not #{desc}")
 
-    # Set description to default value and verfiy
+    # Set description to default value and verify
     desc = vtep.default_description
     vtep.description = desc
     assert_equal(vtep.description, desc, "description is not #{desc}")
   end
 
   def test_mac_distribution
-    id = 'nve1'
-    vtep = VxlanVtep.new(id)
+    vtep = VxlanVtep.new('nve1')
 
     val = :flood
     vtep.mac_distribution = val
@@ -133,8 +131,7 @@ class TestVxlanVtep < CiscoTestCase
   end
 
   def test_shutdown
-    id = 'nve1'
-    vtep = VxlanVtep.new(id)
+    vtep = VxlanVtep.new('nve1')
 
     vtep.shutdown = true
     assert(vtep.shutdown, 'source_interface is not shutdown')
@@ -144,8 +141,7 @@ class TestVxlanVtep < CiscoTestCase
   end
 
   def test_source_interface
-    id = 'nve1'
-    vtep = VxlanVtep.new(id)
+    vtep = VxlanVtep.new('nve1')
 
     # Set source_interface to non-default value
     val = 'loopback55'


### PR DESCRIPTION
1) Refactor vxlan_vtep object to use new yaml refactoring.
2) Added minitests
3) Merged latest develop changes. (I marked these changes so they can be ignored in this review.. sorry for the noise!)

```
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/vxlan/cisco-network-node-utils/tests> ruby test_vxlan_vtep.rb -v -- 10.122.197.222 admin admin
Run options: -v -- --seed 19704

# Running:


Node under test:
  - name  - dt-n9k5-1
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I2.1.74.bin

TestVxlanVtep#test_description = 11.07 s = .
TestVxlanVtep#test_create_destroy_one = 10.20 s = .
TestVxlanVtep#test_create_multiple_negative = 9.48 s = .
TestVxlanVtep#test_source_interface = 9.81 s = .
TestVxlanVtep#test_mac_distribution = 10.84 s = .
TestVxlanVtep#test_shutdown = 10.44 s = .
TestVxlanVtep#test_create_destroy_multiple = 0.84 s = S

Finished in 62.691097s, 0.1117 runs/s, 0.3031 assertions/s.

  1) Skipped:
TestVxlanVtep#test_create_destroy_multiple [test_vxlan_vtep.rb:53]:
Only supported on n7k

7 runs, 19 assertions, 0 failures, 0 errors, 1 skips
```
