### PR TITLE
Feature/grpc bgp fin

### DIFF
--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -327,10 +327,17 @@ module Cisco
       config_get('bgp', 'enforce_first_as', @get_args)
     end
 
-    def enforce_first_as=(enable)
-      @set_args[:state] = (enable ? '' : 'no')
-      config_set('bgp', 'enforce_first_as', @set_args)
-      set_args_keys_default
+    #    def enforce_first_as=(enable)
+    # XR: action is disable (on by default, but command is removed)
+    # Nexus: action is enable (on by default, but no command is nvgenned)
+    def enforce_first_as=(action)
+      # if platform == :ios_xr
+    # 
+      # else
+        @set_args[:state] = (action ? '' : 'no')
+        config_set('bgp', 'enforce_first_as', @set_args)
+        set_args_keys_default
+      # end
     end
 
     def default_enforce_first_as

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -327,17 +327,10 @@ module Cisco
       config_get('bgp', 'enforce_first_as', @get_args)
     end
 
-    #    def enforce_first_as=(enable)
-    # XR: action is disable (on by default, but command is removed)
-    # Nexus: action is enable (on by default, but no command is nvgenned)
     def enforce_first_as=(action)
-      # if platform == :ios_xr
-    # 
-      # else
-        @set_args[:state] = (action ? '' : 'no')
-        config_set('bgp', 'enforce_first_as', @set_args)
-        set_args_keys_default
-      # end
+      @set_args[:state] = (action ? '' : 'no')
+      config_set('bgp', 'enforce_first_as', @set_args)
+      set_args_keys_default
     end
 
     def default_enforce_first_as

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -327,8 +327,8 @@ module Cisco
       config_get('bgp', 'enforce_first_as', @get_args)
     end
 
-    def enforce_first_as=(action)
-      @set_args[:state] = (action ? '' : 'no')
+    def enforce_first_as=(state)
+      @set_args[:state] = (state ? '' : 'no')
       config_set('bgp', 'enforce_first_as', @set_args)
       set_args_keys_default
     end

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -123,17 +123,16 @@ create_destroy_neighbor:
 
 enforce_first_as:
   # XR 'enabled' means command is nvgenned with 'disable' at the end
-  #  'bgp enforce-first-as disable'
+  #  i.e. 'bgp enforce-first-as disable'
   # Nexus 'enabled' means command is nvgenned with 'no' at the beginning
-  #  'no enforce-first-as'
-  # XR 'false/no' means command is removed
-  # Nexus 'false/no' means 'no command' is nvgenned
+  #  i.e. 'no enforce-first-as'
   kind: boolean
-  default_value: true
   cli_ios_xr:
+    default_value: false
     config_get_token_append: '/^bgp enforce-first-as disable$/'
     config_set_append: ' <state> bgp enforce-first-as disable'
   cli_nexus:
+    default_value: true
     config_get_token_append: '/^(no )?enforce-first-as$/'
     config_set_append: '<state> enforce-first-as'
 

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -122,13 +122,20 @@ create_destroy_neighbor:
   config_set_append: '<state> neighbor <nbr>'
 
 enforce_first_as:
-  # TODO: Different format for IOS XR
-  # Enabled by default, disabled by command
-  # 'bgp enforce-first-as disable'
+  # XR 'enabled' means command is nvgenned with 'disable' at the end
+  #  'bgp enforce-first-as disable'
+  # Nexus 'enabled' means command is nvgenned with 'no' at the beginning
+  #  'no enforce-first-as'
+  # XR 'false/no' means command is removed
+  # Nexus 'false/no' means 'no command' is nvgenned
   kind: boolean
-  config_get_token_append: '/^(no )?enforce-first-as$/'
-  config_set_append: '<state> enforce-first-as'
   default_value: true
+  cli_ios_xr:
+    config_get_token_append: '/^bgp enforce-first-as disable$/'
+    config_set_append: ' <state> bgp enforce-first-as disable'
+  cli_nexus:
+    config_get_token_append: '/^(no )?enforce-first-as$/'
+    config_set_append: '<state> enforce-first-as'
 
 feature:
   kind: boolean

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -411,13 +411,9 @@ class TestRouterBgp < CiscoTestCase
   def test_default_enforce_first_as
     asnum = 55
     bgp = RouterBgp.new(asnum)
-    if platform == :ios_xr
-      refute(bgp.enforce_first_as,
-             'bgp enforce-first-as value should be enabled = false')
-    else
-      assert(bgp.enforce_first_as,
-             'bgp enforce-first-as value should be enabled = true')
-    end
+    assert_equal(bgp.default_enforce_first_as,
+                 bgp.enforce_first_as,
+                 'bgp enforce-first-as default value is incorrect')
     bgp.destroy
   end
 

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -403,21 +403,21 @@ class TestRouterBgp < CiscoTestCase
     assert(bgp.enforce_first_as,
            'bgp enforce-first-as should be enabled')
     bgp.enforce_first_as = false
-    if platform == :ios_xr
-      assert(bgp.enforce_first_as,
-             'bgp enforce-first-as disable should be empty')
-    else
-      refute(bgp.enforce_first_as,
-             'bgp enforce-first-as should be disabled')
-    end
+    refute(bgp.enforce_first_as,
+           'bgp enforce-first-as should be disabled')
     bgp.destroy
   end
 
   def test_default_enforce_first_as
     asnum = 55
     bgp = RouterBgp.new(asnum)
-    assert(bgp.enforce_first_as,
-           'bgp enforce-first-as value should be enabled = true')
+    if platform == :ios_xr
+      refute(bgp.enforce_first_as,
+             'bgp enforce-first-as value should be enabled = false')
+    else
+      assert(bgp.enforce_first_as,
+             'bgp enforce-first-as value should be enabled = true')
+    end
     bgp.destroy
   end
 

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -397,7 +397,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_enforce_first_as
-    # skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     bgp.enforce_first_as = true
@@ -415,7 +414,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_default_enforce_first_as
-    # skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert(bgp.enforce_first_as,

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -396,21 +396,26 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_set_get_enforce_first_as
-    skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
+  def test_enforce_first_as
+    # skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     bgp.enforce_first_as = true
     assert(bgp.enforce_first_as,
            'bgp enforce-first-as should be enabled')
     bgp.enforce_first_as = false
-    refute(bgp.enforce_first_as,
-           'bgp enforce-first-as should be disabled')
+    if platform == :ios_xr
+      assert(bgp.enforce_first_as,
+             'bgp enforce-first-as disable should be empty')
+    else
+      refute(bgp.enforce_first_as,
+             'bgp enforce-first-as should be disabled')
+    end
     bgp.destroy
   end
 
   def test_default_enforce_first_as
-    skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
+    # skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert(bgp.enforce_first_as,


### PR DESCRIPTION
Making enforce_first_as work on XR.

Minitest pass on XR and Nexus.

Puppet test - toggled enforce_first_as off and on in the following manifest - checked that it was applied and removed from both global VRF and non-global vrf correctly.

``` puppet
node 'default' {
  cisco_bgp { 'default_vrf_global':
    ensure                                 => present,
    asn                                    => 55,
    vrf                                    => 'default',
    router_id                              => '1.1.1.1',

    confederation_id                       => '33',
    cluster_id                             => '55',
    graceful_restart_timers_restart        => '131',
    graceful_restart_timers_stalepath_time => '311',
    bestpath_med_confed                    => true,
    graceful_restart => true,
    enforce_first_as                       => true,
}

  cisco_bgp { 'vrf_blue':
    ensure                                 => present,
    asn                                    => 55,
    vrf                                    => 'blue',
    router_id                              => '192.168.0.66',

    # Best Path Properties
    bestpath_always_compare_med            => true,
    bestpath_aspath_multipath_relax        => true,
    bestpath_compare_routerid              => true,
    bestpath_cost_community_ignore         => true,

    # Timer Properties
    timer_bgp_keepalive                    => '46',
    timer_bgp_holdtime                     => '111',

    enforce_first_as                       => true,
    }
  }
```

Rubocop happy on both ruby files, no puppet changes required.
