### PR TITLE
Get all_vnis for 9k and destoy method destroys vlan-vni mapping

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vni.yaml
@@ -1,13 +1,13 @@
 # vni
 ---
 all_vnis:
-  config_get: "show vni"
-  config_get_token: '/^(\d+)\s/'
-
-all_vnis_n9k:
-  multiple: true
-  config_get: "show running vlan"
-  config_get_token: '/vn-segment (\d+)/'
+  /N7K/:
+    config_get: "show vni"
+    config_get_token: '/^(\d+)\s/'
+  else:
+    multiple: true
+    config_get: "show running vlan"
+    config_get_token: '/vn-segment (\d+)/'
 
 bridge_domain:
   config_get: "show vni"
@@ -22,21 +22,21 @@ create:
   config_set: ["vni %s" , "end"]
 
 destroy:
-  config_set: "no vni %s"
+  config_set: "no vni <vni>"
 
 encap_dot1q:
   config_set: ["encapsulation profile vni %s", "%s dot1q %s vni %s", "end"]
   default_value: ~
 
 feature:
-  config_get: "show feature"
-  config_get_token: '/^vni\s+\d+\s+(\S+)/'
-  config_set: "%s feature vni"
-
-feature_n9k:
-  config_get: " show running | i ^feature"
-  config_get_token: '/^feature vn-segment-vlan-based$/'
-  config_set: "<state> feature vn-segment-vlan-based"
+  /N7K/:
+    config_get: "show feature"
+    config_get_token: '/^vni\s+\d+\s+(\S+)/'
+    config_set: "<state> feature vni"
+  else:
+    config_get: " show running | i ^feature"
+    config_get_token: '/^feature vn-segment-vlan-based$/'
+    config_set: "<state> feature vn-segment-vlan-based"
 
 feature_nv_overlay:
   config_get: " show running | i ^feature"

--- a/lib/cisco_node_utils/cmd_ref/vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vni.yaml
@@ -4,6 +4,11 @@ all_vnis:
   config_get: "show vni"
   config_get_token: '/^(\d+)\s/'
 
+all_vnis_n9k:
+  multiple: true
+  config_get: "show running vlan"
+  config_get_token: '/vn-segment (\d+)/'
+
 bridge_domain:
   config_get: "show vni"
   config_get_token: [ '/^%d\s+\S+\s+(\d+)/' ]
@@ -41,7 +46,7 @@ feature_nv_overlay:
 mapped_vlan:
   config_get: 'show running vlan'
   config_get_token: ['/^vlan <vlan>$/', '/^vn-segment (\d+)$/']
-  config_set: ['vlan <vlan>', '<state> vn-segment <vni>']
+  config_set: ['vlan <vlan>', '<state> vn-segment <vni> ; end']
   default_value: ""
 
 shutdown:

--- a/tests/test_vni.rb
+++ b/tests/test_vni.rb
@@ -48,7 +48,7 @@ class TestVni < CiscoTestCase
     assert_equal(100, vni.mapped_vlan,
                  'Error: mapped-vlan mismatch')
     # Now clear the vni vlan mapping
-    vni.mapped_vlan = vni.default_vlan
+    vni.mapped_vlan = vni.default_mapped_vlan
     assert_equal(nil, vni.mapped_vlan,
                  'Error: cannot clear vni vlan mapping')
   end
@@ -65,7 +65,7 @@ class TestVni < CiscoTestCase
     # Clear all mappings
     vni_to_vlan_map.each do |vni, _vlan|
       vni_id = Vni.new(vni)
-      vni_id.mapped_vlan = vni_id.default_vlan
+      vni_id.mapped_vlan = vni_id.default_mapped_vlan
       assert_equal(nil, vni_id.mapped_vlan,
                    'Error: cannot clear vni vlan mapping')
     end


### PR DESCRIPTION
1. Added code to get all_vnis for n9k
2. Added code to destroy the vlan-vni mapping when destroy is called

Minitest passes:

sjc-ads-1546:262> ruby-2.1.1 tests/test_vni.rb -v -- 10.122.197.174 admin admin
Run options: -v -- --seed 23235
# Running:

Node under test:
- name  - agent-lab1-nx
- type  - N9K-NXOSV
- image - bootflash:///nxos.7.0.3.I2.1.bin

TestVni#test_on_off = 7.40 s = .
TestVni#test_multiple_vnis_vlans = 12.25 s = .
TestVni#test_mapped_vlan = 5.34 s = .

Finished in 24.986780s, 0.1201 runs/s, 0.4002 assertions/s.

3 runs, 10 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/aloaggar/pnc/cisco-network-node-utils/coverage. 403 / 560 LOC (71.96%) covered.
