### PR TITLE
Minor cleanups for cisco_interface and yaml

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -24,8 +24,8 @@ all_interfaces:
 
 channel_group:
   kind: int
-  config_get_token_append: ['/^channel-group (\d+)$/']
-  config_set_append: ["%s channel-group %s %s"]
+  config_get_token_append: '/^channel-group (\d+)$/'
+  config_set_append: "%s channel-group %s %s"
   default_value: ''
 
 create:
@@ -42,9 +42,8 @@ destroy:
 
 duplex:
   kind: string
-  config_get: "show running interface all"
-  config_get_token: ['/^interface %s$/i', '/^duplex (.*)$/']
-  config_set: ["interface %s", "duplex %s"]
+  config_get_token_append: '/^duplex (.*)$/'
+  config_set_append: "duplex %s"
   default_value: "auto"
 
 encapsulation_dot1q:
@@ -174,9 +173,8 @@ shutdown_vlan:
     default_value: true
 
 speed:
-  config_get: "show running interface all"
-  config_get_token: ['/^interface %s$/i', '/^speed (.*)$/']
-  config_set: ["interface %s", "speed %s"]
+  config_get_token_append: '/^speed (.*)$/'
+  config_set_append: "speed %s"
   default_value: "auto"
 
 svi_autostate:

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -88,6 +88,12 @@ module Cisco
         config_set('interface',
                    'channel_group', @name, 'no', '', '')
       else
+        # 'force' is needed by cli_nxos to handle the case where a port-channel
+        # interface is created prior to the channel-group cli; in which case
+        # the properties of the port-channel interface will be different from
+        # the ethernet interface. 'force' is not needed if the port-channel is
+        # created as a result of the channel-group cli but since it does no
+        # harm we will use it every time.
         config_set('interface',
                    'channel_group', @name, '', val, 'force')
       end


### PR DESCRIPTION
test_interface.rb minitest passes on n3k, n31, n9k, n9kv
