### PR TITLE
clean up l2rib command too when vxlan_global is disabled.

### DIFF
--- a/lib/cisco_node_utils/vxlan_global.rb
+++ b/lib/cisco_node_utils/vxlan_global.rb
@@ -34,6 +34,7 @@ module Cisco
 
     def disable
       config_set('vxlan_global', 'feature', state: 'no')
+      dup_host_mac_detection_default
     end
 
     # Check current state of the configuration
@@ -161,8 +162,8 @@ module Cisco
       else
         state = ''
       end
-        config_set('vxlan_global', 'anycast_gateway_mac',
-                   state: state, mac_addr: mac_addr)
+      config_set('vxlan_global', 'anycast_gateway_mac',
+                 state: state, mac_addr: mac_addr)
     end
 
     def default_anycast_gateway_mac


### PR DESCRIPTION
rubocop and minitest passes.
