### PR TITLE
Correctly remove/restore IP when changing VRF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changelog
   - Added support for `auto_default`, `default_only`, `kind`, and `multiple`
   - Added filtering by product ID (`/N7K/`) and by client type (`cli_nexus`)
 
+### Fixed
+
+* Interface: correctly restore IP address when changing VRF membership
+
 ## [v1.1.0]
 
 ### New feature support

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1136,4 +1136,36 @@ class TestInterface < CiscoTestCase
     assert_equal(vrf, interface.vrf)
     interface.destroy
   end
+
+  def test_vrf_change_with_ip_addr
+    interface = Interface.new('loopback1')
+    address = '192.168.100.1'
+    length = 24
+    interface_ipv4_config('loopback1', address, length)
+    assert_equal(address, interface.ipv4_address)
+    assert_equal(length, interface.ipv4_netmask_length)
+
+    vrf1 = 'test1'
+    interface.vrf = vrf1
+    assert_equal(address, interface.ipv4_address,
+                 'IPv4 address wrong after changing from vrf default => test1')
+    assert_equal(length, interface.ipv4_netmask_length,
+                 'IPv4 mask wrong after changing from vrf default => test1')
+    assert_equal(vrf1, interface.vrf)
+
+    vrf2 = 'test2'
+    interface.vrf = vrf2
+    assert_equal(address, interface.ipv4_address,
+                 'IPv4 address wrong after changing from vrf test1 => test2')
+    assert_equal(length, interface.ipv4_netmask_length,
+                 'IPv4 mask wrong after changing from vrf test1 => test2')
+    assert_equal(vrf2, interface.vrf)
+
+    interface.vrf = DEFAULT_IF_VRF
+    assert_equal(address, interface.ipv4_address,
+                 'IPv4 address wrong after changing from vrf test2 => default')
+    assert_equal(length, interface.ipv4_netmask_length,
+                 'IPv4 mask wrong after changing from vrf test2 => default')
+    assert_equal(DEFAULT_IF_VRF, interface.vrf)
+  end
 end


### PR DESCRIPTION
When testing with Puppet I found an issue - XR doesn't let you change VRF if there's an IP address configured:

`"'RSI' detected the 'fatal' condition 'The interface's numbered and unnumbered IPv4/IPv6 addresses must be removed prior to changing or deleting the VRF'"`

Additionally, when changing the VRF on Nexus, any existing IP address configuration is lost.

Solution:
- Add minitest case for changing VRF with an IP address present
- in Interface class, get current IP address before changing VRF, remove it (if on XR), and restore it after changing VRF.
