### PR TITLE
Add default_value to limit_resource_module_type

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vdc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vdc.yaml
@@ -24,10 +24,9 @@ default_vdc_name:
   config_get_token: '/^vdc (\S+) id 1$/' # Assumes id 1 for default vdc
 
 limit_resource_module_type:
-  # No default_value. This can differ on every device so a default
-  # check is meaningless and idempotence is not possible for 'default'.
   config_get_token_append: '/^limit-resource module-type (.*)/'
   config_set_append: '<state> limit-resource module-type <mods>'
+  default_value: ''
 
 vdc_support:
   # This is a only used for determining support for VDCs


### PR DESCRIPTION
- cisco_vdc property
- I initially kept this out intentionally but found that it simplifies the puppet provider code with it in place
- minitest passes
