### PR TITLE
apply to acl commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changelog
 * Extend interface with `channel_group` attribute and support for fabric path attributes
 * Extend vrf with `vni` attribute
 * Extend vlan with `mode` attribute
+* Extend interface with access lists attributes (@bansalpradeep)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,10 @@ Changelog
 * `Cisco::UnsupportedError` exception class, raised when a command is explicitly marked as unsupported on a particular class of nodes.
 * Extend bgp with attributes: `fast_external_fallover`,`flush_routes`,`isolate`,`neighbor_down_fib_accelerate`
 * Extend bgp_af with attributes: `suppress_inactive`, `default_metric`, `table_map`, `inject_map`, `distance_ebgp`,`distance_ibgp`,`distance_local`
+* Extend interface with attributes: `channel_group`, `ipv4_acl_in`, `ipv4_acl_out`, `ipv6_acl_in`, `ipv6_acl_out`. Also add support for fabric path attributes
 * Extend interface with `channel_group` attribute and support for fabric path attributes
 * Extend vrf with `vni` attribute
 * Extend vlan with `mode` attribute
-* Extend interface with access lists attributes (@bansalpradeep)
 
 ### Changed
 

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -12,6 +12,13 @@ access_vlan:
   kind: int
   default_value: 1
 
+acl_ipv4:
+  config_get_token_append: '/^ip access-group (.*)/'
+  config_set_append: "ip access-group %s %s"
+acl_ipv6:
+  config_get_token_append: '/^ipv6 traffic-filter (.*)/'
+  config_set_append: "ipv6 traffic-filter %s %s"
+
 admin_state_ethernet_noswitchport_shutdown:
   # TODO: is this actually used?
   cli_nexus:

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -12,13 +12,6 @@ access_vlan:
   kind: int
   default_value: 1
 
-acl_ipv4:
-  config_get_token_append: '/^ip access-group (.*)/'
-  config_set_append: "ip access-group %s %s"
-acl_ipv6:
-  config_get_token_append: '/^ipv6 traffic-filter (.*)/'
-  config_set_append: "ipv6 traffic-filter %s %s"
-
 admin_state_ethernet_noswitchport_shutdown:
   # TODO: is this actually used?
   cli_nexus:
@@ -72,6 +65,14 @@ feature_vlan:
     config_get_token: '/^feature interface-vlan$/'
     config_set: "%s feature interface-vlan"
 
+ipv4_acl_in:
+  config_get_token_append: '/^ip access-group (\S+) in/'
+  config_set_append: "%s ip access-group %s in"
+
+ipv4_acl_out:
+  config_get_token_append: '/^ip access-group (\S+) out/'
+  config_set_append: "%s ip access-group %s out"
+
 ipv4_addr_mask:
   # This handles both primary and secondary addresses
   multiple:
@@ -110,6 +111,14 @@ ipv4_redirects_other_interfaces:
     '/^\s+ip redirects/',
     '/^\s+no ip redirects/'
     ]
+
+ipv6_acl_in:
+  config_get_token_append: '/^ipv6 traffic-filter (\S+) in/'
+  config_set_append: "%s ipv6 traffic-filter %s in"
+
+ipv6_acl_out:
+  config_get_token_append: '/^ipv6 traffic-filter (\S+) out/'
+  config_set_append: "%s ipv6 traffic-filter %s out"
 
 mtu:
   kind: int

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -68,10 +68,12 @@ feature_vlan:
 ipv4_acl_in:
   config_get_token_append: '/^ip access-group (\S+) in/'
   config_set_append: "%s ip access-group %s in"
+  default_value: ~
 
 ipv4_acl_out:
   config_get_token_append: '/^ip access-group (\S+) out/'
   config_set_append: "%s ip access-group %s out"
+  default_value: ~
 
 ipv4_addr_mask:
   # This handles both primary and secondary addresses
@@ -115,11 +117,12 @@ ipv4_redirects_other_interfaces:
 ipv6_acl_in:
   config_get_token_append: '/^ipv6 traffic-filter (\S+) in/'
   config_set_append: "%s ipv6 traffic-filter %s in"
+  default_value: ~
 
 ipv6_acl_out:
   config_get_token_append: '/^ipv6 traffic-filter (\S+) out/'
   config_set_append: "%s ipv6 traffic-filter %s out"
-
+  default_value: ~
 mtu:
   kind: int
   config_get_token_append: '/^mtu (.*)$/'

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -74,6 +74,20 @@ module Cisco
       raise "[#{@name}] '#{e.command}' : #{e.clierror}"
     end
 
+    def acl
+      config_get('interface', 'acl', @name)
+    end
+
+    def acl_apply(attrs)
+      if attrs[:afi] == 'ip'
+        config_set('interface', 'acl_ipv4',
+                   @name, attrs[:acl_name], attrs[:dir])
+      else
+        config_set('interface', 'acl_ipv6',
+                   @name, attrs[:acl_name], attrs[:dir])
+      end
+    end
+
     def default_access_vlan
       config_get_default('interface', 'access_vlan')
     end
@@ -202,7 +216,8 @@ module Cisco
         config_set('fex', 'feature', '')
       when :disabled
         config_set('fex', 'feature', 'no') if curr == :enabled
-        return
+        return/
+
       when :installed
         config_set('fex', 'feature_install', '') if curr == :uninstalled
       when :uninstalled

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -88,6 +88,10 @@ module Cisco
       config_set('interface', 'ipv4_acl_in', @name, state, val)
     end
 
+    def default_ipv4_acl_in
+      config_get_default('interface', 'ipv4_acl_in')
+    end
+
     def ipv4_acl_out
       config_get('interface', 'ipv4_acl_out', @name)
     end
@@ -100,6 +104,10 @@ module Cisco
         val = ipv4_acl_out
       end
       config_set('interface', 'ipv4_acl_out', @name, state, val)
+    end
+
+    def default_ipv4_acl_out
+      config_get_default('interface', 'ipv4_acl_out')
     end
 
     def ipv6_acl_in
@@ -116,6 +124,10 @@ module Cisco
       config_set('interface', 'ipv6_acl_in', @name, state, val)
     end
 
+    def default_ipv6_acl_in
+      config_get_default('interface', 'ipv6_acl_in')
+    end
+
     def ipv6_acl_out
       config_get('interface', 'ipv6_acl_out', @name)
     end
@@ -128,6 +140,10 @@ module Cisco
         val = ipv6_acl_out
       end
       config_set('interface', 'ipv6_acl_out', @name, state, val)
+    end
+
+    def default_ipv6_acl_out
+      config_get_default('interface', 'ipv6_acl_out')
     end
 
     def default_access_vlan

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -74,18 +74,60 @@ module Cisco
       raise "[#{@name}] '#{e.command}' : #{e.clierror}"
     end
 
-    def acl
-      config_get('interface', 'acl', @name)
+    def ipv4_acl_in
+      config_get('interface', 'ipv4_acl_in', @name)
     end
 
-    def acl_apply(attrs)
-      if attrs[:afi] == 'ip'
-        config_set('interface', 'acl_ipv4',
-                   @name, attrs[:acl_name], attrs[:dir])
+    def ipv4_acl_in=(val)
+      if val
+        state = ''
       else
-        config_set('interface', 'acl_ipv6',
-                   @name, attrs[:acl_name], attrs[:dir])
+        state = 'no'
+        val = ipv4_acl_in
       end
+      config_set('interface', 'ipv4_acl_in', @name, state, val)
+    end
+
+    def ipv4_acl_out
+      config_get('interface', 'ipv4_acl_out', @name)
+    end
+
+    def ipv4_acl_out=(val)
+      if val
+        state = ''
+      else
+        state = 'no'
+        val = ipv4_acl_out
+      end
+      config_set('interface', 'ipv4_acl_out', @name, state, val)
+    end
+
+    def ipv6_acl_in
+      config_get('interface', 'ipv6_acl_in', @name)
+    end
+
+    def ipv6_acl_in=(val)
+      if val
+        state = ''
+      else
+        state = 'no'
+        val = ipv6_acl_in
+      end
+      config_set('interface', 'ipv6_acl_in', @name, state, val)
+    end
+
+    def ipv6_acl_out
+      config_get('interface', 'ipv6_acl_out', @name)
+    end
+
+    def ipv6_acl_out=(val)
+      if val
+        state = ''
+      else
+        state = 'no'
+        val = ipv6_acl_out
+      end
+      config_set('interface', 'ipv6_acl_out', @name, state, val)
     end
 
     def default_access_vlan
@@ -216,8 +258,7 @@ module Cisco
         config_set('fex', 'feature', '')
       when :disabled
         config_set('fex', 'feature', 'no') if curr == :enabled
-        return/
-
+        return
       when :installed
         config_set('fex', 'feature_install', '') if curr == :uninstalled
       when :uninstalled

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -779,7 +779,7 @@ class TestInterface < CiscoTestCase
     interface_ethernet_default(interfaces_id[0])
   end
 
-  def test_acl
+  def test_ipv4_acl
     # Sample cli:
     #
     #   interface Ethernet1/1

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -361,7 +361,6 @@ class TestInterface < CiscoTestCase
     end
   end
 
-  # def validate_acl(inttype_h)
   def test_interface_create_name_nil
     assert_raises(TypeError) do
       Interface.new(nil)
@@ -779,27 +778,46 @@ class TestInterface < CiscoTestCase
     interface_ethernet_default(interfaces_id[0])
   end
 
-  def test_create_acl
-    attr_acl_ipv4 = {
-      afi:      'ip',
-      acl_name: 'foo4',
-      dir:      'in',
-    }
-    attr_acl_ipv6 = {
-      afi:      'ipv6',
-      acl_name: 'foo6',
-      dir:      'in',
-    }
+  def test_ipv4_acl
+    # Sample cli:
+    #
+    #   interface Ethernet1/1
+    #     ip access-group v4acl1 in
+    #     ip access-group v4acl2 out
+    #
+    interface_ethernet_default(interfaces[0])
+    intf = Interface.new(interfaces[0])
 
-    interface = create_interface
-    interface.acl_apply(attr_acl_ipv4)
-    pattern = (/^\s+ip access-group (.*)/)
-    assert_show_match(pattern: pattern,
-                      msg:     'Error: ipv4 acl not applied on the interface')
-    interface.acl_apply(attr_acl_ipv6)
-    pattern = (/^\s+ipv6 traffic-filter (.*)/)
-    assert_show_match(pattern: pattern,
-                      msg:     'Error: ipv6 acl not applied on the interface')
+    intf.ipv4_acl_in = 'v4acl1'
+    assert_equal('v4acl1', intf.ipv4_acl_in)
+    intf.ipv4_acl_out = 'v4acl2'
+    assert_equal('v4acl2', intf.ipv4_acl_out)
+
+    intf.ipv4_acl_in = 'v4acl3'
+    assert_equal('v4acl3', intf.ipv4_acl_in)
+    intf.ipv4_acl_out = 'v4acl4'
+    assert_equal('v4acl4', intf.ipv4_acl_out)
+  end
+
+  def test_ipv6_acl
+    # Sample cli:
+    #
+    #   interface Ethernet1/1
+    #     ipv6 traffic-filter v6acl1 in
+    #     ipv6 traffic-filter v6acl2 out
+    #
+    interface_ethernet_default(interfaces[0])
+    intf = Interface.new(interfaces[0])
+
+    intf.ipv6_acl_in = 'v6acl1'
+    assert_equal('v6acl1', intf.ipv6_acl_in)
+    intf.ipv6_acl_out = 'v6acl2'
+    assert_equal('v6acl2', intf.ipv6_acl_out)
+
+    intf.ipv6_acl_in = 'v6acl3'
+    assert_equal('v6acl3', intf.ipv6_acl_in)
+    intf.ipv6_acl_out = 'v6acl4'
+    assert_equal('v6acl4', intf.ipv6_acl_out)
   end
 
   def test_interface_ipv4_address
@@ -1054,7 +1072,6 @@ class TestInterface < CiscoTestCase
     # pre-configure
     inttype_h = config_from_hash(inttype_h)
 
-    print inttype_h
     # Steps to cleanup the preload configuration
     cfg = []
     inttype_h.each_key do |k|
@@ -1073,7 +1090,6 @@ class TestInterface < CiscoTestCase
       validate_ipv4_redirects(inttype_h)
       validate_interface_shutdown(inttype_h)
       validate_vrf(inttype_h)
-      # validate_acl(inttype_h)
       config(*cfg)
     rescue Minitest::Assertion
       # clean up before failing

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -361,6 +361,7 @@ class TestInterface < CiscoTestCase
     end
   end
 
+  # def validate_acl(inttype_h)
   def test_interface_create_name_nil
     assert_raises(TypeError) do
       Interface.new(nil)
@@ -778,6 +779,29 @@ class TestInterface < CiscoTestCase
     interface_ethernet_default(interfaces_id[0])
   end
 
+  def test_create_acl
+    attr_acl_ipv4 = {
+      afi:      'ip',
+      acl_name: 'foo4',
+      dir:      'in',
+    }
+    attr_acl_ipv6 = {
+      afi:      'ipv6',
+      acl_name: 'foo6',
+      dir:      'in',
+    }
+
+    interface = create_interface
+    interface.acl_apply(attr_acl_ipv4)
+    pattern = (/^\s+ip access-group (.*)/)
+    assert_show_match(pattern: pattern,
+                      msg:     'Error: ipv4 acl not applied on the interface')
+    interface.acl_apply(attr_acl_ipv6)
+    pattern = (/^\s+ipv6 traffic-filter (.*)/)
+    assert_show_match(pattern: pattern,
+                      msg:     'Error: ipv6 acl not applied on the interface')
+  end
+
   def test_interface_ipv4_address
     interface = create_interface
     interface.switchport_mode = :disabled
@@ -1030,6 +1054,7 @@ class TestInterface < CiscoTestCase
     # pre-configure
     inttype_h = config_from_hash(inttype_h)
 
+    print inttype_h
     # Steps to cleanup the preload configuration
     cfg = []
     inttype_h.each_key do |k|
@@ -1048,6 +1073,7 @@ class TestInterface < CiscoTestCase
       validate_ipv4_redirects(inttype_h)
       validate_interface_shutdown(inttype_h)
       validate_vrf(inttype_h)
+      # validate_acl(inttype_h)
       config(*cfg)
     rescue Minitest::Assertion
       # clean up before failing

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/acl'
 require_relative '../lib/cisco_node_utils/interface'
 
 include Cisco
@@ -778,13 +779,18 @@ class TestInterface < CiscoTestCase
     interface_ethernet_default(interfaces_id[0])
   end
 
-  def test_ipv4_acl
+  def test_acl
     # Sample cli:
     #
     #   interface Ethernet1/1
     #     ip access-group v4acl1 in
     #     ip access-group v4acl2 out
     #
+
+    # create acls first
+    %w(v4acl1 v4acl2 v4acl3 v4acl4).each do |acl_name|
+      Acl.new('ipv4', acl_name)
+    end
     interface_ethernet_default(interfaces[0])
     intf = Interface.new(interfaces[0])
 
@@ -797,6 +803,16 @@ class TestInterface < CiscoTestCase
     assert_equal('v4acl3', intf.ipv4_acl_in)
     intf.ipv4_acl_out = 'v4acl4'
     assert_equal('v4acl4', intf.ipv4_acl_out)
+
+    intf.ipv4_acl_in = intf.default_ipv4_acl_in
+    assert_equal(nil, intf.ipv4_acl_in)
+    intf.ipv4_acl_out = intf.default_ipv4_acl_out
+    assert_equal(nil, intf.ipv4_acl_out)
+
+    # delete acls
+    %w(v4acl1 v4acl2 v4acl3 v4acl4).each do |acl_name|
+      config('no ip access-list ' + acl_name)
+    end
   end
 
   def test_ipv6_acl
@@ -809,6 +825,11 @@ class TestInterface < CiscoTestCase
     interface_ethernet_default(interfaces[0])
     intf = Interface.new(interfaces[0])
 
+    # create acls first
+    %w(v6acl1 v6acl2 v6acl3 v6acl4).each do |acl_name|
+      Acl.new('ipv6', acl_name)
+    end
+
     intf.ipv6_acl_in = 'v6acl1'
     assert_equal('v6acl1', intf.ipv6_acl_in)
     intf.ipv6_acl_out = 'v6acl2'
@@ -818,6 +839,16 @@ class TestInterface < CiscoTestCase
     assert_equal('v6acl3', intf.ipv6_acl_in)
     intf.ipv6_acl_out = 'v6acl4'
     assert_equal('v6acl4', intf.ipv6_acl_out)
+
+    intf.ipv6_acl_in = intf.default_ipv6_acl_in
+    assert_equal(nil, intf.ipv6_acl_in)
+    intf.ipv6_acl_out = intf.default_ipv6_acl_out
+    assert_equal(nil, intf.ipv6_acl_out)
+
+    # delete acls
+    %w(v6acl1 v6acl2 v6acl3 v6acl4).each do |acl_name|
+      config('no ipv6 access-list ' + acl_name)
+    end
   end
 
   def test_interface_ipv4_address


### PR DESCRIPTION
Minitest result

TestInterface#test_interface_ipv4_address = 5.22 s = .
TestInterface#test_interface_speed_change = 4.99 s = .
TestInterface#test_interface_description_nil = 0.81 s = .
TestInterface#test_interface_create_valid = 0.82 s = .
TestInterface#test_interface_encapsulation_dot1q_change = 5.07 s = .
TestInterface#test_interface_speed_invalid = 1.16 s = .
TestInterface#test_negotiate_auto_ethernet = 3.57 s = S
TestInterface#test_interface_duplex_invalid = 4.18 s = .
TestInterface#test_negotiate_auto_portchannel = 6.90 s = .

Finished in 410.424292s, 0.1096 runs/s, 0.7967 assertions/s.

  1) Skipped:
TestInterface#test_negotiate_auto_ethernet [tests/test_interface.rb:717]:
Skip test: Interface type does not allow config change

45 runs, 327 assertions, 0 failures, 0 errors, 1 skips
Coverage report generated for MiniTest to /home/puppet-agent/pradeepb/prad_latest/cisco-network-node-utils/coverage. 628 / 811 LOC (77.44%) covered.
