### PR TITLE
VNI refactor #1

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vni.yaml
@@ -1,56 +1,71 @@
 # vni
 ---
+_exclude: [/N5K/, /N6K/]
 all_vnis:
+  multiple:
   /N7K/:
-    config_get: "show vni"
+    # MT-full only
+    config_get: 'show vni'
     config_get_token: '/^(\d+)\s/'
-  else:
-    multiple: true
-    config_get: "show running vlan"
+  /N(3|9)K/:
+    # MT-lite only
+    config_get: 'show running vlan'
     config_get_token: '/vn-segment (\d+)/'
 
 bridge_domain:
-  config_get: "show vni"
+  # MT-full only
+  config_get: 'show vni'
   config_get_token: [ '/^%d\s+\S+\s+(\d+)/' ]
-  config_set: ["bridge-domain %d", "%s member vni %d", "end"]
+  config_set: ['bridge-domain <domain>', '<state> member vni <vni>', 'end']
   default_value: ~
 
 bridge_domain_activate:
-  config_set: ["%s system bridge-domain add %d", "end"]
+  config_set: ['<state> system bridge-domain add <domain>', 'end']
 
 create:
-  config_set: ["vni %s" , "end"]
+  config_set: ['vni <vni>' , 'end']
 
 destroy:
-  config_set: "no vni <vni>"
+  /N7K/:
+    # MT-full only
+    config_set: 'no vni <vni>'
+  /N(3|9)K/:
+    # MT-lite only
+    config_set: ['vlan <vlan>', 'no vn-segment <vni> ; end']
 
 encap_dot1q:
   config_set: ["encapsulation profile vni %s", "%s dot1q %s vni %s", "end"]
   default_value: ~
 
 feature:
+  config_get: 'show running | i ^feature'
   /N7K/:
-    config_get: "show feature"
-    config_get_token: '/^vni\s+\d+\s+(\S+)/'
-    config_set: "<state> feature vni"
-  else:
-    config_get: " show running | i ^feature"
+    # MT-Full only
+    config_get_token: '/^feature vni$/'
+    config_set: 'feature vni'
+  /(N(3|9)K)/:
+    # MT-lite only
     config_get_token: '/^feature vn-segment-vlan-based$/'
-    config_set: "<state> feature vn-segment-vlan-based"
+    config_set: 'feature vn-segment-vlan-based'
 
 feature_nv_overlay:
-  config_get: " show running | i ^feature"
+  config_get: 'show running | i ^feature'
   config_get_token: '/^feature nv overlay$/'
-  config_set: "<state> feature nv overlay"
+  config_set: 'feature nv overlay'
 
 mapped_vlan:
-  config_get: 'show running vlan'
-  config_get_token: ['/^vlan <vlan>$/', '/^vn-segment (\d+)$/']
-  config_set: ['vlan <vlan>', '<state> vn-segment <vni> ; end']
-  default_value: ""
+  # MT-lite only
+  /(N(3|9)K)/:
+    config_get: 'show running vlan'
+    config_get_token: ['/^vlan <vlan>$/', '/^vn-segment (\d+)$/']
+    config_set: ['vlan <vlan>', '<state> vn-segment <vni> ; end']
+    default_value: ''
 
 shutdown:
-  config_get: "show vni"
-  config_get_token: '/^%d\s+(\S+)/'
-  config_set: ["vni %d", "%s shutdown", "end"]
-  default_value: false
+  # MT-Full only
+  /N7K/:
+    kind: boolean
+    config_get: 'show vni'
+    config_get_token: '/^<vni> +Down/'
+    config_set: ['vni <vni>', '<state> shutdown', 'end']
+    default_value: false

--- a/lib/cisco_node_utils/vni.rb
+++ b/lib/cisco_node_utils/vni.rb
@@ -15,8 +15,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-require File.join(File.dirname(__FILE__), 'node_util')
+#
+# ----
+# This provider supports both MT-full (N7K) and MT-lite (N3K/N9K),
+# each of which have their own feature requirements and clis.
+#
+# MT-full cli:                      MT-lite cli:
+#   feature nv overlay              feature nv overlay
+#   feature nvi                     feature vn-segment-vlan-based
+#   system bridge-domain 100-113
+#   bridge-domain 100
+#     member vni 100
+#   vni 10001                       vlan 100
+#     shutdown                        vn-segment 10001
+#
+# mapped_vlan (vn-segment) and mapped_bd (member vni) are mutually exclusive.
+# ----
+#
+require_relative 'node_util'
 
 module Cisco
   # node_utils class for Vni
@@ -32,9 +48,8 @@ module Cisco
 
     def self.vnis
       hash = {}
-      return hash if config_get('vni', 'feature').nil?
       vni_list = config_get('vni', 'all_vnis')
-      return hash if vni_list.nil? || vni_list == {}
+      return hash if vni_list.nil?
 
       vni_list.each do |id|
         hash[id] = Vni.new(id, false)
@@ -42,51 +57,53 @@ module Cisco
       hash
     end
 
-    def feature
-      vni = config_get('vni', 'feature')
-      return :disabled if vni.nil?
-      :enabled
+    # feature vni
+    def self.feature_vni_enabled
+      config_get('vni', 'feature')
+    rescue Cisco::CliError => e
+      # cmd will syntax reject when feature is not enabled
+      raise unless e.clierror =~ /Syntax error/
+      return false
     end
 
-    def feature_set(vni_set)
-      curr = feature
-      return if curr == vni_set
+    def self.feature_vni_enable
+      Vni.feature_nv_overlay_enable unless Vni.feature_nv_overlay_enabled
+      config_set('vni', 'feature')
+    end
 
-      case vni_set
-      when :enabled
-        config_set('vni', 'feature', state: '')
-      when :disabled
-        if /N9K/.match(node.product_id)
-          # feature nv overlay is a dependency for disabling
-          # feature vn-segment-vlan-based. Disable it first.
-          if config_get('vni', 'feature_nv_overlay')
-            config_set('vni', 'feature_nv_overlay', state: 'no')
-            # Disabling feature nv overlay takes about 7-8 seconds.
-            # Sleep for the time.
-            sleep(8)
-          end
-        end
-        config_set('vni', 'feature', state: 'no') if curr == :enabled
-        return
-      end
+    # feature nv overlay
+    def self.feature_nv_overlay_enabled
+      config_get('vni', 'feature_nv_overlay')
     rescue Cisco::CliError => e
-      raise "[#{@name}] '#{e.command}' : #{e.clierror}"
+      # cmd will syntax reject when feature is not enabled
+      raise unless e.clierror =~ /Syntax error/
+      return false
+    end
+
+    def self.feature_nv_overlay_enable
+      config_set('vni', 'feature_nv_overlay')
     end
 
     def create
-      feature_set(:enabled) unless :enabled == feature
-      return if /N9K/.match(node.product_id)
-      config_set('vni', 'create', @vni_id)
+      Vni.feature_vni_enable unless Vni.feature_vni_enabled
+      config_set('vni', 'create', vni: @vni_id) if
+        /N7K/.match(node.product_id)
     end
 
     def destroy
-      if /N9K/.match(node.product_id)
-        # Just destroy the vni-vlan mapping
-        config_set('vni', 'mapped_vlan', vlan: mapped_vlan,
-                   state: 'no', vni: @vni_id)
-      else
-        config_set('vni', 'destroy', vni: @vni_id)
+      # Platform differences: For vni's mapped under the vlan config just remove
+      # the vni config and not the vlan config; for standalone vni configs
+      # remove the entire vni config. The yaml cmdref will ignore the unneeded
+      # keys for the standalone vni config.
+
+      keys = { vni: @vni_id }
+      # TBD: Hardcoding a platform check for now. Remove during refactor.
+      if /N[39]K/.match(node.product_id)
+        vlan = mapped_vlan
+        return if vlan.nil?
+        keys[:vlan] = vlan
       end
+      config_set('vni', 'destroy', keys)
     end
 
     def cli_error_check(result)
@@ -159,7 +176,7 @@ module Cisco
     #  final_hash
     # end # end of encap_dot1q
 
-    def encap_dot1q=(val, prev_val=nil)
+    def encap_dot1q=(val, prev_val=nil) # TBD REFACTOR
       debug "val is of class #{val.class} and is #{val} prev is #{prev_val}"
       # When prev_val is nil, HashDiff doesn't do a `+' on each element, so this
       if prev_val.nil?
@@ -195,25 +212,20 @@ module Cisco
     end
 
     def bridge_domain
-      bd_arr = config_get('vni', 'bridge_domain', @vni_id)
+      bd_arr = config_get('vni', 'bridge_domain', vni: @vni_id)
       bd_arr.first.to_i
     end
 
-    def bridge_domain=(val)
-      no_cmd = (val) ? '' : 'no'
-      config_set('vni', 'bridge_domain_activate', no_cmd, val)
-      config_set('vni', 'bridge_domain', val, no_cmd, @vni_id)
+    def bridge_domain=(domain)
+      # TBD: ACTIVATE SHOULD BE SEPARATE SETTER AND POSSIBLY RENAMED
+      state = (domain) ? '' : 'no'
+      config_set('vni', 'bridge_domain_activate', state: state, domain: domain)
+      config_set('vni', 'bridge_domain', state: state, domain: domain,
+                 vni: @vni_id)
     end
 
     def default_bridge_domain
       config_get_default('vni', 'bridge_domain')
-    end
-
-    def shutdown
-      result = config_get('vni', 'shutdown', @vni_id)
-      return default_shutdown if result.nil?
-      # valid result is either: "active"(aka no shutdown) or "shutdown"
-      result.first[/shut/] ? true : false
     end
 
     def mapped_vlan
@@ -221,12 +233,13 @@ module Cisco
       return nil if vlans.nil?
       vlans.each do |vlan|
         return vlan.to_i if
-              config_get('vni', 'mapped_vlan', vlan: vlan) == @vni_id
+          config_get('vni', 'mapped_vlan', vlan: vlan) == @vni_id
       end
       nil
     end
 
     def mapped_vlan=(vlan)
+      # TBD: fail UnsupportedError unless /N9K/.match(node.product_id)
       if vlan == default_mapped_vlan
         state = 'no'
         vlan = mapped_vlan
@@ -244,9 +257,14 @@ module Cisco
       config_get_default('vni', 'mapped_vlan')
     end
 
-    def shutdown=(val)
-      no_cmd = (val) ? '' : 'no'
-      result = config_set('vni', 'shutdown', @vni_id, no_cmd)
+    def shutdown
+      config_get('vni', 'shutdown', vni: @vni_id)
+    end
+
+    def shutdown=(state)
+      # TBD: fail UnsupportedError unless /N7K/.match(node.product_id)
+      state = (state) ? '' : 'no'
+      result = config_set('vni', 'shutdown', state: state, vni: @vni_id)
       cli_error_check(result)
     rescue CliError => e
       raise "[vni #{@vni_id}] '#{e.command}' : #{e.clierror}"

--- a/tests/test_vni.rb
+++ b/tests/test_vni.rb
@@ -21,6 +21,7 @@ include Cisco
 class TestVni < CiscoTestCase
   def setup
     super
+    skip('Only supported on N3K,N7K,N9K') unless node.product_id[/N[379]K/]
     no_vni
   end
 
@@ -30,44 +31,73 @@ class TestVni < CiscoTestCase
   end
 
   def no_vni
-    config('no feature vn-segment-vlan-based')
+    config('no feature vni') if node.product_id[/N7K/]
+    config('no feature vn-segment-vlan-based') if node.product_id[/N(3|9)K/]
   end
 
-  def test_on_off
-    vni = Vni.new(1_000_0, true)
-    assert_equal(:enabled, vni.feature, 'Error: vni feature not enabled')
+  def test_mt_full_vni_create_destroy
+    skip('Only supported on N7K') unless node.product_id[/N7K/]
+    v1 = Vni.new(10_001)
+    v2 = Vni.new(10_002)
+    v3 = Vni.new(10_003)
+    assert_equal(3, Vni.vnis.keys.count)
 
-    vni.feature_set(:disabled)
-    assert_equal(:disabled, vni.feature, 'Error: vni feature still enabled')
+    v2.destroy
+    assert_equal(2, Vni.vnis.keys.count)
+
+    v1.destroy
+    v3.destroy
+    assert_equal(0, Vni.vnis.keys.count)
   end
 
-  def test_mapped_vlan
+  # def test_mt_full_encapsulation_dot1q
+  # TBD
+  # end
+
+  # def test_mt_full_mapped_bd
+  # TBD
+  # end
+
+  def test_mt_full_shutdown
+    skip('Only supported on N7K') unless node.product_id[/N7K/]
+    vni = Vni.new(10_000)
+    vni.shutdown = true
+    assert(vni.shutdown)
+
+    vni.shutdown = false
+    refute(vni.shutdown)
+
+    vni.shutdown = !vni.default_shutdown
+    assert_equal(!vni.default_shutdown, vni.shutdown)
+
+    vni.shutdown = vni.default_shutdown
+    assert_equal(vni.default_shutdown, vni.shutdown)
+  end
+
+  def test_mt_lite_mapped_vlan
+    skip('Only supported on N3K,N9K') unless node.product_id[/N[39]K/]
     # Set the vni vlan mapping
-    vni = Vni.new(1_000_0)
-    vni.mapped_vlan = 100
-    assert_equal(100, vni.mapped_vlan,
+    v = Vni.new(10_000)
+    v.mapped_vlan = 100
+    assert_equal(100, v.mapped_vlan,
                  'Error: mapped-vlan mismatch')
     # Now clear the vni vlan mapping
-    vni.mapped_vlan = vni.default_mapped_vlan
-    assert_equal(nil, vni.mapped_vlan,
-                 'Error: cannot clear vni vlan mapping')
-  end
+    v.mapped_vlan = v.default_mapped_vlan
+    assert_nil(v.mapped_vlan, 'Error: cannot clear vni vlan mapping')
+    v.destroy
 
-  def test_multiple_vnis_vlans
-    # Set vni to vlan mappings
-    vni_to_vlan_map = { 1_000_0 => 100, 2_000_0 => 200, 3_000_0 => 300 }
+    # Multiples: Set vni to vlan mappings
+    vni_to_vlan_map = { 10_000 => 100, 20_000 => 200, 30_000 => 300 }
     vni_to_vlan_map.each do |vni, vlan|
-      vni_id = Vni.new(vni)
-      vni_id.mapped_vlan = vlan
-      assert_equal(vlan, vni_id.mapped_vlan,
-                   'Error: mapped-vlan mismatch')
+      v = Vni.new(vni)
+      v.mapped_vlan = vlan
+      assert_equal(vlan, v.mapped_vlan, 'Error: mapped-vlan mismatch')
     end
     # Clear all mappings
-    vni_to_vlan_map.each do |vni, _vlan|
-      vni_id = Vni.new(vni)
-      vni_id.mapped_vlan = vni_id.default_mapped_vlan
-      assert_equal(nil, vni_id.mapped_vlan,
-                   'Error: cannot clear vni vlan mapping')
+    vni_to_vlan_map.each do |vni, _|
+      v = Vni.new(vni)
+      v.mapped_vlan = v.default_mapped_vlan
+      assert_nil(v.mapped_vlan, 'Error: cannot clear vni vlan mapping')
     end
   end
 end


### PR DESCRIPTION
This is step 1 of the refactor, there is still plenty to fix in here.

The main thrust of this was adding platform checks for the n7k vs n9k differences. I suspect this needs more tweaking.

I updated the yaml to use key-val and added platform checks there too.

Fixed the feature methods.

Added additional tests to minitest along with platform checks.
