### PR TITLE
fix "weight" attribute setting.

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
@@ -173,7 +173,7 @@ unsuppress_map:
   default_value: ''
 
 weight:
-  auto_default: false
+  kind: int
   config_get_token_append: '/^weight (\d+)$/'
   config_set_append: '<state> weight <int>'
   default_value: false

--- a/tests/test_bgp_neighbor_af.rb
+++ b/tests/test_bgp_neighbor_af.rb
@@ -617,7 +617,7 @@ class TestRouterBgpNeighborAF < CiscoTestCase
   def test_weight
     @@matrix.values.each do |af_args|
       af, dbg = clean_af(af_args)
-      weight(af, dbg) unless dbg.include?('l2vpn/evpn') # && platform == :nexus
+      weight(af, dbg) unless dbg.include?('l2vpn/evpn')
     end
   end
 

--- a/tests/test_bgp_neighbor_af.rb
+++ b/tests/test_bgp_neighbor_af.rb
@@ -612,4 +612,25 @@ class TestRouterBgpNeighborAF < CiscoTestCase
     assert_empty(af.soo,
                  "Test 4. #{dbg} Failed to set default '#{val}'")
   end
+
+  # --------------------------------
+  def test_weight
+    @@matrix.values.each do |af_args|
+      af, dbg = clean_af(af_args)
+      weight(af, dbg) unless dbg.include?('l2vpn/evpn') # && platform == :nexus
+    end
+  end
+
+  def weight(af, dbg)
+    # check the default value before set
+    assert_equal(af.default_weight, af.weight,
+                 "Test 1. #{dbg} Error: should be default value")
+
+    af.weight = 22
+    assert_equal(22, af.weight, "Test 2. #{dbg} Failed to set weight")
+
+    af.weight = af.default_weight
+    assert_equal(af.default_weight, af.weight,
+                 "Test 3. #{dbg} Failed to remove weight")
+  end
 end


### PR DESCRIPTION
"weight" attribute had an error, beaker tests for bgp_neighbor_af failed at the step of
 "TestStep :: 1.1 Default Properties :: IDEMPOTENCE".

fixed this issue, and add test_weight in mini-tests suite.

The following tests passed.
1). minitest for test_bgp_neighbor_af on nexus
2). minitest for test_bgp_neighbor_af on xr
3). beaker tests on nexus passed the step of
"TestStep :: 1.1 Default Properties [ensure => present] :: MANIFEST"
and eventually failed at the step of
"TestStep :: 5.12.1 Non Default Misc Map commands Part 1 [ensure => present] :: MANIFEST"
