### PR TITLE
Feature/grpc bgp fin

### DIFF
--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -328,18 +328,16 @@ module Cisco
     end
 
     def enforce_first_as=(enable)
-      if platform == :ios_xr
-        # XR enforce_first_as is on by default (=>true)
-        # =>true  = enable enforce_first_as  = 'no bgp enforce-first-as disable'
-        # =>false = disable enforce_first_as = 'bgp enforce-first-as disable'
-        @set_args[:state] = (enable ? 'no' : '')
-        config_set('bgp', 'enforce_first_as', @set_args)
-        set_args_keys_default
-      else
-        @set_args[:state] = (enable ? '' : 'no')
-        config_set('bgp', 'enforce_first_as', @set_args)
-        set_args_keys_default
-      end
+      # enforce_first_as is on by default (=>true)
+      # XR =>true  = enable enforce_first_as  = 'no bgp enforce-first-as disable'
+      # XR =>false = disable enforce_first_as = 'bgp enforce-first-as disable'
+      # Nexus nvgens the 'no' command.
+      # Nexus =>true  = enable enforce_first_as  = 'enforce-first-as'
+      # Nexus =>false = disable enforce_first_as = 'no enforce-first-as'
+      enable = !enable if platform == :ios_xr
+      @set_args[:state] = (enable ? '' : 'no')
+      config_set('bgp', 'enforce_first_as', @set_args)
+      set_args_keys_default
     end
 
     def default_enforce_first_as
@@ -481,18 +479,16 @@ module Cisco
     end
 
     def log_neighbor_changes=(enable)
-      if platform == :ios_xr
         # XR logging is on by default (=>true)
-        # =>true  = enable logging  = 'no bgp log neighbor changes disable'
-        # =>false = disable logging = 'bgp log neighbor changes disable'
-        @set_args[:state] = (enable ? 'no' : '')
-        config_set('bgp', 'log_neighbor_changes', @set_args)
-        set_args_keys_default
-      else
-        @set_args[:state] = (enable ? '' : 'no')
-        config_set('bgp', 'log_neighbor_changes', @set_args)
-        set_args_keys_default
-      end
+        # XR =>true  = enable logging  = 'no bgp log neighbor changes disable'
+        # XR =>false = disable logging = 'bgp log neighbor changes disable'
+        # Nexus logging is off by default (=>false)
+        # Nexus =>true  = enable logging  = 'log-neighbor-changes'
+        # Nexus =>false = disable logging = 'no log-neighbor-changes'
+      enable = !enable if platform == :ios_xr
+      @set_args[:state] = (enable ? '' : 'no')
+      config_set('bgp', 'log_neighbor_changes', @set_args)
+      set_args_keys_default
     end
 
     def default_log_neighbor_changes

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -471,8 +471,8 @@ module Cisco
       config_get('bgp', 'log_neighbor_changes', @get_args)
     end
 
-    def log_neighbor_changes=(enable)
-      @set_args[:state] = (enable ? '' : 'no')
+    def log_neighbor_changes=(state)
+      @set_args[:state] = (state ? '' : 'no')
       config_set('bgp', 'log_neighbor_changes', @set_args)
       set_args_keys_default
     end

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -327,10 +327,19 @@ module Cisco
       config_get('bgp', 'enforce_first_as', @get_args)
     end
 
-    def enforce_first_as=(state)
-      @set_args[:state] = (state ? '' : 'no')
-      config_set('bgp', 'enforce_first_as', @set_args)
-      set_args_keys_default
+    def enforce_first_as=(enable)
+      if platform == :ios_xr
+        # XR enforce_first_as is on by default (=>true)
+        # =>true  = enable enforce_first_as  = 'no bgp enforce-first-as disable'
+        # =>false = disable enforce_first_as = 'bgp enforce-first-as disable'
+        @set_args[:state] = (enable ? 'no' : '')
+        config_set('bgp', 'enforce_first_as', @set_args)
+        set_args_keys_default
+      else
+        @set_args[:state] = (enable ? '' : 'no')
+        config_set('bgp', 'enforce_first_as', @set_args)
+        set_args_keys_default
+      end
     end
 
     def default_enforce_first_as
@@ -471,10 +480,19 @@ module Cisco
       config_get('bgp', 'log_neighbor_changes', @get_args)
     end
 
-    def log_neighbor_changes=(state)
-      @set_args[:state] = (state ? '' : 'no')
-      config_set('bgp', 'log_neighbor_changes', @set_args)
-      set_args_keys_default
+    def log_neighbor_changes=(enable)
+      if platform == :ios_xr
+        # XR logging is on by default (=>true)
+        # =>true  = enable logging  = 'no bgp log neighbor changes disable'
+        # =>false = disable logging = 'bgp log neighbor changes disable'
+        @set_args[:state] = (enable ? 'no' : '')
+        config_set('bgp', 'log_neighbor_changes', @set_args)
+        set_args_keys_default
+      else
+        @set_args[:state] = (enable ? '' : 'no')
+        config_set('bgp', 'log_neighbor_changes', @set_args)
+        set_args_keys_default
+      end
     end
 
     def default_log_neighbor_changes

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -122,17 +122,12 @@ create_destroy_neighbor:
   config_set_append: '<state> neighbor <nbr>'
 
 enforce_first_as:
-  # XR 'enabled' means command is nvgenned with 'disable' at the end
-  #  i.e. 'bgp enforce-first-as disable'
-  # Nexus 'enabled' means command is nvgenned with 'no' at the beginning
-  #  i.e. 'no enforce-first-as'
   kind: boolean
+    default_value: true
   cli_ios_xr:
-    default_value: false
     config_get_token_append: '/^bgp enforce-first-as disable$/'
     config_set_append: ' <state> bgp enforce-first-as disable'
   cli_nexus:
-    default_value: true
     config_get_token_append: '/^(no )?enforce-first-as$/'
     config_set_append: '<state> enforce-first-as'
 
@@ -191,11 +186,12 @@ graceful_restart_timers_stalepath_time:
 
 log_neighbor_changes:
   kind: boolean
-  default_value: false
   cli_ios_xr:
+    default_value: true
     config_get_token_append: '/^bgp log neighbor changes disable$/'
     config_set_append: ' <state> bgp log neighbor changes disable'
   cli_nexus:
+    default_value: false
     config_get_token_append: '/^log-neighbor-changes$/'
     config_set_append: '<state> log-neighbor-changes'
 

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -199,7 +199,6 @@ log_neighbor_changes:
     config_get_token_append: '/^log-neighbor-changes$/'
     config_set_append: '<state> log-neighbor-changes'
 
-
 maxas_limit:
   # Note: Does not exist in IOS XR
   cli_nexus:

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -191,12 +191,14 @@ graceful_restart_timers_stalepath_time:
 
 log_neighbor_changes:
   kind: boolean
-  #TODO: Equivalent for bgp is 'bgp log'
-  # Currently supported but broken in IOS XR
+  default_value: false
+  cli_ios_xr:
+    config_get_token_append: '/^bgp log neighbor changes disable$/'
+    config_set_append: ' <state> bgp log neighbor changes disable'
   cli_nexus:
     config_get_token_append: '/^log-neighbor-changes$/'
     config_set_append: '<state> log-neighbor-changes'
-    default_value: false
+
 
 maxas_limit:
   # Note: Does not exist in IOS XR

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -123,7 +123,7 @@ create_destroy_neighbor:
 
 enforce_first_as:
   kind: boolean
-    default_value: true
+  default_value: true
   cli_ios_xr:
     config_get_token_append: '/^bgp enforce-first-as disable$/'
     config_set_append: ' <state> bgp enforce-first-as disable'

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -111,6 +111,8 @@ module Cisco
           value = false
         elsif /^no / =~ value
           value = false
+        elsif /disable$/ =~ value
+          value = false
         else
           value = true
         end

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -588,8 +588,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_set_get_log_neighbor_changes
-    skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
+  def test_log_neighbor_changes
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         bgp = setup_default
@@ -606,8 +605,7 @@ class TestRouterBgp < CiscoTestCase
     end
   end
 
-  def test_get_log_neighbor_changes_not_configured
-    skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
+  def test_log_neighbor_changes_not_configured
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.log_neighbor_changes,
@@ -616,7 +614,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_default_log_neighbor_changes
-    skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     refute(bgp.default_log_neighbor_changes,

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -413,7 +413,7 @@ class TestRouterBgp < CiscoTestCase
 
     bgp.enforce_first_as = true
     assert(bgp.enforce_first_as)
-    refute_show_match(msg: 'enforce-first-as should not be enabled')
+    refute_show_match(msg: 'enforce-first-as should be enabled')
 
     bgp.destroy
   end
@@ -621,21 +621,25 @@ class TestRouterBgp < CiscoTestCase
     end
     bgp.log_neighbor_changes = false
     refute(bgp.log_neighbor_changes)
+
+    msg_disable = 'log neighbor changes should be disabled'
+    msg_enable  = 'log neighbor changes should be enabled'
+
     if platform == :ios_xr
       # XR the disable keyword added
-      assert_show_match(msg: 'log neighbor changes should be disabled')
+      assert_show_match(msg: msg_disable)
     else
       # Nexus the command is removed
-      refute_show_match(msg: 'log neighbor changes should be disabled')
+      refute_show_match(msg: msg_disable)
     end
     bgp.log_neighbor_changes = true
     assert(bgp.log_neighbor_changes)
     if platform == :ios_xr
       # XR removes the whole command including disable keyword
-      refute_show_match(msg: 'log neighbor changes should not be enabled')
+      refute_show_match(msg: msg_enable)
     else
       # Nexus adds the log-neighbor-changes command
-      assert_show_match(msg: 'log neighbor changes should not be enabled')
+      assert_show_match(msg: msg_enable)
     end
     bgp.destroy
   end

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -471,11 +471,9 @@ class TestRouterBgp < CiscoTestCase
                  "bgp graceful restart default timer value should be '120'")
     assert_equal(300, bgp.default_graceful_restart_timers_stalepath_time,
                  "bgp graceful restart default timer value should be '300'")
-    if platform == :nexus
-      refute(bgp.default_graceful_restart_helper,
-             'graceful restart helper default value ' \
-             'should be enabled = false')
-    end
+    refute(bgp.default_graceful_restart_helper,
+           'graceful restart helper default value ' \
+           'should be enabled = false') if platform == :nexus
     # rubocop:enable Style/GuardClause
   end
 

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -855,7 +855,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_set_get_timer_bgp_keepalive_hold
+  def test_timer_bgp_keepalive_hold
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         bgp = setup_default
@@ -883,8 +883,7 @@ class TestRouterBgp < CiscoTestCase
     end
   end
 
-  def test_default_timer_keepalive_hold_default
-    skip(XR_SUPPORTED_BROKEN) if platform == :ios_xr
+  def test_default_timer_bgp_keepalive_hold_default
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_equal(%w(60 180), bgp.default_timer_bgp_keepalive_hold,

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -401,29 +401,36 @@ class TestRouterBgp < CiscoTestCase
     asnum = 55
     bgp = RouterBgp.new(asnum)
     if platform == :ios_xr
-      @device.cmd('term width 300')
       # Lets assert based on XR standard output if a command is not found
       pattern = 'No such configuration item'
 
-      # Test default
+      # Test default running-config test
       s = @device.cmd("show running-config router bgp #{asnum} " \
                       'bgp enforce-first-as disable')
       assert_match(pattern, s,
                    'bgp enforce-first-as disable should not be enabled')
 
-      # Disable enforce-first-as
+      # Disable enforce-first-as running-config test
       bgp.enforce_first_as = false
       s = @device.cmd("show running-config router bgp #{asnum} " \
                       'bgp enforce-first-as disable')
       refute_match(pattern, s,
                    'bgp enforce-first-as disable should be enabled')
 
-      # Enable enforce-first-as
+      # Enable enforce-first-as running-config test
       bgp.enforce_first_as = true
       s = @device.cmd("show running-config router bgp #{asnum} " \
                       'bgp enforce-first-as disable')
       assert_match(pattern, s,
                    'bgp enforce-first-as disable should not be enabled')
+
+      # Test node utils reporting
+      bgp.enforce_first_as = true
+      assert(bgp.enforce_first_as,
+             'bgp enforce-first-as disable should not be enabled')
+      bgp.enforce_first_as = false
+      refute(bgp.enforce_first_as,
+             'bgp enforce-first-as disable should be enabled')
     else
       bgp.enforce_first_as = true
       assert(bgp.enforce_first_as,
@@ -624,7 +631,6 @@ class TestRouterBgp < CiscoTestCase
 
   def log_neighbor_changes(bgp)
     if platform == :ios_xr
-      @device.cmd('term width 300')
       # Lets assert based on XR standard output if a command is not found
       pattern = 'No such configuration item'
 
@@ -634,25 +640,33 @@ class TestRouterBgp < CiscoTestCase
         vrf_str = "vrf #{@vrf}"
       end
 
-      # Test default
+      # Test default running-config test
       s = @device.cmd("show running-config router bgp #{@asnum} " \
                       "#{vrf_str} bgp log neighbor changes disable")
       assert_match(pattern, s,
                    'bgp log_neighbor_changes disable should not be enabled')
 
-      # Disable log neighbors
+      # Disable log neighbors running-config test
       bgp.log_neighbor_changes = false
       s = @device.cmd("show running-config router bgp #{@asnum} " \
                       "#{vrf_str} bgp log neighbor changes disable")
       refute_match(pattern, s,
                    'bgp log_neighbor_changes disable should be enabled')
 
-      # Enable log neighbors
+      # Enable log neighbors running-config test
       bgp.log_neighbor_changes = true
       s = @device.cmd("show running-config router bgp #{@asnum} " \
                       "#{vrf_str} bgp log neighbor changes disable")
       assert_match(pattern, s,
                    'bgp log_neighbor_changes disable should not be enabled')
+
+      # Test node utils reporting
+      bgp.log_neighbor_changes = true
+      assert(bgp.log_neighbor_changes,
+             "vrf #{@vrf}: bgp log_neighbor_changes should not be enabled")
+      bgp.log_neighbor_changes = false
+      refute(bgp.log_neighbor_changes,
+             "vrf #{@vrf}: bgp log_neighbor_changes should be disabled")
     else
       bgp.log_neighbor_changes = true
       assert(bgp.log_neighbor_changes,
@@ -660,8 +674,8 @@ class TestRouterBgp < CiscoTestCase
       bgp.log_neighbor_changes = false
       refute(bgp.log_neighbor_changes,
              "vrf #{@vrf}: bgp log_neighbor_changes should be disabled")
-      bgp.destroy
     end
+    bgp.destroy
   end
 
   def test_log_neighbor_changes_not_configured

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -324,10 +324,6 @@ class TestRouterBgp < CiscoTestCase
     if platform == :nexus
       refute(bgp.bestpath_med_non_deterministic,
              'bgp bestpath_med_non_deterministic should *NOT* be enabled')
-    else
-      assert_raises(Cisco::UnsupportedError) do
-        bgp.bestpath_med_non_deterministic
-      end
     end
     bgp.destroy
   end
@@ -350,10 +346,6 @@ class TestRouterBgp < CiscoTestCase
     if platform == :nexus
       refute(bgp.default_bestpath_med_non_deterministic,
              'default value for bestpath_med_non_deterministic should be false')
-    else
-      assert_raises(Cisco::UnsupportedError) do
-        bgp.default_bestpath_med_non_deterministic
-      end
     end
     bgp.destroy
   end
@@ -483,10 +475,6 @@ class TestRouterBgp < CiscoTestCase
       refute(bgp.default_graceful_restart_helper,
              'graceful restart helper default value ' \
              'should be enabled = false')
-    else
-      assert_raises(Cisco::UnsupportedError) do
-        bgp.default_graceful_restart_helper
-      end
     end
     # rubocop:enable Style/GuardClause
   end
@@ -698,6 +686,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_get_reconnect_interval_default
+    skip('Not supported on IOS XR') if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_equal(60, bgp.reconnect_interval,
@@ -815,6 +804,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_get_timer_bestpath_limit_default
+    skip('Not supported on IOS XR') if platform == :ios_xr
     asnum = 55
     bgp = RouterBgp.new(asnum)
     assert_equal(300, bgp.timer_bestpath_limit,
@@ -823,6 +813,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_set_get_timer_bestpath_limit_always
+    skip('Not supported on IOS XR') if platform == :ios_xr
     %w(test_default test_vrf).each do |t|
       if t == 'test_default'
         bgp = setup_default


### PR DESCRIPTION
Node Utils for remaining missing BGP global properties - log neighbor changes and bgp keep alive timers.

Some default mini tests failing due to recent changes - fixed those.

Rubocop happy on all ruby files.

Minitest pass on NX and XR.

Applied the below manifest and toggled the log_neighbor_changes property - verified that they were applied to my router and that they were omniwhatitsname.

``` puppet
node 'default' {
  cisco_bgp { 'default_vrf_global':
    ensure                                 => present,
    asn                                    => 55,
    vrf                                    => 'default',
    router_id                              => '1.1.1.1',

    confederation_id                       => '33',
    cluster_id                             => '55',
    graceful_restart_timers_restart        => '131',
    graceful_restart_timers_stalepath_time => '311',
    bestpath_med_confed                    => true,
    graceful_restart => true,
    enforce_first_as                       => true,
    log_neighbor_changes                   => false,
}
  cisco_bgp { 'vrf_blue':
    ensure                                 => present,
    asn                                    => 55,
    vrf                                    => 'blue',
    router_id                              => '192.168.0.66',

    # Best Path Properties
    bestpath_always_compare_med            => true,
    bestpath_aspath_multipath_relax        => true,
    bestpath_compare_routerid              => true,
    bestpath_cost_community_ignore         => true,

    # Timer Properties
    timer_bgp_keepalive                    => '46',
    timer_bgp_holdtime                     => '111',

    enforce_first_as                       => true,
    log_neighbor_changes                   => false,
    }
  }
```
