### PR TITLE
remove extra arg in self.globals

### DIFF
--- a/lib/cisco_node_utils/portchannel_global.rb
+++ b/lib/cisco_node_utils/portchannel_global.rb
@@ -31,7 +31,7 @@ module Cisco
       hash = {}
       # if the key already exists, no need create instance
       hash['default'] =
-          PortChannelGlobal.new('default', false)
+          PortChannelGlobal.new('default')
       hash
     end
 


### PR DESCRIPTION
Remove extra arg in self.globals as this is unnecessary since we do not instantiate portchannel_global
