### PR TITLE
fix "weight" attribute setting.

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
@@ -221,7 +221,6 @@ unsuppress_map:
 
 weight:
   kind: int
-  auto_default: false
   config_get_token_append: '/^weight (\d+)$/'
   config_set_append: ' <state> weight <int>'
   default_value: false

--- a/tests/test_bgp_neighbor_af.rb
+++ b/tests/test_bgp_neighbor_af.rb
@@ -758,13 +758,15 @@ class TestRouterBgpNeighborAF < CiscoTestCase
   end
 
   def weight(af, dbg)
-    af.weight = 22
-    assert_equal(22, af.weight, "Test 1. #{dbg} Failed to set weight")
+    # check the default value before set
+    assert_equal(af.default_weight, af.weight,
+                 "Test 1. #{dbg} Error: should be default value")
 
-    # Seems odd to set an int to false - but normally there's a default value
-    # of some kind but in bgp weight is ignored unless configured. 0 is not
-    # acceptable as is nvgens.
-    af.weight = false
-    assert_equal(nil, af.weight, "Test 2. #{dbg} Failed to remove weight")
+    af.weight = 22
+    assert_equal(22, af.weight, "Test 2. #{dbg} Failed to set weight")
+
+    af.weight = af.default_weight
+    assert_equal(af.default_weight, af.weight,
+                 "Test 3. #{dbg} Failed to set to default weight")
   end
 end


### PR DESCRIPTION
fix the broken beaker tests for "weight" for nexus.
