### PR TITLE
Catch and skip suppress_arp TCAM error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ Changelog
 * Extend interface with `channel_group` attribute and support for fabric path attributes
 * Extend vrf with `vni` attribute
 * Extend vlan with `mode` attribute
-* Extended vxlan_vtep_vni with `associate-vrf` support
 
 ### Changed
 

--- a/tests/test_vxlan_vtep_vni.rb
+++ b/tests/test_vxlan_vtep_vni.rb
@@ -166,9 +166,15 @@ class TestVxlanVtepVni < CiscoTestCase
     # Test: Check suppress_arp is not configured.
     refute(vni.suppress_arp, 'suppress_arp should be disabled')
 
-    # Test: Enable suppress_arp
-    vni.suppress_arp = true
-    assert(vni.suppress_arp, 'suppress_arp should be enabled')
+    begin
+      # Test: Enable suppress_arp
+      vni.suppress_arp = true
+      assert(vni.suppress_arp, 'suppress_arp should be enabled')
+    rescue CliError => e
+      msg = 'TCAM reconfiguration required followed by reload' \
+        " Skipping test case.\n#{e}"
+      skip(msg) if /ERROR: Please configure TCAM/.match(e.to_s)
+    end
 
     # Test: Default
     vni.suppress_arp = vni.default_suppress_arp


### PR DESCRIPTION
```
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/vxlan/cisco-network-node-utils> ruby tests/test_vxlan_vtep_vni.rb -v -n test_suppress_arp -- 10.122.197.222 admin admin
Run options: -v -n test_suppress_arp -- --seed 45311

# Running:


Node under test:
  - name  - dt-n9k5-1
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I2.1.74.bin

TestVxlanVtepVni#test_suppress_arp = 9.97 s = S

Finished in 9.969990s, 0.1003 runs/s, 0.1003 assertions/s.

  1) Skipped:
TestVxlanVtepVni#test_suppress_arp [tests/test_vxlan_vtep_vni.rb:176]:
TCAM reconfiguration required followed by reload Skipping test case.
CliError: ' suppress-arp' rejected with message:
'ERROR: Please configure TCAM region for Ingress ARP-Ether ACL before configuring ARP supression.'

1 runs, 1 assertions, 0 failures, 0 errors, 1 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/vxlan/cisco-network-node-utils/coverage. 462 / 681 LOC (67.84%) covered.
```
