### PR TITLE
channel_group property addition to interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+## [Unreleased]
+
 ### New feature support
 * Fabric Path
   * fabricpath_global (@dcheriancisco)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 Changelog
 =========
 
-## [Unreleased]
+### Added
+
+* port_channel property to `Cisco::Interface` class
 
 ### New feature support
 * VXLAN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
 Changelog
 =========
 
-### Added
-
-* port_channel property to `Cisco::Interface` class
-
 ### New feature support
 * VXLAN
   * vxlan_global (@alok-aggarwal)
@@ -14,6 +10,7 @@ Changelog
 
 * `Cisco::UnsupportedError` exception class, raised when a command is explicitly marked as unsupported on a particular class of nodes.
 * Extend cisco_vrf with `vni` attribute
+* Extend cisco_interface with `channel_group` property
 
 ### Changed
 

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -18,14 +18,15 @@ admin_state_ethernet_noswitchport_shutdown:
     /N7K/:
       default_value: "shutdown"
 
-all_channel_groups:
-  multiple:
-  config_get: "show running interface all | include channel-group"
-  config_get_token: ['/channel-group (\d+)$/']
-
 all_interfaces:
   multiple:
   config_get_token: '/^interface (.*)/'
+
+channel_group:
+  kind: int
+  config_get_token_append: ['/^channel-group (\d+)$/']
+  config_set_append: ["%s channel-group %s %s"]
+  default_value: ''
 
 create:
   config_set: "interface %s"
@@ -141,15 +142,6 @@ negotiate_auto_portchannel:
       config_get_token_append: '/^(no )?negotiate auto$/'
       config_set_append: "%s negotiate auto"
       default_value: true
-
-port_channel:
-  kind: int
-  config_get: "show running interface all"
-  config_get_token: ['/^interface %s$/i', '/^channel-group (\d+)$/']
-  config_set: ["interface %s", "%s channel-group %s %s"]
-
-port_channel_destroy:
-  config_set: ["no interface port-channel %s"]
 
 shutdown:
   kind: boolean

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -18,6 +18,11 @@ admin_state_ethernet_noswitchport_shutdown:
     /N7K/:
       default_value: "shutdown"
 
+all_channel_groups:
+  multiple:
+  config_get: "show running interface all | include channel-group"
+  config_get_token: ['/channel-group (\d+)$/']
+
 all_interfaces:
   multiple:
   config_get_token: '/^interface (.*)/'
@@ -136,6 +141,15 @@ negotiate_auto_portchannel:
       config_get_token_append: '/^(no )?negotiate auto$/'
       config_set_append: "%s negotiate auto"
       default_value: true
+
+port_channel:
+  kind: int
+  config_get: "show running interface all"
+  config_get_token: ['/^interface %s$/i', '/^channel-group (\d+)$/']
+  config_set: ["interface %s", "%s channel-group %s %s"]
+
+port_channel_destroy:
+  config_set: ["no interface port-channel %s"]
 
 shutdown:
   kind: boolean

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -84,7 +84,7 @@ module Cisco
 
     def channel_group=(val)
       fail "channel_group is not supported on #{name}" unless @name[/Ethernet/i]
-      if val.empty?
+      if val.to_s.empty?
         config_set('interface',
                    'channel_group', @name, 'no', '', '')
       else

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1101,7 +1101,7 @@ class TestInterface < CiscoTestCase
 
   def test_interface_channel_group_add_delete
     interface = Interface.new(interfaces[0])
-    pc = '100'
+    pc = 100
     interface.channel_group = pc
     assert_equal(pc.to_i, interface.channel_group)
     interface.channel_group = interface.default_channel_group

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -261,7 +261,7 @@ class TestInterface < CiscoTestCase
     # Validate the collection
     inttype_h.each do |k, v|
       # Skipping loopback, proxy arp not supported
-      next if (k == 'loopback0')
+      next if k == 'loopback0'
 
       interface = v[:interface]
       cmd = show_cmd(interface.name)
@@ -1097,5 +1097,24 @@ class TestInterface < CiscoTestCase
     interface.vrf = vrf
     assert_equal(vrf, interface.vrf)
     interface.destroy
+  end
+
+  def test_interface_port_channel_add_delete
+    interface1 = Interface.new(interfaces[0])
+    interface2 = Interface.new(interfaces[1])
+    interface3 = Interface.new(interfaces[2])
+    pc = '100'
+    interface1.port_channel = pc
+    interface2.port_channel = pc
+    interface3.port_channel = pc
+    assert_equal(pc.to_i, interface1.port_channel)
+    assert_equal(pc.to_i, interface2.port_channel)
+    assert_equal(pc.to_i, interface3.port_channel)
+    interface1.port_channel = ''
+    interface2.port_channel = ''
+    interface3.port_channel = ''
+    assert_nil(interface1.port_channel)
+    assert_nil(interface2.port_channel)
+    assert_nil(interface3.port_channel)
   end
 end

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1099,22 +1099,12 @@ class TestInterface < CiscoTestCase
     interface.destroy
   end
 
-  def test_interface_port_channel_add_delete
-    interface1 = Interface.new(interfaces[0])
-    interface2 = Interface.new(interfaces[1])
-    interface3 = Interface.new(interfaces[2])
+  def test_interface_channel_group_add_delete
+    interface = Interface.new(interfaces[0])
     pc = '100'
-    interface1.port_channel = pc
-    interface2.port_channel = pc
-    interface3.port_channel = pc
-    assert_equal(pc.to_i, interface1.port_channel)
-    assert_equal(pc.to_i, interface2.port_channel)
-    assert_equal(pc.to_i, interface3.port_channel)
-    interface1.port_channel = ''
-    interface2.port_channel = ''
-    interface3.port_channel = ''
-    assert_nil(interface1.port_channel)
-    assert_nil(interface2.port_channel)
-    assert_nil(interface3.port_channel)
+    interface.channel_group = pc
+    assert_equal(pc.to_i, interface.channel_group)
+    interface.channel_group = interface.default_channel_group
+    assert_equal(interface.default_channel_group, interface.channel_group)
   end
 end


### PR DESCRIPTION
MiniTest results for n9k, n7k and n6k are as below.
Please note that one one test "test_interface_port_channel_add_delete" is added by me. This passed on all the above platforms. However there are other failures on n7k and n6k which are not related to this change.
# n6k_tests

```
[saichint@sjc-ads-6603 /ws/saichint-sjc/puppet_agent/cisco-network-node-utils/tests] $ ruby test_interface.rb -v -- 10.122.84.92 admin nbv12345
Run options: -v -- --seed 53384

# Running:


Node under test:
  - name  - n6k-92
  - type  - N6K-C6001-64P
  - image - bootflash:///n6000-uk9-kickstart.7.3.0.N1.0.213.bin

TestInterface#test_interface_vrf_default = 6.50 s = .
TestInterface#test_negotiate_auto_ethernet = 25.43 s = .
TestInterface#test_interface_get_access_vlan_switchport_disabled = 4.38 s = .
TestInterface#test_interface_shutdown_valid = 6.12 s = .
TestInterface#test_interface_create_name_invalid = 1.59 s = .
TestInterface#test_interface_create_valid = 1.78 s = .
TestInterface#test_interface_speed_change = 2.48 s = F
TestInterface#test_interface_description_valid = 1.97 s = E
TestInterface#test_interface_description_zero_length = 3.07 s = .
TestInterface#test_interface_create_does_not_exist = 1.76 s = .
TestInterface#test_interface_encapsulation_dot1q_change = 4.33 s = F
TestInterface#test_interface_vrf_override = 3.42 s = .
TestInterface#test_interface_vrf_empty = 3.24 s = .
TestInterface#test_interface_encapsulation_dot1q_invalid = 4.88 s = .
TestInterface#test_interface_get_access_vlan_switchport_trunk = 6.19 s = .
TestInterface#test_interface_create_name_nil = 1.59 s = .
TestInterface#test_negotiate_auto_portchannel = 18.93 s = .
TestInterface#test_interface_ipv4_address = 7.54 s = .
TestInterface#test_interface_ipv4_all_interfaces = 98.65 s = .
TestInterface#test_interface_mtu_invalid = 2.96 s = .
TestInterface#test_interface_get_access_vlan = 5.92 s = .
TestInterface#test_interface_vrf_exceeds_max_length = 1.94 s = .
TestInterface#test_interface_duplex_valid = 6.49 s = .
TestInterface#test_interface_speed_valid = 5.40 s = .
TestInterface#test_interface_speed_invalid = 2.44 s = .
TestInterface#test_negotiate_auto_loopback = 2.12 s = .
TestInterface#test_interface_ipv4_proxy_arp = 9.49 s = .
TestInterface#test_interface_mtu_valid = 5.51 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig = 4.97 s = .
TestInterface#test_interface_encapsulation_dot1q_valid = 4.39 s = F
TestInterface#test_interface_ipv4_addr_mask_set_netmask_invalid = 4.65 s = .
TestInterface#test_interface_ipv4_redirects = 8.86 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig_secondary = 5.45 s = .
TestInterface#test_interfaces_not_empty = 2.60 s = .
TestInterface#test_interface_duplex_invalid = 5.20 s = .
TestInterface#test_interface_vrf_invalid_type = 1.79 s = .
TestInterface#test_interface_description_too_long = 3.54 s = .
TestInterface#test_interface_mtu_change = 6.72 s = .
TestInterface#test_interface_description_nil = 1.76 s = .
TestInterface#test_interface_duplex_change = 8.21 s = .
TestInterface#test_interface_vrf_valid = 3.15 s = .
TestInterface#test_interface_port_channel_add_delete = 15.87 s = .
TestInterface#test_interface_ipv4_addr_mask_set_address_invalid = 4.47 s = .

Finished in 327.774984s, 0.1312 runs/s, 1.1044 assertions/s.

  1) Failure:
TestInterface#test_interface_speed_change [test_interface.rb:85]:
[ethernet1/1] 'speed 100' : ERROR: Ethernet1/1: Configuration does not match the port capability.


  2) Error:
TestInterface#test_interface_description_valid:
RuntimeError: [ethernet1/1] ' description bcdefghijklmnopqrstuvwxyz 0123456789abcdefghijklmnopqrstuvwxyz 0123456789abcdefghijklmnopqrstuvwxyz 0123456789abcdefghijklmnopqrstuvwxyz 0123456789abcdefghijklmnopqrstuvwxyz 0123456789abcdefghijklmnopqrstuvwxyz 0123456789abcdefghijklmnopqrstuv' : ERROR: error: name too long. max size allowed is 80
    /ws/saichint-sjc/puppet_agent/cisco-network-node-utils/lib/cisco_node_utils/interface.rb:92:in `rescue in description='
    /ws/saichint-sjc/puppet_agent/cisco-network-node-utils/lib/cisco_node_utils/interface.rb:85:in `description='
    test_interface.rb:415:in `block in test_interface_description_valid'
    test_interface.rb:411:in `upto'
    test_interface.rb:411:in `test_interface_description_valid'


  3) Failure:
TestInterface#test_interface_encapsulation_dot1q_change [test_interface.rb:427]:
Expected: 20
  Actual: ""


  4) Failure:
TestInterface#test_interface_encapsulation_dot1q_valid [test_interface.rb:448]:
Expected: 20
  Actual: ""

43 runs, 362 assertions, 3 failures, 1 errors, 0 skips
Coverage report generated for MiniTest to /ws/saichint-sjc/puppet_agent/cisco-network-node-utils/tests/coverage. 0.0 / 0.0 LOC (100.0%) covered.
```
# n9k tests

```
[saichint@sjc-ads-6603 /ws/saichint-sjc/puppet_agent/cisco-network-node-utils/tests] $ ruby test_interface.rb -v -- 10.122.197.117 admin admin
Run options: -v -- --seed 61063

# Running:


Node under test:
  - name  - agent-lab13-nx
  - type  - N9K-NXOSV
  - image - bootflash:///nxos.7.0.3.I2.1.bin

TestInterface#test_interface_ipv4_proxy_arp = 10.87 s = .
TestInterface#test_interface_vrf_exceeds_max_length = 1.85 s = .
TestInterface#test_interface_ipv4_all_interfaces = 81.80 s = .
TestInterface#test_interface_vrf_invalid_type = 6.79 s = .
TestInterface#test_interface_encapsulation_dot1q_change = 7.50 s = .
TestInterface#test_interface_create_valid = 1.64 s = .
TestInterface#test_interface_duplex_change = 8.08 s = .
TestInterface#test_interface_encapsulation_dot1q_valid = 7.23 s = .
TestInterface#test_interface_create_name_nil = 6.48 s = .
TestInterface#test_interface_create_does_not_exist = 1.67 s = .
TestInterface#test_interface_create_name_invalid = 1.57 s = .
TestInterface#test_interface_speed_valid = 6.31 s = .
TestInterface#test_interface_duplex_invalid = 5.88 s = .
TestInterface#test_interface_vrf_default = 3.66 s = .
TestInterface#test_interface_get_access_vlan = 6.59 s = .
TestInterface#test_negotiate_auto_portchannel = 10.08 s = .
TestInterface#test_interface_vrf_empty = 9.13 s = .
TestInterface#test_interface_mtu_change = 12.05 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig_secondary = 6.83 s = .
TestInterface#test_interface_speed_change = 7.23 s = .
TestInterface#test_interface_encapsulation_dot1q_invalid = 5.88 s = .
TestInterface#test_negotiate_auto_ethernet = 5.18 s = S
TestInterface#test_interface_vrf_override = 3.06 s = .
TestInterface#test_interface_description_zero_length = 2.39 s = .
TestInterface#test_interface_description_valid = 6.13 s = .
TestInterface#test_interface_duplex_valid = 7.37 s = .
TestInterface#test_interface_ipv4_redirects = 15.40 s = .
TestInterface#test_interface_description_too_long = 4.63 s = .
TestInterface#test_interface_get_access_vlan_switchport_disabled = 5.24 s = .
TestInterface#test_interface_mtu_invalid = 2.55 s = .
TestInterface#test_interface_get_access_vlan_switchport_trunk = 6.88 s = .
TestInterface#test_interface_port_channel_add_delete = 7.50 s = .
TestInterface#test_interface_speed_invalid = 2.21 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig = 7.27 s = .
TestInterface#test_interface_ipv4_addr_mask_set_address_invalid = 5.33 s = .
TestInterface#test_interface_ipv4_addr_mask_set_netmask_invalid = 6.13 s = .
TestInterface#test_interface_shutdown_valid = 7.48 s = .
TestInterface#test_interface_mtu_valid = 6.20 s = .
TestInterface#test_interface_vrf_valid = 2.64 s = .
TestInterface#test_negotiate_auto_loopback = 3.09 s = .
TestInterface#test_interfaces_not_empty = 2.22 s = .
TestInterface#test_interface_ipv4_address = 7.74 s = .
TestInterface#test_interface_description_nil = 1.75 s = .

Finished in 327.527337s, 0.1313 runs/s, 0.9862 assertions/s.

  1) Skipped:
TestInterface#test_negotiate_auto_ethernet [test_interface.rb:717]:
Skip test: Interface type does not allow config change

43 runs, 323 assertions, 0 failures, 0 errors, 1 skips
Coverage report generated for MiniTest to /ws/saichint-sjc/puppet_agent/cisco-network-node-utils/tests/coverage. 0.0 / 0.0 LOC (100.0%) covered.
```
# n7k tests

```
[saichint@sjc-ads-6603 /ws/saichint-sjc/puppet_agent/cisco-network-node-utils/tests] $ ruby test_interface.rb -v -- 172.23.148.240 admin nbv_12345
Run options: -v -- --seed 919

# Running:


Node under test:
  - name  - switch
  - type  - N7K-C7010
  - image - bootflash:///n7000-s2-dk9.7.3.0.OAC.0.8.gbin

TestInterface#test_interface_vrf_default = 2.85 s = .
TestInterface#test_interface_duplex_invalid = 1.79 s = F
TestInterface#test_interface_create_does_not_exist = 0.98 s = .
TestInterface#test_interface_encapsulation_dot1q_invalid = 3.37 s = .
TestInterface#test_interface_vrf_valid = 1.69 s = .
TestInterface#test_negotiate_auto_portchannel = 1.03 s = S
TestInterface#test_interface_description_nil = 0.99 s = .
TestInterface#test_interface_create_name_invalid = 0.92 s = .
TestInterface#test_interface_description_valid = 3.28 s = .
TestInterface#test_interface_vrf_override = 1.74 s = .
TestInterface#test_interface_get_access_vlan_switchport_disabled = 3.18 s = .
TestInterface#test_interface_create_valid = 0.98 s = .
TestInterface#test_interface_create_name_nil = 0.90 s = .
TestInterface#test_interface_mtu_invalid = 1.53 s = .
TestInterface#test_interface_speed_change = 1.43 s = F
TestInterface#test_negotiate_auto_ethernet = 2.70 s = F
TestInterface#test_interface_description_zero_length = 1.64 s = .
TestInterface#test_interface_ipv4_address = 2.45 s = E
TestInterface#test_interface_mtu_change = 4.40 s = .
TestInterface#test_interface_encapsulation_dot1q_change = 4.43 s = .
TestInterface#test_interface_ipv4_proxy_arp = 5.40 s = .
TestInterface#test_interface_duplex_change = 1.42 s = F
TestInterface#test_interface_speed_invalid = 1.40 s = .
TestInterface#test_negotiate_auto_loopback = 1.05 s = .
TestInterface#test_interface_ipv4_addr_mask_set_address_invalid = 3.29 s = .
TestInterface#test_interface_vrf_exceeds_max_length = 1.06 s = .
TestInterface#test_interface_speed_valid = 1.42 s = F
TestInterface#test_interface_description_too_long = 1.07 s = F
TestInterface#test_interface_port_channel_add_delete = 12.13 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig = 5.34 s = .
TestInterface#test_interface_get_access_vlan_switchport_trunk = 4.66 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig_secondary = 4.16 s = .
TestInterface#test_interface_shutdown_valid = 4.56 s = .
TestInterface#test_interface_ipv4_all_interfaces = 5.07 s = E
TestInterface#test_interface_vrf_empty = 1.67 s = .
TestInterface#test_interfaces_not_empty = 0.92 s = .
TestInterface#test_interface_vrf_invalid_type = 1.00 s = .
TestInterface#test_interface_mtu_valid = 3.85 s = .
TestInterface#test_interface_duplex_valid = 1.49 s = F
TestInterface#test_interface_ipv4_addr_mask_set_netmask_invalid = 3.30 s = .
TestInterface#test_interface_ipv4_redirects = 5.41 s = .
TestInterface#test_interface_encapsulation_dot1q_valid = 3.84 s = .
TestInterface#test_interface_get_access_vlan = 4.75 s = .

Finished in 120.580239s, 0.3566 runs/s, 1.0698 assertions/s.

  1) Failure:
TestInterface#test_interface_duplex_invalid [test_interface.rb:85]:
[ethernet9/1] 'speed 1000' : ERROR: Ethernet9/1: Configuration does not match the port capability.


  2) Skipped:
TestInterface#test_negotiate_auto_portchannel [/ws/saichint-sjc/puppet_agent/cisco-network-node-utils/tests/basetest.rb:103]:
Feature 'interface', attribute 'negotiate_auto_portchannel', operation 'config_set' is unsupported on this node


  3) Failure:
TestInterface#test_interface_speed_change [test_interface.rb:85]:
[ethernet9/1] 'speed 100' : ERROR: Ethernet9/1: Configuration does not match the port capability.


  4) Failure:
TestInterface#test_negotiate_auto_ethernet [test_interface.rb:719]:
Feature 'interface', attribute 'negotiate_auto_ethernet', operation 'config_set' is unsupported on this node


  5) Error:
TestInterface#test_interface_ipv4_address:
RuntimeError: [ethernet9/1] 'no ip address ' :  no ip address [ { ip-addr   ip-mask  |  ip-prefix } [route-preference  pref ] [tag  tag ]]  |     ip address  { ip-addr   ip-mask  |  ip-prefix } [route-preference  pref ] [tag  tag ]
name ip_address_primary_command
 no ip address [ { ip-addr   ip-mask  |  ip-prefix } secondary [route-preference  pref ] [tag  tag ]]  |   ip address { ip-addr   ip-mask  |  ip-prefix } secondary [route-preference  pref ] [tag  tag ]
name ip_address_secondary_command
 no ip address [ { ip-addr   ip-mask  |  ip-prefix } [route-preference  pref ] [tag  tag ]]  |     ip address  { ip-addr   ip-mask  |  ip-prefix } [route-preference  pref ] [tag  tag ]
name ip_address_primary_command
 no ip address [ { ip-addr   ip-mask  |  ip-prefix } secondary [route-preference  pref ] [tag  tag ]]  |   ip address { ip-addr   ip-mask  |  ip-prefix } secondary [route-preference  pref ] [tag  tag ]
name ip_address_secondary_command
% Ambiguous command
    /ws/saichint-sjc/puppet_agent/cisco-network-node-utils/lib/cisco_node_utils/interface.rb:157:in `rescue in ipv4_addr_mask_set'
    /ws/saichint-sjc/puppet_agent/cisco-network-node-utils/lib/cisco_node_utils/interface.rb:149:in `ipv4_addr_mask_set'
    test_interface.rb:806:in `test_interface_ipv4_address'


  6) Failure:
TestInterface#test_interface_duplex_change [test_interface.rb:85]:
[ethernet9/1] 'speed 1000' : ERROR: Ethernet9/1: Configuration does not match the port capability.


  7) Failure:
TestInterface#test_interface_speed_valid [test_interface.rb:85]:
[ethernet9/1] 'speed 1000' : ERROR: Ethernet9/1: Configuration does not match the port capability.


  8) Failure:
TestInterface#test_interface_description_too_long [test_interface.rb:403]:
RuntimeError expected but nothing was raised.


  9) Error:
TestInterface#test_interface_ipv4_all_interfaces:
RuntimeError: [ethernet9/1] 'no ip address ' :  no ip address [ { ip-addr   ip-mask  |  ip-prefix } [route-preference  pref ] [tag  tag ]]  |     ip address  { ip-addr   ip-mask  |  ip-prefix } [route-preference  pref ] [tag  tag ]
name ip_address_primary_command
 no ip address [ { ip-addr   ip-mask  |  ip-prefix } secondary [route-preference  pref ] [tag  tag ]]  |   ip address { ip-addr   ip-mask  |  ip-prefix } secondary [route-preference  pref ] [tag  tag ]
name ip_address_secondary_command
 no ip address [ { ip-addr   ip-mask  |  ip-prefix } [route-preference  pref ] [tag  tag ]]  |     ip address  { ip-addr   ip-mask  |  ip-prefix } [route-preference  pref ] [tag  tag ]
name ip_address_primary_command
 no ip address [ { ip-addr   ip-mask  |  ip-prefix } secondary [route-preference  pref ] [tag  tag ]]  |   ip address { ip-addr   ip-mask  |  ip-prefix } secondary [route-preference  pref ] [tag  tag ]
name ip_address_secondary_command
% Ambiguous command
    /ws/saichint-sjc/puppet_agent/cisco-network-node-utils/lib/cisco_node_utils/interface.rb:157:in `rescue in ipv4_addr_mask_set'
    /ws/saichint-sjc/puppet_agent/cisco-network-node-utils/lib/cisco_node_utils/interface.rb:149:in `ipv4_addr_mask_set'
    test_interface.rb:246:in `block in validate_ipv4_address'
    test_interface.rb:221:in `each'
    test_interface.rb:221:in `validate_ipv4_address'
    test_interface.rb:1046:in `test_interface_ipv4_all_interfaces'


 10) Failure:
TestInterface#test_interface_duplex_valid [test_interface.rb:85]:
[ethernet9/1] 'speed 1000' : ERROR: Ethernet9/1: Configuration does not match the port capability.

43 runs, 129 assertions, 7 failures, 2 errors, 1 skips
Coverage report generated for MiniTest to /ws/saichint-sjc/puppet_agent/cisco-network-node-utils/tests/coverage. 0.0 / 0.0 LOC (100.0%) covered.
```
