### PR TITLE
   vni refactor #1

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vni.yaml
@@ -1,51 +1,61 @@
 # vni
 ---
 all_vnis:
-  config_get: "show vni"
-  config_get_token: '/^(\d+)\s/'
+  multiple:
+  /N7K/:
+    config_get: 'show vni'
+    config_get_token: '/^(\d+)\s/'
+  /N9K/:
+    config_get: 'show running vlan'
+    config_get_token: '/vn-segment (\d+)/'
 
 bridge_domain:
-  config_get: "show vni"
+  config_get: 'show vni'
   config_get_token: [ '/^%d\s+\S+\s+(\d+)/' ]
-  config_set: ["bridge-domain %d", "%s member vni %d", "end"]
+  config_set: ['bridge-domain <domain>', '<state> member vni <vni>', 'end']
   default_value: ~
 
 bridge_domain_activate:
-  config_set: ["%s system bridge-domain add %d", "end"]
+  config_set: ['<state> system bridge-domain add <domain>', 'end']
 
 create:
-  config_set: ["vni %s" , "end"]
+  config_set: ['vni <vni>' , 'end']
 
 destroy:
-  config_set: "no vni %s"
+  /N7K/:
+    config_set: 'no vni <vni>'
+  /N9K/:
+    config_set: ['vlan <vlan>', 'no vn-segment <vni> ; end']
 
 encap_dot1q:
   config_set: ["encapsulation profile vni %s", "%s dot1q %s vni %s", "end"]
   default_value: ~
 
 feature:
-  config_get: "show feature"
-  config_get_token: '/^vni\s+\d+\s+(\S+)/'
-  config_set: "%s feature vni"
-
-feature_n9k:
-  config_get: " show running | i ^feature"
-  config_get_token: '/^feature vn-segment-vlan-based$/'
-  config_set: "<state> feature vn-segment-vlan-based"
+  config_get: 'show running | i ^feature'
+  /N7K/:
+    config_get_token: '/^feature vni$/'
+    config_set: 'feature vni'
+  /N9K/: 
+    config_get_token: '/^feature vn-segment-vlan-based$/'
+    config_set: 'feature vn-segment-vlan-based'
 
 feature_nv_overlay:
-  config_get: " show running | i ^feature"
+  config_get: 'show running | i ^feature'
   config_get_token: '/^feature nv overlay$/'
-  config_set: "<state> feature nv overlay"
+  config_set: 'feature nv overlay'
 
 mapped_vlan:
-  config_get: 'show running vlan'
-  config_get_token: ['/^vlan <vlan>$/', '/^vn-segment (\d+)$/']
-  config_set: ['vlan <vlan>', '<state> vn-segment <vni>']
-  default_value: ""
+  /N9K/:
+    config_get: 'show running vlan'
+    config_get_token: ['/^vlan <vlan>$/', '/^vn-segment (\d+)$/']
+    config_set: ['vlan <vlan>', '<state> vn-segment <vni> ; end']
+    default_value: ''
 
 shutdown:
-  config_get: "show vni"
-  config_get_token: '/^%d\s+(\S+)/'
-  config_set: ["vni %d", "%s shutdown", "end"]
-  default_value: false
+  /N7K/:
+    kind: boolean
+    config_get: 'show vni'
+    config_get_token: '/^<vni> +Down/'
+    config_set: ['vni <vni>', '<state> shutdown', 'end']
+    default_value: false

--- a/lib/cisco_node_utils/vni.rb
+++ b/lib/cisco_node_utils/vni.rb
@@ -32,10 +32,8 @@ module Cisco
 
     def self.vnis
       hash = {}
-      feature = config_get('vni', 'feature')
-      return hash if (:enabled != feature.to_sym)
       vni_list = config_get('vni', 'all_vnis')
-      return hash if vni_list.nil? || vni_list == {}
+      return hash if vni_list.nil?
 
       vni_list.each do |id|
         hash[id] = Vni.new(id, false)
@@ -43,55 +41,46 @@ module Cisco
       hash
     end
 
-    def feature
-      if /N9K/.match(node.product_id)
-        vni = config_get('vni', 'feature_n9k')
-      else
-        vni = config_get('vni', 'feature')
-      end
-      return :disabled if vni.nil?
-      :enabled
+    # feature vni
+    def self.feature_vni_enabled
+      config_get('vni', 'feature')
+    rescue Cisco::CliError => e
+      # cmd will syntax reject when feature is not enabled
+      raise unless e.clierror =~ /Syntax error/
+      return false
     end
 
-    def feature_set(vni_set)
-      curr = feature
-      return if curr == vni_set
+    def self.feature_vni_enable
+      # feature nv overlay is a dependency for feature vni
+      Vni.feature_nv_overlay_enable unless Vni.feature_nv_overlay_enabled
+      config_set('vni', 'feature')
+    end
 
-      case vni_set
-      when :enabled
-        if /N9K/.match(node.product_id)
-          config_set('vni', 'feature_n9k', state: '')
-        else
-          config_set('vni', 'feature', '')
-        end
-      when :disabled
-        if /N9K/.match(node.product_id)
-          # feature nv overlay is a dependency for disabling
-          # feature vn-segment-vlan-based. Disable it first.
-          if config_get('vni', 'feature_nv_overlay')
-            config_set('vni', 'feature_nv_overlay', state: 'no')
-            # Disabling feature nv overlay takes about 7-8 seconds.
-            # Sleep for the time.
-            sleep(8)
-          end
-          config_set('vni', 'feature_n9k', state: 'no') if curr == :enabled
-        else
-          config_set('vni', 'feature', 'no') if curr == :enabled
-        end
-        return
-      end
+    # feature nv overlay
+    def self.feature_nv_overlay_enabled
+      config_get('vni', 'feature_nv_overlay')
     rescue Cisco::CliError => e
-      raise "[#{@name}] '#{e.command}' : #{e.clierror}"
+      # cmd will syntax reject when feature is not enabled
+      raise unless e.clierror =~ /Syntax error/
+      return false
+    end
+
+    def self.feature_nv_overlay_enable
+      config_set('vni', 'feature_nv_overlay')
     end
 
     def create
-      feature_set(:enabled) unless :enabled == feature
-      return if /N9K/.match(node.product_id)
-      config_set('vni', 'create', @vni_id)
+      Vni.feature_vni_enable unless Vni.feature_vni_enabled
+      config_set('vni', 'create', vni: @vni_id) if
+        /N7K/.match(node.product_id)
     end
 
     def destroy
-      config_set('vni', 'destroy', @vni_id)
+      # Platform differences: For vni's mapped under the vlan config just remove
+      # the vni config and not the vlan config; for standalone vni configs
+      # remove the entire vni config. The yaml cmdref will ignore the unneeded
+      # keys for the standalone vni config.
+      config_set('vni', 'destroy', state: 'no', vlan: mapped_vlan, vni: @vni_id)
     end
 
     def cli_error_check(result)
@@ -99,7 +88,7 @@ module Cisco
       # instead just displays a STDOUT error message; thus NXAPI does not detect
       # the failure and we must catch it by inspecting the "body" hash entry
       # returned by NXAPI. This cli behavior is unlikely to change.
-      fail result[2]['body'] unless result[2]['body'].empty?
+      fail result[2]['body'] if /ERROR:/.match(result[2]['body'].to_s)
     end
 
     # TODO: This method will be refactored as part of US52662
@@ -164,7 +153,7 @@ module Cisco
     #  final_hash
     # end # end of encap_dot1q
 
-    def encap_dot1q=(val, prev_val=nil)
+    def encap_dot1q=(val, prev_val=nil) # TBD REFACTOR
       debug "val is of class #{val.class} and is #{val} prev is #{prev_val}"
       # When prev_val is nil, HashDiff doesn't do a `+' on each element, so this
       if prev_val.nil?
@@ -200,25 +189,20 @@ module Cisco
     end
 
     def bridge_domain
-      bd_arr = config_get('vni', 'bridge_domain', @vni_id)
+      bd_arr = config_get('vni', 'bridge_domain', vni: @vni_id)
       bd_arr.first.to_i
     end
 
-    def bridge_domain=(val)
-      no_cmd = (val) ? '' : 'no'
-      config_set('vni', 'bridge_domain_activate', no_cmd, val)
-      config_set('vni', 'bridge_domain', val, no_cmd, @vni_id)
+    def bridge_domain=(domain)
+      # TBD: ACTIVATE SHOULD BE SEPARATE SETTER AND POSSIBLY RENAMED 
+      state = (domain) ? '' : 'no'
+      config_set('vni', 'bridge_domain_activate', state: state, domain: domain)
+      config_set('vni', 'bridge_domain', state: state, domain: domain,
+                 vni: @vni_id)
     end
 
     def default_bridge_domain
       config_get_default('vni', 'bridge_domain')
-    end
-
-    def shutdown
-      result = config_get('vni', 'shutdown', @vni_id)
-      return default_shutdown if result.nil?
-      # valid result is either: "active"(aka no shutdown) or "shutdown"
-      result.first[/shut/] ? true : false
     end
 
     def mapped_vlan
@@ -226,28 +210,38 @@ module Cisco
       return nil if vlans.nil?
       vlans.each do |vlan|
         return vlan.to_i if
-              config_get('vni', 'mapped_vlan', vlan: vlan) == @vni_id
+          config_get('vni', 'mapped_vlan', vlan: vlan) == @vni_id
       end
       nil
     end
 
     def mapped_vlan=(vlan)
-      if vlan == default_vlan
+      # TBD: fail UnsupportedError unless /N9K/.match(node.product_id)
+      if vlan == default_mapped_vlan
         state = 'no'
         vlan = mapped_vlan
       else
         state = ''
       end
-      config_set('vni', 'mapped_vlan', vlan: vlan, state: state, vni: @vni_id)
+      result = config_set('vni', 'mapped_vlan', vlan: vlan,
+                          state: state, vni: @vni_id)
+      cli_error_check(result)
+    rescue CliError => e
+      raise "[vni #{@vni_id}] '#{e.command}' : #{e.clierror}"
     end
 
-    def default_vlan
+    def default_mapped_vlan
       config_get_default('vni', 'mapped_vlan')
     end
 
-    def shutdown=(val)
-      no_cmd = (val) ? '' : 'no'
-      result = config_set('vni', 'shutdown', @vni_id, no_cmd)
+    def shutdown
+      config_get('vni', 'shutdown', vni: @vni_id)
+    end
+
+    def shutdown=(state)
+      # TBD: fail UnsupportedError unless /N7K/.match(node.product_id)
+      state = (state) ? '' : 'no'
+      result = config_set('vni', 'shutdown', state: state, vni: @vni_id)
       cli_error_check(result)
     rescue CliError => e
       raise "[vni #{@vni_id}] '#{e.command}' : #{e.clierror}"

--- a/tests/test_vni.rb
+++ b/tests/test_vni.rb
@@ -21,6 +21,7 @@ include Cisco
 class TestVni < CiscoTestCase
   def setup
     super
+    skip('Only supported on N7K,N9K') unless node.product_id[/N[7|9]K/]
     no_vni
   end
 
@@ -30,32 +31,41 @@ class TestVni < CiscoTestCase
   end
 
   def no_vni
-    config('no feature vn-segment-vlan-based')
+    config('no feature vni') if node.product_id[/N7K/]
+    config('no feature vn-segment-vlan-based') if node.product_id[/N9K/]
   end
 
-  def test_on_off
-    vni = Vni.new(1_000_0, true)
-    assert_equal(:enabled, vni.feature, 'Error: vni feature not enabled')
+  def test_vni_create_destroy
+    skip('Only supported on N7K') unless node.product_id[/N7K/]
+    v1 = Vni.new(10_001)
+    v2 = Vni.new(10_002)
+    v3 = Vni.new(10_003)
+    assert_equal(3, Vni.vnis.keys.count)
 
-    vni.feature_set(:disabled)
-    assert_equal(:disabled, vni.feature, 'Error: vni feature still enabled')
+    v2.destroy
+    assert_equal(2, Vni.vnis.keys.count)
+
+    v1.destroy
+    v3.destroy
+    assert_equal(0, Vni.vnis.keys.count)
   end
 
   def test_mapped_vlan
+    skip('Only supported on N9K') unless node.product_id[/N9K/]
     # Set the vni vlan mapping
-    vni = Vni.new(1_000_0)
+    vni = Vni.new(10_000)
     vni.mapped_vlan = 100
     assert_equal(100, vni.mapped_vlan,
                  'Error: mapped-vlan mismatch')
     # Now clear the vni vlan mapping
-    vni.mapped_vlan = vni.default_vlan
-    assert_equal(nil, vni.mapped_vlan,
-                 'Error: cannot clear vni vlan mapping')
+    vni.mapped_vlan = vni.default_mapped_vlan
+    assert_nil(vni.mapped_vlan, 'Error: cannot clear vni vlan mapping')
   end
 
   def test_multiple_vnis_vlans
+    skip('Only supported on N9K') unless node.product_id[/N9K/]
     # Set vni to vlan mappings
-    vni_to_vlan_map = { 1_000_0 => 100, 2_000_0 => 200, 3_000_0 => 300 }
+    vni_to_vlan_map = { 10_000 => 100, 20_000 => 200, 30_000 => 300 }
     vni_to_vlan_map.each do |vni, vlan|
       vni_id = Vni.new(vni)
       vni_id.mapped_vlan = vlan
@@ -65,9 +75,24 @@ class TestVni < CiscoTestCase
     # Clear all mappings
     vni_to_vlan_map.each do |vni, _vlan|
       vni_id = Vni.new(vni)
-      vni_id.mapped_vlan = vni_id.default_vlan
-      assert_equal(nil, vni_id.mapped_vlan,
-                   'Error: cannot clear vni vlan mapping')
+      vni_id.mapped_vlan = vni_id.default_mapped_vlan
+      assert_nil(vni_id.mapped_vlan, 'Error: cannot clear vni vlan mapping')
     end
+  end
+
+  def test_shutdown
+    skip('Only supported on N7K') unless node.product_id[/N7K/]
+    vni = Vni.new(10_000)
+    vni.shutdown = true
+    assert(vni.shutdown)
+
+    vni.shutdown = false
+    refute(vni.shutdown)
+
+    vni.shutdown = !vni.default_shutdown
+    assert_equal(!vni.default_shutdown, vni.shutdown)
+
+    vni.shutdown = vni.default_shutdown
+    assert_equal(vni.default_shutdown, vni.shutdown)
   end
 end


### PR DESCRIPTION
```
This is step 1 of the refactor, there is still plenty to fix in here.

The main thrust of this was adding platform checks for the n7k vs n9k differences. I suspect this needs more tweaking. Deepak & Alok should give these changes a once-over in case I excluded something I shouldn't have.

I updated the yaml to use key-val and added platform checks there too.

Fixed the feature methods.

Added additional tests to minitest along with platform checks.
```
