### PR TITLE
CMD_ref, Node_util and minitest files for cisco_vni- specific to 9k/3k.

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vni.yaml
@@ -1,0 +1,51 @@
+# vni
+---
+all_vnis:
+  config_get: "show vni"
+  config_get_token: '/^(\d+)\s/'
+
+bridge_domain:
+  config_get: "show vni"
+  config_get_token: [ '/^%d\s+\S+\s+(\d+)/' ]
+  config_set: ["bridge-domain %d", "%s member vni %d", "end"]
+  default_value: ~
+
+bridge_domain_activate:
+  config_set: ["%s system bridge-domain add %d", "end"]
+
+create:
+  config_set: ["vni %s" , "end"]
+
+destroy:
+  config_set: "no vni %s"
+
+encap_dot1q:
+  config_set: ["encapsulation profile vni %s", "%s dot1q %s vni %s", "end"]
+  default_value: ~
+
+feature:
+  config_get: "show feature"
+  config_get_token: '/^vni\s+\d+\s+(\S+)/'
+  config_set: "%s feature vni"
+
+feature_n9k:
+  config_get: " show running | i ^feature"
+  config_get_token: '/^feature vn-segment-vlan-based$/'
+  config_set: "<state> feature vn-segment-vlan-based"
+
+feature_nv_overlay:
+  config_get: " show running | i ^feature"
+  config_get_token: '/^feature nv overlay$/'
+  config_set: "<state> feature nv overlay"
+
+mapped_vlan:
+  config_get: 'show running vlan'
+  config_get_token: ['/^vlan <vlan>$/', '/^vn-segment (\d+)$/']
+  config_set: ['vlan <vlan>', '<state> vn-segment <vni>']
+  default_value: ""
+
+shutdown:
+  config_get: "show vni"
+  config_get_token: '/^%d\s+(\S+)/'
+  config_set: ["vni %d", "%s shutdown", "end"]
+  default_value: false

--- a/tests/test_vni.rb
+++ b/tests/test_vni.rb
@@ -1,0 +1,73 @@
+# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/vni'
+
+include Cisco
+
+# TestVni - Minitest for Vni node utility
+class TestVni < CiscoTestCase
+  def setup
+    super
+    no_vni
+  end
+
+  def teardown
+    no_vni
+    super
+  end
+
+  def no_vni
+    config('no feature vn-segment-vlan-based')
+  end
+
+  def test_on_off
+    vni = Vni.new(1_000_0, true)
+    assert_equal(:enabled, vni.feature, 'Error: vni feature not enabled')
+
+    vni.feature_set(:disabled)
+    assert_equal(:disabled, vni.feature, 'Error: vni feature still enabled')
+  end
+
+  def test_mapped_vlan
+    # Set the vni vlan mapping
+    vni = Vni.new(1_000_0)
+    vni.mapped_vlan = 100
+    assert_equal(100, vni.mapped_vlan,
+                 'Error: mapped-vlan mismatch')
+    # Now clear the vni vlan mapping
+    vni.mapped_vlan = vni.default_vlan
+    assert_equal(nil, vni.mapped_vlan,
+                 'Error: cannot clear vni vlan mapping')
+  end
+
+  def test_multiple_vnis_vlans
+    # Set vni to vlan mappings
+    vni_to_vlan_map = { 1_000_0 => 100, 2_000_0 => 200, 3_000_0 => 300 }
+    vni_to_vlan_map.each do |vni, vlan|
+      vni_id = Vni.new(vni)
+      vni_id.mapped_vlan = vlan
+      assert_equal(vlan, vni_id.mapped_vlan,
+                   'Error: mapped-vlan mismatch')
+    end
+    # Clear all mappings
+    vni_to_vlan_map.each do |vni, _vlan|
+      vni_id = Vni.new(vni)
+      vni_id.mapped_vlan = vni_id.default_vlan
+      assert_equal(nil, vni_id.mapped_vlan,
+                   'Error: cannot clear vni vlan mapping')
+    end
+  end
+end


### PR DESCRIPTION
Please review 9k specific code in vni.rb and yaml files. The 7k code still needs to be refactored. 

Here are the methods to be reviewed:
feature
feature_set
Create
mapped_vlan
mapped_vlan=(vlan)
default_vlan

Look for this condition 
 if /N9K/.match(node.product_id)

No Rubocop errors.
Minitest passes:
# Running:

Node under test:
- name  - agent-lab1-nx
- type  - N9K-NXOSV
- image - bootflash:///nxos.7.0.3.I2.1.bin

TestVni#test_on_off = 6.48 s = .
TestVni#test_multiple_vnis_vlans = 13.08 s = .
TestVni#test_mapped_vlan = 5.35 s = .

Finished in 24.904488s, 0.1205 runs/s, 0.4015 assertions/s.
