### PR TITLE
Uprev to rubocop 0.35.1

### DIFF
--- a/cisco_node_utils.gemspec
+++ b/cisco_node_utils.gemspec
@@ -30,7 +30,7 @@ Currently supports NX-OS nodes.
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rubocop', '= 0.34.2'
+  spec.add_development_dependency 'rubocop', '= 0.35.1'
   spec.add_development_dependency 'simplecov', '~> 0.9'
   spec.add_runtime_dependency 'cisco_nxapi', '~> 1.0'
 end

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -56,8 +56,10 @@ module Cisco
 
       hash_final = {}
       asnum = asnum.to_i unless /\d+.\d+/.match(asnum)
+      # rubocop:disable Style/AlignHash
       hash_tmp = { asnum =>
         { 'default' => RouterBgp.new(asnum, 'default', false) } }
+      # rubocop:enable Style/AlignHash
       vrf_ids = config_get('bgp', 'vrf', asnum: asnum)
       unless vrf_ids.nil?
         vrf_ids.each do |vrf|

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -56,10 +56,9 @@ module Cisco
 
       hash_final = {}
       asnum = asnum.to_i unless /\d+.\d+/.match(asnum)
-      # rubocop:disable Style/AlignHash
-      hash_tmp = { asnum =>
-        { 'default' => RouterBgp.new(asnum, 'default', false) } }
-      # rubocop:enable Style/AlignHash
+      hash_tmp = {
+        asnum => { 'default' => RouterBgp.new(asnum, 'default', false) }
+      }
       vrf_ids = config_get('bgp', 'vrf', asnum: asnum)
       unless vrf_ids.nil?
         vrf_ids.each do |vrf|

--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -40,7 +40,7 @@ module Cisco
         af_hash[asn] = {}
         vrfs.keys.each do |vrf_name|
           get_args = { asnum: asn }
-          get_args[:vrf] = vrf_name unless (vrf_name == 'default')
+          get_args[:vrf] = vrf_name unless vrf_name == 'default'
           # Call yaml and search for address-family statements
           af_list = config_get('bgp_af', 'all_afs', get_args)
 

--- a/lib/cisco_node_utils/bgp_neighbor_af.rb
+++ b/lib/cisco_node_utils/bgp_neighbor_af.rb
@@ -37,7 +37,7 @@ module Cisco
         vrfs.keys.each do |vrf|
           af_hash[asn][vrf] = {}
           get_args = { asnum: asn }
-          get_args[:vrf] = vrf unless (vrf == 'default')
+          get_args[:vrf] = vrf unless vrf == 'default'
 
           nbrs = config_get('bgp_neighbor', 'all_neighbors', get_args)
           next if nbrs.nil?

--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -118,8 +118,7 @@ module Cisco
 
     def self.delta_add_remove(should, current=[])
       # Remove nil entries from array
-      should.each(&:compact!) unless should.empty? if depth(should) > 1
-
+      should.each(&:compact!) if depth(should) > 1
       delta = { add: should - current, remove: current - should }
 
       # Delete entries from :remove if f1 is an update to an existing command

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -401,8 +401,8 @@ module Cisco
     def switchport_enable_and_mode(mode_set)
       switchport_enable unless switchport
 
-      if (:fex_fabric == mode_set)
-        fex_feature_set(:enabled) unless (:enabled == fex_feature)
+      if :fex_fabric == mode_set
+        fex_feature_set(:enabled) unless :enabled == fex_feature
       end
       config_set('interface', switchport_mode_lookup_string, @name, '',
                  IF_SWITCHPORT_MODE[mode_set])

--- a/lib/cisco_node_utils/platform.rb
+++ b/lib/cisco_node_utils/platform.rb
@@ -164,7 +164,7 @@ module Cisco
       # convert to expected format
       virts_hsh = {}
       virts.each do |serv|
-        # rubocop:disable Style/AlignHash, Style/ExtraSpacing
+        # rubocop:disable Style/AlignHash
         virts_hsh[serv['name']] = {
           'package_info' => { 'name'     => serv['package_name'],
                               'path'     => serv['ova_path'],
@@ -184,7 +184,7 @@ module Cisco
                               'cpu'      => serv['cpu_reservation'],
           },
         }
-        # rubocop:enable Style/AlignHash, Style/ExtraSpacing
+        # rubocop:enable Style/AlignHash
       end
       virts_hsh
     end

--- a/lib/cisco_node_utils/router_ospf_vrf.rb
+++ b/lib/cisco_node_utils/router_ospf_vrf.rb
@@ -56,8 +56,10 @@ module Cisco
       RouterOspf.routers.each do |instance|
         name = instance[0]
         vrf_ids = config_get('ospf', 'vrf', name: name)
+        # rubocop:disable Style/AlignHash
         hash_tmp = { name =>
           { 'default' => RouterOspfVrf.new(name, 'default', false) } }
+        # rubocop:enable Style/AlignHash
         unless vrf_ids.nil?
           vrf_ids.each do |vrf|
             hash_tmp[name][vrf] = RouterOspfVrf.new(name, vrf, false)

--- a/lib/cisco_node_utils/router_ospf_vrf.rb
+++ b/lib/cisco_node_utils/router_ospf_vrf.rb
@@ -56,10 +56,9 @@ module Cisco
       RouterOspf.routers.each do |instance|
         name = instance[0]
         vrf_ids = config_get('ospf', 'vrf', name: name)
-        # rubocop:disable Style/AlignHash
-        hash_tmp = { name =>
-          { 'default' => RouterOspfVrf.new(name, 'default', false) } }
-        # rubocop:enable Style/AlignHash
+        hash_tmp = {
+          name => { 'default' => RouterOspfVrf.new(name, 'default', false) }
+        }
         unless vrf_ids.nil?
           vrf_ids.each do |vrf|
             hash_tmp[name][vrf] = RouterOspfVrf.new(name, vrf, false)

--- a/lib/cisco_node_utils/syslog_server.rb
+++ b/lib/cisco_node_utils/syslog_server.rb
@@ -31,10 +31,10 @@ module Cisco
       fail TypeError unless name.length > 0
       @name = name
 
-      fail TypeError unless level.is_a?(Integer) unless level.nil?
+      fail TypeError unless level.is_a?(Integer) || level.nil?
       @level = level
 
-      fail TypeError unless vrf.is_a?(String) unless vrf.nil?
+      fail TypeError unless vrf.is_a?(String) || vrf.nil?
       @vrf = vrf
 
       create if instantiate

--- a/tests/test_command_config.rb
+++ b/tests/test_command_config.rb
@@ -120,7 +120,7 @@ class TestCommandConfig < CiscoTestCase
       sleep 30 # long-running command
       curr = @device.cmd('show int brief | count')[/^(\d+)$/]
       flunk('Timeout while creating 1024 loopback interfaces' \
-            "(pre:#{pre} curr:#{curr}") unless (pre == curr - 1024)
+            "(pre:#{pre} curr:#{curr}") unless pre == curr - 1024
     end
 
     # Remove 1024 loopback interfaces
@@ -134,7 +134,7 @@ class TestCommandConfig < CiscoTestCase
       sleep 30 # long-running: n95 can take 70+ sec to remove all of these
       curr = @device.cmd(show_int_count)[/^(\d+)$/]
       flunk('Timeout while deleting 1024 loopback interfaces ' \
-            "(pre:#{pre} curr:#{curr}") unless (pre == curr)
+            "(pre:#{pre} curr:#{curr}") unless pre == curr
     end
   end
 

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -261,7 +261,7 @@ class TestInterface < CiscoTestCase
     # Validate the collection
     inttype_h.each do |k, v|
       # Skipping loopback, proxy arp not supported
-      next if (k == 'loopback0')
+      next if k == 'loopback0'
 
       interface = v[:interface]
       cmd = show_cmd(interface.name)

--- a/tests/test_node_ext.rb
+++ b/tests/test_node_ext.rb
@@ -226,8 +226,8 @@ vrf blue",
     assert_equal('switch', name)
 
     return unless configured_name
-    config("hostname #{configured_name}") if (switchname == false)
-    config("switchname #{configured_name}") if (switchname == true)
+    config("hostname #{configured_name}") if switchname == false
+    config("switchname #{configured_name}") if switchname == true
   end
 
   def test_node_get_host_name_when_set
@@ -256,8 +256,8 @@ vrf blue",
     assert_equal('xyz', host_name)
 
     if configured_name
-      config("hostname #{configured_name}") if (switchname == false)
-      config("switchname #{configured_name}") if (switchname == true)
+      config("hostname #{configured_name}") if switchname == false
+      config("switchname #{configured_name}") if switchname == true
     else
       switchname ? config('no switchname') : config('no hostname')
     end

--- a/tests/test_platform.rb
+++ b/tests/test_platform.rb
@@ -181,7 +181,7 @@ class TestPlatform < CiscoTestCase
     vir_hsh_hsh = {}
     unless vir_arr.nil?
       vir_arr.each do |serv|
-        # rubocop:disable Style/AlignHash, Style/ExtraSpacing
+        # rubocop:disable Style/AlignHash
         vir_hsh_hsh[serv['name']] = {
           'package_info' => { 'name'     => serv['package_name'],
                               'path'     => serv['ova_path'],
@@ -201,7 +201,7 @@ class TestPlatform < CiscoTestCase
                               'cpu'      => serv['cpu_reservation'],
           },
         }
-        # rubocop:enable Style/AlignHash, Style/ExtraSpacing
+        # rubocop:enable Style/AlignHash
       end
     end
     assert_equal(vir_hsh_hsh, Platform.virtual_services)

--- a/tests/test_router_ospf_vrf.rb
+++ b/tests/test_router_ospf_vrf.rb
@@ -131,7 +131,7 @@ class TestRouterOspfVrf < CiscoTestCase
         cot: RouterOspfVrf::OSPF_AUTO_COST[:mbps], dm: 15_000,
         id: '9.0.0.2', l1: 130, l2: 530, l3: 1030, s1: 300,
         s2: 600, s3: 1100
-      },
+      }
     },
     'bxb300' => {
       'default' => {
@@ -139,7 +139,7 @@ class TestRouterOspfVrf < CiscoTestCase
         cot: RouterOspfVrf::OSPF_AUTO_COST[:mbps], dm: 10_000,
         id: '10.0.0.3', l1: 130, l2: 530, l3: 1030, s1: 300,
         s2: 600, s3: 1100
-      },
+      }
     },
   )
   # rubocop:enable Style/AlignHash
@@ -557,7 +557,7 @@ class TestRouterOspfVrf < CiscoTestCase
         cot: RouterOspfVrf::OSPF_AUTO_COST[:mbps], dm: 15_000,
         id: '9.0.0.2', l1: 130, l2: 530, l3: 1030, s1: 300,
         s2: 600, s3: 1100
-      },
+      }
     },
     'bxb300' => {
       'default' => {


### PR DESCRIPTION
Rubocop now clean for version 0.35.1.  Minitest has errors, but they happen for both `feature/rubocop-uprev` and `develop` branches.
