### PR TITLE
Add command line options to update-hooks

### DIFF
--- a/bin/git/update-hooks
+++ b/bin/git/update-hooks
@@ -42,6 +42,7 @@ while [ "$#" -gt 0 ]; do
             ;;
         (*)
             echo "Unrecognized option: $1"
+            usage
             exit 1
             ;;
     esac

--- a/bin/git/update-hooks
+++ b/bin/git/update-hooks
@@ -20,7 +20,7 @@ usage() {
     echo "Options:"
     echo "  --dry-run       Do not make any updates"
     echo "  -v  --verbose   Verbose output, including diffs of updated files"
-    echo "  --help          Display this help text"
+    echo "  -h  --help      Display this help text"
 }
 
 # Flags that can be set from the command line, with default values
@@ -30,7 +30,7 @@ verbose=0
 # parse command line options
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        (--help)
+        (-h|--help)
             usage
             exit 0
             ;;

--- a/bin/git/update-hooks
+++ b/bin/git/update-hooks
@@ -12,6 +12,43 @@ HOOK_DIR="$(git rev-parse --show-toplevel)/.git/hooks"
 
 . "$SRC_DIR/hook_lib"
 
+usage() {
+    echo "Usage: update-hooks [OPTION]"
+    echo "Update the hooks in the local git repository to match those"
+    echo "under version control."
+    echo
+    echo "Options:"
+    echo "  --dry-run       Do not make any updates"
+    echo "  -v  --verbose   Verbose output, including diffs of updated files"
+    echo "  --help          Display this help text"
+}
+
+# Flags that can be set from the command line, with default values
+make_updates=1  # the inverse of --dry-run
+verbose=0
+
+# parse command line options
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        (--help)
+            usage
+            exit 0
+            ;;
+        (-v|--verbose)
+            verbose=1
+            ;;
+        (--dry-run)
+            make_updates=0
+            ;;
+        (*)
+            echo "Unrecognized option: $1"
+            exit 1
+            ;;
+    esac
+    shift 1
+done
+
+
 install_hook_wrapper() {
     local hook=$1
     # Does the symlink exist?
@@ -19,11 +56,15 @@ install_hook_wrapper() {
         # If a hook already exists and is a file:
         if [ -f $HOOK_DIR/$hook ]; then
             step_name "Moving existing '$hook' script to '$hook-local'"
-            mv $HOOK_DIR/$hook $HOOK_DIR/$hook-local
+            if [ $make_updates == 1 ]; then
+                mv $HOOK_DIR/$hook $HOOK_DIR/$hook-local
+            fi
         fi
         # create the symlink to our wrapper script
         step_name "Installing hook wrapper script for '$hook'"
-        ln -s -f ./hooks-wrapper $HOOK_DIR/$hook
+        if [ $make_updates == 1 ]; then
+            ln -s -f ./hooks-wrapper $HOOK_DIR/$hook
+        fi
     fi
 }
 
@@ -32,14 +73,22 @@ check_update() {
     local dest=$2
     if [ ! -e "$dest" ] ; then
         step_name "Creating new file at '$dest':"
-        git diff --color --no-index /dev/null $src
-        cp $src $dest
+        if [ $verbose == 1 ]; then
+            git diff --color --no-index /dev/null $src
+        fi
+        if [ $make_updates == 1 ]; then
+            cp $src $dest
+        fi
     else
         diff $src $dest >> /dev/null
         if [ $? -ne 0 ] ; then
             step_name "File '$dest' will be updated: "
-            git diff --color --no-index $dest $src
-            cp -f $src $dest
+            if [ $verbose == 1 ]; then
+                git diff --color --no-index $dest $src
+            fi
+            if [ $make_updates == 1 ]; then
+                cp -f $src $dest
+            fi
         fi
     fi
 }

--- a/bin/git/update-hooks
+++ b/bin/git/update-hooks
@@ -20,12 +20,14 @@ usage() {
     echo "Options:"
     echo "  --dry-run       Do not make any updates"
     echo "  -v  --verbose   Verbose output, including diffs of updated files"
+    echo "  --[no-]pager    Explicity request or suppress pagination in git diff"
     echo "  -h  --help      Display this help text"
 }
 
 # Flags that can be set from the command line, with default values
 make_updates=1  # the inverse of --dry-run
 verbose=0
+pager= # default to whatever defaults git has configured
 
 # parse command line options
 while [ "$#" -gt 0 ]; do
@@ -36,6 +38,12 @@ while [ "$#" -gt 0 ]; do
             ;;
         (-v|--verbose)
             verbose=1
+            ;;
+        (--pager)
+            pager=--paginate
+            ;;
+        (--no-pager)
+            pager=--no-pager
             ;;
         (--dry-run)
             make_updates=0
@@ -75,7 +83,7 @@ check_update() {
     if [ ! -e "$dest" ] ; then
         step_name "Creating new file at '$dest':"
         if [ $verbose == 1 ]; then
-            git diff --color --no-index /dev/null $src
+            git ${pager} diff --color --no-index /dev/null $src
         fi
         if [ $make_updates == 1 ]; then
             cp $src $dest
@@ -85,7 +93,7 @@ check_update() {
         if [ $? -ne 0 ] ; then
             step_name "File '$dest' will be updated: "
             if [ $verbose == 1 ]; then
-                git diff --color --no-index $dest $src
+                git ${pager} diff --color --no-index $dest $src
             fi
             if [ $make_updates == 1 ]; then
                 cp -f $src $dest


### PR DESCRIPTION
The previous behavior of this script displayed, via git diff, all
updates to hooks installed by the script.  This requires user
interaction to page through the diff.  This was especially cumbersome on
the initial run, when the full contents of all hooks were displayed,
requiring the user to <spacebar> through pages of text.

This commit adds simple command line option parsing and recognizes the
following options:

```
--help         displays usage text

-v, --verbose  verbose output, including diffs of updated files
               (the diffs are no longer displayed by default)

--dry-run      Do not make any updates (but print the same messages
               that are normally printed to notify the user of which
               files are to be updated)
```
