### PR TITLE
Enable channel-group and Bundle-Ether for XR

### DIFF
--- a/lib/cisco_node_utils/client/client.rb
+++ b/lib/cisco_node_utils/client/client.rb
@@ -38,6 +38,10 @@ class Cisco::Client
   attr_reader :platform
 
   def initialize(address=nil, username=nil, password=nil)
+    if self.class == Cisco::Client
+      fail NotImplementedError, 'Cisco::Client is an abstract class. ' \
+        "Instantiate one of #{@@clients} or use Cisco::Client.create() instead"
+    end
     validate_args(address, username, password)
     @address = address
     @username = username

--- a/lib/cisco_node_utils/client/grpc/client.rb
+++ b/lib/cisco_node_utils/client/grpc/client.rb
@@ -261,7 +261,7 @@ class Cisco::Client::GRPC < Cisco::Client
         #
         match = /\n\n(.*)\n\n\Z/m.match(message)
         if match.nil?
-          rejected = '(see message)'
+          rejected = '(unknown, see error message)'
         else
           rejected = match[1].split("\n")
         end

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -20,13 +20,14 @@ all_interfaces:
   config_get_token: '/^interface (.*)/'
 
 channel_group:
-  # TODO: XR support
-  _exclude: [cli_ios_xr]
   kind: int
   default_value: false
   cli_nexus:
     config_get_token_append: '/^channel-group (\d+)$/'
     config_set_append: "<state> channel-group <val> <force>"
+  cli_ios_xr:
+    config_get_token_append: '/^bundle id (\d+).*$/'
+    config_set_append: "<state> bundle id <val>"
 
 create:
   config_set: "interface <name>"
@@ -54,11 +55,13 @@ encapsulation_dot1q:
   config_set_append: "<state> encapsulation dot1q <vlan>"
 
 feature_lacp:
-  _exclude: [cli_ios_xr]
   kind: boolean
-  config_get: "show running | i ^feature"
-  config_get_token: '/^feature lacp$/'
-  config_set: "<state> feature lacp"
+  cli_nexus:
+    config_get: "show running | i ^feature"
+    config_get_token: '/^feature lacp$/'
+    config_set: "<state> feature lacp"
+  cli_ios_xr:
+    default_only: true
 
 feature_vlan:
   _exclude: [cli_ios_xr]
@@ -158,10 +161,12 @@ negotiate_auto_ethernet:
 
 negotiate_auto_other_interfaces:
   kind: boolean
+  _exclude: [cli_ios_xr]
   default_only: false
 
 negotiate_auto_portchannel:
   kind: boolean
+  _exclude: [cli_ios_xr]
   cli_nexus:
     test_config_get_regex: [
     '/^\s+no negotiate auto/',
@@ -173,10 +178,6 @@ negotiate_auto_portchannel:
       config_get_token_append: '/^(no )?negotiate auto$/'
       config_set_append: "<state> negotiate auto"
       default_value: true
-  cli_ios_xr:
-    config_get_token_append: '/^negotiation auto$/'
-    config_set_append: "<state> negotiation auto"
-    default_value: true
 
 shutdown:
   kind: boolean

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -38,7 +38,7 @@ module Cisco
     #                                     MgmtEth
     ETHERNET = Regexp.new('(Ethernet|GigE|MgmtEth)', Regexp::IGNORECASE)
     # Regexp to match various link bundle interface variants
-    PORTCHANNEL = Regexp.new('(port-channel|bundle-Ether)', Regexp::IGNORECASE)
+    PORTCHANNEL = Regexp.new('(port-channel|Bundle-Ether)', Regexp::IGNORECASE)
 
     attr_reader :name
 
@@ -94,12 +94,13 @@ module Cisco
     def channel_group=(val)
       fail "channel_group is not supported on #{@name}" unless
         @name[/Ethernet/i]
-      # 'force' is needed by cli_nxos to handle the case where a port-channel
+      # 'force' is needed by cli_nexus to handle the case where a port-channel
       # interface is created prior to the channel-group cli; in which case
       # the properties of the port-channel interface will be different from
       # the ethernet interface. 'force' is not needed if the port-channel is
       # created as a result of the channel-group cli but since it does no
       # harm we will use it every time.
+      # cli_ios_xr simply ignores 'force'.
       if val
         state = ''
         force = 'force'

--- a/tests/.rubocop.yml
+++ b/tests/.rubocop.yml
@@ -9,7 +9,7 @@ Metrics/CyclomaticComplexity:
   Max: 15
 
 Metrics/MethodLength:
-  Max: 95
+  Max: 100
 
 Metrics/PerceivedComplexity:
   Max: 17

--- a/tests/.rubocop.yml
+++ b/tests/.rubocop.yml
@@ -9,7 +9,7 @@ Metrics/CyclomaticComplexity:
   Max: 15
 
 Metrics/MethodLength:
-  Max: 93
+  Max: 95
 
 Metrics/PerceivedComplexity:
   Max: 17

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -692,7 +692,13 @@ class TestInterface < CiscoTestCase
 
     # Create interface member of this group (required for XR)
     member = Interface.new(interfaces[0])
-    member.channel_group = 10
+    begin
+      member.channel_group = 10
+    rescue Cisco::UnsupportedError
+      # Some XR platform/version combinations don't support port-channel intfs
+      skip('bundle id config not supported on this node') if platform == :ios_xr
+      raise
+    end
 
     inf_name = "#{@port_channel}10"
     interface = Interface.new(inf_name)
@@ -1078,7 +1084,13 @@ class TestInterface < CiscoTestCase
       @switchport_shutdown_hash['shutdown_ethernet_noswitchport_shutdown'])
 
     # pre-configure
-    Interface.new(interfaces[1]).channel_group = 48
+    begin
+      Interface.new(interfaces[1]).channel_group = 48
+    rescue Cisco::UnsupportedError
+      raise unless platform == :ios_xr
+      # Some XR platform/version combos don't support port-channels
+      inttype_h.delete("#{@port_channel}48")
+    end
 
     inttype_h = config_from_hash(inttype_h)
 

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -477,6 +477,7 @@ class TestInterface < CiscoTestCase
     assert_equal(20, subif.encapsulation_dot1q)
     subif.encapsulation_dot1q = 25
     assert_equal(25, subif.encapsulation_dot1q)
+    subif.destroy
     interface_ethernet_default(interfaces_id[0])
   end
 
@@ -685,29 +686,37 @@ class TestInterface < CiscoTestCase
   end
 
   def test_negotiate_auto_portchannel
-    # TODO: get Bundle-Ether working for XR/gRPC
-    if platform == :ios_xr
-      skip 'No support yet for configuration of Bundle-Ether interfaces'
-    end
     ref = cmd_ref.lookup('interface',
                          'negotiate_auto_portchannel')
     assert(ref, 'Error, reference not found')
 
+    # Create interface member of this group (required for XR)
+    member = Interface.new(interfaces[0])
+    member.channel_group = 10
+
     inf_name = "#{@port_channel}10"
-    config("interface #{@port_channel} 10")
     interface = Interface.new(inf_name)
-    default = ref.default_value
-    @default_show_command = show_cmd(inf_name)
+    if platform == :ios_xr
+      assert_nil(interface.negotiate_auto)
+      assert_nil(interface.default_negotiate_auto)
+      assert_raises(Cisco::UnsupportedError) do
+        interface.negotiate_auto = false
+      end
+    else
+      default = ref.default_value
+      @default_show_command = show_cmd(inf_name)
 
-    # Test with switchport
-    negotiate_auto_helper(interface, default, ref)
+      # Test with switchport
+      negotiate_auto_helper(interface, default, ref)
 
-    # Test with no switchport
-    config("interface #{@port_channel} 10", 'no switchport')
-    negotiate_auto_helper(interface, default, ref)
+      # Test with no switchport
+      config("interface #{@port_channel} 10", 'no switchport')
+      negotiate_auto_helper(interface, default, ref)
+    end
 
     # Cleanup
     config("no interface #{@port_channel} 10")
+    member.channel_group = false # rubocop:disable Lint/UselessSetterCall
   end
 
   def test_negotiate_auto_ethernet
@@ -1027,26 +1036,24 @@ class TestInterface < CiscoTestCase
         vrf_new:             'test2',
         default_vrf:         DEFAULT_IF_VRF,
       }
-      # TODO: Bundle-Ether should be supported on XR,
-      # but we're not there yet with it.
-      inttype_h["#{@port_channel}48"] = {
-        address_len:         '10.7.1.1/15',
-        proxy_arp:           false,
-        redirects:           false,
-        description:         'Company B',
-        description_new:     'Dr. Bond',
-        default_description: DEFAULT_IF_DESCRIPTION,
-        shutdown:            false,
-        change_shutdown:     true,
-        default_shutdown:    false,
-        switchport:          :disabled,
-        default_switchport:  :disabled,
-        access_vlan:         DEFAULT_IF_ACCESS_VLAN,
-        default_access_vlan: DEFAULT_IF_ACCESS_VLAN,
-        vrf_new:             'test2',
-        default_vrf:         DEFAULT_IF_VRF,
-      }
     end
+    inttype_h["#{@port_channel}48"] = {
+      address_len:         '10.7.1.1/15',
+      proxy_arp:           false,
+      redirects:           false,
+      description:         'Company B',
+      description_new:     'Dr. Bond',
+      default_description: DEFAULT_IF_DESCRIPTION,
+      shutdown:            false,
+      change_shutdown:     true,
+      default_shutdown:    false,
+      switchport:          platform == :ios_xr ? nil : :disabled,
+      default_switchport:  platform == :ios_xr ? nil : :disabled,
+      access_vlan:         DEFAULT_IF_ACCESS_VLAN,
+      default_access_vlan: DEFAULT_IF_ACCESS_VLAN,
+      vrf_new:             'test2',
+      default_vrf:         DEFAULT_IF_VRF,
+    }
     inttype_h['loopback0'] = {
       address_len:         '11.7.1.1/15',
       redirects:           false, # (not supported on loopback)
@@ -1071,6 +1078,8 @@ class TestInterface < CiscoTestCase
       @switchport_shutdown_hash['shutdown_ethernet_noswitchport_shutdown'])
 
     # pre-configure
+    Interface.new(interfaces[1]).channel_group = 48
+
     inttype_h = config_from_hash(inttype_h)
 
     # Steps to cleanup the preload configuration
@@ -1095,6 +1104,7 @@ class TestInterface < CiscoTestCase
     rescue Minitest::Assertion
       # clean up before failing
       config(*cfg)
+      Interface.new(interfaces[1]).channel_group = false
       raise
     end
   end


### PR DESCRIPTION
Now that we have `channel_group` for cisco_interface, we can enable support for Bundle-Ether interfaces on XR. 

minitest:

```
Node under test:
  - name  - ios
  - type  - R-IOSXRV9000-RP
TestInterface#test_interface_ipv4_proxy_arp = 12.21 s = .
TestInterface#test_negotiate_auto_portchannel = 11.69 s = .
TestInterface#test_vrf_change_with_ip_addr = 18.78 s = .
TestInterface#test_negotiate_auto_loopback = 4.83 s = .
TestInterface#test_interface_channel_group_add_delete = 7.87 s = .
TestInterface#test_interface_ipv4_all_interfaces = 75.16 s = .
TestInterface#test_interface_vrf_default = 4.50 s = .
TestInterface#test_interface_create_name_nil = 0.94 s = .
Connection reset by peer? Try again
TestInterface#test_interface_description_too_long = 2.02 s = S
TestInterface#test_interface_create_does_not_exist = 2.21 s = .
TestInterface#test_interface_ipv4_addr_mask_set_address_invalid = 4.22 s = .
TestInterface#test_interface_create_name_invalid = 1.06 s = .
TestInterface#test_interface_ipv4_addr_mask_set_netmask_invalid = 4.53 s = .
TestInterface#test_encapsulation_dot1q = 11.46 s = .
TestInterface#test_interface_vrf_invalid_type = 2.51 s = .
TestInterface#test_negotiate_auto_ethernet = 3.19 s = .
TestInterface#test_interface_vrf_exceeds_max_length = 5.48 s = .
TestInterface#test_interface_description_valid = 7.99 s = .
TestInterface#test_interface_vrf_empty = 4.96 s = .
TestInterface#test_interfaces_not_empty = 1.15 s = .
TestInterface#test_interface_create_valid = 4.57 s = .
TestInterface#test_interface_description_zero_length = 4.37 s = .
TestInterface#test_interface_description_nil = 2.63 s = .
TestInterface#test_interface_ipv4_address = 7.93 s = .
TestInterface#test_interface_mtu_invalid = 22.78 s = .
TestInterface#test_interface_vrf_valid = 8.57 s = .
TestInterface#test_speed = 3.72 s = .
TestInterface#test_interface_mtu_change = 6.98 s = .
TestInterface#test_interface_shutdown_valid = 7.18 s = .
TestInterface#test_interface_mtu_valid = 5.03 s = .
TestInterface#test_interface_ipv4_redirects = 17.25 s = .
TestInterface#test_interface_vrf_override = 8.45 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig = 6.46 s = .
TestInterface#test_svi_prop_nil_when_ethernet = 7.03 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig_secondary = 7.42 s = .
TestInterface#test_duplex = 4.33 s = .
TestInterface#test_mtu_invalid_loopback = 3.96 s = .

Fabulous run in 315.438502s, 0.1173 runs/s, 0.7513 assertions/s.

  1) Skipped:
TestInterface#test_interface_description_too_long [tests/test_interface.rb:450]:
No description length limit on IOS XR

37 runs, 237 assertions, 0 failures, 0 errors, 1 skips
```
