### PR TITLE
Update client for grpc API breakage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,5 @@ rvm:
   - 2.1.6
   - 2.0.0-p648 # specify non-clang version of ruby
 
-before_install:
-  - git clone https://github.com/grpc/grpc.git
-  - cd grpc
-  - git checkout release-0_12
-  - gem build grpc.gemspec
-  - gem install --local --force grpc-*.gem
-  - mkdir -p ../vendor/cache
-  - cp grpc-*.gem ../vendor/cache
-  - cd ..
-  - rm -rf grpc
-
 script:
  - bundle exec rake

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -37,7 +37,7 @@ begin
   os == 'ios_xr' || deps << Gem::Dependency.new('net_http_unix',
                                                 '~> 0.2', '>= 0.2.1')
   # NX-OS doesn't need gRPC
-  os == 'nexus' || deps << Gem::Dependency.new('grpc', '~> 0.11')
+  os == 'nexus' || deps << Gem::Dependency.new('grpc', '~> 0.12')
 
   deps.each do |dep|
     installed = dep.matching_specs


### PR DESCRIPTION
An API change to grpc's authentication process broke our client. ([grpc #4412](https://github.com/grpc/grpc/pull/4412))

Channel must now be explicitly specified as insecure.

update_metadata keyword was removed from stub creation. Authentication
is now included as metadata in requests to the server.
