### PR TITLE
acl&ace node utils, mini test and yaml cmd file

### DIFF
--- a/lib/cisco_node_utils/ace_v4.rb
+++ b/lib/cisco_node_utils/ace_v4.rb
@@ -21,20 +21,20 @@ module Cisco
 
     # name: name of the router instance
     # instantiate: true = create router instance
-    def initialize(acl_name, seqno, afi, instantiate=true)
+    def initialize(acl_name, seqno, afi)
       @acl_name = acl_name
       @afi = afi
       @seqno = seqno
-      @set_args = @get_args = {acl_name: @acl_name, seqno: @seqno}
+      @set_args = @get_args = { acl_name: @acl_name, seqno: @seqno }
     end
 
     # Create a hash of all current router instances.
     def self.aces
-      instances = config_get('acl_v4' , 'ace')
+      instances = config_get('acl_v4', 'ace')
       return {} if instances.nil?
       hash = {}
       instances.each do |name|
-          hash[name] = Ace.new(acl_name, false)
+        hash[name] = Ace.new(acl_name, false)
       end
       return hash
     rescue Cisco::CliError => e
@@ -42,7 +42,7 @@ module Cisco
       raise unless e.clierror =~ /Syntax error/
       return {}
     end
-    
+
     # Destroy a router instance; disable feature on last instance
     def destroy
       config_ace('no')
@@ -64,7 +64,7 @@ module Cisco
     def seqno
       match = config_get('acl_v4', 'ace', @get_args)
       return if match.nil?
-      seqno = match[0]
+      match[0]
     end
 
     # setter of seqno
@@ -76,7 +76,7 @@ module Cisco
     def action
       match = config_get('acl_v4', 'ace', @get_args)
       return if match.nil?
-      action = match[1]
+      match[1]
     end
 
     # setter of action
@@ -88,9 +88,9 @@ module Cisco
     def proto
       match = config_get('acl_v4', 'ace', @get_args)
       return if match.nil?
-      proto = match[2]
+      match[2]
     end
-    
+
     # setter of proto
     def proto=(proto)
       @set_args[:proto] = proto
@@ -100,9 +100,9 @@ module Cisco
     def v4_src_addr_format
       match = config_get('acl_v4', 'ace', @get_args)
       return if match.nil?
-      src_addr = match[3]
+      match[3]
     end
-    
+
     # setter of v4_src_addr_format
     def v4_src_addr_format=(src_addr)
       @set_args[:v4_src_addr_format] = src_addr
@@ -112,9 +112,9 @@ module Cisco
     def v4_src_port_format
       match = config_get('acl_v4', 'ace', @get_args)
       return if match.nil?
-      src_port = match[5]
+      match[5]
     end
-    
+
     # setter of v4_src_port_format
     def v4_src_port_format=(src_port)
       @set_args[:v4_src_port_format] = src_port
@@ -124,9 +124,9 @@ module Cisco
     def v4_dst_addr_format
       match = config_get('acl_v4', 'ace', @get_args)
       return if match.nil?
-      dst_addr = match[6]
+      match[6]
     end
-    
+
     # setter of v4_dst_addr_format
     def v4_dst_addr_format=(dst_addr)
       @set_args[:v4_dst_addr_format] = dst_addr
@@ -136,9 +136,9 @@ module Cisco
     def v4_dst_port_format
       match = config_get('acl_v4', 'ace', @get_args)
       return if match.nil?
-      src_port = match[7]
+      match[7]
     end
-    
+
     # setter of v4_dst_port_format
     def v4_dst_port_format=(src_port)
       @set_args[:v4_dst_port_format] = src_port
@@ -148,9 +148,9 @@ module Cisco
     def option_format
       match = config_get('acl_v4', 'ace', @get_args)
       return if match.nil?
-      option_format = match[7]
+      match[8]
     end
-    
+
     # setter of option_format
     def option_format=(option)
       @set_args[:option_format] = option

--- a/lib/cisco_node_utils/ace_v4.rb
+++ b/lib/cisco_node_utils/ace_v4.rb
@@ -1,0 +1,159 @@
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'node_util'
+
+module Cisco
+  # RouterAcl - node utility class for RouterAcl config mgmt.
+  class Ace < NodeUtil
+    attr_reader :acl_name, :seqno, :afi
+
+    # name: name of the router instance
+    # instantiate: true = create router instance
+    def initialize(acl_name, seqno, afi, instantiate=true)
+      @acl_name = acl_name
+      @afi = afi
+      @seqno = seqno
+      @set_args = @get_args = {acl_name: @acl_name, seqno: @seqno}
+    end
+
+    # Create a hash of all current router instances.
+    def self.aces
+      instances = config_get('acl_v4' , 'ace')
+      return {} if instances.nil?
+      hash = {}
+      instances.each do |name|
+          hash[name] = Ace.new(acl_name, false)
+      end
+      return hash
+    rescue Cisco::CliError => e
+      # CLI will syntax reject when feature is not enabled
+      raise unless e.clierror =~ /Syntax error/
+      return {}
+    end
+    
+    # Destroy a router instance; disable feature on last instance
+    def destroy
+      config_ace('no')
+    rescue Cisco::CliError => e
+      # CLI will syntax reject when feature is not enabled
+      raise unless e.clierror =~ /Syntax error/
+    end
+
+    # First create acl
+    def config_ace(state='')
+      @set_args[:state] = state
+      config_set('acl_v4', 'ace', @set_args)
+    end
+
+    # ----------
+    # PROPERTIES
+    # ----------
+    # getter of seqno
+    def seqno
+      match = config_get('acl_v4', 'ace', @get_args)
+      return if match.nil?
+      seqno = match[0]
+    end
+
+    # setter of seqno
+    def seqno=(state)
+      @set_args[:state] = state ? '' : 'no'
+    end
+
+    # getter of action
+    def action
+      match = config_get('acl_v4', 'ace', @get_args)
+      return if match.nil?
+      action = match[1]
+    end
+
+    # setter of action
+    def action=(action)
+      @set_args[:action] = action
+    end
+
+    # getter of proto
+    def proto
+      match = config_get('acl_v4', 'ace', @get_args)
+      return if match.nil?
+      proto = match[2]
+    end
+    
+    # setter of proto
+    def proto=(proto)
+      @set_args[:proto] = proto
+    end
+
+    # getter of v4_src_addr_format
+    def v4_src_addr_format
+      match = config_get('acl_v4', 'ace', @get_args)
+      return if match.nil?
+      src_addr = match[3]
+    end
+    
+    # setter of v4_src_addr_format
+    def v4_src_addr_format=(src_addr)
+      @set_args[:v4_src_addr_format] = src_addr
+    end
+
+    # getter of v4_src_port_format
+    def v4_src_port_format
+      match = config_get('acl_v4', 'ace', @get_args)
+      return if match.nil?
+      src_port = match[5]
+    end
+    
+    # setter of v4_src_port_format
+    def v4_src_port_format=(src_port)
+      @set_args[:v4_src_port_format] = src_port
+    end
+
+    # getter of v4_dst_addr_format
+    def v4_dst_addr_format
+      match = config_get('acl_v4', 'ace', @get_args)
+      return if match.nil?
+      dst_addr = match[6]
+    end
+    
+    # setter of v4_dst_addr_format
+    def v4_dst_addr_format=(dst_addr)
+      @set_args[:v4_dst_addr_format] = dst_addr
+    end
+
+    # getter of v4_dst_port_format
+    def v4_dst_port_format
+      match = config_get('acl_v4', 'ace', @get_args)
+      return if match.nil?
+      src_port = match[7]
+    end
+    
+    # setter of v4_dst_port_format
+    def v4_dst_port_format=(src_port)
+      @set_args[:v4_dst_port_format] = src_port
+    end
+
+    # getter of option_format
+    def option_format
+      match = config_get('acl_v4', 'ace', @get_args)
+      return if match.nil?
+      option_format = match[7]
+    end
+    
+    # setter of option_format
+    def option_format=(option)
+      @set_args[:option_format] = option
+    end
+  end
+end

--- a/lib/cisco_node_utils/acl.rb
+++ b/lib/cisco_node_utils/acl.rb
@@ -24,13 +24,13 @@ module Cisco
     def initialize(acl_name, afi, instantiate=true)
       @acl_name = acl_name
       @afi = afi
-      @set_args = @get_args = {acl_name: @acl_name} 
+      @set_args = @get_args = { acl_name: @acl_name }
       create if instantiate
     end
 
     def self.acls
-      instances = config_get('acl_v4' , 'acl') if @afi == "v4"
-      instances = config_get('acl_v6' , 'acl') if @afi == "v6"
+      instances = config_get('acl_v4', 'acl') if @afi == 'v4'
+      instances = config_get('acl_v6', 'acl') if @afi == 'v6'
       return {} if instances.nil?
       hash = {}
       instances.each do |name|
@@ -45,7 +45,7 @@ module Cisco
 
     # config ip access-list and create
     def create
-        config_acl('')
+      config_acl('')
     end
 
     # Destroy a router instance; disable feature on last instance
@@ -58,8 +58,8 @@ module Cisco
 
     def config_acl(state)
       @set_args[:state] = state
-      config_set('acl_v4', 'acl', @set_args) if @afi == "v4"
-      config_set('acl_v6', 'acl', @set_args) if @afi == "v6"
+      config_set('acl_v4', 'acl', @set_args) if @afi == 'v4'
+      config_set('acl_v6', 'acl', @set_args) if @afi == 'v6'
     end
 
     # ----------
@@ -67,27 +67,28 @@ module Cisco
     # ----------
     # getter acl info
     def acl
-      config_get('acl_v4', 'acl', @get_args) if @afi == "v4"
-      config_get('acl_v6', 'acl', @get_args) if @afi == "v6"
+      config_get('acl_v4', 'acl', @get_args) if @afi == 'v4'
+      config_get('acl_v6', 'acl', @get_args) if @afi == 'v6'
     end
+
     # setter acl info
     def acl=(state)
-      @set_args[:state] = (state ? '' : 'no') 
-      config_set('acl_v4', 'acl', @set_args) if @afi == "v4"
-      config_set('acl_v6', 'acl', @set_args) if @afi == "v6"
+      @set_args[:state] = (state ? '' : 'no')
+      config_set('acl_v4', 'acl', @set_args) if @afi == 'v4'
+      config_set('acl_v6', 'acl', @set_args) if @afi == 'v6'
     end
 
     # getter stats perentry info
     def stats_perentry
-      config_get('acl_v4', 'stats_perentry', @get_args) if @afi == "v4"
-      config_get('acl_v6', 'stats_perentry', @get_args) if @afi == "v6"
+      config_get('acl_v4', 'stats_perentry', @get_args) if @afi == 'v4'
+      config_get('acl_v6', 'stats_perentry', @get_args) if @afi == 'v6'
     end
 
     # setter stats perentry info
     def stats_perentry=(state)
-      @set_args[:state] = (state ? '' : 'no') 
-      config_set('acl_v4', 'stats_perentry', @set_args) if @afi == "v4"
-      config_set('acl_v6', 'stats_perentry', @set_args) if @afi == "v6"
+      @set_args[:state] = (state ? '' : 'no')
+      config_set('acl_v4', 'stats_perentry', @set_args) if @afi == 'v4'
+      config_set('acl_v6', 'stats_perentry', @set_args) if @afi == 'v6'
     end
   end
 end

--- a/lib/cisco_node_utils/acl.rb
+++ b/lib/cisco_node_utils/acl.rb
@@ -1,0 +1,93 @@
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'node_util'
+
+module Cisco
+  # RouterAcl - node utility class for RouterAcl config mgmt.
+  class Acl < NodeUtil
+    attr_reader :acl_name, :afi
+
+    # name: name of the router instance
+    # instantiate: true = create router instance
+    def initialize(acl_name, afi, instantiate=true)
+      @acl_name = acl_name
+      @afi = afi
+      @set_args = @get_args = {acl_name: @acl_name} 
+      create if instantiate
+    end
+
+    def self.acls
+      instances = config_get('acl_v4' , 'acl') if @afi == "v4"
+      instances = config_get('acl_v6' , 'acl') if @afi == "v6"
+      return {} if instances.nil?
+      hash = {}
+      instances.each do |name|
+        hash[name] = Acl.new(acl_name, false)
+      end
+      return hash
+    rescue Cisco::CliError => e
+      # CLI will syntax reject when feature is not enabled
+      raise unless e.clierror =~ /Syntax error/
+      return {}
+    end
+
+    # config ip access-list and create
+    def create
+        config_acl('')
+    end
+
+    # Destroy a router instance; disable feature on last instance
+    def destroy
+      config_acl('no')
+    rescue Cisco::CliError => e
+      # CLI will syntax reject when feature is not enabled
+      raise unless e.clierror =~ /Syntax error/
+    end
+
+    def config_acl(state)
+      @set_args[:state] = state
+      config_set('acl_v4', 'acl', @set_args) if @afi == "v4"
+      config_set('acl_v6', 'acl', @set_args) if @afi == "v6"
+    end
+
+    # ----------
+    # PROPERTIES
+    # ----------
+    # getter acl info
+    def acl
+      config_get('acl_v4', 'acl', @get_args) if @afi == "v4"
+      config_get('acl_v6', 'acl', @get_args) if @afi == "v6"
+    end
+    # setter acl info
+    def acl=(state)
+      @set_args[:state] = (state ? '' : 'no') 
+      config_set('acl_v4', 'acl', @set_args) if @afi == "v4"
+      config_set('acl_v6', 'acl', @set_args) if @afi == "v6"
+    end
+
+    # getter stats perentry info
+    def stats_perentry
+      config_get('acl_v4', 'acl', @get_args) if @afi == "v4"
+      config_get('acl_v6', 'acl', @get_args) if @afi == "v6"
+    end
+
+    # setter stats perentry info
+    def stats_perentry=(state)
+      @set_args[:state] = (state ? '' : 'no') 
+      config_set('acl_v4', 'acl', @set_args) if @afi == "v4"
+      config_set('acl_v6', 'acl', @set_args) if @afi == "v6"
+    end
+  end
+end

--- a/lib/cisco_node_utils/acl.rb
+++ b/lib/cisco_node_utils/acl.rb
@@ -79,15 +79,15 @@ module Cisco
 
     # getter stats perentry info
     def stats_perentry
-      config_get('acl_v4', 'acl', @get_args) if @afi == "v4"
-      config_get('acl_v6', 'acl', @get_args) if @afi == "v6"
+      config_get('acl_v4', 'stats_perentry', @get_args) if @afi == "v4"
+      config_get('acl_v6', 'stats_perentry', @get_args) if @afi == "v6"
     end
 
     # setter stats perentry info
     def stats_perentry=(state)
       @set_args[:state] = (state ? '' : 'no') 
-      config_set('acl_v4', 'acl', @set_args) if @afi == "v4"
-      config_set('acl_v6', 'acl', @set_args) if @afi == "v6"
+      config_set('acl_v4', 'stats_perentry', @set_args) if @afi == "v4"
+      config_set('acl_v6', 'stats_perentry', @set_args) if @afi == "v6"
     end
   end
 end

--- a/lib/cisco_node_utils/cmd_ref/acl_v4.yaml
+++ b/lib/cisco_node_utils/cmd_ref/acl_v4.yaml
@@ -1,0 +1,25 @@
+# Command Reference Common ACL
+#
+# For documentation please see:
+#   - README_YAML.md
+#
+---
+_template:
+  config_get: 'show run aclmgr'
+  config_get_token: '/^ip access-list <acl_name>$/'
+  config_set: 'ip access-list <acl_name>'
+
+ace:
+  config_get_token_append: '/\s+(<seqno>)\s+(permit|deny)\s+(sctp|tcp|ip|udp|pim|icmp|igmp|gre|nos|pcp|ospf|eigrp|ahp|esp|\d+)\s+(any|host \S+|\S+\/\d+|\S+ [:\.0-9a-fA-F]+)\s+(eq \d+|neq \d+|lt \d+|gt \d+|range \d+ \d+)*\s*(any|host \S+|\S+\/\d+|\S+ [:\.0-9a-fA-F]+)\s*(eq \d+|neq \d+|lt \d+|gt \d+|range \d+ \d+)*( [a-zA-Z0-9\/ ]*)*$'
+  config_set_append: 
+      '<state> <seqno> <action> <proto> <v4_src_addr_format> <v4_src_port_format> <v4_dst_addr_format> <v4_dst_port_format> <option_format>'
+
+acl:
+  config_get_token: '/^ip access-list (/s+)$/'
+  config_set: '<state> ip access-list <acl_name>'
+                      
+stats_perentry:
+  kind: boolean
+  config_get_token_append: '/statistics per-entry$/'
+  config_set_append: '<state> statistics per-entry'
+  default_value: false

--- a/lib/cisco_node_utils/cmd_ref/acl_v6.yaml
+++ b/lib/cisco_node_utils/cmd_ref/acl_v6.yaml
@@ -1,0 +1,24 @@
+# Command Reference Common ACL
+#
+# For documentation please see:
+#   - README_YAML.md
+#
+---
+_template:
+  config_get: 'show run aclmgr'
+  config_get_token: '/^ipv6 access-list <acl_name>$/'
+  config_set: "ipv6 access-list <acl_name>"
+
+ace:
+  config_get_token_append: '\s+(<seqno>)\s+(permit|deny)\s+(sctp|tcp|ip|udp|pim|icmp|igmp|gre|nos|pcp|ospf|eigrp|ahp|esp|\d+)\s+(any|host \S+|\S+\/\d+|\S+ [:\.0-9a-fA-F]+)\s+(eq \d+|neq \d+|lt \d+|gt \d+|range \d+ \d+)*\s*(any|host \S+|\S+\/\d+|\S+ [:\.0-9a-fA-F]+)\s*(eq \d+|neq \d+|lt \d+|gt \d+|range \d+ \d+)*( [a-zA-Z0-9\/ ]*)*$'
+  config_set_append: '<state> <seqno> <action> <proto> <v6_src_addr_format> <v6_dst_addr_format> <option_format>'
+
+acl:
+  config_get_token: '/^ipv6 access-list <acl_name>$/'
+  config_set: '<state> ipv6 access-list <acl_name>'
+
+stats_perentry:
+  kind: boolean
+  config_get_token_append: '/statistics per-entry$/'
+  config_set_append: '<state> statistics per-entry'
+  default_value: false

--- a/tests/test_ace_v4.rb
+++ b/tests/test_ace_v4.rb
@@ -23,9 +23,9 @@ class TestAceV4 < CiscoTestCase
   def setup
     # setup runs at the beginning of each test
     super
-    @acl_name = "test-foo-1"
+    @acl_name = 'test-foo-1'
     @seqno = 10
-    @afi = "v4"
+    @afi = 'v4'
     no_ip_access_list_foo
   end
 
@@ -45,13 +45,13 @@ class TestAceV4 < CiscoTestCase
   def test_router_create_one
     acl = Acl.new(@acl_name, @afi)
     ace = Ace.new(@acl_name, @seqno, @afi)
-    ace.action = "permit"
-    ace.proto  = "tcp"
-    ace.v4_src_addr_format = "7.8.9.6 2.3.4.5"
-    ace.v4_src_port_format = "eq 40"
-    ace.v4_dst_addr_format = "1.2.3.4/32"
-    ace.v4_dst_port_format = "neq 20"
-    ace.option_format = "precedence critical"
+    ace.action = 'permit'
+    ace.proto  = 'tcp'
+    ace.v4_src_addr_format = '7.8.9.6 2.3.4.5'
+    ace.v4_src_port_format = 'eq 40'
+    ace.v4_dst_addr_format = '1.2.3.4/32'
+    ace.v4_dst_port_format = 'neq 20'
+    ace.option_format = 'precedence critical'
     ace.config_ace
     @default_show_command = "show runn | sec 'ip access-list #{@acl_name}'"
     assert_show_match(pattern: /\s+#{ace.seqno} #{ace.action} #{ace.proto}.*$/,

--- a/tests/test_ace_v4.rb
+++ b/tests/test_ace_v4.rb
@@ -1,0 +1,64 @@
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/acl'
+require_relative '../lib/cisco_node_utils/ace_v4'
+
+# TestX__CLASS_NAME__X - Minitest for X__CLASS_NAME__X node utility class
+class TestAceV4 < CiscoTestCase
+  attr_reader :acl_name, :seqno, :afi
+
+  def setup
+    # setup runs at the beginning of each test
+    super
+    @acl_name = "test-foo-1"
+    @seqno = 10
+    @afi = "v4"
+    no_ip_access_list_foo
+  end
+
+  def teardown
+    # teardown runs at the end of each test
+    no_ip_access_list_foo
+    super
+  end
+
+  def no_ip_access_list_foo
+    # Turn the feature off for a clean test.
+    config('no ip access-list ' + @acl_name)
+  end
+
+  # TESTS
+
+  def test_router_create_one
+    acl = Acl.new(@acl_name, @afi)
+    ace = Ace.new(@acl_name, @seqno, @afi)
+    ace.action = "permit"
+    ace.proto  = "tcp"
+    ace.v4_src_addr_format = "7.8.9.6 2.3.4.5"
+    ace.v4_src_port_format = "eq 40"
+    ace.v4_dst_addr_format = "1.2.3.4/32"
+    ace.v4_dst_port_format = "neq 20"
+    ace.option_format = "precedence critical"
+    ace.config_ace
+    @default_show_command = "show runn | sec 'ip access-list #{@acl_name}'"
+    assert_show_match(pattern: /\s+#{ace.seqno} #{ace.action} #{ace.proto}.*$/,
+                      msg:     "failed to create ace seqno #{@seqno}")
+    ace.destroy
+    refute_show_match(pattern: /\s+#{ace.seqno} #{ace.action} #{ace.proto}.*$/,
+                      msg:     "failed to remove ace seqno #{@seqno}")
+    acl.destroy
+  end
+end

--- a/tests/test_acl.rb
+++ b/tests/test_acl.rb
@@ -1,0 +1,87 @@
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/acl'
+
+class TestAcl < CiscoTestCase
+  attr_reader :acl_name_v4, :acl_name_v6
+  def setup
+    # setup runs at the beginning of each test
+    super
+    @acl_name_v4 = "test-foo-v4-1"
+    @acl_name_v6 = "test-foo-v6-1"
+    no_ip_access_list_foo
+  end
+
+  def teardown
+    # teardown runs at the end of each test
+    no_ip_access_list_foo
+    super
+  end
+
+  def no_ip_access_list_foo
+    # Turn the feature off for a clean test.
+    config('no ip access-list ' + @acl_name_v4)
+    config('no ipv6 access-list ' + @acl_name_v6)
+  end
+
+  # TESTS
+
+  def test_router_create_acl_v4
+    name = @acl_name_v4
+    rtr = Acl.new(name, "v4")
+    @default_show_command = "show runn | i 'ip access-list #{name}'"
+    assert_show_match(pattern: /^ip access-list #{name}$/,
+                      msg:     "failed to create acl #{name}")
+    rtr.destroy
+    refute_show_match(pattern: /^ip access-list #{name}$/,
+                      msg:     "failed to destroy acl #{name}")
+  end
+
+  def test_router_stats_enable
+    name = @acl_name_v4
+    rtr = Acl.new(name, "v4")
+    rtr.stats_perentry = true
+    @default_show_command = "show runn | sec 'ip access-list #{name}'"
+    assert_show_match(pattern: /statistics per-entry/,
+                      msg:     "failed to enable stats")
+    rtr.destroy
+    refute_show_match(pattern: /^ip access-list #{name}$/,
+                      msg:     "failed to destroy acl #{name}")
+  end
+
+  def test_router_create_acl_v6
+    name = @acl_name_v6
+    rtr = Acl.new(name, "v6")
+    @default_show_command = "show runn | i 'ipv6 access-list #{name}'"
+    assert_show_match(pattern: /^ipv6 access-list #{name}$/,
+                      msg:     "failed to create acl #{name}")
+    rtr.destroy
+    refute_show_match(pattern: /^ipv6 access-list #{name}$/,
+                      msg:     "failed to destroy acl #{name}")
+  end
+
+  def test_router_stats_enable_v6
+    name = @acl_name_v6
+    rtr = Acl.new(name, "v6")
+    rtr.stats_perentry = true
+    @default_show_command = "show runn | sec 'ipv6 access-list #{name}'"
+    assert_show_match(pattern: /statistics per-entry/,
+                      msg:     "failed to enable stats")
+    rtr.destroy
+    refute_show_match(pattern: /^ipv6 access-list #{name}$/,
+                      msg:     "failed to destroy acl #{name}")
+  end
+end

--- a/tests/test_acl.rb
+++ b/tests/test_acl.rb
@@ -15,13 +15,14 @@
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/acl'
 
+# test client for acl creation and deletion
 class TestAcl < CiscoTestCase
   attr_reader :acl_name_v4, :acl_name_v6
   def setup
     # setup runs at the beginning of each test
     super
-    @acl_name_v4 = "test-foo-v4-1"
-    @acl_name_v6 = "test-foo-v6-1"
+    @acl_name_v4 = 'test-foo-v4-1'
+    @acl_name_v6 = 'test-foo-v6-1'
     no_ip_access_list_foo
   end
 
@@ -41,9 +42,9 @@ class TestAcl < CiscoTestCase
 
   def test_router_create_acl_v4
     name = @acl_name_v4
-    rtr = Acl.new(name, "v4")
+    rtr = Acl.new(name, 'v4')
     @default_show_command = "show runn | i 'ip access-list #{name}'"
-    assert_show_match(pattern: /^ip access-list #{name}$/,
+    assert_show_match(pattern: %r{/^ip access-list #{name}$/},
                       msg:     "failed to create acl #{name}")
     rtr.destroy
     refute_show_match(pattern: /^ip access-list #{name}$/,
@@ -52,11 +53,11 @@ class TestAcl < CiscoTestCase
 
   def test_router_stats_enable
     name = @acl_name_v4
-    rtr = Acl.new(name, "v4")
+    rtr = Acl.new(name, 'v4')
     rtr.stats_perentry = true
     @default_show_command = "show runn | sec 'ip access-list #{name}'"
     assert_show_match(pattern: /statistics per-entry/,
-                      msg:     "failed to enable stats")
+                      msg:     'failed to enable stats')
     rtr.destroy
     refute_show_match(pattern: /^ip access-list #{name}$/,
                       msg:     "failed to destroy acl #{name}")
@@ -64,7 +65,7 @@ class TestAcl < CiscoTestCase
 
   def test_router_create_acl_v6
     name = @acl_name_v6
-    rtr = Acl.new(name, "v6")
+    rtr = Acl.new(name, 'v6')
     @default_show_command = "show runn | i 'ipv6 access-list #{name}'"
     assert_show_match(pattern: /^ipv6 access-list #{name}$/,
                       msg:     "failed to create acl #{name}")
@@ -75,11 +76,11 @@ class TestAcl < CiscoTestCase
 
   def test_router_stats_enable_v6
     name = @acl_name_v6
-    rtr = Acl.new(name, "v6")
+    rtr = Acl.new(name, 'v6')
     rtr.stats_perentry = true
     @default_show_command = "show runn | sec 'ipv6 access-list #{name}'"
     assert_show_match(pattern: /statistics per-entry/,
-                      msg:     "failed to enable stats")
+                      msg:     'failed to enable stats')
     rtr.destroy
     refute_show_match(pattern: /^ipv6 access-list #{name}$/,
                       msg:     "failed to destroy acl #{name}")


### PR DESCRIPTION
[18:02 shenma-laas]($):$ ruby test_acl.rb -v -- 10.122.197.183 admin admin
Run options: -v -- --seed 11454
# Running:

Node under test:
- name  - agent-lab3-nx
- type  - N9K-NXOSV
- image - bootflash:///nxos.7.0.3.I2.1.bin

TestAcl#test_router_stats_enable = 6.77 s = .
TestAcl#test_router_stats_enable_v6 = 4.45 s = .
TestAcl#test_router_create_acl_v4 = 4.25 s = .
TestAcl#test_router_create_acl_v6 = 4.09 s = .

Finished in 19.564593s, 0.2045 runs/s, 1.2267 assertions/s.

4 runs, 24 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /auto/tftp-sjc-users3/shenma/cisco-network-node-utils/tests/coverage. 0.0 / 0.0 LOC (100.0%) covered.
# 

[02:41 shenma-laas]:$ ruby test_ace_v4.rb -v -- 10.122.197.183 admin admin
Run options: -v -- --seed 55981
# Running:

Node under test:
- name  - agent-lab3-nx
- type  - N9K-NXOSV
- image - bootflash:///nxos.7.0.3.I2.1.bin

TestAceV4#test_router_create_one = 7.94 s = .

Finished in 7.939242s, 0.1260 runs/s, 0.7557 assertions/s.

1 runs, 6 assertions, 0 failures, 0 errors, 0 skips
# Coverage report generated for MiniTest to /auto/tftp-sjc-users3/shenma/cisco-network-node-utils/tests/coverage. 0.0 / 0.0 LOC (100.0%) covered.

[02:46 shenma-laas]:$ rubocop test_ace_v4.rb 
Inspecting 1 file
.
#1 file inspected, no offenses detected

[02:50 shenma-laas]:$ rubocop tests/test_acl.rb 
Inspecting 1 file
.
#1 file inspected, no offenses detected

[02:59 shenma-laas]:$ rubocop lib/cisco_node_utils/ace_v4.rb
Inspecting 1 file
.
#1 file inspected, no offenses detected

[03:02 shenma-laas]:$ rubocop lib/cisco_node_utils/acl.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
