### PR TITLE
Fix feature nv overlay in tests

### DIFF
--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -237,8 +237,7 @@ module Cisco
 
     # advertise_l2vpn_evpn
     def advertise_l2vpn_evpn
-      Feature.feature_nv_overlay_enable unless
-        Feature.feature_nv_overlay_enabled?
+      Feature.nv_overlay_enable unless Feature.nv_overlay_enabled?
       return false unless RouterBgpAF.feature_nv_overlay_evpn_enabled
       config_get('bgp_af', 'advertise_l2vpn_evpn', @get_args)
     end

--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -66,26 +66,6 @@ module Cisco
       config_set('bgp', 'address_family', @set_args)
     end
 
-    def feature_nv_overlay_enabled?
-      config_get('feature', 'nv_overlay')
-    rescue Cisco::CliError => e
-      # cmd will syntax when feature is not enabled.
-      raise unless e.clierror =~ /Syntax error/
-      return false
-    end
-
-    def feature_nv_overlay_enable
-      # Note: vdc platforms restrict this feature to F3 or newer linecards
-      config_set('feature', 'nv_overlay')
-    end
-
-    def self.feature_nv_overlay_supported?
-      config_set('feature', 'nv_overlay')
-    rescue Cisco::CliError => e
-      raise unless e.clierror =~ /not capable of supporting nv overlay feature/
-      false
-    end
-
     # This is an enable-only method for enabling the 'nv overlay evpn' feature
     def self.feature_nv_overlay_evpn_enable
       config_set('bgp_af', 'feature_nv_overlay_evpn')
@@ -257,7 +237,8 @@ module Cisco
 
     # advertise_l2vpn_evpn
     def advertise_l2vpn_evpn
-      feature_nv_overlay_enable unless feature_nv_overlay_enabled?
+      Feature.feature_nv_overlay_enable unless
+        Feature.feature_nv_overlay_enabled?
       return false unless RouterBgpAF.feature_nv_overlay_evpn_enabled
       config_get('bgp_af', 'advertise_l2vpn_evpn', @get_args)
     end

--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -57,6 +57,7 @@ module Cisco
     end
 
     def create
+      feature_nv_overlay_enable unless feature_nv_overlay_enabled?
       set_args_keys(state: '')
       config_set('bgp', 'address_family', @set_args)
     end
@@ -64,6 +65,26 @@ module Cisco
     def destroy
       set_args_keys(state: 'no')
       config_set('bgp', 'address_family', @set_args)
+    end
+
+    def feature_nv_overlay_enabled?
+      config_get('feature', 'nv_overlay')
+    rescue Cisco::CliError => e
+      # cmd will syntax when feature is not enabled.
+      raise unless e.clierror =~ /Syntax error/
+      return false
+    end
+
+    def feature_nv_overlay_enable
+      # Note: vdc platforms restrict this feature to F3 or newer linecards
+      config_set('feature', 'nv_overlay')
+    end
+
+    def self.feature_nv_overlay_supported?
+      config_set('feature', 'nv_overlay')
+    rescue Cisco::CliError => e
+      raise unless e.clierror =~ /not capable of supporting nv overlay feature/
+      false
     end
 
     # This is an enable-only method for enabling the 'nv overlay evpn' feature

--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -57,7 +57,6 @@ module Cisco
     end
 
     def create
-      feature_nv_overlay_enable unless feature_nv_overlay_enabled?
       set_args_keys(state: '')
       config_set('bgp', 'address_family', @set_args)
     end
@@ -258,6 +257,7 @@ module Cisco
 
     # advertise_l2vpn_evpn
     def advertise_l2vpn_evpn
+      feature_nv_overlay_enable unless feature_nv_overlay_enabled?
       return false unless RouterBgpAF.feature_nv_overlay_evpn_enabled
       config_get('bgp_af', 'advertise_l2vpn_evpn', @get_args)
     end

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -1,8 +1,7 @@
-# vxlan
+# feature
 ---
-_exclude: [/N(5|6)/]
-
-feature_nv_overlay:
+nv_overlay:
+  _exclude: [/N(5|6)/]
   kind: boolean
   config_get: 'show running nv overlay'
   config_get_token: '/^feature nv overlay$/'

--- a/lib/cisco_node_utils/cmd_ref/vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vni.yaml
@@ -48,11 +48,6 @@ feature:
     config_get_token: '/^feature vn-segment-vlan-based$/'
     config_set: 'feature vn-segment-vlan-based'
 
-feature_nv_overlay:
-  config_get: 'show running | i ^feature'
-  config_get_token: '/^feature nv overlay$/'
-  config_set: 'feature nv overlay'
-
 mapped_vlan:
   # MT-lite only
   /N(3|9)/:

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -1,0 +1,42 @@
+# January 2016, Robert W Gries
+#
+# Copyright (c) 2015-16 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'node_util'
+
+module Cisco
+  # Feature - node util class for managing common features
+  class Feature < NodeUtil
+    def self.feature_nv_overlay_enabled?
+      config_get('feature', 'nv_overlay')
+    rescue Cisco::CliError => e
+      # cmd will syntax when feature is not enabled.
+      raise unless e.clierror =~ /Syntax error/
+      return false
+    end
+
+    def self.feature_nv_overlay_enable
+      # Note: vdc platforms restrict this feature to F3 or newer linecards
+      config_set('feature', 'nv_overlay')
+    end
+
+    def self.feature_nv_overlay_supported?
+      config_set('feature', 'nv_overlay')
+    rescue Cisco::CliError => e
+      raise unless e.clierror =~ /not capable of supporting nv overlay feature/
+      false
+    end
+  end
+end

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -19,7 +19,7 @@ require_relative 'node_util'
 module Cisco
   # Feature - node util class for managing common features
   class Feature < NodeUtil
-    def self.feature_nv_overlay_enabled?
+    def self.nv_overlay_enabled?
       config_get('feature', 'nv_overlay')
     rescue Cisco::CliError => e
       # cmd will syntax when feature is not enabled.
@@ -27,12 +27,12 @@ module Cisco
       return false
     end
 
-    def self.feature_nv_overlay_enable
+    def self.nv_overlay_enable
       # Note: vdc platforms restrict this feature to F3 or newer linecards
       config_set('feature', 'nv_overlay')
     end
 
-    def self.feature_nv_overlay_supported?
+    def self.nv_overlay_supported?
       config_set('feature', 'nv_overlay')
     rescue Cisco::CliError => e
       raise unless e.clierror =~ /not capable of supporting nv overlay feature/

--- a/lib/cisco_node_utils/vni.rb
+++ b/lib/cisco_node_utils/vni.rb
@@ -67,13 +67,20 @@ module Cisco
     end
 
     def self.feature_vni_enable
-      Vni.feature_nv_overlay_enable unless Vni.feature_nv_overlay_enabled
+      feature_nv_overlay_enable unless feature_nv_overlay_enabled?
       config_set('vni', 'feature')
     end
 
+    def self.feature_nv_overlay_supported?
+      config_set('feature', 'nv_overlay')
+    rescue Cisco::CliError => e
+      raise unless e.clierror =~ /not capable of supporting nv overlay feature/
+      false
+    end
+
     # feature nv overlay
-    def self.feature_nv_overlay_enabled
-      config_get('vni', 'feature_nv_overlay')
+    def self.feature_nv_overlay_enabled?
+      config_get('feature', 'nv_overlay')
     rescue Cisco::CliError => e
       # cmd will syntax reject when feature is not enabled
       raise unless e.clierror =~ /Syntax error/
@@ -81,7 +88,7 @@ module Cisco
     end
 
     def self.feature_nv_overlay_enable
-      config_set('vni', 'feature_nv_overlay')
+      config_set('feature', 'nv_overlay')
     end
 
     def self.mt_full_support

--- a/lib/cisco_node_utils/vni.rb
+++ b/lib/cisco_node_utils/vni.rb
@@ -68,8 +68,7 @@ module Cisco
     end
 
     def self.feature_vni_enable
-      Feaure.feature_nv_overlay_enable unless
-        Feature.feature_nv_overlay_enabled?
+      Feature.nv_overlay_enable unless Feature.nv_overlay_enabled?
       config_set('vni', 'feature')
     end
 

--- a/lib/cisco_node_utils/vni.rb
+++ b/lib/cisco_node_utils/vni.rb
@@ -33,6 +33,7 @@
 # ----
 #
 require_relative 'node_util'
+require_relative 'feature'
 
 module Cisco
   # node_utils class for Vni
@@ -67,28 +68,9 @@ module Cisco
     end
 
     def self.feature_vni_enable
-      feature_nv_overlay_enable unless feature_nv_overlay_enabled?
+      Feaure.feature_nv_overlay_enable unless
+        Feature.feature_nv_overlay_enabled?
       config_set('vni', 'feature')
-    end
-
-    def self.feature_nv_overlay_supported?
-      config_set('feature', 'nv_overlay')
-    rescue Cisco::CliError => e
-      raise unless e.clierror =~ /not capable of supporting nv overlay feature/
-      false
-    end
-
-    # feature nv overlay
-    def self.feature_nv_overlay_enabled?
-      config_get('feature', 'nv_overlay')
-    rescue Cisco::CliError => e
-      # cmd will syntax reject when feature is not enabled
-      raise unless e.clierror =~ /Syntax error/
-      return false
-    end
-
-    def self.feature_nv_overlay_enable
-      config_set('feature', 'nv_overlay')
     end
 
     def self.mt_full_support

--- a/lib/cisco_node_utils/vxlan_vtep.rb
+++ b/lib/cisco_node_utils/vxlan_vtep.rb
@@ -35,7 +35,7 @@ module Cisco
 
     def self.vteps
       hash = {}
-      return hash unless feature_nv_overlay_enabled
+      return hash unless feature_nv_overlay_enabled?
       vtep_list = config_get('vxlan_vtep', 'all_interfaces')
       return hash if vtep_list.nil?
 
@@ -46,8 +46,8 @@ module Cisco
       hash
     end
 
-    def self.feature_nv_overlay_enabled
-      config_get('vxlan', 'feature_nv_overlay')
+    def self.feature_nv_overlay_enabled?
+      config_get('feature', 'nv_overlay')
     rescue Cisco::CliError => e
       # cmd will syntax when feature is not enabled.
       raise unless e.clierror =~ /Syntax error/
@@ -56,7 +56,14 @@ module Cisco
 
     def self.feature_nv_overlay_enable
       # Note: vdc platforms restrict this feature to F3 or newer linecards
-      config_set('vxlan', 'feature_nv_overlay')
+      config_set('feature', 'nv_overlay')
+    end
+
+    def self.feature_nv_overlay_supported?
+      config_set('feature', 'nv_overlay')
+    rescue Cisco::CliError => e
+      raise unless e.clierror =~ /not capable of supporting nv overlay feature/
+      false
     end
 
     def self.mt_full_support
@@ -69,7 +76,7 @@ module Cisco
 
     def create
       VxlanVtep.feature_nv_overlay_enable unless
-        VxlanVtep.feature_nv_overlay_enabled
+        VxlanVtep.feature_nv_overlay_enabled?
       if VxlanVtep.mt_lite_support
         Vrf.feature_vn_segment_vlan_based_enable unless
           Vrf.feature_vn_segment_vlan_based_enabled

--- a/lib/cisco_node_utils/vxlan_vtep.rb
+++ b/lib/cisco_node_utils/vxlan_vtep.rb
@@ -35,7 +35,7 @@ module Cisco
 
     def self.vteps
       hash = {}
-      return hash unless feature_nv_overlay_enabled?
+      return hash unless Feature.feature_nv_overlay_enabled?
       vtep_list = config_get('vxlan_vtep', 'all_interfaces')
       return hash if vtep_list.nil?
 
@@ -44,26 +44,6 @@ module Cisco
         hash[id] = VxlanVtep.new(id, false)
       end
       hash
-    end
-
-    def self.feature_nv_overlay_enabled?
-      config_get('feature', 'nv_overlay')
-    rescue Cisco::CliError => e
-      # cmd will syntax when feature is not enabled.
-      raise unless e.clierror =~ /Syntax error/
-      return false
-    end
-
-    def self.feature_nv_overlay_enable
-      # Note: vdc platforms restrict this feature to F3 or newer linecards
-      config_set('feature', 'nv_overlay')
-    end
-
-    def self.feature_nv_overlay_supported?
-      config_set('feature', 'nv_overlay')
-    rescue Cisco::CliError => e
-      raise unless e.clierror =~ /not capable of supporting nv overlay feature/
-      false
     end
 
     def self.mt_full_support
@@ -75,8 +55,8 @@ module Cisco
     end
 
     def create
-      VxlanVtep.feature_nv_overlay_enable unless
-        VxlanVtep.feature_nv_overlay_enabled?
+      Feature.feature_nv_overlay_enable unless
+        Feature.feature_nv_overlay_enabled?
       if VxlanVtep.mt_lite_support
         Vrf.feature_vn_segment_vlan_based_enable unless
           Vrf.feature_vn_segment_vlan_based_enabled

--- a/lib/cisco_node_utils/vxlan_vtep.rb
+++ b/lib/cisco_node_utils/vxlan_vtep.rb
@@ -35,7 +35,7 @@ module Cisco
 
     def self.vteps
       hash = {}
-      return hash unless Feature.feature_nv_overlay_enabled?
+      return hash unless Feature.nv_overlay_enabled?
       vtep_list = config_get('vxlan_vtep', 'all_interfaces')
       return hash if vtep_list.nil?
 
@@ -55,8 +55,7 @@ module Cisco
     end
 
     def create
-      Feature.feature_nv_overlay_enable unless
-        Feature.feature_nv_overlay_enabled?
+      Feature.nv_overlay_enable unless Feature.nv_overlay_enabled?
       if VxlanVtep.mt_lite_support
         Vrf.feature_vn_segment_vlan_based_enable unless
           Vrf.feature_vn_segment_vlan_based_enabled

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -675,6 +675,8 @@ class TestRouterBgpAF < CiscoTestCase
 
   ## feature nv overlay evpn
   def test_feature_nv_overlay_evpn
+    skip('Platform does not support nv overlay feature') unless
+      RouterBgpAF.feature_nv_overlay_supported?
     config('no nv overlay evpn')
     RouterBgpAF.feature_nv_overlay_evpn_enable
     assert(RouterBgpAF.feature_nv_overlay_evpn_enabled,

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -677,7 +677,7 @@ class TestRouterBgpAF < CiscoTestCase
   ## feature nv overlay evpn
   def test_feature_nv_overlay_evpn
     skip('Platform does not support nv overlay feature') unless
-      Feature.feature_nv_overlay_supported?
+      Feature.nv_overlay_supported?
     config('no nv overlay evpn')
     RouterBgpAF.feature_nv_overlay_evpn_enable
     assert(RouterBgpAF.feature_nv_overlay_evpn_enabled,

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -21,6 +21,7 @@
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/bgp'
 require_relative '../lib/cisco_node_utils/bgp_af'
+require_relative '../lib/cisco_node_utils/feature'
 
 # TestRouterBgpAF - Minitest for RouterBgpAF class
 class TestRouterBgpAF < CiscoTestCase
@@ -676,7 +677,7 @@ class TestRouterBgpAF < CiscoTestCase
   ## feature nv overlay evpn
   def test_feature_nv_overlay_evpn
     skip('Platform does not support nv overlay feature') unless
-      RouterBgpAF.feature_nv_overlay_supported?
+      Feature.feature_nv_overlay_supported?
     config('no nv overlay evpn')
     RouterBgpAF.feature_nv_overlay_evpn_enable
     assert(RouterBgpAF.feature_nv_overlay_evpn_enabled,

--- a/tests/test_vni.rb
+++ b/tests/test_vni.rb
@@ -24,6 +24,8 @@ class TestVni < CiscoTestCase
     super
     skip('Platform does not support MT-full or MT-lite') unless
       Vni.mt_full_support || Vni.mt_lite_support
+    skip('Platform does not support nv overlay feature') unless
+      Vni.feature_nv_overlay_supported?
   end
 
   def teardown

--- a/tests/test_vni.rb
+++ b/tests/test_vni.rb
@@ -26,7 +26,7 @@ class TestVni < CiscoTestCase
     skip('Platform does not support MT-full or MT-lite') unless
       Vni.mt_full_support || Vni.mt_lite_support
     skip('Platform does not support nv overlay feature') unless
-      Feature.feature_nv_overlay_supported?
+      Feature.nv_overlay_supported?
   end
 
   def teardown

--- a/tests/test_vni.rb
+++ b/tests/test_vni.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/feature'
 require_relative '../lib/cisco_node_utils/vni'
 require_relative '../lib/cisco_node_utils/vdc'
 
@@ -25,7 +26,7 @@ class TestVni < CiscoTestCase
     skip('Platform does not support MT-full or MT-lite') unless
       Vni.mt_full_support || Vni.mt_lite_support
     skip('Platform does not support nv overlay feature') unless
-      Vni.feature_nv_overlay_supported?
+      Feature.feature_nv_overlay_supported?
   end
 
   def teardown

--- a/tests/test_vxlan_vtep.rb
+++ b/tests/test_vxlan_vtep.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/feature'
 require_relative '../lib/cisco_node_utils/vxlan_vtep'
 require_relative '../lib/cisco_node_utils/vdc'
 
@@ -25,7 +26,7 @@ class TestVxlanVtep < CiscoTestCase
     skip('Platform does not support MT-full or MT-lite') unless
       VxlanVtep.mt_full_support || VxlanVtep.mt_lite_support
     skip('Platform does not support nv overlay feature') unless
-      VxlanVtep.feature_nv_overlay_supported?
+      Feature.feature_nv_overlay_supported?
   end
 
   def teardown

--- a/tests/test_vxlan_vtep.rb
+++ b/tests/test_vxlan_vtep.rb
@@ -24,6 +24,8 @@ class TestVxlanVtep < CiscoTestCase
     super
     skip('Platform does not support MT-full or MT-lite') unless
       VxlanVtep.mt_full_support || VxlanVtep.mt_lite_support
+    skip('Platform does not support nv overlay feature') unless
+      VxlanVtep.feature_nv_overlay_supported?
   end
 
   def teardown

--- a/tests/test_vxlan_vtep.rb
+++ b/tests/test_vxlan_vtep.rb
@@ -26,7 +26,7 @@ class TestVxlanVtep < CiscoTestCase
     skip('Platform does not support MT-full or MT-lite') unless
       VxlanVtep.mt_full_support || VxlanVtep.mt_lite_support
     skip('Platform does not support nv overlay feature') unless
-      Feature.feature_nv_overlay_supported?
+      Feature.nv_overlay_supported?
   end
 
   def teardown


### PR DESCRIPTION
Skip applicable tests when unable to set `feature nv overlay`.

All tests pass on platforms that support `nv overlay` and also on platforms that do not.

New behavior for platforms that do no support `nv overlay`:

```
~/cisco-network-node-utils$ ruby tests/test_vni.rb -v
Run options: -v --seed 37891

# Running:


Node under test:
  - name  - n3k-103
  - type  - N3K-C3048TP-1GE
  - image - 

TestVni#test_mt_full_shutdown = 2.43 s = S
TestVni#test_mt_full_vni_create_destroy = 0.97 s = S
TestVni#test_mt_lite_mapped_vlan = 0.98 s = S

Finished in 4.383573s, 0.6844 runs/s, 0.0000 assertions/s.

  1) Skipped:
TestVni#test_mt_full_shutdown [tests/test_vni.rb:27]:
Platform does not support nv overlay feature


  2) Skipped:
TestVni#test_mt_full_vni_create_destroy [tests/test_vni.rb:27]:
Platform does not support nv overlay feature


  3) Skipped:
TestVni#test_mt_lite_mapped_vlan [tests/test_vni.rb:27]:
Platform does not support nv overlay feature
```
