### PR TITLE
add vni to cisco_vrf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog
 ### Added
 
 * `Cisco::UnsupportedError` exception class, raised when a command is explicitly marked as unsupported on a particular class of nodes.
-* Extend cisco_vrf with vni attribute
+* Extend cisco_vrf with `vni` attribute
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 ### Added
 
 * `Cisco::UnsupportedError` exception class, raised when a command is explicitly marked as unsupported on a particular class of nodes.
+* Extend cisco_vrf with vni attribute
 
 ### Changed
 

--- a/lib/cisco_node_utils/cmd_ref/vrf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vrf.yaml
@@ -24,3 +24,10 @@ shutdown:
   config_get_token: ['/^vrf context <vrf>$/i', '/^shutdown$/']
   config_set: ["vrf context <vrf>", "<state> shutdown"]
   default_value: false
+
+vni:
+  kind: int
+  config_get: "show running | section 'vrf context'"
+  config_get_token: ['/^vrf context <vrf>$/i', '/^vni (\d+)$/']
+  config_set: ["vrf context <vrf>", "<state> vni <id>"]
+  default_value: false

--- a/lib/cisco_node_utils/cmd_ref/vrf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vrf.yaml
@@ -19,7 +19,7 @@ destroy:
 
 feature_vn_segment_vlan_based:
   _exclude:
-    - /N7K/  # Support for multi-tenancy full only
+    - [/N7K/]  # Support for multi-tenancy full only
   kind: boolean
   default_value: false
   cli_nexus:
@@ -44,6 +44,8 @@ shutdown:
   default_value: false
 
 vni:
+  _exclude:
+    - [/N3/]   # N3: Support Unknown
   kind: int
   config_get: "show running | section 'vrf context'"
   config_get_token: ['/^vrf context <vrf>$/i', '/^vni (\d+)$/']

--- a/lib/cisco_node_utils/cmd_ref/vrf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vrf.yaml
@@ -1,5 +1,4 @@
-# vrf.yaml
----
+
 all_vrfs:
   multiple: true
   config_get: "show running | section 'vrf context'"
@@ -18,6 +17,25 @@ description:
 destroy:
   config_set: "no vrf context <vrf>"
 
+feature_vn_segment_vlan_based:
+  _exclude:
+    - /N7K/  # Support for multi-tenancy full only
+  kind: boolean
+  default_value: false
+  cli_nexus:
+    config_get: 'show running section feature'
+    config_get_token: '/^feature vn-segment-vlan-based$/'
+    config_set: 'feature vn-segment-vlan-based'
+
+feature_vni:
+  _exclude: [/N3K/, /N9K/]   # Support for multi-tenancy lite only
+  kind: boolean
+  default_value: false
+  cli_nexus:
+    config_get: 'show running section feature'
+    config_get_token: '/^feature vni$/'
+    config_set: 'feature vni'
+
 shutdown:
   kind: boolean
   config_get: "show running | section 'vrf context'"
@@ -31,3 +49,5 @@ vni:
   config_get_token: ['/^vrf context <vrf>$/i', '/^vni (\d+)$/']
   config_set: ["vrf context <vrf>", "<state> vni <id>"]
   default_value: false
+
+

--- a/lib/cisco_node_utils/vrf.rb
+++ b/lib/cisco_node_utils/vrf.rb
@@ -74,20 +74,52 @@ module Cisco
       raise "[vrf #{@name}] '#{e.command}' : #{e.clierror}"
     end
 
+    def self.feature_vni_enabled
+      config_get('vrf', 'feature_vni')
+    rescue Cisco::CliError => e
+      # cmd will syntax reject when feature is not enabled
+      raise unless e.clierror =~ /Syntax error/
+      return false
+    end
+
+    def self.feature_vni_enable
+      config_set('vrf', 'feature_vni')
+    end
+
+    def self.feature_vn_segment_vlan_based_enabled
+      config_get('vrf', 'feature_vn_segment_vlan_based')
+    rescue Cisco::CliError => e
+      # cmd will syntax reject when feature is not enabled
+      raise unless e.clierror =~ /Syntax error/
+      return false
+    end
+
+    def self.feature_vn_segment_vlan_based_enable
+      config_set('vrf', 'feature_vn_segment_vlan_based')
+    end
+
+    def enable_vni_features
+      # config_get_default returns nil if command is unsupported on a platform
+      unless config_get_default('vrf', 'feature_vni').nil?
+        Vrf.feature_vni_enable unless Vrf.feature_vni_enabled
+      end
+      return if config_get_default('vrf', 'feature_vn_segment_vlan_based').nil?
+      Vrf.feature_vn_segment_vlan_based_enable unless
+        Vrf.feature_vn_segment_vlan_based_enabled
+    end
+
     # Vni (Getter/Setter/Default)
     def vni
       config_get('vrf', 'vni', @args)
     end
 
     def vni=(id)
-      if id == default_vni
-        @args[:state] = 'no'
-        @args[:id] = vni
-      else
-        @args[:state] = ''
-        @args[:id] = id
-      end
-      config_set('vrf', 'vni', @args)
+      enable_vni_features
+      no_cmd = (id) ? '' : 'no'
+      id = (id) ? id : vni
+      config_set('vrf', 'vni', vrf: @name, state: no_cmd, id: id)
+    rescue Cisco::CliError => e
+      raise "[vrf #{@name}] '#{e.command}' : #{e.clierror}"
     end
 
     def default_vni

--- a/lib/cisco_node_utils/vrf.rb
+++ b/lib/cisco_node_utils/vrf.rb
@@ -73,5 +73,25 @@ module Cisco
     rescue Cisco::CliError => e
       raise "[vrf #{@name}] '#{e.command}' : #{e.clierror}"
     end
+
+    # Vni (Getter/Setter/Default)
+    def vni
+      config_get('vrf', 'vni', @args)
+    end
+
+    def vni=(id)
+      if id == default_vni
+        @args[:state] = 'no'
+        @args[:id] = vni
+      else
+        @args[:state] = ''
+        @args[:id] = id
+      end
+      config_set('vrf', 'vni', @args)
+    end
+
+    def default_vni
+      config_get_default('vrf', 'vni')
+    end
   end # class
 end # module

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -89,4 +89,21 @@ class TestVrf < CiscoTestCase
     assert_empty(vrf.description, 'failed to remove description')
     vrf.destroy
   end
+
+  def test_vrf_vni
+    vrf = Vrf.new('test_vrf_vni')
+    vrf.vni = 4096
+    assert_equal(4096, vrf.vni,
+                 "vrf vni should be set to '4096'")
+    vrf.vni = vrf.default_vni
+    assert_equal(vrf.default_vni, vrf.vni,
+                 'vrf vni should be set to default value')
+    vrf.destroy
+  end
+
+  def test_vrf_default_vni
+    vrf = Vrf.new('test_vrf_default_vni')
+    assert_equal(vrf.default_vni, vrf.vni,
+                 'vrf vni should be default value')
+  end
 end

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -100,10 +100,4 @@ class TestVrf < CiscoTestCase
                  'vrf vni should be set to default value')
     vrf.destroy
   end
-
-  def test_vrf_default_vni
-    vrf = Vrf.new('test_vrf_default_vni')
-    assert_equal(vrf.default_vni, vrf.vni,
-                 'vrf vni should be default value')
-  end
 end


### PR DESCRIPTION
1. pass minitest
   TestVrf#test_vrf_shutdown_valid = 4.73 s = .
   TestVrf#test_vrf_name_zero_length = 0.90 s = .
   TestVrf#test_vrf_vni = 1.34 s = .
   TestVrf#test_vrf_collection_not_empty = 0.86 s = .
   TestVrf#test_vrf_default_vni = 0.92 s = .
   TestVrf#test_vrf_description = 2.47 s = .
   TestVrf#test_vrf_name_type_invalid = 0.87 s = .
   TestVrf#test_vrf_create_and_destroy = 1.07 s = .
   TestVrf#test_vrf_name_too_long = 0.76 s = .
   Finished in 13.920047s, 0.6465 runs/s, 1.5805 assertions/s.
   9 runs, 22 assertions, 0 failures, 0 errors, 0 skips
2. pass static analysis
3. it need For the N7K (supports multi-tenanacy full), you need to enable :

feature vni
And for N9k/3k (all platforms which support only mult-tenancy lite):

feature vn-segment-vlan-based different in differnt platform, but I pass the test after I unable the feature.
