### PR TITLE
BUGFIX: Ace.aces hash afi key was missing

### DIFF
--- a/lib/cisco_node_utils/ace.rb
+++ b/lib/cisco_node_utils/ace.rb
@@ -29,17 +29,18 @@ module Cisco
       afis = %w(ipv4 ipv6)
       hash = {}
       afis.each do |afi|
+        hash[afi] = {}
         acls = config_get('acl', 'all_acls', afi: Acl.afi_cli(afi))
         next if acls.nil?
 
         acls.each do |acl_name|
-          hash[acl_name] = {}
+          hash[afi][acl_name] = {}
           aces = config_get('acl', 'all_aces',
                             afi: Acl.afi_cli(afi), acl_name: acl_name)
           next if aces.nil?
 
           aces.each do |seqno|
-            hash[acl_name][seqno] = Ace.new(afi, acl_name, seqno)
+            hash[afi][acl_name][seqno] = Ace.new(afi, acl_name, seqno)
           end
         end
       end

--- a/tests/test_ace.rb
+++ b/tests/test_ace.rb
@@ -16,8 +16,8 @@ require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/acl'
 require_relative '../lib/cisco_node_utils/ace'
 
-# TestX__CLASS_NAME__X - Minitest for X__CLASS_NAME__X node utility class
-class TestAceV4 < CiscoTestCase
+# TestAce - Minitest for Ace node utility class
+class TestAce < CiscoTestCase
   def setup
     # setup runs at the beginning of each test
     super
@@ -108,7 +108,7 @@ class TestAceV4 < CiscoTestCase
     afi_cli = Acl.afi_cli(afi)
     all_aces = Ace.aces
     found = false
-    all_aces[acl_name].each do |seqno, _inst|
+    all_aces[afi][acl_name].each do |seqno, _inst|
       next unless seqno.to_i == @seqno.to_i
       found = true
     end


### PR DESCRIPTION
The Acl.acls code has the same logic but was already correct.

Minitest: 2 runs, 28 assertions, 0 failures, 0 errors, 0 skips
