### PR TITLE
Fix Travis for ruby 2.0.0 and improve build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,23 @@
-# We'd like to use the Docker infrastructure,
-# but can't install libgrpc-dev at present in that environment. Sigh.
-# sudo: false
-sudo: true
-
+# Use Docker infrastructure
+sudo: false
 
 language: ruby
 cache: bundler
 rvm:
   - 2.2.2
   - 2.1.6
-  - 2.0.0
+  - 2.0.0-p648 # specify non-clang version of ruby
 
 before_install:
-  # sudo apt-get install libgrpc-dev doesn't work in Travis.
-  # So instead we compile and install from source,
-  # which takes about 10 minutes. Not too painful.
-  - sudo apt-get install build-essential autoconf libtool
   - git clone https://github.com/grpc/grpc.git
   - cd grpc
   - git checkout release-0_12
-  - git submodule update --init
-  - make
-  - sudo make install
-  - cd src/ruby/
   - gem build grpc.gemspec
   - gem install --local --force grpc-*.gem
-  - mkdir -p ../../../vendor/cache
-  - gem install --force --local grpc-*.gem
-  - cp grpc-*.gem ../../../vendor/cache
-  - cd ../../..
+  - mkdir -p ../vendor/cache
+  - cp grpc-*.gem ../vendor/cache
+  - cd ..
   - rm -rf grpc
-  # Also install net_http_unix to keep the nxapi submodule happy
-  - gem install net_http_unix
 
 script:
  - bundle exec rake


### PR DESCRIPTION
### Ruby 2.0.0 Fix

The default 2.0.0 ruby version selected by rvm changed from `ruby-2.0.0-p598` to `ruby-2.0.0-p647-clang` in [Travis Build #790](https://travis-ci.org/cisco/cisco-network-node-utils/builds/96803756).

It seems that there's a warning introduced while compiling with ruby-clang, which causes the build to error.

I changed the travis script to explicitly specify the ruby 2.0.0 patch number, ruby-2.0.0-p648.  Now Travis passes for every version of ruby.
### Improved Build Script

[gRPC #4538](https://github.com/grpc/grpc/pull/4538) bundled grpc's C core with the ruby source, allowing us to `gem install grpc` without needing to install the `libgrpc-dev` dependency.

This eliminates the need to build and install grpc from source, trimming travis build time from 5-6 minutes to 1-2 minutes.  We can also begin to use Travis's Docker infrastructure since we do not need sudo privilege anymore.
