### PR TITLE
Pim, Pim Rp-address, Pim Rp-address Group list node-utils APIs & Mini…

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/pim.yaml
+++ b/lib/cisco_node_utils/cmd_ref/pim.yaml
@@ -9,12 +9,12 @@ _template:
 
 all_ssm_ranges:
   multiple:
-  config_get_token_append : '/^\s*ip pim ssm range (.*)$/'
+  config_get_token_append : '/^<afi> pim ssm range (.*)$/'
 
 feature:
   config_get_token_append: '/^feature pim$/'
   config_set: "feature pim"
 
 ssm_range:
-  config_get_token_append: '/^ip pim ssm range (.*)/'
-  config_set_append: "<state> ip pim ssm range <ssm_range>"
+  config_get_token_append: '/^<afi> pim ssm range (.*)/'
+  config_set_append: "<state> <afi> pim ssm range <ssm_range>"

--- a/lib/cisco_node_utils/cmd_ref/pim.yaml
+++ b/lib/cisco_node_utils/cmd_ref/pim.yaml
@@ -5,7 +5,7 @@ _template:
   config_get_token :
     - '/^vrf context <vrf>$/'
   config_set :
-    - "vrf context <vrf>"
+    - 'vrf context <vrf>'
 
 all_ssm_ranges:
   multiple:

--- a/lib/cisco_node_utils/cmd_ref/pim.yaml
+++ b/lib/cisco_node_utils/cmd_ref/pim.yaml
@@ -5,7 +5,7 @@ _template:
   config_get_token :
     - '/^vrf context <vrf>$/'
   config_set :
-    - 'vrf context <vrf>'
+    - "vrf context <vrf>"
 
 all_ssm_ranges:
   multiple:

--- a/lib/cisco_node_utils/cmd_ref/pim.yaml
+++ b/lib/cisco_node_utils/cmd_ref/pim.yaml
@@ -1,0 +1,20 @@
+# pim
+---
+_template:
+  config_get : "show run pim all"
+  config_get_token :
+    - '/^vrf context <vrf>$/'
+  config_set :
+    - "vrf context <vrf>"
+
+all_ssm_ranges:
+  multiple:
+  config_get_token_append : '/^\s*ip pim ssm range (.*)$/'
+
+feature:
+  config_get_token_append: '/^feature pim$/'
+  config_set: "feature pim"
+
+ssm_range:
+  config_get_token_append: '/^ip pim ssm range (.*)/'
+  config_set_append: "<state> ip pim ssm range <ssm_range>"

--- a/lib/cisco_node_utils/cmd_ref/pim.yaml
+++ b/lib/cisco_node_utils/cmd_ref/pim.yaml
@@ -9,12 +9,12 @@ _template:
 
 all_ssm_ranges:
   multiple:
-  config_get_token_append : '/^<afi> pim ssm range (.*)$/'
+  config_get_token_append : '/^\s*ip pim ssm range (.*)$/'
 
 feature:
   config_get_token_append: '/^feature pim$/'
   config_set: "feature pim"
 
 ssm_range:
-  config_get_token_append: '/^<afi> pim ssm range (.*)/'
-  config_set_append: "<state> <afi> pim ssm range <ssm_range>"
+  config_get_token_append: '/^ip pim ssm range (.*)/'
+  config_set_append: "<state> ip pim ssm range <ssm_range>"

--- a/lib/cisco_node_utils/cmd_ref/pim_rp_address.yaml
+++ b/lib/cisco_node_utils/cmd_ref/pim_rp_address.yaml
@@ -1,0 +1,32 @@
+# pim_rp_address
+---
+_template:
+  config_get : "show run pim all"
+  config_get_token :
+    - '/^vrf context <vrf>$/'
+  config_set :
+    - "vrf context <vrf>"
+
+all_group_lists:
+  multiple:
+  config_get_token_append : '/^ip pim rp-address ([0-9\.]+) group-list (\S+)/'
+
+all_rp_addresses:
+  multiple:
+  config_get_token_append: '/^ip pim rp-address (.*)$/'
+
+feature:
+  config_get_token_append: '/^feature pim$/'
+  config_set: "feature pim"
+
+group_list:
+  default_value: ~
+  config_get_token_append: '/^ip pim rp-address (\S+) group-list (\S+)/'
+  config_set_append: "<state> ip pim rp-address <addr> group-list <group>"
+
+rp_address:
+  multiple:
+  config_get_token_append: '/^ip pim rp-address (\S+)/'
+  config_set_append: "<state> ip pim rp-address <addr>"
+  default_value: ~
+

--- a/lib/cisco_node_utils/pim.rb
+++ b/lib/cisco_node_utils/pim.rb
@@ -39,7 +39,6 @@ module Cisco
       else
         @get_args = @set_args = { state: '', vrf: @vrf }
       end
-<<<<<<< HEAD
       enable if instantiate
     end
 
@@ -50,9 +49,6 @@ module Cisco
       fail ArgumentError, "Argument afi must be 'ipv4'" unless
         afi[/(ipv4)/]
       afi[/ipv4/] ? 'ip' : afi
-=======
-      enable if instantiate && !Pim.enabled
->>>>>>> parent of e4346a1... NXAPI Implementation & Mini Tests for Pim
     end
 
     # set_args_keys_default
@@ -98,11 +94,7 @@ module Cisco
     # ssm_range : setter
     # -------------------
     def ssm_range=(range)
-<<<<<<< HEAD
       set_args_keys(state: '', ssm_range: range)
-=======
-      @set_args[:ssm_range] = range
->>>>>>> parent of e4346a1... NXAPI Implementation & Mini Tests for Pim
       config_set('pim', 'ssm_range', @set_args)
     end
   end

--- a/lib/cisco_node_utils/pim.rb
+++ b/lib/cisco_node_utils/pim.rb
@@ -1,4 +1,4 @@
-# NXAPI implementation of the Pim class
+# PIM feature
 # Provides configuration of PIM and its various properties
 # like ssm-range, etc
 #
@@ -26,20 +26,20 @@ require_relative 'node_util'
 module Cisco
   # node_utils class for Pim
   class Pim < NodeUtil
-    attr_reader :vrf, :afi
+    attr_reader :vrf
 
     # Constructor with vrf
     # ---------------------
-    def initialize(afi, vrf='default', instantiate=true)
+    def initialize(vrf='default', instantiate=true)
       fail ArgumentError unless vrf.is_a? String
       fail ArgumentError unless vrf.length > 0
       @vrf = vrf
-      @afi = Pim.afi_cli(afi)
       if @vrf == 'default'
-        @get_args = @set_args = { state: '', afi: @afi }
+        @get_args = @set_args = { state: '' }
       else
-        @get_args = @set_args = { state: '', vrf: @vrf, afi: @afi }
+        @get_args = @set_args = { state: '', vrf: @vrf }
       end
+<<<<<<< HEAD
       enable if instantiate
     end
 
@@ -50,13 +50,15 @@ module Cisco
       fail ArgumentError, "Argument afi must be 'ipv4'" unless
         afi[/(ipv4)/]
       afi[/ipv4/] ? 'ip' : afi
+=======
+      enable if instantiate && !Pim.enabled
+>>>>>>> parent of e4346a1... NXAPI Implementation & Mini Tests for Pim
     end
 
     # set_args_keys_default
     # ----------------------
     def set_args_keys_default
-      keys = { afi: @afi }
-      keys[:vrf] = @vrf unless @vrf == 'default'
+      keys = { vrf: @vrf }
       @get_args = @set_args = keys
     end
 
@@ -76,7 +78,8 @@ module Cisco
     # Check Feature pim state
     # --------------------------
     def self.enabled
-      config_get('pim', 'feature')
+      feature_state = config_get('pim', 'feature')
+      return !(feature_state.nil? || feature_state.empty?)
     rescue Cisco::CliError => e
       return false if e.clierror =~ /Syntax error/
       raise
@@ -89,13 +92,17 @@ module Cisco
     # -------------------
     def ssm_range
       ranges = config_get('pim', 'ssm_range', @get_args)
-      ranges.split.sort
+      ranges.split(' ').sort
     end
 
     # ssm_range : setter
     # -------------------
     def ssm_range=(range)
+<<<<<<< HEAD
       set_args_keys(state: '', ssm_range: range)
+=======
+      @set_args[:ssm_range] = range
+>>>>>>> parent of e4346a1... NXAPI Implementation & Mini Tests for Pim
       config_set('pim', 'ssm_range', @set_args)
     end
   end

--- a/lib/cisco_node_utils/pim.rb
+++ b/lib/cisco_node_utils/pim.rb
@@ -49,7 +49,7 @@ module Cisco
       # Add ipv6 support later
       fail ArgumentError, "Argument afi must be 'ipv4'" unless
         afi[/(ipv4)/]
-      afi[/ipv4/] ? 'ip' : ''
+      afi[/ipv4/] ? 'ip' : afi
     end
 
     # set_args_keys_default
@@ -95,7 +95,7 @@ module Cisco
     # ssm_range : setter
     # -------------------
     def ssm_range=(range)
-      set_args_keys(ssm_range: range)
+      set_args_keys(state: '', ssm_range: range)
       config_set('pim', 'ssm_range', @set_args)
     end
   end

--- a/lib/cisco_node_utils/pim.rb
+++ b/lib/cisco_node_utils/pim.rb
@@ -1,0 +1,92 @@
+# PIM feature
+# Provides configuration of PIM and its various properties
+# like ssm-range, etc
+#
+# Smitha Gopalan, November 2015
+#
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#-------------------------------------------------------
+# CLI: ip pim ssm-range <range>  (under different VRFs)
+#-------------------------------------------------------
+
+require_relative 'node_util'
+
+module Cisco
+  # node_utils class for Pim
+  class Pim < NodeUtil
+    attr_reader :vrf
+
+    # Constructor with vrf
+    # ---------------------
+    def initialize(vrf='default', instantiate=true)
+      fail ArgumentError unless vrf.is_a? String
+      fail ArgumentError unless vrf.length > 0
+      @vrf = vrf
+      if @vrf == 'default'
+        @get_args = @set_args = { state: '' }
+      else
+        @get_args = @set_args = { state: '', vrf: @vrf }
+      end
+      enable if instantiate && !Pim.enabled
+    end
+
+    # set_args_keys_default
+    # ----------------------
+    def set_args_keys_default
+      keys = { vrf: @vrf }
+      @get_args = @set_args = keys
+    end
+
+    # set_args_key
+    # -------------
+    def set_args_keys(hash={}) # rubocop:disable Style/AccessorMethodName
+      set_args_keys_default
+      @set_args = @get_args.merge!(hash) unless hash.empty?
+    end
+
+    # Enable Feature pim
+    # -------------------
+    def enable
+      config_set('pim', 'feature')
+    end
+
+    # Check Feature pim state
+    # --------------------------
+    def self.enabled
+      feature_state = config_get('pim', 'feature')
+      return !(feature_state.nil? || feature_state.empty?)
+    rescue Cisco::CliError => e
+      return false if e.clierror =~ /Syntax error/
+      raise
+    end
+
+    # Properties:
+    #-----------
+
+    # ssm_range : getter
+    # -------------------
+    def ssm_range
+      ranges = config_get('pim', 'ssm_range', @get_args)
+      ranges.split(' ').sort
+    end
+
+    # ssm_range : setter
+    # -------------------
+    def ssm_range=(range)
+      @set_args[:ssm_range] = range
+      config_set('pim', 'ssm_range', @set_args)
+    end
+  end
+end

--- a/lib/cisco_node_utils/pim_group_list.rb
+++ b/lib/cisco_node_utils/pim_group_list.rb
@@ -1,0 +1,132 @@
+# PIM feature
+# Provides configuration of PIM configuration of rp-addresses with group-lists
+#
+# Smitha Gopalan, November 2015
+#
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#-------------------------------------------------------------------------------
+# CLI: ip pim rp-address <rp-address> group-list <group> (under different VRFs)
+#-------------------------------------------------------------------------------
+
+require_relative 'node_util'
+require 'pp'
+
+module Cisco
+  # node_utils class for pim grouplist
+  class PimGroupList < NodeUtil
+    attr_reader :rp_addr, :vrf, :group
+
+    # Constructor with grouplist and vrf
+    # ----------------------------------
+    def initialize(rp_addr, group, vrf='default', instantiate=true)
+      fail ArgumentError unless vrf.is_a? String
+      fail ArgumentError unless vrf.length > 0
+      @rp_addr = rp_addr
+      @group = group
+      @vrf = vrf
+      if @vrf == 'default'
+        @get_args = @set_args = { state: '', addr: @rp_addr, group: @group }
+      else
+        @get_args = @set_args = { state: '', addr: @rp_addr,
+                                  vrf: @vrf, group: @group }
+      end
+      create if instantiate
+    end
+
+    # Create a hash of [rp-addr,grouplist]=>vrf mappings
+    # --------------------------------------------------
+    def self.group_lists
+      hash_final = {}
+      rp_addrs = config_get('pim_rp_address', 'all_group_lists')
+      return hash_final if rp_addrs.nil?
+      rp_addrs.each do |addr_and_group|
+        # Get the RPs under default VRF
+        addr = addr_and_group[0]
+        group = addr_and_group[1]
+        hash_final[addr_and_group] = {}
+        hash_final[addr_and_group]['default'] = PimGroupList.new(addr, group,
+                                                                 'default',
+                                                                 false)
+      end
+      # Getting all custom vrfs rp_Addrs
+      vrf_ids = config_get('vrf', 'all_vrfs')
+      vrf_ids.delete_if { |vrf_id| vrf_id == 'management' }
+      vrf_ids.each do |vrf|
+        get_args = { rp_addr: @rp_addr, vrf: @vrf, group: @group }
+        get_args[:vrf] = vrf
+        rpaddrs = config_get('pim_rp_address', 'all_group_lists', get_args)
+        next if rpaddrs.nil?
+        rpaddrs.each do |addr_and_group|
+          addr = addr_and_group[0]
+          group = addr_and_group[1]
+          hash_final[addr_and_group] ||= {}
+          hash_final[addr_and_group][vrf] = PimGroupList.new(addr, group,
+                                                             vrf, false)
+        end
+      end
+      puts 'FINAL HASH is: '
+      pp '-------------'
+      # pp hash_final
+      hash_final
+    end
+
+    # set_args_keys_default
+    # ---------------------
+    def set_args_keys_default
+      keys = { addr: @rp_addr, vrf: @vrf, group: @group }
+      @get_args = @set_args = keys
+    end
+
+    # set_args_key
+    # -------------
+    def set_args_keys(hash={}) # rubocop:disable Style/AccessorMethodName
+      set_args_keys_default
+      @set_args = @get_args.merge!(hash) unless hash.empty?
+    end
+
+    # Enable Feature pim
+    # -------------------
+    def enable
+      config_set('pim_rp_address', 'feature')
+    end
+
+    # Check if feature pim is enabled
+    # -------------------------------
+    def self.enabled
+      feature_state = config_get('pim_rp_address', 'feature')
+      return !(feature_state.nil? || feature_state.empty?)
+    rescue Cisco::CliError => e
+      return false if e.clierror =~ /Syntax error/
+      raise
+    end
+
+    # Create pim grouplist instance
+    # ---------------------------------
+    def create
+      PimGroupList.enable unless PimGroupList.enabled
+      config_set('pim_rp_address', 'group_list', @set_args)
+    end
+
+    # Destroy pim grouplist instance
+    # ----------------------------------
+    def destroy
+      set_args_keys(state: 'no')
+      if @set_args.include?(:vrf) && @set_args[:vrf] == 'default'
+        @set_args.delete(:vrf)
+      end
+      config_set('pim_rp_address', 'group_list', @set_args)
+    end
+  end
+end

--- a/lib/cisco_node_utils/pim_rp_address.rb
+++ b/lib/cisco_node_utils/pim_rp_address.rb
@@ -1,0 +1,123 @@
+# PIM feature
+# Provides configuration of PIM configuration with rp-addresses
+#
+# Smitha Gopalan, November 2015
+#
+# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#------------------------------------------------------------
+# CLI: ip pim rp-address <rp-address> (under different VRFs)
+#------------------------------------------------------------
+
+require_relative 'node_util'
+require 'pp'
+
+module Cisco
+  # node_utils class for pim_rp_address
+  class PimRpAddress < NodeUtil
+    attr_reader :rp_addr, :vrf
+
+    # Constructor with rp_address and vrf
+    # --------------------------------------
+    def initialize(rp_addr, vrf='default', instantiate=true)
+      fail ArgumentError unless vrf.is_a? String
+      fail ArgumentError unless vrf.length > 0
+      @rp_addr = rp_addr
+      @vrf = vrf
+      if @vrf == 'default'
+        @get_args = @set_args = { state: '', addr: @rp_addr }
+      else
+        @get_args = @set_args = { state: '', addr: @rp_addr, vrf: @vrf }
+      end
+      create if instantiate
+    end
+
+    # Create a hash of rp_address=>vrf mappings
+    # --------------------------------------------
+    def self.rp_addresses
+      hash_final = {}
+      rp_addrs = config_get('pim_rp_address', 'all_rp_addresses')
+      return hash_final if rp_addrs.nil?
+
+      # Get the RPs under default VRF
+      rp_addrs.each do |addr|
+        hash_final[addr] = {}
+        hash_final[addr]['default'] = PimRpAddress.new(addr, 'default', false)
+      end
+      # Getting all custom vrfs rp_Addrs"
+      vrf_ids = config_get('vrf', 'all_vrfs')
+      vrf_ids.delete_if { |vrf_id| vrf_id == 'management' }
+      vrf_ids.each do |vrf|
+        get_args = { rp_addr: @rp_addr, vrf: @vrf }
+        get_args[:vrf] = vrf
+        rp_addrs = config_get('pim_rp_address', 'all_rp_addresses', get_args)
+        next if rp_addrs.nil?
+        rp_addrs.each do |addr|
+          hash_final[addr] ||= {}
+          hash_final[addr][vrf] = PimRpAddress.new(addr, vrf, false)
+        end
+      end
+      puts 'FINAL HASH is: '
+      pp '-------------'
+      pp hash_final
+    end
+
+    # set_args_keys_default
+    # ----------------------
+    def set_args_keys_default
+      keys = { addr: @rp_addr, vrf: @vrf }
+      @get_args = @set_args = keys
+    end
+
+    # set_args_key
+    # -------------
+    def set_args_keys(hash={}) # rubocop:disable Style/AccessorMethodName
+      set_args_keys_default
+      @set_args = @get_args.merge!(hash) unless hash.empty?
+    end
+
+    # Enable Feature pim
+    # ---------------------
+    def enable
+      config_set('pim_rp_address', 'feature')
+    end
+
+    # Check Feature pim state
+    # --------------------------
+    def self.enabled
+      feature_state = config_get('pim_rp_address', 'feature')
+      return !(feature_state.nil? || feature_state.empty?)
+    rescue Cisco::CliError => e
+      return false if e.clierror =~ /Syntax error/
+      raise
+    end
+
+    # Create pim rp_addr instance
+    # ------------------------------
+    def create
+      PimRpAddress.enable unless PimRpAddress.enabled
+      config_set('pim_rp_address', 'rp_address', @set_args)
+    end
+
+    # Destroy pim rp_addr instance
+    # ------------------------------
+    def destroy
+      set_args_keys(state: 'no')
+      if @set_args.include?(:vrf) && @set_args[:vrf] == 'default'
+        @set_args.delete(:vrf)
+      end
+      config_set('pim_rp_address', 'rp_address', @set_args)
+    end
+  end
+end

--- a/tests/test_pim.rb
+++ b/tests/test_pim.rb
@@ -66,7 +66,7 @@ class TestPim < CiscoTestCase
   # Tests single ssm range none under default vrf
   #-----------------------------------------------
   def test_single_ssm_range_single_vrf
-    %w(ipv4).each do |afi|
+    %w(ipv4).each do |afi|      
       create_single_ssm_range_single_vrf(afi)
     end
   end  

--- a/tests/test_pim.rb
+++ b/tests/test_pim.rb
@@ -39,66 +39,70 @@
 #-------------------------------------------------------------------------------
 
 require_relative 'ciscotest'
+require 'pp'
 require_relative '../lib/cisco_node_utils/pim'
 
 include Cisco
 
 # TestPim - Minitest for Pim Feature
 class TestPim < CiscoTestCase
-
-  # Enables feature pim
-  #---------------------
   def setup
     super
     config('no feature pim')
     config('feature pim')
   end
 
-  # Creates single ssm range under default vrf
+  def teardown
+#    config('no feature pim')
+#    super
+  end
+
+  # Tests single ssm range under default vrf
   #-----------------------------------------------
-  def create_single_ssm_range_single_vrf(afi)
+  def test_single_ssm_range_single_vrf
+
+    puts "test_single_ssm_range_single_vrf: "
+    puts "================================"
     range = '229.0.0.0/8'
-    p1 = Pim.new(afi)
+    p1 = Pim.new()
     p1.ssm_range=(range)
     assert_equal(p1.ssm_range, range.split(' ').sort)
   end
 
   # Tests single ssm range none under default vrf
   #-----------------------------------------------
+<<<<<<< HEAD
   def test_single_ssm_range_single_vrf
     %w(ipv4).each do |afi|      
       create_single_ssm_range_single_vrf(afi)
     end
   end  
+=======
+  def test_single_ssm_range_none_single_vrf
+>>>>>>> parent of e4346a1... NXAPI Implementation & Mini Tests for Pim
 
-  # Creates single ssm range none under default vrf
-  #-----------------------------------------------
-  def create_single_ssm_range_none_single_vrf(afi)
+    puts "test_single_ssm_range_none_single_vrf: "
+    puts "==============================="
     range = 'none'
-    p1 = Pim.new(afi)
+    p1 = Pim.new()
     p1.ssm_range=(range)
     assert_equal(p1.ssm_range, range.split(' ').sort)
   end
 
-  # Tests single ssm range none under default vrf
+  # Tests multiple ssm ranges under different vrfs 
   #-----------------------------------------------
-  def test_single_ssm_range_none_single_vrf
-    %w(ipv4).each do |afi|
-      create_single_ssm_range_none_single_vrf(afi)
-    end
-  end
+  def test_multiple_ssm_range_multiple_vrfs
 
-  # Creates multiple ssm ranges under different vrfs 
-  #-----------------------------------------------
-  def create_multiple_ssm_range_multiple_vrfs(afi)
+    puts "test_multiple_ssm_range_multiple_vrfs: "
+    puts "======================================="
     range = '229.0.0.0/8 225.0.0.0/8 224.0.0.0/8'
     range2 = '230.0.0.0/8 228.0.0.0/8 224.0.0.0/8'
     range3 = 'none'
     vrf = 'red'
     vrf3 ='black'
-    p1 = Pim.new(afi)
-    p2 = Pim.new(afi, vrf)
-    p3 = Pim.new(afi, vrf3)
+    p1 = Pim.new()
+    p2 = Pim.new(vrf)
+    p3 = Pim.new(vrf3)
     p1.ssm_range=(range)
     p2.ssm_range=(range2)
     p3.ssm_range=(range3)
@@ -107,23 +111,18 @@ class TestPim < CiscoTestCase
     assert_equal(p3.ssm_range, range3.split(' ').sort)
   end
   
-  # Tests multiple ssm ranges under different vrfs 
+  # Tests multiple ssm ranges overwrite under different vrfs 
   #-----------------------------------------------
-  def test_multiple_ssm_range_multiple_vrfs
-    %w(ipv4).each do |afi|
-      create_multiple_ssm_range_multiple_vrfs(afi)
-    end
-  end  
+  def test_multiple_ssm_range_overwrite_multiple_vrfs
 
-  # Creates multiple ssm ranges overwrite under different vrfs 
-  #-----------------------------------------------
-  def create_multiple_ssm_range_overwrite_multiple_vrfs(afi)
+    puts "test_multiple_ssm_range_overwrite_multiple_vrfs: "
+    puts "======================================="
     range = '229.0.0.0/8 225.0.0.0/8 224.0.0.0/8'
     range2 = '230.0.0.0/8 228.0.0.0/8 224.0.0.0/8'
     range3 = 'none'
     vrf = 'red'
-    p1 = Pim.new(afi)
-    p2 = Pim.new(afi, vrf)
+    p1 = Pim.new()
+    p2 = Pim.new(vrf)
     p1.ssm_range=(range)
     p2.ssm_range=(range2)
     assert_equal(p1.ssm_range, range.split(' ').sort)
@@ -132,29 +131,16 @@ class TestPim < CiscoTestCase
     assert_equal(p2.ssm_range, range3.split(' ').sort)
   end
   
-  # Tests multiple ssm ranges overwrite under different vrfs 
-  #-----------------------------------------------
-  def test_multiple_ssm_range_overwrite_multiple_vrfs
-    %w(ipv4).each do |afi|
-      create_multiple_ssm_range_overwrite_multiple_vrfs(afi)
-    end
-  end  
-
-  # Creates single invalid ssm range under vrf default
+  # Tests single invalid ssm range under vrf default
   #---------------------------------------------------
-  def create_single_invalid_ssm_range_single_vrf(afi)
+  def test_single_invalid_ssm_range_single_vrf
+
+    puts "test_single_invalid_ssm_range_single_vrf: "
+    puts "=========================================="
     range = '1.1.1.1/8'
-    p1 = Pim.new(afi)
+    p1 = Pim.new()
     assert_raises(CliError ) do
       p1.ssm_range=(range)
     end
   end
-  
-  # Tests single invalid ssm range under vrf default
-  #---------------------------------------------------
-  def test_single_invalid_ssm_range_single_vrf
-    %w(ipv4).each do |afi|
-      create_single_invalid_ssm_range_single_vrf(afi)
-    end
-  end  
 end

--- a/tests/test_pim.rb
+++ b/tests/test_pim.rb
@@ -1,0 +1,138 @@
+# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+#
+# Smitha Gopalan, November 2015
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#-------------------------------------------------------------------------------
+# CLI: ip pim ssm-range <range>  (under different VRFs)
+#-------------------------------------------------------------------------------
+# Testcases: All Tests create all instances within a test
+# 1. test_single_ssm_range_single_vrf:
+#         vrf default, ip pim ssm-range 229.0.0.0/8
+#
+# 2. test_single_ssm_range_none_single_vrf:
+#         vrf default, ip pim ssm-range none
+#
+# 3. test_multiple_ssm_range_multiple_vrfs:
+#         vrf default, ip pim ssm-range 229.0.0.0/8 225.0.0.0/8 224.0.0.0/8
+#         vrf red, ip pim ssm-range 230.0.0.0/8 228.0.0.0/8 224.0.0.0/8
+#         vrf black, ip pim ssm-range none
+#
+# 4. test_multiple_ssm_range_overwrite_multiple_vrfs:
+#         vrf default, ip pim ssm-range 229.0.0.0/8 225.0.0.0/8 224.0.0.0/8
+#         vrf red, ip pim ssm-range 230.0.0.0/8 228.0.0.0/8 224.0.0.0/8 -> 
+#             gets overwritten to
+#         vrf red, ip pim ssm-range none
+#
+# 5. test_single_invalid_ssm_range_single_vrf:
+#         vrf default, ip pim ssm-range 1.1.1.1/8
+#-------------------------------------------------------------------------------
+
+require_relative 'ciscotest'
+require 'pp'
+require_relative '../lib/cisco_node_utils/pim'
+
+include Cisco
+
+# TestPim - Minitest for Pim Feature
+class TestPim < CiscoTestCase
+  def setup
+    super
+    config('no feature pim')
+    config('feature pim')
+  end
+
+  def teardown
+#    config('no feature pim')
+#    super
+  end
+
+  # Tests single ssm range under default vrf
+  #-----------------------------------------------
+  def test_single_ssm_range_single_vrf
+
+    puts "test_single_ssm_range_single_vrf: "
+    puts "================================"
+    range = '229.0.0.0/8'
+    p1 = Pim.new()
+    p1.ssm_range=(range)
+    assert_equal(p1.ssm_range, range.split(' ').sort)
+  end
+
+  # Tests single ssm range none under default vrf
+  #-----------------------------------------------
+  def test_single_ssm_range_none_single_vrf
+
+    puts "test_single_ssm_range_none_single_vrf: "
+    puts "==============================="
+    range = 'none'
+    p1 = Pim.new()
+    p1.ssm_range=(range)
+    assert_equal(p1.ssm_range, range.split(' ').sort)
+  end
+
+  # Tests multiple ssm ranges under different vrfs 
+  #-----------------------------------------------
+  def test_multiple_ssm_range_multiple_vrfs
+
+    puts "test_multiple_ssm_range_multiple_vrfs: "
+    puts "======================================="
+    range = '229.0.0.0/8 225.0.0.0/8 224.0.0.0/8'
+    range2 = '230.0.0.0/8 228.0.0.0/8 224.0.0.0/8'
+    range3 = 'none'
+    vrf = 'red'
+    vrf3 ='black'
+    p1 = Pim.new()
+    p2 = Pim.new(vrf)
+    p3 = Pim.new(vrf3)
+    p1.ssm_range=(range)
+    p2.ssm_range=(range2)
+    p3.ssm_range=(range3)
+    assert_equal(p1.ssm_range, range.split(' ').sort)
+    assert_equal(p2.ssm_range, range2.split(' ').sort)
+    assert_equal(p3.ssm_range, range3.split(' ').sort)
+  end
+  
+  # Tests multiple ssm ranges overwrite under different vrfs 
+  #-----------------------------------------------
+  def test_multiple_ssm_range_overwrite_multiple_vrfs
+
+    puts "test_multiple_ssm_range_overwrite_multiple_vrfs: "
+    puts "======================================="
+    range = '229.0.0.0/8 225.0.0.0/8 224.0.0.0/8'
+    range2 = '230.0.0.0/8 228.0.0.0/8 224.0.0.0/8'
+    range3 = 'none'
+    vrf = 'red'
+    p1 = Pim.new()
+    p2 = Pim.new(vrf)
+    p1.ssm_range=(range)
+    p2.ssm_range=(range2)
+    assert_equal(p1.ssm_range, range.split(' ').sort)
+    assert_equal(p2.ssm_range, range2.split(' ').sort)
+    p2.ssm_range=(range3)
+    assert_equal(p2.ssm_range, range3.split(' ').sort)
+  end
+  
+  # Tests single invalid ssm range under vrf default
+  #---------------------------------------------------
+  def test_single_invalid_ssm_range_single_vrf
+
+    puts "test_single_invalid_ssm_range_single_vrf: "
+    puts "=========================================="
+    range = '1.1.1.1/8'
+    p1 = Pim.new()
+    assert_raises(CliError ) do
+      p1.ssm_range=(range)
+    end
+  end
+end

--- a/tests/test_pim.rb
+++ b/tests/test_pim.rb
@@ -39,32 +39,43 @@
 #-------------------------------------------------------------------------------
 
 require_relative 'ciscotest'
-require 'pp'
 require_relative '../lib/cisco_node_utils/pim'
 
 include Cisco
 
 # TestPim - Minitest for Pim Feature
 class TestPim < CiscoTestCase
+
+  # Enables feature pim
+  #---------------------
   def setup
     super
     config('no feature pim')
     config('feature pim')
   end
 
-  def teardown
-#    config('no feature pim')
-#    super
+  # Creates single ssm range under default vrf
+  #-----------------------------------------------
+  def create_single_ssm_range_single_vrf(afi)
+    range = '229.0.0.0/8'
+    p1 = Pim.new(afi)
+    p1.ssm_range=(range)
+    assert_equal(p1.ssm_range, range.split(' ').sort)
   end
 
-  # Tests single ssm range under default vrf
+  # Tests single ssm range none under default vrf
   #-----------------------------------------------
   def test_single_ssm_range_single_vrf
+    %w(ipv4).each do |afi|
+      create_single_ssm_range_single_vrf(afi)
+    end
+  end  
 
-    puts "test_single_ssm_range_single_vrf: "
-    puts "================================"
-    range = '229.0.0.0/8'
-    p1 = Pim.new()
+  # Creates single ssm range none under default vrf
+  #-----------------------------------------------
+  def create_single_ssm_range_none_single_vrf(afi)
+    range = 'none'
+    p1 = Pim.new(afi)
     p1.ssm_range=(range)
     assert_equal(p1.ssm_range, range.split(' ').sort)
   end
@@ -72,29 +83,22 @@ class TestPim < CiscoTestCase
   # Tests single ssm range none under default vrf
   #-----------------------------------------------
   def test_single_ssm_range_none_single_vrf
-
-    puts "test_single_ssm_range_none_single_vrf: "
-    puts "==============================="
-    range = 'none'
-    p1 = Pim.new()
-    p1.ssm_range=(range)
-    assert_equal(p1.ssm_range, range.split(' ').sort)
+    %w(ipv4).each do |afi|
+      create_single_ssm_range_none_single_vrf(afi)
+    end
   end
 
-  # Tests multiple ssm ranges under different vrfs 
+  # Creates multiple ssm ranges under different vrfs 
   #-----------------------------------------------
-  def test_multiple_ssm_range_multiple_vrfs
-
-    puts "test_multiple_ssm_range_multiple_vrfs: "
-    puts "======================================="
+  def create_multiple_ssm_range_multiple_vrfs(afi)
     range = '229.0.0.0/8 225.0.0.0/8 224.0.0.0/8'
     range2 = '230.0.0.0/8 228.0.0.0/8 224.0.0.0/8'
     range3 = 'none'
     vrf = 'red'
     vrf3 ='black'
-    p1 = Pim.new()
-    p2 = Pim.new(vrf)
-    p3 = Pim.new(vrf3)
+    p1 = Pim.new(afi)
+    p2 = Pim.new(afi, vrf)
+    p3 = Pim.new(afi, vrf3)
     p1.ssm_range=(range)
     p2.ssm_range=(range2)
     p3.ssm_range=(range3)
@@ -103,18 +107,23 @@ class TestPim < CiscoTestCase
     assert_equal(p3.ssm_range, range3.split(' ').sort)
   end
   
-  # Tests multiple ssm ranges overwrite under different vrfs 
+  # Tests multiple ssm ranges under different vrfs 
   #-----------------------------------------------
-  def test_multiple_ssm_range_overwrite_multiple_vrfs
+  def test_multiple_ssm_range_multiple_vrfs
+    %w(ipv4).each do |afi|
+      create_multiple_ssm_range_multiple_vrfs(afi)
+    end
+  end  
 
-    puts "test_multiple_ssm_range_overwrite_multiple_vrfs: "
-    puts "======================================="
+  # Creates multiple ssm ranges overwrite under different vrfs 
+  #-----------------------------------------------
+  def create_multiple_ssm_range_overwrite_multiple_vrfs(afi)
     range = '229.0.0.0/8 225.0.0.0/8 224.0.0.0/8'
     range2 = '230.0.0.0/8 228.0.0.0/8 224.0.0.0/8'
     range3 = 'none'
     vrf = 'red'
-    p1 = Pim.new()
-    p2 = Pim.new(vrf)
+    p1 = Pim.new(afi)
+    p2 = Pim.new(afi, vrf)
     p1.ssm_range=(range)
     p2.ssm_range=(range2)
     assert_equal(p1.ssm_range, range.split(' ').sort)
@@ -123,16 +132,29 @@ class TestPim < CiscoTestCase
     assert_equal(p2.ssm_range, range3.split(' ').sort)
   end
   
-  # Tests single invalid ssm range under vrf default
-  #---------------------------------------------------
-  def test_single_invalid_ssm_range_single_vrf
+  # Tests multiple ssm ranges overwrite under different vrfs 
+  #-----------------------------------------------
+  def test_multiple_ssm_range_overwrite_multiple_vrfs
+    %w(ipv4).each do |afi|
+      create_multiple_ssm_range_overwrite_multiple_vrfs(afi)
+    end
+  end  
 
-    puts "test_single_invalid_ssm_range_single_vrf: "
-    puts "=========================================="
+  # Creates single invalid ssm range under vrf default
+  #---------------------------------------------------
+  def create_single_invalid_ssm_range_single_vrf(afi)
     range = '1.1.1.1/8'
-    p1 = Pim.new()
+    p1 = Pim.new(afi)
     assert_raises(CliError ) do
       p1.ssm_range=(range)
     end
   end
+  
+  # Tests single invalid ssm range under vrf default
+  #---------------------------------------------------
+  def test_single_invalid_ssm_range_single_vrf
+    %w(ipv4).each do |afi|
+      create_single_invalid_ssm_range_single_vrf(afi)
+    end
+  end  
 end

--- a/tests/test_pim.rb
+++ b/tests/test_pim.rb
@@ -73,7 +73,7 @@ class TestPim < CiscoTestCase
   #-----------------------------------------------
 <<<<<<< HEAD
   def test_single_ssm_range_single_vrf
-    %w(ipv4).each do |afi|      
+    %w(ipv4).each do |afi|
       create_single_ssm_range_single_vrf(afi)
     end
   end  

--- a/tests/test_pim_group_list.rb
+++ b/tests/test_pim_group_list.rb
@@ -1,0 +1,246 @@
+# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+#
+# Smitha Gopalan, November 2015
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#-------------------------------------------------------------------------------
+# CLI: ip pim rp-address <rp-address> group-list <group> (under different VRFs)
+#-------------------------------------------------------------------------------
+# Testcases: All Tests create and destroy all instances within a test
+#
+# 1. test_single_grouplist_single_vrf:
+#         vrf default, ip pim rp-address 11.11.11.11 group-list 227.0.0.0/8
+#         vrf default, ip pim rp-address 22.22.22.22 group-list 228.0.0.0/8
+#         vrf default, ip pim rp-address 23.23.23.23 group-list 228.0.0.0/8
+#
+# 2. test_multiple_rpaddrs_multiple_vrfs:
+#         vrf default, ip pim rp-address 11.11.11.11 group-list 227.0.0.0/8
+#         vrf default, ip pim rp-address 12.12.12.12 group-list 228.0.0.0/8
+#         vrf red, ip pim rp-address 22.22.22.22 group-list 227.0.0.0/8
+#         vrf red, ip pim rp-address 23.23.23.23 group-list 228.0.0.0/8
+#         vrf blue, ip pim rp-address 33.33.33.33 group-list 227.0.0.0/8
+#         vrf blue, ip pim rp-address 34.34.34.34 group-list 228.0.0.0/8
+#
+# 3. test_same_rpaddr_same_grouplist_multiple_vrfs:
+#         vrf default, ip pim rp-address 1.1.1.1 group-list 224.0.0.0/8
+#         vrf default, ip pim rp-address 2.2.2.2 group-list 226.0.0.0/8
+#         vrf default, ip pim rp-address 22.22.22.22 group-list 226.0.0.0/8
+#         vrf red, ip pim rp-address 1.1.1.1 group-list 224.0.0.0/8
+#         vrf red, ip pim rp-address 2.2.2.2 group-list 226.0.0.0/8
+#         vrf red, ip pim rp-address 22.22.22.22 group-list 226.0.0.0/8
+#         vrf black, ip pim rp-address 1.1.1.1 group-list 224.0.0.0/8
+#         vrf black, ip pim rp-address 2.2.2.2 group-list 226.0.0.0/8
+#         vrf black, ip pim rp-address 22.22.22.22 group-list 226.0.0.0/8
+#
+# 4. test_single_invalid_rpaddr_single_grouplist_single_vrf:
+#         vrf default, ip pim rp-address 256.256.256.256 group-list 224.0.0.0/8
+#
+# 5. test_single_rpaddr_single_invalid_grouplist_single_vrf:
+#         vrf default, ip pim rp-address 25.25.25.25 group-list 25.0.0.0/8
+#-------------------------------------------------------------------------------
+
+require_relative 'ciscotest'
+require 'pp'
+require_relative '../lib/cisco_node_utils/pim_group_list'
+
+include Cisco
+
+# TestPim - Minitest for Pim Feature
+class TestPimGroupList < CiscoTestCase
+  def setup
+    super
+    config('no feature pim')
+    config('feature pim')
+  end
+
+  def teardown
+#    config('no feature pim')
+#    super
+  end
+
+  # Tests single group list under vrf default
+  #------------------------------------------
+  def test_single_grouplist_single_vrf
+
+    puts "test_single_grouplist_single_vrf: "
+    puts "==============================="
+    rp_addr_d1 = "11.11.11.11"
+    rp_addr_d2 = '22.22.22.22'
+    rp_addr_d3 = '23.23.23.23'
+    vrf = 'default'
+    grouplist1 = "227.0.0.0/8"
+    grouplist2 = '228.0.0.0/8'
+    pd1 = PimGroupList.new(rp_addr_d1, grouplist1)
+    pd2 = PimGroupList.new(rp_addr_d2, grouplist2)
+    pd3 = PimGroupList.new(rp_addr_d3, grouplist2)
+
+    result = {}
+    result = PimGroupList.group_lists
+    
+    rp_addr_d1_def_grouplist1 = [rp_addr_d1, grouplist1]
+    rp_addr_d2_def_grouplist2 = [rp_addr_d2, grouplist2]
+    rp_addr_d3_def_grouplist2 = [rp_addr_d3, grouplist2]
+
+    pp "result"
+    pp "------"
+    pp result
+    
+    assert_includes(result[rp_addr_d1_def_grouplist1], vrf)
+    assert_includes(result[rp_addr_d2_def_grouplist2], vrf)
+    assert_includes(result[rp_addr_d3_def_grouplist2], vrf)
+    
+    pd1.destroy
+    pd2.destroy
+    pd3.destroy
+
+  end
+  
+  # Tests multiple rp addresses under different vrfs 
+  #--------------------------------------------------
+  def test_multiple_rpaddrs_multiple_vrfs
+
+    puts "test_multiple_rpaddrs_multiple_vrfs: "
+    puts "====================================="
+    
+    rp_addr1 = '11.11.11.11'
+    rp_addr12 = '12.12.12.12'
+    vrf1 = 'default'
+    rp_addr2 = '22.22.22.22'
+    rp_addr23 = '23.23.23.23'
+    vrf2 = 'red'
+    rp_addr3 = '33.33.33.33'
+    rp_addr34 = '34.34.34.34'
+    vrf3 = 'blue'
+    grouplist1 = "227.0.0.0/8"
+    grouplist2 = '228.0.0.0/8'
+    p1 = PimGroupList.new(rp_addr1, grouplist1)
+    p12 = PimGroupList.new(rp_addr12, grouplist2)
+    p2 = PimGroupList.new(rp_addr2, grouplist1, vrf2)
+    p23 = PimGroupList.new(rp_addr23, grouplist2, vrf2)
+    p3 = PimGroupList.new(rp_addr3, grouplist1, vrf3)
+    p34 = PimGroupList.new(rp_addr34, grouplist2, vrf3)
+
+    result = {}
+    result = PimGroupList.group_lists
+    
+    pp "result"
+    pp "------"
+    pp result
+    
+    rp_addr1_def_grouplist1 = [rp_addr1, grouplist1]
+    rp_addr12_def_grouplist2 = [rp_addr12, grouplist2]
+    rp_addr2_def_grouplist1 = [rp_addr2, grouplist1]
+    rp_addr23_def_grouplist2 = [rp_addr23, grouplist2]
+    rp_addr3_def_grouplist1 = [rp_addr3, grouplist1]
+    rp_addr34_def_grouplist2 = [rp_addr34, grouplist2]
+    
+    assert_includes(result[rp_addr1_def_grouplist1], vrf1)
+    assert_includes(result[rp_addr12_def_grouplist2], vrf1)
+    assert_includes(result[rp_addr2_def_grouplist1], vrf2)
+    assert_includes(result[rp_addr23_def_grouplist2], vrf2)
+    assert_includes(result[rp_addr3_def_grouplist1], vrf3)
+    assert_includes(result[rp_addr34_def_grouplist2], vrf3)
+    p1.destroy
+    p12.destroy
+    p2.destroy
+    p23.destroy
+    p3.destroy
+    p34.destroy
+  end
+  
+  # Tests same rp address and same grouplists under multiple vrfs 
+  #--------------------------------------------------------------
+  def test_same_rpaddr_same_grouplist_multiple_vrfs
+    
+    rp_addr_d1 = "1.1.1.1"
+    rp_addr_d2 = '2.2.2.2'
+    rp_addr_d3 = '22.22.22.22'
+    vrf = 'default'
+    vrf2 = 'red'
+    vrf3 = 'black'
+    grouplist1 = "224.0.0.0/8"
+    grouplist2 = '226.0.0.0/8'
+    pd1 = PimGroupList.new(rp_addr_d1, grouplist1)
+    pd2 = PimGroupList.new(rp_addr_d1, grouplist2)
+    pd3 = PimGroupList.new(rp_addr_d2, grouplist2)
+
+    p1_red = PimGroupList.new(rp_addr_d1, grouplist1, vrf2)
+    p2_red = PimGroupList.new(rp_addr_d1, grouplist2, vrf2)
+    p3_red = PimGroupList.new(rp_addr_d2, grouplist2, vrf2)
+
+    p1_black = PimGroupList.new(rp_addr_d1, grouplist1, vrf3)
+    p2_black = PimGroupList.new(rp_addr_d1, grouplist2, vrf3)
+    p3_black = PimGroupList.new(rp_addr_d2, grouplist2, vrf3)
+    result = {}
+    result = PimGroupList.group_lists
+
+
+    rp_addr_d1_def_grouplist1 = [rp_addr_d1, grouplist1]
+    rp_addr_d1_def_grouplist2 = [rp_addr_d1, grouplist2]
+    rp_addr_d2_def_grouplist2 = [rp_addr_d1, grouplist2]
+    pp "result"
+    pp "------"
+    pp result
+
+    assert_includes(result[rp_addr_d1_def_grouplist1], vrf)
+    assert_includes(result[rp_addr_d1_def_grouplist2], vrf)
+    assert_includes(result[rp_addr_d2_def_grouplist2], vrf)
+
+    assert_includes(result[rp_addr_d1_def_grouplist1], vrf2)
+    assert_includes(result[rp_addr_d1_def_grouplist2], vrf2)
+    assert_includes(result[rp_addr_d2_def_grouplist2], vrf2)
+
+    assert_includes(result[rp_addr_d1_def_grouplist1], vrf3)
+    assert_includes(result[rp_addr_d1_def_grouplist2], vrf3)
+    assert_includes(result[rp_addr_d2_def_grouplist2], vrf3)
+
+    pd1.destroy
+    pd2.destroy
+    pd3.destroy
+
+    p1_red.destroy
+    p2_red.destroy
+    p3_red.destroy
+
+    p1_black.destroy
+    p2_black.destroy
+    p3_black.destroy
+  end
+
+  # Tests single invalid rp address single grouplist vrf default
+  #---------------------------------------------------------------
+  def test_single_invalid_rpaddr_single_grouplist_single_vrf
+
+    puts "test_single_invalid_rpaddr_single_grouplist_single_vrf: "
+    puts "========================================================"
+    rp_addr = '256.256.256.256'
+    grouplist = "224.0.0.0/8"
+    assert_raises(CliError ) do
+      p1 = PimGroupList.new(rp_addr, grouplist)
+    end
+  end
+  
+  # Tests single rp address single invalid grouplist single vrf
+  #---------------------------------------------------------------
+  def test_single_rpaddr_single_invalid_grouplist_single_vrf
+
+    puts "test_single_rpaddr_single_invalid_grouplist_single_vrf: "
+    puts "========================================================"
+    rp_addr = '25.25.25.25'
+    grouplist = "25.0.0.0/8"
+    vrf = 'red'
+    assert_raises(CliError ) do
+      p1 = PimGroupList.new(rp_addr, grouplist, vrf)
+    end
+  end
+end

--- a/tests/test_pim_rp_address.rb
+++ b/tests/test_pim_rp_address.rb
@@ -1,0 +1,146 @@
+# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+#
+# Smitha Gopalan, November 2015
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------
+# Cli: ip pim rp-address <rp-address> (under different VRFs)
+# ---------------------------------------------------------------------
+# Testcases: All Tests create and destroy all instances within a test
+#
+# 1. test_single_rpaddr_single_vrf : 
+#         vrf default, ip pim rp-address 1.1.1.1
+#
+# 2. test_multiple_rpaddrs_multiple_vrfs:  
+#         vrf default, ip pim rp-address 11.11.11.11
+#         vrf default, ip pim rp-address 12.12.12.12
+#         vrf red, ip pim rp-address 22.22.22.22
+#         vrf red, ip pim rp-address 23.23.23.23
+#         vrf blue, ip pim rp-address 33.33.33.33
+#         vrf blue, ip pim rp-address 34.34.34.34
+#
+# 3. test_same_rpaddr_multiple_vrfs:
+#         vrf default, ip pim rp-address 66.66.66.66
+#         vrf red, ip pim rp-address 66.66.66.66
+#         vrf blue, ip pim rp-address 66.66.66.66
+#
+# 4. test_single_invalid_rpaddr_single_vrf: 
+#         vrf default, ip pim rp-address 256.256.256.256
+# ---------------------------------------------------------------------
+
+require_relative 'ciscotest'
+require 'pp'
+require_relative '../lib/cisco_node_utils/pim_rp_address'
+
+include Cisco
+
+# TestPim - Minitest for Pim Feature
+class TestPimRpAddress < CiscoTestCase
+  def setup
+    super
+    config('no feature pim')
+    config('feature pim')
+  end
+
+  def teardown
+#    config('no feature pim')
+#    super
+  end
+
+  # Tests single rp address under vrf default
+  #------------------------------------------
+  def test_single_rpaddr_single_vrf
+
+    puts "test_single_rpaddr_single_vrf: "
+    puts "==============================="
+    rp_addr = '1.1.1.1'
+    vrf = 'default'
+    p1 = PimRpAddress.new(rp_addr)
+    result = PimRpAddress.rp_addresses
+    assert_includes(result[rp_addr], vrf)
+    p1.destroy
+  end
+  
+  # Tests multiple rp addresses under different vrfs 
+  #--------------------------------------------------
+  def test_multiple_rpaddrs_multiple_vrfs
+
+    puts "test_multiple_rpaddrs_multiple_vrfs: "
+    puts "====================================="
+    
+    rp_addr11 = '11.11.11.11'
+    rp_addr12 = '12.12.12.12'
+    vrf1 = 'default'
+    rp_addr22 = '22.22.22.22'
+    rp_addr23 = '23.23.23.23'
+    vrf2 = 'red'
+    rp_addr33 = '33.33.33.33'
+    rp_addr34 = '34.34.34.34'
+    vrf3 = 'blue'
+    p11 = PimRpAddress.new(rp_addr11)
+    p12 = PimRpAddress.new(rp_addr12)
+    p22 = PimRpAddress.new(rp_addr22, vrf2) 
+    p23 = PimRpAddress.new(rp_addr23, vrf2) 
+    p33 = PimRpAddress.new(rp_addr33, vrf3) 
+    p34 = PimRpAddress.new(rp_addr34, vrf3) 
+
+    result = PimRpAddress.rp_addresses
+    assert_includes(result[rp_addr11], vrf1)
+    assert_includes(result[rp_addr12], vrf1)
+    assert_includes(result[rp_addr22], vrf2)
+    assert_includes(result[rp_addr23], vrf2)
+    assert_includes(result[rp_addr33], vrf3)
+    assert_includes(result[rp_addr34], vrf3)
+    p11.destroy
+    p12.destroy
+    p22.destroy
+    p23.destroy
+    p33.destroy
+    p34.destroy
+  end
+  
+  # Tests same rp address under multiple vrfs 
+  #-------------------------------------------
+  def test_same_rpaddr_multiple_vrfs
+
+    puts "test_same_rpaddr_multiple_vrfs: "
+    puts "================================"
+    rp_addr = '66.66.66.66'
+    vrf1 = 'default'
+    vrf2 = 'red'
+    vrf3 = 'blue'
+    p1 = PimRpAddress.new(rp_addr)
+    p2 = PimRpAddress.new(rp_addr, vrf2) 
+    p3 = PimRpAddress.new(rp_addr, vrf3) 
+    
+    result = PimRpAddress.rp_addresses
+    assert_includes(result[rp_addr], vrf1)
+    assert_includes(result[rp_addr], vrf2)
+    assert_includes(result[rp_addr], vrf3)
+    p1.destroy
+    p2.destroy
+    p3.destroy
+  end
+  
+  # Tests single invalid rp address under vrf default
+  #---------------------------------------------------
+  def test_single_invalid_rpaddr_single_vrf
+
+    puts "test_single_invalid_rpaddr_single_vrf: "
+    puts "======================================="
+    rp_addr = '256.256.256.256'
+    assert_raises(CliError ) do 
+      p1 = PimRpAddress.new(rp_addr)  
+    end
+  end
+end


### PR DESCRIPTION
[Pim-UnitTest.docx](https://github.com/cisco/cisco-network-node-utils/files/62058/Pim-UnitTest.docx)
[PimGrouplist-UnitTest.docx](https://github.com/cisco/cisco-network-node-utils/files/62057/PimGrouplist-UnitTest.docx)
[PimRpAddress-UnitTest.docx](https://github.com/cisco/cisco-network-node-utils/files/62056/PimRpAddress-UnitTest.docx)
1. Pim: 
   Description: This is the node utils API for all Pim related properties.
   CLI: ip pim ssm-range <range>  (under different VRFs)
   Files Associated: pim.yaml, pim.rb, test_pim.rb
   
   MiniTests:
   1. test_single_ssm_range_single_vrf
   2. test_single_ssm_range_none_single_vrf
   3. test_multiple_ssm_range_multiple_vrfs
   4. test_multiple_ssm_range_overwrite_multiple_vrfs
   5. test_single_invalid_ssm_range_single_vrf
   
   Rubocop:
   rtpfe1@agent-lab11-ws:~/smigopal/pimNodeUtil-11-18/cisco-network-node-utils$ rubocop   lib/cisco_node_utils/pim.rb
    warning: parser/current is loading parser/ruby22, which recognizes
    warning: 2.2.3-compliant syntax, but you are running 2.2.1.
    warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
    Inspecting 1 file
     .
   
     1 file inspected, no offenses detected
     rtpfe1@agent-lab11-ws:~/smigopal/pimNodeUtil-11-18/cisco-network-node-utils$
   
    UnitTest: Pim-UnitTest
2. Pim-Rp-Address: 
   Description: This is the node utils API for Pim rp-addresses.
   CLI: CLI: ip pim rp-address <rp-address>  (under different VRFs)
   Files Associated: pim_rp_address.yaml, pim_rp_address.rb, test_pim_rp_address.rb
   
   MiniTests:
   1. test_single_rpaddr_single_vrf  
   2. test_multiple_rpaddrs_multiple_vrfs 
   3. test_same_rpaddr_multiple_vrfs
   4. test_single_invalid_rpaddr_single_vrf

Rubocop:
     rtpfe1@agent-lab11-ws:~/smigopal/pimNodeUtil-11-18/cisco-network-node-utils$ rubocop lib/cisco_node_utils/pim_rp_address.rb
     warning: parser/current is loading parser/ruby22, which recognizes
     warning: 2.2.3-compliant syntax, but you are running 2.2.1.
     warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
     Inspecting 1 file
     .

```
 1 file inspected, no offenses detected
  rtpfe1@agent-lab11-ws:~/smigopal/pimNodeUtil-11-18/cisco-network-node-utils$
```

   Unittest : PimRpAddress-UnitTest
1. Pim Group List:
   Description: This is the node utils API for Pim rp-address group-lists.
   CLI: CLI: ip pim rp-address <rp-address> group-list <group> (under different VRFs)
   Files Associated: pim_rp_address.yaml, pim_group_list.rb, test_pim_group_list.rb
   
   MiniTests:
   1. test_single_grouplist_single_vrf
   2. test_multiple_rpaddrs_multiple_vrfs
   3. test_same_rpaddr_same_grouplist_multiple_vrfs
   4. test_single_invalid_rpaddr_single_grouplist_single_vrf
   5. test_single_rpaddr_single_invalid_grouplist_single_vrf

Rubocop:
      rtpfe1@agent-lab11-ws:~/smigopal/pimNodeUtil-11-18/cisco-network-node-utils$ rubocop lib/cisco_node_utils/pim_group_list.rb
      warning: parser/current is loading parser/ruby22, which recognizes
      warning: 2.2.3-compliant syntax, but you are running 2.2.1.
      warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
       Inspecting 1 file
       .

```
  1 file inspected, no offenses detected
  rtpfe1@agent-lab11-ws:~/smigopal/pimNodeUtil-11-18/cisco-network-node-utils$ 
```

  Unittest : PimGroupList-UnitTest
