### PR TITLE
Remove 'skip' logic in minitest and fix tests

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/inventory.yaml
+++ b/lib/cisco_node_utils/cmd_ref/inventory.yaml
@@ -1,13 +1,10 @@
 # inventory
 ---
 _template:
+  config_get: 'show inventory'
   cli_ios_xr:
-    # TODO: this doesn't work quite right,
-    # as it seems that 'head' ignores 'begin'... :-(
-    config_get: 'show inventory | begin "Rack 0" | utility head count 2'
     test_config_get: 'show inventory'
   cli_nexus:
-    config_get: 'show inventory'
     test_config_get: 'show inventory | no-more'
 
 all:
@@ -39,18 +36,18 @@ inventory:
 
 productid:
   cli_ios_xr:
-    config_get_token: '/PID: ([^ ,]+)/'
+    config_get_token: '/"Rack 0".*\n.*PID: ([^ ,]+)/'
   cli_nexus:
     config_get_token: ["TABLE_inv", "ROW_inv", 0, "productid"]
 
 serialnum:
   cli_ios_xr:
-    config_get_token: '/SN: ([^ ,]+)/'
+    config_get_token: '/"Rack 0".*\n.*SN: ([^ ,]+)/'
   cli_nexus:
     config_get_token: ["TABLE_inv", "ROW_inv", 0, "serialnum"]
 
 versionid:
   cli_ios_xr:
-    config_get_token: '/VID: ([^ ,]+)/'
+    config_get_token: '/"Rack 0".*\n.*VID: ([^ ,]+)/'
   cli_nexus:
     config_get_token: ["TABLE_inv", "ROW_inv", 0, "vendorid"]

--- a/lib/cisco_node_utils/cmd_ref/show_system.yaml
+++ b/lib/cisco_node_utils/cmd_ref/show_system.yaml
@@ -1,5 +1,8 @@
 # show_system
 ---
 uptime:
-  config_get: 'show system uptime'
-  config_get_token: '/.*System uptime:\s+(\d+) days, (\d+) hours, (\d+) minutes, (\d+) seconds/'
+  cli_nexus:
+    config_get: 'show system uptime'
+  cli_ios_xr:
+    config_get: 'show version'
+  config_get_token: '/.*System uptime.*(?:(\d+) days, )?(?:(\d+) hours, )?(?:(\d+) minutes, )?(?:(\d+) seconds)?/'

--- a/lib/cisco_node_utils/cmd_ref/show_version.yaml
+++ b/lib/cisco_node_utils/cmd_ref/show_version.yaml
@@ -11,6 +11,7 @@ board:
   config_get_token: 'proc_board_id'
 
 boot_image:
+  _exclude: [cli_ios_xr]
   config_get_token: "kick_file_name"
   test_config_get_regex: '/.*NXOS image file is: (.*)$.*/'
 
@@ -42,7 +43,10 @@ full:
   config_get: "sh version"
 
 header:
-  config_get_token: "header_str"
+  cli_nexus:
+    config_get_token: "header_str"
+  cli_ios_xr:
+    config_get_token: '/Cisco.*Software/'
 
 host_name:
   cli_nexus:
@@ -54,23 +58,25 @@ host_name:
     default_value: 'ios'
 
 last_reset_reason:
+  _exclude: [cli_ios_xr]
   config_get_token: "rr_reason"
   test_config_get_regex: '/.*\nLast reset.*\n\n?  Reason: (.*)\n/'
 
 last_reset_time:
+  _exclude: [cli_ios_xr]
   kind: string
   default_value: ''
   config_get_token: "rr_ctime"
   test_config_get_regex: '/.*\nLast reset at \d+ usecs after  (.*)\n/'
 
 system_image:
-  cli_nexus:
-    /N7K/:
-      config_get_token: "isan_file_name"
-      test_config_get_regex: '/.*system image file is:    (.*)$.*/'
-    else:
-      config_get_token: "kick_file_name"
-      test_config_get_regex: '/.*NXOS image file is: (.*)$.*/'
+  _exclude: [cli_ios_xr]
+  /N7K/:
+    config_get_token: "isan_file_name"
+    test_config_get_regex: '/.*system image file is:    (.*)$.*/'
+  else:
+    config_get_token: "kick_file_name"
+    test_config_get_regex: '/.*NXOS image file is: (.*)$.*/'
 
 uptime:
   config_get_token: '/uptime is (.*)/'

--- a/lib/cisco_node_utils/cmd_ref/system.yaml
+++ b/lib/cisco_node_utils/cmd_ref/system.yaml
@@ -1,6 +1,12 @@
 # system
 ---
 resources:
-  config_get: "show system resources"
-  test_config_get: "show system resources | no-more"
-  test_config_get_regex: '/.*CPU states  :   (\d+\.\d+)% user,   (\d+\.\d+)% kernel/'
+  cli_nexus:
+    config_get: "show system resources"
+    test_config_get: "show system resources | no-more"
+    test_config_get_regex: '/.*CPU states  :   (\d+\.\d+)% user,   (\d+\.\d+)% kernel/'
+  cli_ios_xr:
+    # grpc doesn't allow this command
+    # config_get: 'monitor threads iteration 1'
+    test_config_get: "monitor threads iteration 1"
+    test_config_get_regex: '/Cpu(s): *([0-9.]+)%us, *([0-9.]+)%sy/'

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -419,8 +419,7 @@ module Cisco
     else
       # find matches and return as array of String if it only does one
       # match in the regex. Otherwise return array of array
-      match = body.split("\n").map { |s| s.scan(regex_query) }
-      match = match.flatten(1)
+      match = body.scan(regex_query)
       return nil if match.empty?
       match = match.flatten if match[0].is_a?(Array) && match[0].length == 1
       return match

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -123,17 +123,6 @@ class TestCase < Minitest::Test
     GC.start
   end
 
-  # Extend standard Minitest error handling to report UnsupportedError as skip
-  def capture_exceptions
-    super do
-      begin
-        yield
-      rescue Cisco::UnsupportedError => e
-        skip(e.to_s)
-      end
-    end
-  end
-
   def config(*args)
     # Send the entire config as one string but be sure not to return until
     # we are safely back out of config mode, i.e. prompt is

--- a/tests/test_command_reference.rb
+++ b/tests/test_command_reference.rb
@@ -34,17 +34,6 @@ class TestCmdRef < Minitest::Test
     @input_file.close!
   end
 
-  # Extend standard Minitest error handling to report UnsupportedError as skip
-  def capture_exceptions
-    super do
-      begin
-        yield
-      rescue Cisco::UnsupportedError => e
-        skip(e.to_s)
-      end
-    end
-  end
-
   def load_file(**args)
     CommandReference.new(**args, :files => [@input_file.path])
   end

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1203,5 +1203,8 @@ class TestInterface < CiscoTestCase
     assert_equal(pc.to_i, interface.channel_group)
     interface.channel_group = interface.default_channel_group
     assert_equal(interface.default_channel_group, interface.channel_group)
+  rescue Cisco::UnsupportedError => e
+    # Some platforms only support channel-group with certain software versions
+    skip(e.to_s)
   end
 end


### PR DESCRIPTION
Remove the logic in our minitest infra that was added early in gRPC development to convert an uncaught Cisco::UnsupportedException to a 'skipped' result. Update the minitests that are currently working on XR so that they do not have any such uncaught exceptions.

The `Node` extended functionality exercised in `test_node_ext` was not fully implemented for XR before, so I finished implementing the parts that are applicable to XR and added appropriate negative tests for the ones that are unsupported.

Tests run successfully against XR:
- test_interface, test_interface_svi, test_interface_switchport
- test_command_reference, test_command_config
- test_router_bgp, test_bgp_neighbor, test_bgp_neighbor_af (test_bgp_af is blocked pending the merge of #136)
