### PR TITLE
non-vrf handing for XR

### DIFF
--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -266,6 +266,7 @@ module Cisco
 
     # Cluster Id (Getter/Setter/Default)
     def cluster_id
+      return nil if platform == :ios_xr && @vrf != 'default'
       config_get('bgp', 'cluster_id', @get_args)
     end
 
@@ -273,7 +274,11 @@ module Cisco
       # In order to remove a bgp cluster_id you cannot simply issue
       # 'no bgp cluster-id'.  IMO this should be possible because you
       # can only configure a single bgp cluster-id.
-      #
+      if platform == :ios_xr && @vrf != 'default'
+        fail Cisco::UnsupportedError.new('bgp', 'cluster_id', 'set',
+                                         'cluster-id is not configurable ' \
+                                         'on a per-VRF basis on IOS XR')
+      end
       # HACK: specify a dummy id when removing the feature.
       dummy_id = 1
       if id == default_cluster_id
@@ -288,11 +293,13 @@ module Cisco
     end
 
     def default_cluster_id
+      return nil if platform == :ios_xr && @vrf != 'default'
       config_get_default('bgp', 'cluster_id')
     end
 
     # Confederation Id (Getter/Setter/Default)
     def confederation_id
+      return nil if platform == :ios_xr && @vrf != 'default'
       config_get('bgp', 'confederation_id', @get_args)
     end
 
@@ -300,7 +307,12 @@ module Cisco
       # In order to remove a bgp confed id you cannot simply issue
       # 'no bgp confederation id'.  IMO this should be possible
       # because you can only configure a single bgp confed id.
-      #
+      if platform == :ios_xr && @vrf != 'default'
+        fail Cisco::UnsupportedError.new('bgp', 'confederation_id', 'set',
+                                         'confederation-id is not ' \
+                                         'configurable ' \
+                                         'on a per-VRF basis on IOS XR')
+      end
       # HACK: specify a dummy id when removing the feature.
       dummy_id = 1
       if id == default_confederation_id
@@ -315,6 +327,7 @@ module Cisco
     end
 
     def default_confederation_id
+      return nil if platform == :ios_xr && @vrf != 'default'
       config_get_default('bgp', 'confederation_id')
     end
 
@@ -346,6 +359,7 @@ module Cisco
       # XR: retrieved as an array.
       # So make it an array in the NX case.
       # Sort the end results to make it consistent across both platforms.
+      return nil if platform == :ios_xr && @vrf != 'default'
       peers = config_get('bgp', 'confederation_peers', @get_args)
       peers = peers.split(' ') if peers.is_a?(String)
       peers.sort
@@ -354,6 +368,12 @@ module Cisco
     def confederation_peers=(should)
       # confederation peers are additive. So create a delta hash of entries
       # and only apply the changes
+      if platform == :ios_xr && @vrf != 'default'
+        fail Cisco::UnsupportedError.new('bgp', 'confederation_peers', 'set',
+                                         'confederation-peers is not ' \
+                                         'configurable ' \
+                                         'on a per-VRF basis on IOS XR')
+      end
       should = should.flatten
       is = confederation_peers
 
@@ -374,34 +394,53 @@ module Cisco
     end
 
     def default_confederation_peers
+      return nil if platform == :ios_xr && @vrf != 'default'
       config_get_default('bgp', 'confederation_peers')
     end
 
     # Graceful Restart Getters
     def graceful_restart
+      return nil if platform == :ios_xr && @vrf != 'default'
       config_get('bgp', 'graceful_restart', @get_args)
     end
 
     def graceful_restart_timers_restart
+      return nil if platform == :ios_xr && @vrf != 'default'
       config_get('bgp', 'graceful_restart_timers_restart', @get_args)
     end
 
     def graceful_restart_timers_stalepath_time
+      return nil if platform == :ios_xr && @vrf != 'default'
       config_get('bgp', 'graceful_restart_timers_stalepath_time', @get_args)
     end
 
     def graceful_restart_helper
+      return nil if platform == :ios_xr && @vrf != 'default'
       config_get('bgp', 'graceful_restart_helper', @get_args)
     end
 
     # Graceful Restart Setters
     def graceful_restart=(enable)
+      if platform == :ios_xr && @vrf != 'default'
+        fail Cisco::UnsupportedError.new('bgp', 'graceful_restart', 'set',
+                                         'graceful_restart is not ' \
+                                         'configurable ' \
+                                         'on a per-VRF basis on IOS XR')
+      end
       @set_args[:state] = (enable ? '' : 'no')
       config_set('bgp', 'graceful_restart', @set_args)
       set_args_keys_default
     end
 
     def graceful_restart_timers_restart=(seconds)
+      if platform == :ios_xr && @vrf != 'default'
+        fail Cisco::UnsupportedError.new('bgp',
+                                         'graceful_restart_timers_restart',
+                                         'set',
+                                         'graceful_restart_timers_restart is ' \
+                                         'not configurable ' \
+                                         'on a per-VRF basis on IOS XR')
+      end
       if seconds == default_graceful_restart_timers_restart
         @set_args[:state] = 'no'
         @set_args[:seconds] = ''
@@ -414,6 +453,14 @@ module Cisco
     end
 
     def graceful_restart_timers_stalepath_time=(seconds)
+      if platform == :ios_xr && @vrf != 'default'
+        fail Cisco::UnsupportedError.new('bgp',
+                                         'graceful_restart_timers_' \
+                                         'stalepath_time', 'set',
+                                         'graceful_restart_timers_' \
+                                         'stalepath_time is not configurable ' \
+                                         'on a per-VRF basis on IOS XR')
+      end
       if seconds == default_graceful_restart_timers_stalepath_time
         @set_args[:state] = 'no'
         @set_args[:seconds] = ''
@@ -426,6 +473,13 @@ module Cisco
     end
 
     def graceful_restart_helper=(enable)
+      if platform == :ios_xr && @vrf != 'default'
+        fail Cisco::UnsupportedError.new('bgp',
+                                         'graceful_restart_helper', 'set',
+                                         'graceful_restart_helper ' \
+                                         'is not configurable ' \
+                                         'on a per-VRF basis on IOS XR')
+      end
       @set_args[:state] = (enable ? '' : 'no')
       config_set('bgp', 'graceful_restart_helper', @set_args)
       set_args_keys_default
@@ -433,18 +487,22 @@ module Cisco
 
     # Graceful Restart Defaults
     def default_graceful_restart
+      return nil if platform == :ios_xr && @vrf != 'default'
       config_get_default('bgp', 'graceful_restart')
     end
 
     def default_graceful_restart_timers_restart
+      return nil if platform == :ios_xr && @vrf != 'default'
       config_get_default('bgp', 'graceful_restart_timers_restart')
     end
 
     def default_graceful_restart_timers_stalepath_time
+      return nil if platform == :ios_xr && @vrf != 'default'
       config_get_default('bgp', 'graceful_restart_timers_stalepath_time')
     end
 
     def default_graceful_restart_helper
+      return nil if platform == :ios_xr && @vrf != 'default'
       config_get_default('bgp', 'graceful_restart_helper')
     end
 
@@ -524,6 +582,7 @@ module Cisco
     end
 
     def default_reconnect_interval
+      return nil if platform == :ios_xr
       config_get_default('bgp', 'reconnect_interval')
     end
 
@@ -633,6 +692,7 @@ module Cisco
     end
 
     def timer_bestpath_limit_always
+      return nil if platform == :ios_xr
       config_get('bgp', 'timer_bestpath_limit_always', @get_args)
     end
 
@@ -655,6 +715,13 @@ module Cisco
     def timer_bestpath_limit_set(seconds, always=false)
       if always
         feature = 'timer_bestpath_limit_always'
+        if platform == :ios_xr
+          fail Cisco::UnsupportedError.new('bgp',
+                                           'timer_bestpath_limit_always',
+                                           'set',
+                                           'timer_bestpath_limit_always is ' \
+                                           'not configurable on IOS XR')
+        end
       else
         feature = 'timer_bestpath_limit'
       end
@@ -683,10 +750,12 @@ module Cisco
     end
 
     def default_timer_bestpath_limit
+      return nil if platform == :ios_xr && @vrf != 'default'
       config_get_default('bgp', 'timer_bestpath_limit')
     end
 
     def default_timer_bestpath_limit_always
+      return nil if platform == :ios_xr && @vrf != 'default'
       config_get_default('bgp', 'timer_bestpath_limit_always')
     end
   end

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -582,7 +582,6 @@ module Cisco
     end
 
     def default_reconnect_interval
-      return nil if platform == :ios_xr
       config_get_default('bgp', 'reconnect_interval')
     end
 
@@ -692,7 +691,6 @@ module Cisco
     end
 
     def timer_bestpath_limit_always
-      return nil if platform == :ios_xr
       config_get('bgp', 'timer_bestpath_limit_always', @get_args)
     end
 

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -1,7 +1,6 @@
 # bgp.yaml
 ---
 _template:
-  config_get: "show running bgp all"
   config_get_token: '/^router bgp <asnum>$/'
   config_get_token_append:
     - '/^vrf <vrf>$/'


### PR DESCRIPTION
Using Glenn's preferred method to deal with bgp global properties that are not supported at a VRF level. Associated minitest changes.

Couple of fix ups to other properties I was skipping in the minitests instead of reasing unsupported.

Rubocop happy.

Minitests:
XR:
63 runs, 204 assertions, 0 failures, 0 errors, 9 skips

Nexus:
63 runs, 242 assertions, 0 failures, 0 errors, 0 skips
