### PR TITLE
Feature/vxlan vtep vni

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 * VXLAN
   * vxlan_global (@alok-aggarwal)
   * vxlan_vtep (@dcheriancisco)
+  * vxlan_vtep_vni (@mikewiebe)
 
 ### Added
 

--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
@@ -1,26 +1,22 @@
 # vxlan_vtep
 ---
+_template:
+  config_get: "show running-config interface all | section 'interface nve'"
+  config_get_token: '/^interface <name>$/i'
+  config_set: 'interface <name>'
+
 all_interfaces:
   multiple:
-  config_get: 'show running-config interface all'
-  config_get_token: '/^interface\s+(nve.*)$/'
+  config_get_token: '/^interface (.*)$/'
 
 mac_distribution:
-  config_get: 'show running-config interface all'
-  config_get_token: ['/^interface <name>$/', '/^host-reachability protocol (\S+)/']
-  config_set: ['interface <name>', '<state> host-reachability protocol <proto>']
-
-#TODO: move to vxlan_vtp_vni.rb
-#member_vni_mgrp:
-#  config_get: 'show running-config interface all'
-#  config_get_token: ['/^interface <name>$/', '/^member vni (\S+)/', '/^mcast-group (\S+)$/']
-#  config_set: ['interface <name>', '<no_cmd> member vni <vni>', 'mcast-group <mcast_grp>','end']
-
-member_vni_arp:
-  config_set: ['interface <name>', '<state> member vni <vni>', 'suppress-arp']
+  config_get_token_append: '/^host-reachability protocol (\S+)/'
+  config_set_append: '<state> host-reachability protocol <proto>'
 
 source_intf:
-  config_get: 'show running-config interface'
-  config_get_token: ['/^interface <name>$/','/^source\-interface (\S+)$/']
-  config_set: ['interface <name>', '<state> source-interface <lpbk_intf>']
+  config_get_token_append: '/^source\-interface (\S+)$/'
+  config_set_append: '<state> source-interface <lpbk_intf>'
   default_value: ''
+
+vni:
+  config_set_append: '<state> member vni <vni>'

--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
@@ -1,0 +1,37 @@
+# vxlan_vtep_vni
+---
+_template:
+  config_get: "show running-config interface all | section 'interface nve'"
+  config_get_token: '/^interface <name>$/i'
+  config_get_token_append:
+    - '/^member vni <vni>$/'
+  config_set: 'interface <name>'
+  config_set_append:
+    - 'member vni <vni>'
+
+all_vnis:
+  multiple:
+  config_get_token_append: '/^member vni (\d+|\d+-\d+)$/'
+
+ingress_replication:
+  kind: string
+  config_get_token_append: '/^ingress-replication protocol (\S+)$/'
+  config_set_append: '<state> ingress-replication protocol <protocol>'
+  default_value: ''
+
+multicast_group:
+  config_get_token_append: '/^mcast-group (\S+)\s?(\S+)?$/'
+  config_set_append: '<state> mcast-group <ip_start> <ip_end>'
+  default_value: ''
+
+peer_list:
+  multiple:
+  config_get_token_append: ['/^ingress-replication protocol static$/', '/^peer-ip (\S+)$/']
+  config_set_append: ['ingress-replication protocol static', '<state> peer-ip <peer>']
+  default_value: []
+
+suppress_arp:
+  kind: boolean
+  config_get_token_append: '/^suppress-arp$/'
+  config_set_append: '<state> suppress-arp'
+  default_value: false

--- a/lib/cisco_node_utils/vxlan_vtep_vni.rb
+++ b/lib/cisco_node_utils/vxlan_vtep_vni.rb
@@ -1,0 +1,177 @@
+#
+# NXAPI implementation of VxlanVtepVni class
+#
+# November 2015 Michael G Wiebe
+#
+# Copyright (c) 2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'cisco_cmn_utils'
+require_relative 'node_util'
+require_relative 'vxlan_vtep'
+
+module Cisco
+  # VxlanVtepVni - node utility for vxlan vtep vni members.
+  class VxlanVtepVni < NodeUtil
+    attr_reader :name, :vni
+
+    def initialize(name, vni, instantiate=true)
+      @name = name
+      @vni = vni
+
+      create if instantiate
+    end
+
+    def self.vnis
+      hash = {}
+      VxlanVtep.vteps.each do |name, _obj|
+        hash[name] = {}
+        get_args = { name: name }
+        vni_list = config_get('vxlan_vtep_vni', 'all_vnis', get_args)
+        next if vni_list.nil?
+        vni_list.each do |vni|
+          hash[name][vni] = VxlanVtepVni.new(name, vni, false)
+        end
+      end
+      hash
+    end
+
+    def ==(other)
+      (name == other.name) && (vni == other.vni)
+    end
+
+    def set_args_keys_default
+      keys = { name: @name, vni: @vni }
+      @get_args = @set_args = keys
+    end
+
+    # rubocop:disable Style/AccessorMethodName
+    def set_args_keys(hash={})
+      set_args_keys_default
+      @set_args = @get_args.merge!(hash) unless hash.empty?
+    end
+    # rubocop:enable Style/AccessorMethodNamefor
+
+    def create
+      set_args_keys(state: '')
+      config_set('vxlan_vtep', 'vni', @set_args)
+    end
+
+    def destroy
+      set_args_keys(state: 'no')
+      config_set('vxlan_vtep', 'vni', @set_args)
+    end
+
+    ########################################################
+    #                      PROPERTIES                      #
+    ########################################################
+
+    def ingress_replication
+      config_get('vxlan_vtep_vni', 'ingress_replication', @get_args)
+    end
+
+    def remove_add_ingress_replication(protocol)
+      if ingress_replication.empty?
+        set_args_keys(state: '', protocol: protocol)
+        config_set('vxlan_vtep_vni', 'ingress_replication', @set_args)
+      else
+        # Sadly, the only way to change between protocols is to
+        # first remove the exisitng protocol.
+        set_args_keys(state: 'no', protocol: ingress_replication)
+        config_set('vxlan_vtep_vni', 'ingress_replication', @set_args)
+        set_args_keys(state: '', protocol: protocol)
+        config_set('vxlan_vtep_vni', 'ingress_replication', @set_args)
+      end
+    end
+
+    def ingress_replication=(protocol)
+      if protocol == default_ingress_replication
+        set_args_keys(state: 'no', protocol: ingress_replication)
+        config_set('vxlan_vtep_vni', 'ingress_replication', @set_args) unless
+          ingress_replication == default_ingress_replication
+      else
+        remove_add_ingress_replication(protocol)
+      end
+    end
+
+    def default_ingress_replication
+      config_get_default('vxlan_vtep_vni', 'ingress_replication')
+    end
+
+    def multicast_group
+      g1, g2 = config_get('vxlan_vtep_vni', 'multicast_group', @get_args)
+      g2.nil? ? g1 : g1 + ' ' + g2
+    end
+
+    def remove_add_multicast_group(ip_start, ip_end)
+      set_args_keys(state: 'no', ip_start: '', ip_end: '')
+      config_set('vxlan_vtep_vni', 'multicast_group', @set_args)
+      set_args_keys(state: '', ip_start: ip_start, ip_end: ip_end)
+      config_set('vxlan_vtep_vni', 'multicast_group', @set_args)
+    end
+
+    def multicast_group=(range)
+      if range == default_multicast_group
+        set_args_keys(state: 'no', ip_start: '', ip_end: '')
+        config_set('vxlan_vtep_vni', 'multicast_group', @set_args)
+      else
+        ip_start, ip_end = range.split(' ')
+        ip_end = '' if ip_end.nil?
+        remove_add_multicast_group(ip_start, ip_end)
+      end
+    end
+
+    def default_multicast_group
+      config_get_default('vxlan_vtep_vni', 'multicast_group')
+    end
+
+    def peer_list
+      config_get('vxlan_vtep_vni', 'peer_list', @get_args)
+    end
+
+    def peer_list=(should_list)
+      delta_hash = Utils.delta_add_remove(should_list, peer_list)
+      return if delta_hash.values.flatten.empty?
+      [:add, :remove].each do |action|
+        CiscoLogger.debug('peer_list' \
+          "#{@get_args}\n #{action}: #{delta_hash[action]}")
+        delta_hash[action].each do |peer|
+          state = (action == :add) ? '' : 'no'
+          @set_args[:state] = state
+          @set_args[:peer] = peer
+          config_set('vxlan_vtep_vni', 'peer_list', @set_args)
+        end
+      end
+    end
+
+    def default_peer_list
+      config_get_default('vxlan_vtep_vni', 'peer_list')
+    end
+
+    def suppress_arp
+      config_get('vxlan_vtep_vni', 'suppress_arp', @get_args)
+    end
+
+    def suppress_arp=(state)
+      # Mac distribution must be enabled for this property
+      VxlanVtep.new(@name).mac_distribution = :evpn
+      set_args_keys(state: (state ? '' : 'no'))
+      config_set('vxlan_vtep_vni', 'suppress_arp', @set_args)
+    end
+
+    def default_suppress_arp
+      config_get_default('vxlan_vtep_vni', 'suppress_arp')
+    end
+  end
+end

--- a/tests/test_vxlan_vtep_vni.rb
+++ b/tests/test_vxlan_vtep_vni.rb
@@ -1,0 +1,153 @@
+# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/vxlan_vtep_vni'
+
+include Cisco
+
+# TestVxlanGlobal - Minitest for VxlanGlobal node utility
+class TestVxlanVtepVni < CiscoTestCase
+  def setup
+    super
+    config('no feature nv overlay')
+    config('feature nv overlay')
+  end
+
+  def teardown
+    config('no feature nv overlay')
+    super
+  end
+
+  def test_vnis
+    # Test empty case
+    assert_empty(VxlanVtepVni.vnis)
+
+    # Create one
+    member1 = '5000'
+    vni1 = VxlanVtepVni.new('nve1', member1)
+    assert_includes(VxlanVtepVni.vnis['nve1'], member1)
+    assert_equal(VxlanVtepVni.vnis['nve1'][member1], vni1)
+
+    # Create several
+    member2 = '5001-6001'
+    member3 = '8888'
+    refute_includes(VxlanVtepVni.vnis['nve1'], member2)
+    refute_includes(VxlanVtepVni.vnis['nve1'], member3)
+
+    vni2 = VxlanVtepVni.new('nve1', member2)
+    vni3 = VxlanVtepVni.new('nve1', member3)
+    assert_includes(VxlanVtepVni.vnis['nve1'], member2)
+    assert_equal(VxlanVtepVni.vnis['nve1'][member2], vni2)
+    assert_includes(VxlanVtepVni.vnis['nve1'], member3)
+    assert_equal(VxlanVtepVni.vnis['nve1'][member3], vni3)
+
+    # Destroy one
+    vni2.destroy
+    refute_includes(VxlanVtepVni.vnis['nve1'], member2)
+    refute_equal(VxlanVtepVni.vnis['nve1'][member2], vni2)
+
+    # Destroy all
+    vni1.destroy
+    vni3.destroy
+    assert_empty(VxlanVtepVni.vnis['nve1'])
+  end
+
+  def test_ingress_replication
+    vni = VxlanVtepVni.new('nve1', '5000')
+
+    # Test non-default values
+    vni.ingress_replication = 'static'
+    assert_equal('static', vni.ingress_replication)
+
+    vni.ingress_replication = 'bgp'
+    assert_equal('bgp', vni.ingress_replication)
+
+    # Test default case
+    ir = vni.default_ingress_replication
+    vni.ingress_replication = ir
+    assert_equal(ir, vni.ingress_replication)
+  end
+
+  def test_multicast_group
+    vni1 = VxlanVtepVni.new('nve1', '6000')
+    vni2 = VxlanVtepVni.new('nve1', '8001-8200')
+
+    # No multicast groups configured
+    assert_empty(vni1.multicast_group)
+
+    # Test single multicast group
+    vni1.multicast_group = '224.1.1.1'
+    assert_equal('224.1.1.1', vni1.multicast_group)
+
+    # Test multicast group range
+    vni2.multicast_group = '224.1.1.1 224.1.1.200'
+    assert_equal('224.1.1.1 224.1.1.200', vni2.multicast_group)
+
+    # Test default
+    vni1.multicast_group = vni1.default_multicast_group
+    assert_empty(vni1.multicast_group)
+    vni2.multicast_group = vni2.default_multicast_group
+    assert_empty(vni2.multicast_group)
+  end
+
+  def test_peer_list
+    vni = VxlanVtepVni.new('nve1', '6000')
+
+    peer_list = ['1.1.1.1', '2.2.2.2', '3.3.3.3', '4.4.4.4']
+
+    # Test: all peers when current is empty
+    should = peer_list.clone
+    vni.peer_list = should
+    result = vni.peer_list
+    assert_equal(should.sort, result.sort,
+                 'Test 1. From empty, to all peers')
+
+    # Test: remove half of the peers
+    should.shift(2)
+    vni.peer_list = should
+    result = vni.peer_list
+    assert_equal(should.sort, result.sort,
+                 'Test 2. Remove half of the peers')
+
+    # Test: restore removed peers
+    should = peer_list.clone
+    vni.peer_list = should
+    result = vni.peer_list
+    assert_equal(should.sort, result.sort,
+                 'Test 3. Restore removed peers')
+
+    # Test: default
+    should = vni.default_peer_list
+    vni.peer_list = should
+    result = vni.peer_list
+    assert_equal(should.sort, result.sort,
+                 'Test 4. Default')
+  end
+
+  def test_suppress_arp
+    vni = VxlanVtepVni.new('nve1', '6000')
+
+    # Test: Check suppress_arp is not configured.
+    refute(vni.suppress_arp, 'suppress_arp should be disabled')
+
+    # Test: Enable suppress_arp
+    vni.suppress_arp = true
+    assert(vni.suppress_arp, 'suppress_arp should be enabled')
+
+    # Test: Default
+    vni.suppress_arp = vni.default_suppress_arp
+    refute(vni.suppress_arp, 'suppress_arp should be disabled')
+  end
+end


### PR DESCRIPTION
New VxlanVtepVni object.

**MiniTest Results for new VxlanVtepVni Object**

```
Node under test:
  - name  - dt-n9k5-1
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I2.1.74.bin

TestVxlanVtepVni#test_ingress_replication = 10.13 s = .
TestVxlanVtepVni#test_multicast_group = 10.24 s = .
TestVxlanVtepVni#test_peer_list = 10.20 s = .
TestVxlanVtepVni#test_suppress_arp = 8.80 s = E
TestVxlanVtepVni#test_vnis = 11.46 s = .

Finished in 50.838232s, 0.0984 runs/s, 0.7081 assertions/s.

  1) Error:
TestVxlanVtepVni#test_suppress_arp:
Cisco::CliError: CliError: ' suppress-arp' rejected with message:
'ERROR: Please configure TCAM region for Ingress ARP-Ether ACL before configuring ARP supression.'
    /nobackup/mwiebe/REPOS_NODE_UTILS/vxlan/cisco-network-node-utils/lib/cisco_node_utils/node.rb:266:in `rescue in config'
    /nobackup/mwiebe/REPOS_NODE_UTILS/vxlan/cisco-network-node-utils/lib/cisco_node_utils/node.rb:263:in `config'
    /nobackup/mwiebe/REPOS_NODE_UTILS/vxlan/cisco-network-node-utils/lib/cisco_node_utils/node.rb:161:in `config_set'
    /nobackup/mwiebe/REPOS_NODE_UTILS/vxlan/cisco-network-node-utils/lib/cisco_node_utils/node_util.rb:58:in `config_set'
    /nobackup/mwiebe/REPOS_NODE_UTILS/vxlan/cisco-network-node-utils/lib/cisco_node_utils/vxlan_vtep_vni.rb:170:in `suppress_arp='
    tests/test_vxlan_vtep_vni.rb:146:in `test_suppress_arp'

5 runs, 36 assertions, 0 failures, 1 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/vxlan/cisco-network-node-utils/coverage. 523 / 672 LOC (77.83%) covered.
```

_Note:_ The failure above needs investigation.  I am not sure how to configure TCAM region for Ingress ARP-Ether ACL but I will address this when I get back from PTO.

**MiniTest Results for VxlanVtep Changes**

```
Node under test:
  - name  - dt-n9k5-1
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I2.1.74.bin

TestVxlanVtep#test_create_multiple_negative = 9.33 s = .
TestVxlanVtep#test_shutdown = 9.00 s = .
TestVxlanVtep#test_mac_distribution = 9.16 s = .
TestVxlanVtep#test_source_interface = 8.88 s = .
TestVxlanVtep#test_description = 8.93 s = .
TestVxlanVtep#test_create_destroy_one = 9.09 s = .
TestVxlanVtep#test_create_destroy_multiple = 0.79 s = S

Finished in 55.187922s, 0.1268 runs/s, 0.3443 assertions/s.

  1) Skipped:
TestVxlanVtep#test_create_destroy_multiple [tests/test_vxlan_vtep.rb:53]:
Only supported on n7k

7 runs, 19 assertions, 0 failures, 0 errors, 1 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/vxlan/cisco-network-node-utils/coverage. 448 / 532 LOC (84.21%) covered.
```
