### PR TITLE
event_history to cisco_bgp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Changelog
   * `flush_routes`
   * `isolate`
   * `neighbor_down_fib_accelerate`
+  * `event_history_cli`, `event_history_detail`, `event_history_events`, `event_history_periodic`
 * Extend bgp_af with attributes:
   * `default_metric`
   * `distance_ebgp`, `distance_ibgp`, `distance_local`

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -328,6 +328,143 @@ module Cisco
       config_get_default('bgp', 'enforce_first_as')
     end
 
+    # event-history
+    # event-history cli [ size <size> ]
+    # Nvgen as True With optional 'size <size>
+    def event_history_cli_get
+      val = config_get('bgp', 'event_history_cli', @get_args)
+      return nil unless val
+      (val[/size/]) ? val.split.last : true
+    end
+
+    def event_history_cli
+      event_history_cli_get.nil? ? false : true
+    end
+
+    def event_history_cli_size
+      val = event_history_cli_get
+      return nil if val.nil?
+      val.is_a?(String) ? val : default_event_history_cli_size
+    end
+
+    def event_history_cli_set(state, size=nil)
+      size = "size #{size}" unless size.nil?
+      @set_args[:state] = (state ? '' : 'no')
+      @set_args[:size] = size
+      config_set('bgp', 'event_history_cli', @set_args)
+      set_args_keys_default
+    end
+
+    def default_event_history_cli
+      config_get_default('bgp', 'event_history_cli')
+    end
+
+    def default_event_history_cli_size
+      config_get_default('bgp', 'event_history_cli_size')
+    end
+
+    # event-history detail [ size <size> ]
+    # Nvgen as True With optional 'size <size>
+    def event_history_detail_get
+      val = config_get('bgp', 'event_history_detail', @get_args)
+      return nil unless val
+      (val[/size/]) ? val.split.last : true
+    end
+
+    def event_history_detail
+      event_history_detail_get.nil? ? false : true
+    end
+
+    def event_history_detail_size
+      val = event_history_detail_get
+      return nil if val.nil?
+      val.is_a?(String) ? val : default_event_history_detail_size
+    end
+
+    def event_history_detail_set(state, size=nil)
+      size = "size #{size}" unless size.nil?
+      @set_args[:state] = (state ? '' : 'no')
+      @set_args[:size] = size
+      config_set('bgp', 'event_history_detail', @set_args)
+      set_args_keys_default
+    end
+
+    def default_event_history_detail
+      config_get_default('bgp', 'event_history_detail')
+    end
+
+    def default_event_history_detail_size
+      config_get_default('bgp', 'event_history_detail_size')
+    end
+
+    # event-history event [ size <size> ]
+    # Nvgen as True With optional 'size <size>
+    def event_history_events_get
+      val = config_get('bgp', 'event_history_events', @get_args)
+      return nil unless val
+      (val[/size/]) ? val.split.last : true
+    end
+
+    def event_history_events
+      event_history_events_get.nil? ? false : true
+    end
+
+    def event_history_events_size
+      val = event_history_events_get
+      return nil if val.nil?
+      val.is_a?(String) ? val : default_event_history_events_size
+    end
+
+    def event_history_events_set(state, size=nil)
+      size = "size #{size}" unless size.nil?
+      @set_args[:state] = (state ? '' : 'no')
+      @set_args[:size] = size
+      config_set('bgp', 'event_history_events', @set_args)
+      set_args_keys_default
+    end
+
+    def default_event_history_events
+      config_get_default('bgp', 'event_history_events')
+    end
+
+    def default_event_history_events_size
+      config_get_default('bgp', 'event_history_events_size')
+    end
+
+    # event-history periodic [ size <size> ]
+    # Nvgen as True With optional 'size <size>
+    def event_history_periodic_get
+      val = config_get('bgp', 'event_history_periodic', @get_args)
+      return nil unless val
+      (val[/size/]) ? val.split.last : true
+    end
+
+    def event_history_periodic
+      event_history_periodic_get.nil? ? false : true
+    end
+
+    def event_history_periodic_size
+      val = event_history_periodic_get
+      return nil if val.nil?
+      val.is_a?(String) ? val : default_event_history_periodic_size
+    end
+
+    def event_history_periodic_set(state, size=nil)
+      size = "size #{size}" unless size.nil?
+      @set_args[:state] = (state ? '' : 'no')
+      @set_args[:size] = size
+      config_set('bgp', 'event_history_periodic', @set_args)
+      set_args_keys_default
+    end
+
+    def default_event_history_periodic
+      config_get_default('bgp', 'event_history_periodic')
+    end
+
+    def default_event_history_periodic_size
+      config_get_default('bgp', 'event_history_periodic_size')
+    end
+
     # Fast External fallover (Getter/Setter/Default)
     def fast_external_fallover
       config_get('bgp', 'fast_external_fallover', @get_args)

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -78,6 +78,42 @@ enforce_first_as:
   config_set_append: '<state> enforce-first-as'
   default_value: true
 
+event_history_cli:
+  config_get_token_append: '/^event-history cli(?: size .*)?/'
+  config_set_append: '<state> event-history cli <size>'
+  auto_default: false
+  default_value: true
+
+event_history_cli_size:
+  default_value: 'small'
+
+event_history_detail:
+  config_get_token_append: '/^event-history detail(?: size .*)?/'
+  config_set_append: '<state> event-history detail <size>'
+  auto_default: false
+  default_value: false
+
+event_history_detail_size:
+  default_value: ~
+
+event_history_events:
+  config_get_token_append: '/^event-history events(?: size .*)?/'
+  config_set_append: '<state> event-history events <size>'
+  auto_default: false
+  default_value: true
+
+event_history_events_size:
+  default_value: 'small'
+
+event_history_periodic:
+  config_get_token_append: '/^event-history periodic(?: size .*)?/'
+  config_set_append: '<state> event-history periodic <size>'
+  auto_default: false
+  default_value: true
+
+event_history_periodic_size:
+  default_value: 'small'
+
 fast_external_fallover:
   kind: boolean
   config_get_token_append: '/^(no )?fast-external-fallover$/'

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -335,6 +335,49 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
+  def test_event_history
+    bgp = RouterBgp.new(55)
+
+    opts = [:cli, :detail, :events, :periodic]
+    opts.each do |opt|
+      # Test basic true
+      bgp.send("event_history_#{opt}_set", true)
+      result = bgp.send("event_history_#{opt}")
+      assert(result, 'Failed to set state to True')
+
+      # Test true with size
+      bgp.send("event_history_#{opt}_set", true, 'large')
+      result = bgp.send("event_history_#{opt}_size")
+      assert_equal('large', result,
+                   'Failed to set True with Size')
+
+      # Test false with size
+      bgp.send("event_history_#{opt}_set", false)
+      result = bgp.send("event_history_#{opt}")
+      refute(result, 'Failed to set state to False')
+
+      # Test true with size, from false
+      bgp.send("event_history_#{opt}_set", true, 'large')
+      result = bgp.send("event_history_#{opt}_size")
+      assert_equal('large', result,
+                   'Failed to set True with Size from false state')
+
+      # Test default size, from true
+      set = bgp.send("default_event_history_#{opt}_size")
+      bgp.send("event_history_#{opt}_set", true, set)
+      result = bgp.send("event_history_#{opt}_size")
+      assert_equal(set, result,
+                   'Failed to set default size from existing')
+
+      # Test default_state
+      set = bgp.send("default_event_history_#{opt}")
+      bgp.send("event_history_#{opt}_set", set)
+      result = bgp.send("event_history_#{opt}")
+      assert_equal(set, result,
+                   'Failed to set state to default')
+    end
+  end
+
   def test_routerbgp_set_get_fast_external_fallover
     asnum = 55
     bgp = RouterBgp.new(asnum)


### PR DESCRIPTION
1. pass minitest
   TestRouterBgp#test_event_history = 13.84 s = .
   Finished in 13.845590s, 0.0722 runs/s, 1.7334 assertions/s.
   1 runs, 24 assertions, 0 failures, 0 errors, 0 skips
2. pass static analysis
