### PR TITLE
Error if keyword substitution yields empty result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Changelog
 * Major refactor and enhancement of `CommandReference` YAML files:
   - Added support for `auto_default`, `default_only`, `kind`, and `multiple`
   - Added filtering by product ID (`/N7K/`) and by client type (`cli_nexus`)
+  - `CommandReference` methods that do key-value style wildcard substitution now raise an `ArgumentError` if the result is empty (because not enough parameters were supplied).
 * `cisco_nxapi` Gem is no longer a dependency as the NXAPI client code has been merged into this Gem under the `Cisco::Client` namespace.
 
 ### Fixed

--- a/lib/cisco_node_utils/cmd_ref/README_YAML.md
+++ b/lib/cisco_node_utils/cmd_ref/README_YAML.md
@@ -119,6 +119,15 @@ irb(main):016:0> ref.config_set(name: 'red', cost: '40', type: 'Gbps')
 => ["router ospf red", "auto-cost reference-bandwidth 40 Gbps"]
 ```
 
+Array elements that contain a parameter that is *not* included in the argument hash are not included in the result:
+
+```ruby
+irb(main):017:0> ref.config_set(name: 'red', cost: '40')
+=> ["router ospf red"]
+```
+
+If this process results in an empty array, then an `ArgumentError` is raised to indicate that not enough parameters were supplied.
+
 Key-value wildcards are moderately more complex to implement than Printf-style wildcards but they are more readable in the Ruby code and are flexible enough to handle significant platform differences in CLI. Key-value wildcards are therefore the recommended approach for new development.
 
 ## Advanced attribute definition

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -134,7 +134,7 @@ module Cisco
     def printf_substitutor(config_key, value)
       arg_c = value.join.scan(/%/).length
       lambda do |*args|
-        unless args.length == arg_count
+        unless args.length == arg_c
           fail ArgumentError,
                "Given #{args.length} args, but #{config_key} requires #{arg_c}"
         end

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -107,6 +107,9 @@ module Cisco
             end
             result.push(line) unless /<\S+>/.match(line)
           end
+          if result.empty?
+            fail ArgumentError, "Arguments given to #{key} yield empty result"
+          end
           preprocess_value(result)
         end
       elsif value.any? { |item| item.is_a?(String) && /%/ =~ item }

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -98,38 +98,51 @@ module Cisco
       return unless value.is_a?(Array)
       if value.any? { |item| item.is_a?(String) && /<\S+>/ =~ item }
         # Key-value substitution
-        define_singleton_method key.to_sym do |**args|
-          result = []
-          value.each do |line|
-            replace = line.scan(/<(\S+)>/).flatten.map(&:to_sym)
-            replace.each do |item|
-              line = line.sub("<#{item}>", args[item].to_s) if args.key?(item)
-            end
-            result.push(line) unless /<\S+>/.match(line)
-          end
-          if result.empty?
-            fail ArgumentError, "Arguments given to #{key} yield empty result"
-          end
-          preprocess_value(result)
-        end
+        define_singleton_method(key.to_sym, key_substitutor(key, value))
       elsif value.any? { |item| item.is_a?(String) && /%/ =~ item }
         # printf-style substitution
-        arg_count = value.join.scan(/%/).length
-        define_singleton_method key.to_sym do |*args|
-          unless args.length == arg_count
-            fail ArgumentError, "Given #{args.length} args, but " \
-              "#{key} requires #{arg_count}"
-          end
-          # Fill in the parameters
-          result = value.map do |line|
-            sprintf(line, *args.shift(line.scan(/%/).length))
-          end
-          preprocess_value(result)
-        end
+        define_singleton_method(key.to_sym, printf_substitutor(key, value))
       else
         # simple static token(s)
         value = preprocess_value(value)
         define_singleton_method key.to_sym, -> { value }
+      end
+    end
+
+    # curried function to define a getter method body that performs key-value
+    # substitution
+    def key_substitutor(config_key, value)
+      lambda do |**args|
+        result = []
+        value.each do |line|
+          replace = line.scan(/<(\S+)>/).flatten.map(&:to_sym)
+          replace.each do |item|
+            line = line.sub("<#{item}>", args[item].to_s) if args.key?(item)
+          end
+          result.push(line) unless /<\S+>/.match(line)
+        end
+        if result.empty?
+          fail ArgumentError,
+               "Arguments given to #{config_key} yield empty result"
+        end
+        preprocess_value(result)
+      end
+    end
+
+    # curried function to define a getter method body that performs
+    # printf-style substitution
+    def printf_substitutor(config_key, value)
+      arg_c = value.join.scan(/%/).length
+      lambda do |*args|
+        unless args.length == arg_count
+          fail ArgumentError,
+               "Given #{args.length} args, but #{config_key} requires #{arg_c}"
+        end
+        # Fill in the parameters
+        result = value.map do |line|
+          sprintf(line, *args.shift(line.scan(/%/).length))
+        end
+        preprocess_value(result)
       end
     end
 

--- a/tests/test_command_reference.rb
+++ b/tests/test_command_reference.rb
@@ -372,6 +372,10 @@ name:
     ['/^router ospf <name>$/',
      '/^vrf <vrf>$/',
      '/^router-id (\S+)$/']
+test2:
+  config_get_token:
+    ['abc <val1> def',
+     'xyz <val2>']
 ))
     reference = load_file
     ref = reference.lookup('test', 'name')
@@ -381,7 +385,15 @@ name:
     token = ref.config_get_token(name: 'blue', vrf: 'green')
     assert_equal([/^router ospf blue$/, /^vrf green$/, /^router-id (\S+)$/],
                  token)
-    # TODO: add negative tests?
+    ref = reference.lookup('test', 'test2')
+    token = ref.config_get_token(val1: '1', val2: '2')
+    assert_equal(['abc 1 def', 'xyz 2'], token)
+    token = ref.config_get_token(val1: '1', extra_val: 'asdf')
+    assert_equal(['abc 1 def'], token)
+    token = ref.config_get_token(val2: '2')
+    assert_equal(['xyz 2'], token)
+    assert_raises(ArgumentError) { token = ref.config_get_token }
+    assert_raises(ArgumentError) { token = ref.config_get_token(extra: 'x') }
   end
 
   def test_config_get_token_printf_substitution


### PR DESCRIPTION
When the command_reference config_get_token and config_set methods use
keyword-based parameter substitution, array elements that contain a
parameter not supplied by the caller will be omitted from the result
array.  This behavior is desired to support, e.g., CLI interaction
involving VRFs, where both the presence or absence of a VRF are
permissible and should result in CLI interaction either containing or
not containing a vrf statement.  However, this behavior makes it easy
for developer oversight or typo to result in an empty command line
(which is bad).

This commit updates command_reference so that if the result of
keyword-based parameter substitution is an empty array then an
ArgumentError will be raised.  It also adds new assertions to test this
behavior to the existing test_config_get_token_hash_substitution test
case, and updates the documentation and changelog.
