### PR TITLE
Unsupported interface properties return nil on XR

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -231,34 +231,34 @@ switchport_autostate_exclude:
   default_value: false
 
 switchport_mode_dot1q_tunnel:
+  _exclude: [cli_ios_xr]
   default_only: ""
 
 switchport_mode_ethernet:
-  cli_nexus:
-    auto_default: false
-    config_get_token_append: '/^(?:no )?switchport mode ?(.*)$/'
-    config_set_append: "<state> switchport mode <mode>"
-    default_value: "access"
-  cli_ios_xr:
-    default_only: ""
+  _exclude: [cli_ios_xr]
+  auto_default: false
+  config_get_token_append: '/^(?:no )?switchport mode ?(.*)$/'
+  config_set_append: "<state> switchport mode <mode>"
+  default_value: "access"
 
 switchport_mode_other_interfaces:
+  _exclude: [cli_ios_xr]
   default_only: ""
 
 switchport_mode_port_channel:
-  cli_nexus:
-    config_get_token_append: '/^switchport mode (.*)$/'
-    config_set_append: "<state> switchport mode <mode>"
-    default_value: ""
-  cli_ios_xr:
-    default_only: ""
+  _exclude: [cli_ios_xr]
+  config_get_token_append: '/^switchport mode (.*)$/'
+  config_set_append: "<state> switchport mode <mode>"
+  default_value: ""
 
 switchport_trunk_allowed_vlan:
+  _exclude: [cli_ios_xr]
   config_get_token_append: '/^switchport trunk allowed vlan (.*)$/'
   config_set_append: "<state> switchport trunk allowed vlan <vlan>"
   default_value: "all"
 
 switchport_trunk_native_vlan:
+  _exclude: [cli_ios_xr]
   kind: int
   config_get_token_append: '/^switchport trunk native vlan (.*)$/'
   config_set_append: "<state> switchport trunk native vlan <vlan>"

--- a/tests/test_interface_switchport.rb
+++ b/tests/test_interface_switchport.rb
@@ -18,12 +18,9 @@ require_relative '../lib/cisco_node_utils/vtp'
 
 include Cisco
 
-# TestInterfaceSwitchport - Minitest for switchport config by Interface class.
+# TestInterfaceSwitchport
+# Parent class for specific types of switchport tests (below)
 class TestInterfaceSwitchport < CiscoTestCase
-  DEFAULT_IF_ACCESS_VLAN = 1
-  DEFAULT_IF_SWITCHPORT_ALLOWED_VLAN = '1-4094'
-  DEFAULT_IF_SWITCHPORT_NATIVE_VLAN = 1
-
   attr_reader :interface
 
   def setup
@@ -33,7 +30,8 @@ class TestInterfaceSwitchport < CiscoTestCase
   end
 
   def teardown
-    interface_ethernet_default(interfaces_id[0])
+    config("default interface ethernet #{interfaces_id[0]}")
+    super
   end
 
   def mgmt_intf
@@ -43,27 +41,13 @@ class TestInterfaceSwitchport < CiscoTestCase
       'MgmtEth0/RP0/CPU0/0'
     end
   end
+end
 
-  def interface_ethernet_default(ethernet_id)
-    config("default interface ethernet #{ethernet_id}")
-  end
-
-  def cmd_ref_switchport_autostate_exclude
-    ref = cmd_ref.lookup('interface',
-                         'switchport_autostate_exclude')
-    assert(ref, 'Error, reference not found for switchport_autostate_exclude')
-    ref
-  end
-
-  # Decides whether to check for a raised Exception or an equal value.
-  def assert_result(expected_result, err_msg, &block)
-    if expected_result.is_a? Class
-      assert_raises(expected_result, &block)
-    else
-      value = block.call
-      assert_equal(expected_result, value, err_msg)
-    end
-  end
+# TestSwitchport - general interface switchport tests.
+class TestSwitchport < TestInterfaceSwitchport
+  DEFAULT_IF_ACCESS_VLAN = 1
+  DEFAULT_IF_SWITCHPORT_ALLOWED_VLAN = '1-4094'
+  DEFAULT_IF_SWITCHPORT_NATIVE_VLAN = 1
 
   def system_default_switchport(state='')
     config("#{state} system default switchport")
@@ -75,26 +59,37 @@ class TestInterfaceSwitchport < CiscoTestCase
 
   def test_interface_get_access_vlan
     interface.switchport_mode = :disabled
-    interface.switchport_mode = :access
-    assert_equal(DEFAULT_IF_ACCESS_VLAN, interface.access_vlan)
+    if platform == :ios_xr
+      assert_raises(Cisco::UnsupportedError) do
+        interface.switchport_mode = :access
+      end
+      assert_nil(interface.access_vlan)
+    else
+      interface.switchport_mode = :access
+      assert_equal(DEFAULT_IF_ACCESS_VLAN, interface.access_vlan)
+    end
   end
 
   def test_interface_get_access_vlan_switchport_disabled
     interface.switchport_mode = :disabled
-    assert_equal(DEFAULT_IF_ACCESS_VLAN, interface.access_vlan)
+    if platform == :ios_xr
+      assert_nil(interface.access_vlan)
+    else
+      assert_equal(DEFAULT_IF_ACCESS_VLAN, interface.access_vlan)
+    end
   end
 
   def test_interface_get_access_vlan_switchport_trunk
     interface.switchport_mode = :disabled
-    interface.switchport_mode = :trunk
-    assert_equal(DEFAULT_IF_ACCESS_VLAN, interface.access_vlan)
-  end
-
-  def test_switchport_vtp_disabled_feature_enabled
-    vtp = Vtp.new(true)
-    refute(interface.switchport_vtp,
-           'Error: interface, access, vtp not disabled')
-    vtp.destroy
+    if platform == :ios_xr
+      assert_raises(Cisco::UnsupportedError) do
+        interface.switchport_mode = :trunk
+      end
+      assert_nil(interface.access_vlan)
+    else
+      interface.switchport_mode = :trunk
+      assert_equal(DEFAULT_IF_ACCESS_VLAN, interface.access_vlan)
+    end
   end
 
   def test_switchport_vtp_disabled_feature_disabled_eth1_1
@@ -115,6 +110,12 @@ class TestInterfaceSwitchport < CiscoTestCase
   end
 
   def test_switchport_vtp_disabled_unsupported_mode_fex
+    if platform == :ios_xr
+      assert_raises(Cisco::UnsupportedError) do
+        interface.switchport_mode = :fex_fabric
+      end
+      return
+    end
     interface.switchport_mode = :fex_fabric
     refute(interface.switchport_vtp,
            'Error: interface, access, vtp not disabled')
@@ -122,150 +123,6 @@ class TestInterfaceSwitchport < CiscoTestCase
     msg = "[#{interfaces[0]}] switchport_mode is not supported " \
           'on this interface'
     assert_equal(msg.downcase, e.message)
-  end
-
-  def test_switchport_vtp_enabled_access
-    vtp = Vtp.new(true)
-    interface.switchport_mode = :access
-    config("interface ethernet #{interfaces_id[0]}", 'vtp')
-
-    assert(interface.switchport_vtp,
-           'Error: interface, access, vtp not enabled')
-    vtp.destroy
-  end
-
-  def test_switchport_vtp_disabled_access
-    vtp = Vtp.new(true)
-    interface.switchport_mode = :access
-    config("interface ethernet #{interfaces_id[0]}", 'no vtp')
-
-    refute(interface.switchport_vtp,
-           'Error: interface, access, vtp not disabled')
-    vtp.destroy
-  end
-
-  def test_switchport_vtp_enabled_trunk
-    vtp = Vtp.new(true)
-    interface.switchport_mode = :trunk
-    config("interface ethernet #{interfaces_id[0]}", 'vtp')
-
-    assert(interface.switchport_vtp,
-           'Error: interface, trunk, vtp not enabled')
-    vtp.destroy
-  end
-
-  def test_switchport_vtp_disabled_trunk
-    vtp = Vtp.new(true)
-    interface.switchport_mode = :trunk
-    refute(interface.switchport_vtp,
-           'Error: interface, trunk, vtp not disabled')
-    vtp.destroy
-  end
-
-  def test_set_switchport_vtp_default_access
-    vtp = Vtp.new(true)
-    interface.switchport_mode = :access
-
-    interface.switchport_vtp = interface.default_switchport_vtp
-    refute(interface.switchport_vtp,
-           'Error:(1) mode :access, vtp should be default (false)')
-
-    interface.switchport_vtp = true
-    assert(interface.switchport_vtp,
-           'Error:(2) mode :access, vtp should be true')
-
-    interface.switchport_vtp = interface.default_switchport_vtp
-    refute(interface.switchport_vtp,
-           'Error:(3) mode :access, vtp should be default (false)')
-
-    vtp.destroy
-  end
-
-  def test_set_switchport_vtp_default_trunk
-    vtp = Vtp.new(true)
-    interface.switchport_mode = :trunk
-    interface.switchport_vtp = interface.default_switchport_vtp
-    refute(interface.switchport_vtp,
-           'Error:(1) mode :trunk, vtp should be default (false)')
-
-    interface.switchport_vtp = true
-    assert(interface.switchport_vtp,
-           'Error:(2) mode :trunk, vtp should be true')
-
-    interface.switchport_vtp = interface.default_switchport_vtp
-    refute(interface.switchport_vtp,
-           'Error:(3) mode :trunk, vtp should be default (false)')
-    vtp.destroy
-  end
-
-  def test_set_switchport_vtp_true_access
-    vtp = Vtp.new(true)
-    interface.switchport_mode = :access
-    interface.switchport_vtp = true
-    assert(interface.switchport_vtp,
-           'Error: interface, access, vtp not enabled')
-    vtp.destroy
-  end
-
-  def test_set_switchport_vtp_true_trunk
-    vtp = Vtp.new(true)
-    interface.switchport_mode = :trunk
-    interface.switchport_vtp = true
-    assert(interface.switchport_vtp,
-           'Error: interface, access, vtp not enabled')
-    vtp.destroy
-  end
-
-  def test_set_switchport_vtp_true_unsupported_mode_disabled
-    vtp = Vtp.new(true)
-    interface.switchport_mode = :disabled
-    refute(interface.switchport_vtp,
-           'Error: interface, access, vtp is enabled')
-    vtp.destroy
-  end
-
-  def test_set_switchport_vtp_true_unsupported_mgmt_intf
-    vtp = Vtp.new(true)
-    interface = Interface.new(mgmt_intf)
-
-    interface.switchport_vtp = true
-    refute(interface.switchport_vtp,
-           'Error: interface, access, vtp is enabled')
-    vtp.destroy
-  end
-
-  def test_set_switchport_vtp_false_access
-    vtp = Vtp.new(true)
-    interface.switchport_mode = :access
-    interface.switchport_vtp = false
-    refute(interface.switchport_vtp,
-           'Error: interface, access, vtp not disabled')
-    vtp.destroy
-  end
-
-  def test_set_switchport_vtp_false_trunk
-    vtp = Vtp.new(true)
-    interface.switchport_mode = :trunk
-    interface.switchport_vtp = false
-    refute(interface.switchport_vtp,
-           'Error: interface, access, vtp not disabled')
-    vtp.destroy
-  end
-
-  def test_set_switchport_vtp_false_unsupported_mode_disabled
-    vtp = Vtp.new(true)
-    interface.switchport_mode = :disabled
-    interface.switchport_vtp = false
-    refute(interface.switchport_vtp,
-           'Error: mode :disabled, vtp should be false')
-    vtp.destroy
-  end
-
-  def test_switchport_autostate_disabled_feature_enabled
-    svi = Interface.new('Vlan23')
-    refute(interface.switchport_autostate_exclude,
-           'Error: interface, access, autostate exclude not disabled')
-    svi.destroy
   end
 
   def test_switchport_autostate_disabled_feature_disabled_eth1_1
@@ -280,184 +137,27 @@ class TestInterfaceSwitchport < CiscoTestCase
   end
 
   def test_switchport_autostate_disabled_unsupported_mode
-    interface.switchport_mode = :disabled
-    refute(interface.switchport_autostate_exclude,
-           'Error: interface, access, autostate exclude not disabled')
-  end
-
-  def test_switchport_autostate_enabled_access
-    svi = Interface.new('Vlan23')
-    config("interface ethernet #{interfaces_id[0]}",
-           'switchport',
-           'switchport autostate exclude')
-
-    cmd_ref = cmd_ref_switchport_autostate_exclude
-    if cmd_ref.config_set?
-      assert(interface.switchport_autostate_exclude,
-             'Error: interface, access, autostate exclude not enabled')
+    if platform == :ios_xr
+      assert_nil(interface.switchport_autostate_exclude)
     else
-      assert_equal(interface.default_switchport_autostate_exclude,
-                   interface.switchport_autostate_exclude,
-                   'Error: interface, access, autostate exclude not disabled')
+      interface.switchport_mode = :disabled
+      refute(interface.switchport_autostate_exclude,
+             'Error: interface, access, autostate exclude not disabled')
     end
-    svi.destroy
-  end
-
-  def test_switchport_autostate_disabled_access
-    svi = Interface.new('Vlan23')
-    refute(interface.switchport_autostate_exclude,
-           'Error: interface, access, autostate exclude not disabled')
-    svi.destroy
-  end
-
-  def test_switchport_autostate_enabled_trunk
-    svi = Interface.new('Vlan23')
-    interface.switchport_mode = :trunk
-    config("interface ethernet #{interfaces_id[0]}",
-           'switchport autostate exclude')
-
-    cmd_ref = cmd_ref_switchport_autostate_exclude
-    if cmd_ref.config_set?
-      assert(interface.switchport_autostate_exclude,
-             'Error: interface, access, autostate exclude not enabled')
-    else
-      assert_equal(interface.default_switchport_autostate_exclude,
-                   interface.switchport_autostate_exclude,
-                   'Error: interface, access, autostate exclude not disabled')
-    end
-    svi.destroy
-  end
-
-  def test_switchport_autostate_disabled_trunk
-    svi = Interface.new('Vlan23')
-    interface.switchport_mode = :trunk
-    config("interface ethernet #{interfaces_id[0]}",
-           'no switchport autostate exclude')
-
-    refute(interface.switchport_autostate_exclude,
-           'Error: interface, access, autostate exclude not disabled')
-    svi.destroy
   end
 
   def test_raise_error_switchport_not_enabled
-    interface.switchport_enable(false)
+    if platform == :ios_xr
+      assert_raises(Cisco::UnsupportedError) do
+        interface.switchport_autostate_exclude = true
+      end
+    else
+      interface.switchport_enable(false)
 
-    assert_raises(RuntimeError) do
-      interface.switchport_autostate_exclude = true
+      assert_raises(RuntimeError) do
+        interface.switchport_autostate_exclude = true
+      end
     end
-  end
-
-  def test_set_switchport_autostate_default_access
-    svi = Interface.new('Vlan23')
-    # switchport must be enabled to configure autostate
-    interface.switchport_enable(true)
-
-    result = interface.default_switchport_autostate_exclude
-    assert_result(result,
-                  'Error: interface, access, autostate exclude not disabled') do
-      interface.switchport_autostate_exclude = result
-    end
-    svi.destroy
-  end
-
-  def test_set_switchport_autostate_default_trunk
-    svi = Interface.new('Vlan23')
-    interface.switchport_mode = :trunk
-
-    # switchport must be enabled to configure autostate
-    interface.switchport_enable(true)
-
-    result = false
-    assert_result(result,
-                  'Error: interface, access, autostate exclude not disabled') do
-      interface.switchport_autostate_exclude = result
-    end
-    svi.destroy
-  end
-
-  def test_set_switchport_autostate_true_access
-    svi = Interface.new('Vlan23')
-    # switchport must be enabled to configure autostate
-    interface.switchport_enable(true)
-
-    result = true
-    assert_result(result,
-                  'Error: interface, access, autostate exclude not disabled') do
-      interface.switchport_autostate_exclude = result
-    end
-    svi.destroy
-  end
-
-  def test_set_switchport_autostate_true_trunk
-    svi = Interface.new('Vlan23')
-    interface.switchport_mode = :trunk
-
-    # switchport must be enabled to configure autostate
-    interface.switchport_enable(true)
-
-    result = true
-    assert_result(result,
-                  'Error: interface, access, autostate exclude not disabled') do
-      interface.switchport_autostate_exclude = result
-    end
-    svi.destroy
-  end
-
-  def test_set_switchport_autostate_true_unsupported_mode_disabled
-    svi = Interface.new('Vlan23')
-    interface.switchport_mode = :disabled
-
-    assert_raises RuntimeError do
-      interface.switchport_autostate_exclude = true
-    end
-    svi.destroy
-  end
-
-  def test_set_switchport_autostate_true_unsupported_mgmt_intf
-    svi = Interface.new('Vlan23')
-    interface = Interface.new(mgmt_intf)
-    assert_raises RuntimeError do
-      interface.switchport_autostate_exclude = true
-    end
-    svi.destroy
-  end
-
-  def test_set_switchport_autostate_false_access
-    svi = Interface.new('Vlan23')
-    # switchport must be enabled to configure autostate
-    interface.switchport_enable(true)
-
-    result = false
-    assert_result(result,
-                  'Error: interface, access, autostate exclude not disabled') do
-      interface.switchport_autostate_exclude = result
-    end
-    svi.destroy
-  end
-
-  def test_set_switchport_autostate_false_trunk
-    svi = Interface.new('Vlan23')
-    interface.switchport_mode = :trunk
-
-    # switchport must be enabled to configure autostate
-    interface.switchport_enable(true)
-
-    result = false
-    assert_result(result,
-                  'Error: interface, access, autostate exclude not disabled') do
-      interface.switchport_autostate_exclude = result
-    end
-    svi.destroy
-  end
-
-  def test_set_switchport_autostate_false_unsupported_mode_disabled
-    svi = Interface.new('Vlan23')
-    interface.switchport_mode = :disabled
-
-    assert_raises RuntimeError do
-      interface.switchport_autostate_exclude = false
-    end
-    svi.destroy
   end
 
   def test_interface_switchport_mode_invalid
@@ -472,6 +172,21 @@ class TestInterfaceSwitchport < CiscoTestCase
   end
 
   def test_interface_switchport_mode_valid
+    if platform == :ios_xr
+      # We don't support any switchport modes on IOS XR
+      # but we allow the user to set :disabled since that's the default.
+      interface.switchport_mode = :disabled
+      assert_nil(interface.switchport_mode)
+      assert_raises(Cisco::UnsupportedError) do
+        interface.switchport_mode = :access
+      end
+      assert_raises(Cisco::UnsupportedError) do
+        interface.switchport_mode = :trunk
+      end
+      assert_nil(interface.switchport_mode)
+      return
+    end
+
     switchport_modes = [
       :unknown,
       :disabled,
@@ -501,6 +216,7 @@ class TestInterfaceSwitchport < CiscoTestCase
   end
 
   def test_interface_switchport_mode_valid_fex
+    skip('Not supported on IOS XR') if platform == :ios_xr
     switchport_modes = [
       :unknown,
       :fex_fabric,
@@ -526,78 +242,73 @@ class TestInterfaceSwitchport < CiscoTestCase
     end
   end
 
-  def test_interface_switchport_trunk_allowed_vlan_all
-    interface.switchport_enable
-    interface.switchport_trunk_allowed_vlan = 'all'
-    assert_equal(
-      DEFAULT_IF_SWITCHPORT_ALLOWED_VLAN,
-      interface.switchport_trunk_allowed_vlan)
-  end
+  def test_interface_switchport_trunk_allowed_vlan
+    if platform == :ios_xr
+      assert_nil(interface.default_switchport_trunk_allowed_vlan)
+      assert_nil(interface.switchport_trunk_allowed_vlan)
+      assert_raises(Cisco::UnsupportedError) do
+        interface.switchport_trunk_allowed_vlan = 'all'
+      end
+      assert_raises(Cisco::UnsupportedError) do
+        interface.switchport_trunk_allowed_vlan = '20'
+      end
+      assert_raises(Cisco::UnsupportedError) do
+        interface.switchport_trunk_allowed_vlan = 'none'
+      end
+    else
+      interface.switchport_enable
+      interface.switchport_trunk_allowed_vlan = 'all'
+      assert_equal(DEFAULT_IF_SWITCHPORT_ALLOWED_VLAN,
+                   interface.switchport_trunk_allowed_vlan)
 
-  def test_interface_switchport_trunk_allowed_vlan_change
-    interface.switchport_enable
-    interface.switchport_trunk_allowed_vlan = '20'
-    assert_equal('20', interface.switchport_trunk_allowed_vlan)
-    interface.switchport_trunk_allowed_vlan = '30'
-    assert_equal('30', interface.switchport_trunk_allowed_vlan)
-  end
+      interface.switchport_trunk_allowed_vlan = '20'
+      assert_equal('20', interface.switchport_trunk_allowed_vlan)
 
-  def test_interface_switchport_trunk_allowed_vlan_default
-    interface.switchport_enable
-    interface.switchport_trunk_allowed_vlan =
-      interface.default_switchport_trunk_allowed_vlan
-    assert_equal(
-      DEFAULT_IF_SWITCHPORT_ALLOWED_VLAN,
-      interface.switchport_trunk_allowed_vlan)
-  end
+      interface.switchport_trunk_allowed_vlan = '30'
+      assert_equal('30', interface.switchport_trunk_allowed_vlan)
 
-  def test_interface_switchport_trunk_allowed_vlan_invalid
-    interface.switchport_enable
-    assert_raises(RuntimeError) do
-      interface.switchport_trunk_allowed_vlan = 'hello'
+      interface.switchport_trunk_allowed_vlan =
+        interface.default_switchport_trunk_allowed_vlan
+      assert_equal(DEFAULT_IF_SWITCHPORT_ALLOWED_VLAN,
+                   interface.switchport_trunk_allowed_vlan)
+
+      assert_raises(RuntimeError) do
+        interface.switchport_trunk_allowed_vlan = 'hello'
+      end
+
+      interface.switchport_trunk_allowed_vlan = 'none'
+      assert_equal('none', interface.switchport_trunk_allowed_vlan)
+
+      interface.switchport_trunk_allowed_vlan = '20, 30'
+      assert_equal('20,30', interface.switchport_trunk_allowed_vlan)
     end
   end
 
-  def test_interface_switchport_trunk_allowed_vlan_none
-    interface.switchport_enable
-    interface.switchport_trunk_allowed_vlan = 'none'
-    assert_equal('none', interface.switchport_trunk_allowed_vlan)
-  end
+  def test_interface_switchport_trunk_native_vlan
+    if platform == :ios_xr
+      assert_nil(interface.switchport_trunk_native_vlan)
+      assert_nil(interface.default_switchport_trunk_native_vlan)
+      assert_raises(Cisco::UnsupportedError) do
+        interface.switchport_trunk_native_vlan = 20
+      end
+    else
+      interface.switchport_enable
 
-  def test_interface_switchport_trunk_allowed_vlan_valid
-    interface.switchport_enable
-    interface.switchport_trunk_allowed_vlan = '20, 30'
-    assert_equal('20,30', interface.switchport_trunk_allowed_vlan)
-  end
+      interface.switchport_trunk_native_vlan = 20
+      assert_equal(20, interface.switchport_trunk_native_vlan)
 
-  def test_interface_switchport_trunk_native_vlan_change
-    interface.switchport_enable
-    interface.switchport_trunk_native_vlan = 20
-    assert_equal(20, interface.switchport_trunk_native_vlan)
-    interface.switchport_trunk_native_vlan = 30
-    assert_equal(30, interface.switchport_trunk_native_vlan)
-  end
+      interface.switchport_trunk_native_vlan = 30
+      assert_equal(30, interface.switchport_trunk_native_vlan)
 
-  def test_interface_switchport_trunk_native_vlan_default
-    interface.switchport_enable
-    interface.switchport_trunk_native_vlan =
-      interface.default_switchport_trunk_native_vlan
-    assert_equal(
-      DEFAULT_IF_SWITCHPORT_NATIVE_VLAN,
-      interface.switchport_trunk_native_vlan)
-  end
+      interface.switchport_trunk_native_vlan =
+        interface.default_switchport_trunk_native_vlan
+      assert_equal(DEFAULT_IF_SWITCHPORT_NATIVE_VLAN,
+                   interface.switchport_trunk_native_vlan)
 
-  def test_interface_switchport_trunk_native_vlan_invalid
-    interface.switchport_enable
-    assert_raises(RuntimeError) do
-      interface.switchport_trunk_native_vlan = '20, 30'
+      assert_raises(RuntimeError) do
+        interface.switchport_trunk_native_vlan = '20, 30'
+      end
     end
-  end
-
-  def test_interface_switchport_trunk_native_vlan_valid
-    interface.switchport_enable
-    interface.switchport_trunk_native_vlan = 20
-    assert_equal(20, interface.switchport_trunk_native_vlan)
   end
 
   # TODO: Run this test at your peril as it can cause timeouts for this test and
@@ -673,5 +384,270 @@ class TestInterfaceSwitchport < CiscoTestCase
   def test_interface_svi_command_on_non_vlan
     assert_raises(RuntimeError) { interface.svi_autostate = true }
     assert_raises(RuntimeError) { interface.svi_management = true }
+  end
+end
+
+# TestInterfaceSwitchportSvi
+# Minitest for Interface switchport configuration in combo with interface-vlan
+# Not applicable to IOS XR
+class TestInterfaceSwitchportSvi < TestInterfaceSwitchport
+  attr_reader :svi
+
+  def setup
+    super
+    skip('VLAN interfaces are not supported on IOS XR') if platform == :ios_xr
+    @svi = Interface.new('Vlan23')
+  end
+
+  def teardown
+    svi.destroy unless platform == :ios_xr
+    super
+  end
+
+  def cmd_ref_switchport_autostate_exclude
+    ref = cmd_ref.lookup('interface',
+                         'switchport_autostate_exclude')
+    assert(ref, 'Error, reference not found for switchport_autostate_exclude')
+    ref
+  end
+
+  def test_switchport_autostate_disabled_feature_enabled
+    refute(interface.switchport_autostate_exclude,
+           'Error: interface, access, autostate exclude not disabled')
+  end
+
+  def test_switchport_autostate_enabled_access
+    config("interface ethernet #{interfaces_id[0]}",
+           'switchport',
+           'switchport autostate exclude')
+
+    cmd_ref = cmd_ref_switchport_autostate_exclude
+    if cmd_ref.config_set?
+      assert(interface.switchport_autostate_exclude,
+             'Error: interface, access, autostate exclude not enabled')
+    else
+      assert_equal(interface.default_switchport_autostate_exclude,
+                   interface.switchport_autostate_exclude,
+                   'Error: interface, access, autostate exclude not disabled')
+    end
+  end
+
+  def test_switchport_autostate_disabled_access
+    refute(interface.switchport_autostate_exclude,
+           'Error: interface, access, autostate exclude not disabled')
+  end
+
+  def test_switchport_autostate_enabled_trunk
+    interface.switchport_mode = :trunk
+    config("interface ethernet #{interfaces_id[0]}",
+           'switchport autostate exclude')
+
+    cmd_ref = cmd_ref_switchport_autostate_exclude
+    if cmd_ref.config_set?
+      assert(interface.switchport_autostate_exclude,
+             'Error: interface, access, autostate exclude not enabled')
+    else
+      assert_equal(interface.default_switchport_autostate_exclude,
+                   interface.switchport_autostate_exclude,
+                   'Error: interface, access, autostate exclude not disabled')
+    end
+  end
+
+  def test_switchport_autostate_disabled_trunk
+    interface.switchport_mode = :trunk
+    config("interface ethernet #{interfaces_id[0]}",
+           'no switchport autostate exclude')
+
+    refute(interface.switchport_autostate_exclude,
+           'Error: interface, access, autostate exclude not disabled')
+  end
+
+  def test_switchport_autostate_access
+    # switchport must be enabled to configure autostate
+    interface.switchport_enable(true)
+
+    interface.switchport_autostate_exclude = true
+    assert(interface.switchport_autostate_exclude,
+           'Error: interface, access, autostate exclude not enabled')
+
+    interface.switchport_autostate_exclude = false
+    refute(interface.switchport_autostate_exclude,
+           'Error: interface, access, autostate exclude not disabled')
+
+    result = interface.default_switchport_autostate_exclude
+    interface.switchport_autostate_exclude = result
+    assert_equal(result, interface.switchport_autostate_exclude,
+                 'Error: interface, access, autostate exclude not disabled')
+  end
+
+  def test_switchport_autostate_trunk
+    interface.switchport_mode = :trunk
+
+    # switchport must be enabled to configure autostate
+    interface.switchport_enable(true)
+
+    interface.switchport_autostate_exclude = true
+    assert(interface.switchport_autostate_exclude,
+           'Error: interface, access, autostate exclude not enabled')
+
+    interface.switchport_autostate_exclude = false
+    refute(interface.switchport_autostate_exclude,
+           'Error: interface, access, autostate exclude not disabled')
+
+    result = interface.default_switchport_autostate_exclude
+    interface.switchport_autostate_exclude = result
+    assert_equal(result, interface.switchport_autostate_exclude,
+                 'Error: interface, access, autostate exclude not disabled')
+  end
+
+  def test_switchport_autostate_unsupported_mode_disabled
+    interface.switchport_mode = :disabled
+
+    assert_raises RuntimeError do
+      interface.switchport_autostate_exclude = true
+    end
+    assert_raises RuntimeError do
+      interface.switchport_autostate_exclude = false
+    end
+  end
+
+  def test_set_switchport_autostate_true_unsupported_mgmt_intf
+    interface = Interface.new(mgmt_intf)
+    assert_raises RuntimeError do
+      interface.switchport_autostate_exclude = true
+    end
+  end
+end
+
+# TestInterfaceSwitchportVtp
+# Minitest for Interface switchport configuration in combo with Vtp class
+# Not applicable to IOS XR
+class TestInterfaceSwitchportVtp < TestInterfaceSwitchport
+  attr_reader :vtp
+
+  def setup
+    super
+    skip('VTP is not supported on IOS XR') if platform == :ios_xr
+    @vtp = Vtp.new(true)
+  end
+
+  def teardown
+    vtp.destroy unless platform == :ios_xr
+    super
+  end
+
+  def test_switchport_vtp_disabled_feature_enabled
+    refute(interface.switchport_vtp,
+           'Error: interface, access, vtp not disabled')
+  end
+
+  def test_switchport_vtp_enabled_access
+    interface.switchport_mode = :access
+    config("interface ethernet #{interfaces_id[0]}", 'vtp')
+
+    assert(interface.switchport_vtp,
+           'Error: interface, access, vtp not enabled')
+  end
+
+  def test_switchport_vtp_disabled_access
+    interface.switchport_mode = :access
+    config("interface ethernet #{interfaces_id[0]}", 'no vtp')
+
+    refute(interface.switchport_vtp,
+           'Error: interface, access, vtp not disabled')
+  end
+
+  def test_switchport_vtp_enabled_trunk
+    interface.switchport_mode = :trunk
+    config("interface ethernet #{interfaces_id[0]}", 'vtp')
+
+    assert(interface.switchport_vtp,
+           'Error: interface, trunk, vtp not enabled')
+  end
+
+  def test_switchport_vtp_disabled_trunk
+    interface.switchport_mode = :trunk
+    refute(interface.switchport_vtp,
+           'Error: interface, trunk, vtp not disabled')
+  end
+
+  def test_set_switchport_vtp_default_access
+    interface.switchport_mode = :access
+
+    interface.switchport_vtp = interface.default_switchport_vtp
+    refute(interface.switchport_vtp,
+           'Error:(1) mode :access, vtp should be default (false)')
+
+    interface.switchport_vtp = true
+    assert(interface.switchport_vtp,
+           'Error:(2) mode :access, vtp should be true')
+
+    interface.switchport_vtp = interface.default_switchport_vtp
+    refute(interface.switchport_vtp,
+           'Error:(3) mode :access, vtp should be default (false)')
+  end
+
+  def test_set_switchport_vtp_default_trunk
+    interface.switchport_mode = :trunk
+    interface.switchport_vtp = interface.default_switchport_vtp
+    refute(interface.switchport_vtp,
+           'Error:(1) mode :trunk, vtp should be default (false)')
+
+    interface.switchport_vtp = true
+    assert(interface.switchport_vtp,
+           'Error:(2) mode :trunk, vtp should be true')
+
+    interface.switchport_vtp = interface.default_switchport_vtp
+    refute(interface.switchport_vtp,
+           'Error:(3) mode :trunk, vtp should be default (false)')
+  end
+
+  def test_set_switchport_vtp_true_access
+    interface.switchport_mode = :access
+    interface.switchport_vtp = true
+    assert(interface.switchport_vtp,
+           'Error: interface, access, vtp not enabled')
+  end
+
+  def test_set_switchport_vtp_true_trunk
+    interface.switchport_mode = :trunk
+    interface.switchport_vtp = true
+    assert(interface.switchport_vtp,
+           'Error: interface, access, vtp not enabled')
+  end
+
+  def test_set_switchport_vtp_true_unsupported_mode_disabled
+    interface.switchport_mode = :disabled
+    refute(interface.switchport_vtp,
+           'Error: interface, access, vtp is enabled')
+  end
+
+  def test_set_switchport_vtp_true_unsupported_mgmt_intf
+    interface = Interface.new(mgmt_intf)
+
+    interface.switchport_vtp = true
+    refute(interface.switchport_vtp,
+           'Error: interface, access, vtp is enabled')
+  end
+
+  def test_set_switchport_vtp_false_access
+    interface.switchport_mode = :access
+    interface.switchport_vtp = false
+    refute(interface.switchport_vtp,
+           'Error: interface, access, vtp not disabled')
+  end
+
+  def test_set_switchport_vtp_false_trunk
+    interface.switchport_mode = :trunk
+    interface.switchport_vtp = false
+    refute(interface.switchport_vtp,
+           'Error: interface, access, vtp not disabled')
+  end
+
+  def test_set_switchport_vtp_false_unsupported_mode_disabled
+    interface.switchport_mode = :disabled
+    interface.switchport_vtp = false
+    refute(interface.switchport_vtp,
+           'Error: mode :disabled, vtp should be false')
   end
 end


### PR DESCRIPTION
Unsupported properties return nil on XR
- switchport
- switchport_mode
- switchport_trunk_allowed_vlan
- switchport_trunk_native_vlan
- switchport_vtp

Stop wrapping Cisco::CliError into RuntimeError

Refactor interface minitests:
- for properties unsupported on XR, explicitly test such instead of
  relying on the default handling of Cisco::UnsupportedError
- for test groups unsupported on XR, explicitly skip

No more auto-skips when running any of test_interface*.rb on XR.
Code coverage same or better than grpc baseline on XR and NXOS.
