### PR TITLE
RD & route-target properties move to vrf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Changelog
 * Fabric Path
   * fabricpath_global (@dcheriancisco)
   * fabricpath_topology (@dcheriancisco)
+* Feature
+  * feature (@robert-w-gries)
 * Interface
   * interface_service_vni (@chrisvanheuveln)
 * PIM
@@ -26,6 +28,8 @@ Changelog
   * snmpnotification (@tphoney)
 * VDC
   * vdc (@chrisvanheuveln)
+* VRF
+  * vrf_af (@chrisvanheuveln)
 * VXLAN
   * vxlan_global (@alok-aggarwal)
   * vxlan_vtep (@dcheriancisco)
@@ -41,6 +45,7 @@ Changelog
   * `flush_routes`
   * `isolate`
   * `neighbor_down_fib_accelerate`
+  * `route_distinguisher`
 * Extend bgp_af with attributes:
   * `default_metric`
   * `distance_ebgp`, `distance_ibgp`, `distance_local`

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -100,7 +100,7 @@ module Cisco
 
     # Create one router bgp instance
     def create
-      Feature.bgp_enable unless Feature.bgp_enabled?
+      Feature.bgp_enable
       router_bgp
     end
 
@@ -660,6 +660,8 @@ module Cisco
     end
 
     def route_distinguisher=(rd)
+      Feature.nv_overlay_enable
+      Feature.nv_overlay_evpn_enable
       if rd == default_route_distinguisher
         @set_args[:state] = 'no'
         @set_args[:rd] = ''

--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -228,9 +228,8 @@ module Cisco
     end
 
     def advertise_l2vpn_evpn=(state)
-      Feature.nv_overlay_enable unless Feature.nv_overlay_enabled?
-      Feature.nv_overlay_evpn_enable if
-        state && !Feature.nv_overlay_evpn_enabled?
+      Feature.nv_overlay_enable
+      Feature.nv_overlay_evpn_enable
       set_args_keys(state: (state ? '' : 'no'))
       config_set('bgp_af', 'advertise_l2vpn_evpn', @set_args)
     end

--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -66,19 +66,6 @@ module Cisco
       config_set('bgp', 'address_family', @set_args)
     end
 
-    # This is an enable-only method for enabling the 'nv overlay evpn' feature
-    def self.feature_nv_overlay_evpn_enable
-      config_set('bgp_af', 'feature_nv_overlay_evpn')
-    end
-
-    def self.feature_nv_overlay_evpn_enabled
-      config_get('bgp_af', 'feature_nv_overlay_evpn')
-    rescue Cisco::CliError => e
-      # cmd will syntax reject when feature is not enabled
-      raise unless e.clierror =~ /Syntax error/
-      return false
-    end
-
     #
     # Helper methods to delete @set_args hash keys
     #
@@ -237,14 +224,13 @@ module Cisco
 
     # advertise_l2vpn_evpn
     def advertise_l2vpn_evpn
-      Feature.nv_overlay_enable unless Feature.nv_overlay_enabled?
-      return false unless RouterBgpAF.feature_nv_overlay_evpn_enabled
       config_get('bgp_af', 'advertise_l2vpn_evpn', @get_args)
     end
 
     def advertise_l2vpn_evpn=(state)
-      RouterBgpAF.feature_nv_overlay_evpn_enable if
-        state && !RouterBgpAF.feature_nv_overlay_evpn_enabled
+      Feature.nv_overlay_enable unless Feature.nv_overlay_enabled?
+      Feature.nv_overlay_evpn_enable if
+        state && !Feature.nv_overlay_evpn_enabled?
       set_args_keys(state: (state ? '' : 'no'))
       config_set('bgp_af', 'advertise_l2vpn_evpn', @set_args)
     end
@@ -646,109 +632,6 @@ module Cisco
 
     def default_redistribute
       config_get_default('bgp_af', 'redistribute')
-    end
-
-    # route target both auto(Getter/Setter/Default)
-    def route_target_both_auto
-      config_get('bgp_af', 'route_target_both_auto', @get_args)
-    end
-
-    def route_target_both_auto=(enable)
-      @set_args[:state] = (enable ? '' : 'no')
-      config_set('bgp_af', 'route_target_both_auto', @set_args)
-      set_args_keys_default
-    end
-
-    def default_route_target_both_auto
-      config_get_default('bgp_af', 'route_target_both_auto')
-    end
-
-    # route target both auto evpn(Getter/Setter/Default)
-    def route_target_both_auto_evpn
-      config_get('bgp_af', 'route_target_both_auto_evpn', @get_args)
-    end
-
-    def route_target_both_auto_evpn=(enable)
-      @set_args[:state] = (enable ? '' : 'no')
-      config_set('bgp_af', 'route_target_both_auto_evpn', @set_args)
-      set_args_keys_default
-    end
-
-    def default_route_target_both_auto_evpn
-      config_get_default('bgp_af', 'route_target_both_auto_evpn')
-    end
-
-    # route target export
-    def route_target_export
-      cmds = config_get('bgp_af', 'route_target_export', @get_args)
-      cmds.sort
-    end
-
-    def route_target_export=(should)
-      route_target_delta(should, route_target_export, 'route_target_export')
-    end
-
-    def default_route_target_export
-      config_get_default('bgp_af', 'route_target_export')
-    end
-
-    # route target export_evpn
-    def route_target_export_evpn
-      cmds = config_get('bgp_af', 'route_target_export_evpn', @get_args)
-      cmds.sort
-    end
-
-    def route_target_export_evpn=(should)
-      route_target_delta(should, route_target_export_evpn,
-                         'route_target_export_evpn')
-    end
-
-    def default_route_target_export_evpn
-      config_get_default('bgp_af', 'route_target_export_evpn')
-    end
-
-    # route target import
-    def route_target_import
-      cmds = config_get('bgp_af', 'route_target_import', @get_args)
-      cmds.sort
-    end
-
-    def route_target_import=(should)
-      route_target_delta(should, route_target_import, 'route_target_import')
-    end
-
-    def default_route_target_import
-      config_get_default('bgp_af', 'route_target_import')
-    end
-
-    # route target import_evpn
-    def route_target_import_evpn
-      cmds = config_get('bgp_af', 'route_target_import_evpn', @get_args)
-      cmds.sort
-    end
-
-    def route_target_import_evpn=(should)
-      route_target_delta(should, route_target_import_evpn,
-                         'route_target_import_evpn')
-    end
-
-    def default_route_target_import_evpn
-      config_get_default('bgp_af', 'route_target_import_evpn')
-    end
-
-    def route_target_delta(should, is, prop)
-      delta_hash = Utils.delta_add_remove(should, is)
-      return if delta_hash.values.flatten.empty?
-      [:add, :remove].each do |action|
-        CiscoLogger.debug("#{prop}" \
-          "#{@get_args}\n #{action}: #{delta_hash[action]}")
-        delta_hash[action].each do |community|
-          state = (action == :add) ? '' : 'no'
-          @set_args[:state] = state
-          @set_args[:community] = community
-          config_set('bgp_af', prop, @set_args)
-        end
-      end
     end
 
     #

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -120,12 +120,6 @@ fast_external_fallover:
   config_set_append: '<state> fast-external-fallover'
   default_value: true
 
-feature:
-  kind: boolean
-  config_get: "show running bgp"
-  config_get_token: '/^feature bgp$/'
-  config_set: "<state> feature bgp"
-
 flush_routes:
   kind: boolean
   config_get_token_append: '/^flush-routes$/'
@@ -189,6 +183,7 @@ reconnect_interval:
   default_value: 60
 
 route_distinguisher:
+  # This property is also supported by vrf.yaml
   config_get_token: ['/^vrf context <vrf>$/i', '/^rd (\S+)$/']
   config_set: ["vrf context <vrf>", "<state> rd <rd>"]
   default_value: ""

--- a/lib/cisco_node_utils/cmd_ref/bgp_af.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp_af.yaml
@@ -106,13 +106,6 @@ distance_ibgp:
 distance_local:
   default_value: 220
 
-# This is a multi-provider, enable-only feature. Do not disable from provider.
-feature_nv_overlay_evpn:
-  kind: boolean
-  config_get: "show running | section nv"
-  config_get_token: '/^nv overlay evpn$/'
-  config_set: "nv overlay evpn"
-
 inject_map:
   multiple: true
   config_get_token_append: '/^inject-map (\S+) exist-map (\S+) *(copy-attributes)?$/'
@@ -151,49 +144,6 @@ redistribute:
 redistribute_policy:
   # route-map/policy is optional on some platforms, required on others
   config_set_append: '<state> redistribute <protocol> route-map <policy>'
-
-#config in vrf context
-route_target_both_auto:
-  config_get: 'sh run | section vrf' 
-  config_get_token: ['/^vrf context <vrf>$/i', '/^address-family <afi> <safi>$/i', '/^route-target both auto$/']
-  config_set: ["vrf context <vrf>", "address-family <afi> <safi>", "<state> route-target both auto"]
-  kind: boolean
-  default_value: false
-
-route_target_both_auto_evpn:
-  config_get: 'sh run | section vrf' 
-  config_get_token: ['/^vrf context <vrf>$/i', '/^address-family <afi> <safi>$/i', '/^route-target both auto evpn$/']
-  config_set: ["vrf context <vrf>", "address-family <afi> <safi>", "<state> route-target both auto evpn"]
-  kind: boolean
-  default_value: false
-
-route_target_export:
-  config_get: 'sh run | section vrf' 
-  config_get_token: ['/^vrf context <vrf>$/i', '/^address-family <afi> <safi>$/i', '/^route-target export (\S+)$/']
-  config_set: ["vrf context <vrf>", "address-family <afi> <safi>", "<state> route-target export <community>"]
-  multiple: true
-  default_value: []
-
-route_target_export_evpn:
-  config_get: 'sh run | section vrf' 
-  config_get_token: ['/^vrf context <vrf>$/i', '/^address-family <afi> <safi>$/i', '/^route-target export (\S+) evpn$/']
-  config_set: ["vrf context <vrf>", "address-family <afi> <safi>", "<state> route-target export <community> evpn"]
-  multiple: true
-  default_value: []
-
-route_target_import:
-  config_get: 'sh run | section vrf' 
-  config_get_token: ['/^vrf context <vrf>$/i', '/^address-family <afi> <safi>$/i', '/^route-target import (\S+)$/']
-  config_set: ["vrf context <vrf>", "address-family <afi> <safi>", "<state> route-target import <community>"]
-  multiple: true
-  default_value: []
-
-route_target_import_evpn:
-  config_get: 'sh run | section vrf' 
-  config_get_token: ['/^vrf context <vrf>$/i', '/^address-family <afi> <safi>$/i', '/^route-target import (\S+) evpn$/']
-  config_set: ["vrf context <vrf>", "address-family <afi> <safi>", "<state> route-target import <community> evpn"]
-  multiple: true
-  default_value: []
 
 suppress_inactive:
   kind: boolean

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -1,8 +1,31 @@
 # feature
 ---
+bgp:
+  kind: boolean
+  config_get: "show running | i feature"
+  config_get_token: '/^feature bgp$/'
+  config_set: "<state> feature bgp"
+
 nv_overlay:
   _exclude: [/N(5|6)/]
   kind: boolean
   config_get: 'show running nv overlay'
   config_get_token: '/^feature nv overlay$/'
   config_set: "feature nv overlay"
+
+nv_overlay_evpn:
+  # TBD: Not a feature but a dependency for several properties
+  kind: boolean
+  config_get: "show running | section nv"
+  config_get_token: '/^nv overlay evpn$/'
+  config_set: "nv overlay evpn"
+
+vn_segment_vlan_based:
+  # MT-lite only
+  /N(3|9)/:
+    kind: boolean
+    default_value: false
+    cli_nexus:
+      config_get: 'show running section feature'
+      config_get_token: '/^feature vn-segment-vlan-based$/'
+      config_set: 'feature vn-segment-vlan-based'

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -4,7 +4,7 @@ bgp:
   kind: boolean
   config_get: "show running | i feature"
   config_get_token: '/^feature bgp$/'
-  config_set: "<state> feature bgp"
+  config_set: "feature bgp"
 
 nv_overlay:
   _exclude: [/N(3|5|6)/]
@@ -25,8 +25,7 @@ vn_segment_vlan_based:
   # MT-lite only
   /N(3|9)/:
     kind: boolean
+    config_get: 'show running section feature'
+    config_get_token: '/^feature vn-segment-vlan-based$/'
+    config_set: 'feature vn-segment-vlan-based'
     default_value: false
-    cli_nexus:
-      config_get: 'show running section feature'
-      config_get_token: '/^feature vn-segment-vlan-based$/'
-      config_set: 'feature vn-segment-vlan-based'

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -7,7 +7,7 @@ bgp:
   config_set: "<state> feature bgp"
 
 nv_overlay:
-  _exclude: [/N(5|6)/]
+  _exclude: [/N(3|5|6)/]
   kind: boolean
   config_get: 'show running nv overlay'
   config_get_token: '/^feature nv overlay$/'
@@ -15,6 +15,7 @@ nv_overlay:
 
 nv_overlay_evpn:
   # TBD: Not a feature but a dependency for several properties
+  _exclude: [/N(3|5|6)/]
   kind: boolean
   config_get: "show running | section nv"
   config_get_token: '/^nv overlay evpn$/'

--- a/lib/cisco_node_utils/cmd_ref/vrf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vrf.yaml
@@ -1,46 +1,88 @@
+# vrf.yaml
+---
+_template:
+  config_get: "show running all | section '^vrf context'"
+  config_get_token: '/^vrf context <vrf>$/'
+  config_get_token_append:
+    - '/^address-family <afi> <safi>$/'
+  config_set: 'vrf context <vrf>'
+  config_set_append:
+    - 'address-family <afi> <safi>'
+
+address_family:
+  config_set: ['vrf context <vrf>', '<state> address-family <afi> <safi>']
+
+all_vrf_afs:
+  multiple: true
+  config_get_token_append: '/^address-family (\S+) (\S+)$/'
 
 all_vrfs:
   multiple: true
-  config_get: "show running | section 'vrf context'"
   config_get_token: '/^vrf context (.*)/'
 
 create:
-  config_set:  "vrf context <vrf>"
+  config_set:  'vrf context <vrf>'
 
 description:
+  config_get_token_append: '/^description (.*)/'
+  config_set_append: '<state> description <desc>'
   kind: string
-  config_get: "show running | section 'vrf context'"
-  config_get_token: ['/^vrf context <vrf>$/i', '/^description (.*)/']
-  config_set: ["vrf context <vrf>", "<state> description <desc>"]
-  default_value: ""
+  default_value: ''
 
 destroy:
-  config_set: "no vrf context <vrf>"
+  config_set: 'no vrf context <vrf>'
 
-feature_vn_segment_vlan_based:
-  # MT-lite only
-  /N(3|9)/:
-    kind: boolean
-    default_value: false
-    cli_nexus:
-      config_get: 'show running section feature'
-      config_get_token: '/^feature vn-segment-vlan-based$/'
-      config_set: 'feature vn-segment-vlan-based'
+route_distinguisher:
+  config_get_token_append: '/^rd (\S+)$/'
+  config_set_append: '<state> rd <rd>'
+  default_value: ''
+
+route_target_both_auto:
+  kind: boolean
+  config_get_token_append: '/^route-target both auto$/'
+  config_set_append: '<state> route-target both auto'
+  default_value: false
+
+route_target_both_auto_evpn:
+  kind: boolean
+  config_get_token_append: '/^route-target both auto evpn$/'
+  config_set_append: '<state> route-target both auto evpn'
+  default_value: false
+
+route_target_export:
+  multiple: true
+  config_get_token_append: '/^route-target export (\S+)$/'
+  config_set_append: '<state> route-target export <community>'
+  default_value: []
+
+route_target_export_evpn:
+  multiple: true
+  config_get_token_append: '/^route-target export (\S+) evpn$/'
+  config_set_append: '<state> route-target export <community> evpn'
+  default_value: []
+
+route_target_import:
+  multiple: true
+  config_get_token_append: '/^route-target import (\S+)$/'
+  config_set_append: '<state> route-target import <community>'
+  default_value: []
+
+route_target_import_evpn:
+  multiple: true
+  config_get_token_append: '/^route-target import (\S+) evpn$/'
+  config_set_append: '<state> route-target import <community> evpn'
+  default_value: []
 
 shutdown:
   kind: boolean
-  config_get: "show running | section 'vrf context'"
-  config_get_token: ['/^vrf context <vrf>$/i', '/^shutdown$/']
-  config_set: ["vrf context <vrf>", "<state> shutdown"]
+  config_get_token_append: '/^shutdown$/'
+  config_set_append: '<state> shutdown'
   default_value: false
 
 vni: # TBD Should this move to the vni provider as vrf_vni?
   # MT-lite only
   /N9/:
     kind: int
-    config_get: "show running | section 'vrf context'"
-    config_get_token: ['/^vrf context <vrf>$/i', '/^vni (\d+)$/']
-    config_set: ["vrf context <vrf>", "<state> vni <id>"]
+    config_get_token_append: '/^vni (\d+)$/'
+    config_set_append: '<state> vni <id>'
     default_value: false
-
-

--- a/lib/cisco_node_utils/evpn_vni.rb
+++ b/lib/cisco_node_utils/evpn_vni.rb
@@ -14,10 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative 'bgp'
-require_relative 'bgp_af'
 require_relative 'cisco_cmn_utils'
 require_relative 'node_util'
+require_relative 'feature'
 
 module Cisco
   # node_utils class for evpn_vni
@@ -37,7 +36,7 @@ module Cisco
     # Creat a hash of all vni instance
     def self.vnis
       hash = {}
-      return hash unless RouterBgp.enabled
+      return hash unless Feature.bgp_enabled?
       vni_list = config_get('evpn_vni', 'vni')
       return hash if vni_list.nil?
 
@@ -64,12 +63,12 @@ module Cisco
 
     # enable feature bgp and nv overlay evpn
     def self.enable
-      RouterBgp.enable
-      RouterBgpAF.feature_nv_overlay_evpn_enable
+      Feature.bgp_enable
+      Feature.nv_overlay_evpn_enable
     end
 
     def self.enabled
-      RouterBgp.enabled && RouterBgpAF.feature_nv_overlay_evpn_enabled
+      Feature.bgp_enabled? && Feature.nv_overlay_evpn_enabled?
     end
 
     def set_args_keys_default

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -23,9 +23,9 @@ module Cisco
     # however, for test purposes it is sometimes convenient to support
     # feature disablement for cleanup purposes.
     # ---------------------------
-    def self.bgp_enable(state='')
+    def self.bgp_enable
       return if bgp_enabled?
-      config_set('feature', 'bgp', state: state)
+      config_set('feature', 'bgp')
     end
 
     def self.bgp_enabled?

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -19,17 +19,34 @@ require_relative 'node_util'
 module Cisco
   # Feature - node util class for managing common features
   class Feature < NodeUtil
-    def self.nv_overlay_enabled?
-      config_get('feature', 'nv_overlay')
+    # Note that in most cases the enable methods should only enable;
+    # however, for test purposes it is sometimes convenient to support
+    # feature disablement for cleanup purposes.
+    # ---------------------------
+    def self.bgp_enable(state='')
+      config_set('feature', 'bgp', state: state)
+    end
+
+    def self.bgp_enabled?
+      config_get('feature', 'bgp')
     rescue Cisco::CliError => e
-      # cmd will syntax when feature is not enabled.
+      # cmd will syntax reject when feature is not enabled
       raise unless e.clierror =~ /Syntax error/
       return false
     end
 
+    # ---------------------------
     def self.nv_overlay_enable
       # Note: vdc platforms restrict this feature to F3 or newer linecards
       config_set('feature', 'nv_overlay')
+    end
+
+    def self.nv_overlay_enabled?
+      config_get('feature', 'nv_overlay')
+    rescue Cisco::CliError => e
+      # cmd will syntax reject when feature is not enabled.
+      raise unless e.clierror =~ /Syntax error/
+      return false
     end
 
     def self.nv_overlay_supported?
@@ -38,5 +55,33 @@ module Cisco
       raise unless e.clierror =~ /not capable of supporting nv overlay feature/
       false
     end
+
+    # ---------------------------
+    def self.nv_overlay_evpn_enable
+      config_set('feature', 'nv_overlay_evpn')
+    end
+
+    def self.nv_overlay_evpn_enabled?
+      config_get('feature', 'nv_overlay_evpn')
+    rescue Cisco::CliError => e
+      # cmd will syntax reject when feature is not enabled
+      raise unless e.clierror =~ /Syntax error/
+      return false
+    end
+
+    # ---------------------------
+    def self.vn_segment_vlan_based_enable
+      config_set('feature', 'vn_segment_vlan_based')
+    end
+
+    def self.vn_segment_vlan_based_enabled?
+      config_get('feature', 'vn_segment_vlan_based')
+    rescue Cisco::CliError => e
+      # cmd will syntax reject when feature is not enabled
+      raise unless e.clierror =~ /Syntax error/
+      return false
+    end
+
+    # ---------------------------
   end
 end

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -24,20 +24,18 @@ module Cisco
     # feature disablement for cleanup purposes.
     # ---------------------------
     def self.bgp_enable(state='')
+      return if bgp_enabled?
       config_set('feature', 'bgp', state: state)
     end
 
     def self.bgp_enabled?
       config_get('feature', 'bgp')
-    rescue Cisco::CliError => e
-      # cmd will syntax reject when feature is not enabled
-      raise unless e.clierror =~ /Syntax error/
-      return false
     end
 
     # ---------------------------
     def self.nv_overlay_enable
       # Note: vdc platforms restrict this feature to F3 or newer linecards
+      return if nv_overlay_enabled?
       config_set('feature', 'nv_overlay')
     end
 
@@ -49,37 +47,24 @@ module Cisco
       return false
     end
 
-    def self.nv_overlay_supported?
-      config_set('feature', 'nv_overlay')
-    rescue Cisco::CliError => e
-      raise unless e.clierror =~ /not capable of supporting nv overlay feature/
-      false
-    end
-
     # ---------------------------
     def self.nv_overlay_evpn_enable
+      return if nv_overlay_evpn_enabled?
       config_set('feature', 'nv_overlay_evpn')
     end
 
     def self.nv_overlay_evpn_enabled?
       config_get('feature', 'nv_overlay_evpn')
-    rescue Cisco::CliError => e
-      # cmd will syntax reject when feature is not enabled
-      raise unless e.clierror =~ /Syntax error/
-      return false
     end
 
     # ---------------------------
     def self.vn_segment_vlan_based_enable
+      return if vn_segment_vlan_based_enabled?
       config_set('feature', 'vn_segment_vlan_based')
     end
 
     def self.vn_segment_vlan_based_enabled?
       config_get('feature', 'vn_segment_vlan_based')
-    rescue Cisco::CliError => e
-      # cmd will syntax reject when feature is not enabled
-      raise unless e.clierror =~ /Syntax error/
-      return false
     end
 
     # ---------------------------

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -642,7 +642,9 @@ module Cisco
     end
 
     def vlan_mapping
-      config_get('interface', 'vlan_mapping', @name).each(&:compact!)
+      match = config_get('interface', 'vlan_mapping', @name)
+      match.each(&:compact!) unless match.nil?
+      match
     end
 
     def vlan_mapping=(should_list)

--- a/lib/cisco_node_utils/vni.rb
+++ b/lib/cisco_node_utils/vni.rb
@@ -67,8 +67,8 @@ module Cisco
       return false
     end
 
-    def self.feature_vni_enable
-      Feature.nv_overlay_enable unless Feature.nv_overlay_enabled?
+    def self.feature_vni_enable # TBD: move this to feature.rb
+      Feature.nv_overlay_enable
       config_set('vni', 'feature')
     end
 

--- a/lib/cisco_node_utils/vrf.rb
+++ b/lib/cisco_node_utils/vrf.rb
@@ -86,8 +86,9 @@ module Cisco
 
     def route_distinguisher=(rd)
       # feature bgp and nv overlay required for rd cli in NXOS
-      Feature.bgp_enable unless Feature.bgp_enabled?
-      Feature.nv_overlay_enable unless Feature.nv_overlay_enabled?
+      Feature.bgp_enable
+      Feature.nv_overlay_enable
+      Feature.nv_overlay_evpn_enable
       if rd == default_route_distinguisher
         state = 'no'
         rd = ''
@@ -107,8 +108,7 @@ module Cisco
     end
 
     def vni=(id)
-      Feature.vn_segment_vlan_based_enable unless
-        Feature.vn_segment_vlan_based_enabled?
+      Feature.vn_segment_vlan_based_enable
       no_cmd = (id) ? '' : 'no'
       id = (id) ? id : vni
       config_set('vrf', 'vni', vrf: @name, state: no_cmd, id: id)

--- a/lib/cisco_node_utils/vrf_af.rb
+++ b/lib/cisco_node_utils/vrf_af.rb
@@ -18,6 +18,7 @@
 
 require_relative 'cisco_cmn_utils'
 require_relative 'node_util'
+require_relative 'feature'
 
 module Cisco
   # VrfAF - node utility class for VRF Address-Family configuration
@@ -72,6 +73,12 @@ module Cisco
       @set_args = @get_args.merge!(hash) unless hash.empty?
     end
 
+    def route_target_feature_enable
+      Feature.bgp_enable
+      Feature.nv_overlay_enable
+      Feature.nv_overlay_evpn_enable
+    end
+
     ########################################################
     #                      PROPERTIES                      #
     ########################################################
@@ -81,6 +88,7 @@ module Cisco
     end
 
     def route_target_both_auto=(state)
+      route_target_feature_enable
       set_args_keys(state: (state ? '' : 'no'))
       config_set('vrf', 'route_target_both_auto', @set_args)
     end
@@ -95,6 +103,7 @@ module Cisco
     end
 
     def route_target_both_auto_evpn=(state)
+      route_target_feature_enable
       set_args_keys(state: (state ? '' : 'no'))
       config_set('vrf', 'route_target_both_auto_evpn', @set_args)
     end
@@ -165,6 +174,7 @@ module Cisco
     # route_target_delta is a common helper function for the route_target
     # properties. It walks the delta hash and adds/removes each target cli.
     def route_target_delta(should, is, prop)
+      route_target_feature_enable
       delta_hash = Utils.delta_add_remove(should, is)
       return if delta_hash.values.flatten.empty?
       [:add, :remove].each do |action|

--- a/lib/cisco_node_utils/vrf_af.rb
+++ b/lib/cisco_node_utils/vrf_af.rb
@@ -1,0 +1,181 @@
+# VRF_AF provider class
+#
+# January 2016, Chris Van Heuveln
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'cisco_cmn_utils'
+require_relative 'node_util'
+
+module Cisco
+  # VrfAF - node utility class for VRF Address-Family configuration
+  class VrfAF < NodeUtil
+    attr_reader :name
+
+    def initialize(vrf, af, instantiate=true)
+      validate_args(vrf, af)
+      create if instantiate
+    end
+
+    def self.afs
+      hash = {}
+      vrfs = config_get('vrf', 'all_vrfs')
+      vrfs.each do |vrf|
+        hash[vrf] = {}
+        afs = config_get('vrf', 'all_vrf_afs', vrf: vrf)
+
+        next if afs.nil?
+        afs.each do |af|
+          hash[vrf][af] = VrfAF.new(vrf, af, false)
+        end
+      end
+      hash
+    end
+
+    def create
+      config_set('vrf', 'address_family', set_args_keys(state: ''))
+    end
+
+    def destroy
+      config_set('vrf', 'address_family', set_args_keys(state: 'no'))
+    end
+
+    def validate_args(vrf, af)
+      fail ArgumentError unless vrf.is_a?(String) && (vrf.length > 0)
+      fail ArgumentError, "'af' must be an array specifying afi and safi" unless
+        af.is_a?(Array) || af.length == 2
+      @vrf = vrf.downcase
+      @afi, @safi = af
+      set_args_keys_default
+    end
+
+    def set_args_keys_default
+      keys = { afi: @afi, safi: @safi }
+      keys[:vrf] = @vrf unless @vrf == 'default'
+      @get_args = @set_args = keys
+    end
+
+    def set_args_keys(hash={}) # rubocop:disable Style/AccessorMethodName
+      set_args_keys_default
+      @set_args = @get_args.merge!(hash) unless hash.empty?
+    end
+
+    ########################################################
+    #                      PROPERTIES                      #
+    ########################################################
+
+    def route_target_both_auto
+      config_get('vrf', 'route_target_both_auto', @get_args)
+    end
+
+    def route_target_both_auto=(state)
+      set_args_keys(state: (state ? '' : 'no'))
+      config_set('vrf', 'route_target_both_auto', @set_args)
+    end
+
+    def default_route_target_both_auto
+      config_get_default('vrf', 'route_target_both_auto')
+    end
+
+    # --------------------------
+    def route_target_both_auto_evpn
+      config_get('vrf', 'route_target_both_auto_evpn', @get_args)
+    end
+
+    def route_target_both_auto_evpn=(state)
+      set_args_keys(state: (state ? '' : 'no'))
+      config_set('vrf', 'route_target_both_auto_evpn', @set_args)
+    end
+
+    def default_route_target_both_auto_evpn
+      config_get_default('vrf', 'route_target_both_auto_evpn')
+    end
+
+    # --------------------------
+    def route_target_export
+      cmds = config_get('vrf', 'route_target_export', @get_args)
+      cmds.sort
+    end
+
+    def route_target_export=(should)
+      route_target_delta(should, route_target_export, 'route_target_export')
+    end
+
+    def default_route_target_export
+      config_get_default('vrf', 'route_target_export')
+    end
+
+    # --------------------------
+    def route_target_export_evpn
+      cmds = config_get('vrf', 'route_target_export_evpn', @get_args)
+      cmds.sort
+    end
+
+    def route_target_export_evpn=(should)
+      route_target_delta(should, route_target_export_evpn,
+                         'route_target_export_evpn')
+    end
+
+    def default_route_target_export_evpn
+      config_get_default('vrf', 'route_target_export_evpn')
+    end
+
+    # --------------------------
+    def route_target_import
+      cmds = config_get('vrf', 'route_target_import', @get_args)
+      cmds.sort
+    end
+
+    def route_target_import=(should)
+      route_target_delta(should, route_target_import, 'route_target_import')
+    end
+
+    def default_route_target_import
+      config_get_default('vrf', 'route_target_import')
+    end
+
+    # --------------------------
+    def route_target_import_evpn
+      cmds = config_get('vrf', 'route_target_import_evpn', @get_args)
+      cmds.sort
+    end
+
+    def route_target_import_evpn=(should)
+      route_target_delta(should, route_target_import_evpn,
+                         'route_target_import_evpn')
+    end
+
+    def default_route_target_import_evpn
+      config_get_default('vrf', 'route_target_import_evpn')
+    end
+
+    # --------------------------
+    # route_target_delta is a common helper function for the route_target
+    # properties. It walks the delta hash and adds/removes each target cli.
+    def route_target_delta(should, is, prop)
+      delta_hash = Utils.delta_add_remove(should, is)
+      return if delta_hash.values.flatten.empty?
+      [:add, :remove].each do |action|
+        CiscoLogger.debug("#{prop}" \
+          "#{@get_args}\n #{action}: #{delta_hash[action]}")
+        delta_hash[action].each do |community|
+          state = (action == :add) ? '' : 'no'
+          set_args_keys(state: state, community: community)
+          config_set('vrf', prop, @set_args)
+        end
+      end
+    end
+  end # class
+end # module

--- a/lib/cisco_node_utils/vxlan_vtep.rb
+++ b/lib/cisco_node_utils/vxlan_vtep.rb
@@ -57,8 +57,8 @@ module Cisco
     def create
       Feature.nv_overlay_enable unless Feature.nv_overlay_enabled?
       if VxlanVtep.mt_lite_support
-        Vrf.feature_vn_segment_vlan_based_enable unless
-          Vrf.feature_vn_segment_vlan_based_enabled
+        Feature.vn_segment_vlan_based_enable unless
+          Feature.vn_segment_vlan_based_enabled?
       end
       # re-use the "interface command ref hooks"
       config_set('interface', 'create', @name)

--- a/lib/cisco_node_utils/vxlan_vtep.rb
+++ b/lib/cisco_node_utils/vxlan_vtep.rb
@@ -55,11 +55,8 @@ module Cisco
     end
 
     def create
-      Feature.nv_overlay_enable unless Feature.nv_overlay_enabled?
-      if VxlanVtep.mt_lite_support
-        Feature.vn_segment_vlan_based_enable unless
-          Feature.vn_segment_vlan_based_enabled?
-      end
+      Feature.nv_overlay_enable
+      Feature.vn_segment_vlan_based_enable if VxlanVtep.mt_lite_support
       # re-use the "interface command ref hooks"
       config_set('interface', 'create', @name)
     end

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -674,16 +674,6 @@ class TestRouterBgpAF < CiscoTestCase
   end
   # rubocop:enable Metrics/AbcSize,Metrics/MethodLength
 
-  ## feature nv overlay evpn
-  def test_feature_nv_overlay_evpn
-    skip('Platform does not support nv overlay feature') unless
-      Feature.nv_overlay_supported?
-    config('no nv overlay evpn')
-    RouterBgpAF.feature_nv_overlay_evpn_enable
-    assert(RouterBgpAF.feature_nv_overlay_evpn_enabled,
-           'Error:feature nv overlay evpn is not enabled')
-  end
-
   ##
   ## distance
   ##
@@ -1108,87 +1098,6 @@ class TestRouterBgpAF < CiscoTestCase
     expected = { add: [], remove: [] }
     result = Utils.delta_add_remove(should, current)
     assert_equal(expected, result, 'Test 5. delta mismatch')
-  end
-
-  # test route_target
-  def test_route_target
-    afs = [%w(ipv4 unicast), %w(ipv6 unicast)]
-    afs.each do |af|
-      route_target(55, 'red', af)
-    end
-  end
-
-  def route_target(asn, vrf, af)
-    # Common test for route-target providers. Tests evpn and non-evpn.
-
-    bgp_af = RouterBgpAF.new(asn, vrf, af)
-
-    # test route target both auto and route target both auto evpn
-    refute(bgp_af.default_route_target_both_auto,
-           'default value for route target both auto should be false')
-
-    refute(bgp_af.default_route_target_both_auto_evpn,
-           'default value for route target both auto evpn should be false')
-
-    bgp_af.route_target_both_auto = true
-    assert(bgp_af.route_target_both_auto, "vrf context #{vrf} af #{af}: "\
-           'bgp_af route-target both auto should be enabled')
-
-    bgp_af.route_target_both_auto = false
-    refute(bgp_af.route_target_both_auto, "vrf context #{vrf} af #{af}: "\
-           'bgp_af route-target both auto should be disabled')
-
-    bgp_af.route_target_both_auto_evpn = true
-    assert(bgp_af.route_target_both_auto_evpn, "vrf context #{vrf} af #{af}: "\
-           'bgp_af route-target both auto evpn should be enabled')
-
-    bgp_af.route_target_both_auto_evpn = false
-    refute(bgp_af.route_target_both_auto_evpn, "vrf context #{vrf} af #{af}: "\
-           'bgp_af route-target both auto evpn should be disabled')
-
-    opts = [:import, :export]
-
-    # Master list of communities to test against
-    master = ['1:1', '2:2', '3:3', '4:5']
-
-    # Test 1: both/import/export when no commands are present. Each target
-    # option will be tested with and without evpn (6 separate types)
-    should = master.clone
-    route_target_tester(bgp_af, af, opts, should, 'Test 1')
-
-    # Test 2: remove half of the entries
-    should = ['1:1', '4:4']
-    route_target_tester(bgp_af, af, opts, should, 'Test 2')
-
-    # Test 3: restore the removed entries
-    should = master.clone
-    route_target_tester(bgp_af, af, opts, should, 'Test 3')
-
-    # Test 4: 'default'
-    should = bgp_af.default_route_target_import
-    route_target_tester(bgp_af, af, opts, should, 'Test 4')
-  end
-
-  def route_target_tester(bgp_af, af, opts, should, test_id)
-    # First configure all four property types
-    opts.each do |opt|
-      # non-evpn
-      bgp_af.send("route_target_#{opt}=", should)
-      # evpn
-      bgp_af.send("route_target_#{opt}_evpn=", should)
-    end
-
-    # Now check the results
-    opts.each do |opt|
-      # non-evpn
-      result = bgp_af.send("route_target_#{opt}")
-      assert_equal(should, result,
-                   "#{test_id} : #{af} : route_target_#{opt}")
-      # evpn
-      result = bgp_af.send("route_target_#{opt}_evpn")
-      assert_equal(should, result,
-                   "#{test_id} : #{af} : route_target_#{opt}_evpn")
-    end
   end
 
   ##

--- a/tests/test_evpn_vni.rb
+++ b/tests/test_evpn_vni.rb
@@ -45,7 +45,11 @@ class TestEvpnVni < CiscoTestCase
     assert_equal(true, vni_list.empty?, 'VLAN collection is empty')
   end
 
-  def test_set_get_route_distinguisher
+  def test_route_distinguisher
+    if node.product_id[/N3/]
+      skip('Platform does not support nv overlay feature') unless
+        Feature.nv_overlay_supported?
+    end
     vni = EvpnVni.new(4096)
     vni.route_distinguisher = 'auto'
     assert_equal('auto', vni.route_distinguisher,

--- a/tests/test_evpn_vni.rb
+++ b/tests/test_evpn_vni.rb
@@ -46,10 +46,6 @@ class TestEvpnVni < CiscoTestCase
   end
 
   def test_route_distinguisher
-    if node.product_id[/N3/]
-      skip('Platform does not support nv overlay feature') unless
-        Feature.nv_overlay_supported?
-    end
     vni = EvpnVni.new(4096)
     vni.route_distinguisher = 'auto'
     assert_equal('auto', vni.route_distinguisher,

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -783,10 +783,6 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_route_distinguisher
-    if node.product_id[/N3/]
-      skip('Platform does not support nv overlay feature') unless
-        Feature.nv_overlay_supported?
-    end
     bgp = RouterBgp.new(55, 'blue')
     bgp.route_distinguisher = 'auto'
     assert_equal('auto', bgp.route_distinguisher)

--- a/tests/test_vni.rb
+++ b/tests/test_vni.rb
@@ -25,8 +25,6 @@ class TestVni < CiscoTestCase
     super
     skip('Platform does not support MT-full or MT-lite') unless
       Vni.mt_full_support || Vni.mt_lite_support
-    skip('Platform does not support nv overlay feature') unless
-      Feature.nv_overlay_supported?
   end
 
   def teardown

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -14,6 +14,7 @@
 
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/vrf'
+require_relative '../lib/cisco_node_utils/vrf_af'
 require_relative '../lib/cisco_node_utils/vni'
 
 include Cisco
@@ -24,20 +25,29 @@ class TestVrf < CiscoTestCase
 
   def setup
     super
+    vrf_clean
+  end
+
+  def teardown
+    super
+    vrf_clean
+  end
+
+  def vrf_clean
     vrfs = Vrf.vrfs
-    vrfs.each_value do |vrf|
-      next unless vrf.name =~ /^test_vrf/
-      config("no vrf context #{vrf.name}")
+    vrfs.keys do |vrf|
+      next if vrf[/management/]
+      config("no vrf context #{vrf}")
     end
   end
 
-  def test_vrf_collection_not_empty
+  def test_collection_not_empty
     vrfs = Vrf.vrfs
     refute_empty(vrfs, 'VRF collection is empty')
     assert(vrfs.key?('management'), 'VRF management does not exist')
   end
 
-  def test_vrf_create_and_destroy
+  def test_create_and_destroy
     v = Vrf.new('test_vrf')
     vrfs = Vrf.vrfs
     assert(vrfs.key?('test_vrf'), 'Error: failed to create vrf test_vrf')
@@ -47,19 +57,19 @@ class TestVrf < CiscoTestCase
     refute(vrfs.key?('test_vrf'), 'Error: failed to destroy vrf test_vrf')
   end
 
-  def test_vrf_name_type_invalid
+  def test_name_type_invalid
     assert_raises(TypeError, 'Wrong vrf name type did not raise type error') do
       Vrf.new(1000)
     end
   end
 
-  def test_vrf_name_zero_length
+  def test_name_zero_length
     assert_raises(Cisco::CliError, "Zero length name didn't raise CliError") do
       Vrf.new('')
     end
   end
 
-  def test_vrf_name_too_long
+  def test_name_too_long
     name = 'a' * VRF_NAME_SIZE
     assert_raises(Cisco::CliError,
                   'vrf name misconfig did not raise CliError') do
@@ -67,9 +77,9 @@ class TestVrf < CiscoTestCase
     end
   end
 
-  def test_vrf_shutdown_valid
+  def test_shutdown_valid
     shutdown_states = [true, false]
-    v = Vrf.new('test_vrf_shutdown')
+    v = Vrf.new('test_shutdown')
     shutdown_states.each do |start|
       shutdown_states.each do |finish|
         v.shutdown = start
@@ -81,8 +91,8 @@ class TestVrf < CiscoTestCase
     v.destroy
   end
 
-  def test_vrf_description
-    vrf = Vrf.new('test_vrf_description')
+  def test_description
+    vrf = Vrf.new('test_description')
     vrf.description = 'tested by minitest'
     assert_equal('tested by minitest', vrf.description,
                  'failed to set description')
@@ -91,9 +101,9 @@ class TestVrf < CiscoTestCase
     vrf.destroy
   end
 
-  def test_vrf_vni
+  def test_vni
     skip('Platform does not support MT-lite') unless Vni.mt_lite_support
-    vrf = Vrf.new('test_vrf_vni')
+    vrf = Vrf.new('test_vni')
     vrf.vni = 4096
     assert_equal(4096, vrf.vni,
                  "vrf vni should be set to '4096'")
@@ -101,5 +111,133 @@ class TestVrf < CiscoTestCase
     assert_equal(vrf.default_vni, vrf.vni,
                  'vrf vni should be set to default value')
     vrf.destroy
+  end
+
+  def test_route_distinguisher
+    if node.product_id[/N3/]
+      skip('Platform does not support nv overlay feature') unless
+        Feature.nv_overlay_supported?
+    end
+    v = Vrf.new('blue')
+    v.route_distinguisher = 'auto'
+    assert_equal('auto', v.route_distinguisher)
+
+    v.route_distinguisher = '1:1'
+    assert_equal('1:1', v.route_distinguisher)
+
+    v.route_distinguisher = '2:3'
+    assert_equal('2:3', v.route_distinguisher)
+
+    v.route_distinguisher = v.default_route_distinguisher
+    assert_empty(v.route_distinguisher,
+                 'v route_distinguisher should *NOT* be configured')
+    v.destroy
+  end
+
+  def test_vrf_af_create_destroy
+    v1 = VrfAF.new('cyan', %w(ipv4 unicast))
+    v2 = VrfAF.new('cyan', %w(ipv6 unicast))
+    v3 = VrfAF.new('red', %w(ipv4 unicast))
+    v4 = VrfAF.new('blue', %w(ipv4 unicast))
+    v5 = VrfAF.new('red', %w(ipv6 unicast))
+    assert_equal(2, VrfAF.afs['cyan'].keys.count)
+    assert_equal(2, VrfAF.afs['red'].keys.count)
+    assert_equal(1, VrfAF.afs['blue'].keys.count)
+
+    v1.destroy
+    v5.destroy
+    assert_equal(1, VrfAF.afs['cyan'].keys.count)
+    assert_equal(1, VrfAF.afs['red'].keys.count)
+    assert_equal(1, VrfAF.afs['blue'].keys.count)
+
+    v2.destroy
+    v3.destroy
+    v4.destroy
+    assert_equal(0, VrfAF.afs['cyan'].keys.count)
+    assert_equal(0, VrfAF.afs['red'].keys.count)
+    assert_equal(0, VrfAF.afs['blue'].keys.count)
+  end
+
+  def test_route_target
+    [%w(ipv4 unicast), %w(ipv6 unicast)].each { |af| route_target(af) }
+  end
+
+  def route_target(af)
+    # Common tester for route-target properties. Tests evpn and non-evpn.
+    #   route_target_both_auto
+    #   route_target_both_auto_evpn
+    #   route_target_export
+    #   route_target_export_evpn
+    #   route_target_import
+    #   route_target_import_evpn
+    vrf = 'red'
+    v = VrfAF.new(vrf, af)
+
+    # test route target both auto and route target both auto evpn
+    refute(v.default_route_target_both_auto,
+           'default value for route target both auto should be false')
+
+    refute(v.default_route_target_both_auto_evpn,
+           'default value for route target both auto evpn should be false')
+
+    v.route_target_both_auto = true
+    assert(v.route_target_both_auto, "vrf context #{vrf} af #{af}: "\
+           'v route-target both auto should be enabled')
+
+    v.route_target_both_auto = false
+    refute(v.route_target_both_auto, "vrf context #{vrf} af #{af}: "\
+           'v route-target both auto should be disabled')
+
+    v.route_target_both_auto_evpn = true
+    assert(v.route_target_both_auto_evpn, "vrf context #{vrf} af #{af}: "\
+           'v route-target both auto evpn should be enabled')
+
+    v.route_target_both_auto_evpn = false
+    refute(v.route_target_both_auto_evpn, "vrf context #{vrf} af #{af}: "\
+           'v route-target both auto evpn should be disabled')
+
+    opts = [:import, :export]
+
+    # Master list of communities to test against
+    master = ['1:1', '2:2', '3:3', '4:5']
+
+    # Test 1: both/import/export when no commands are present. Each target
+    # option will be tested with and without evpn (6 separate types)
+    should = master.clone
+    route_target_tester(v, af, opts, should, 'Test 1')
+
+    # Test 2: remove half of the entries
+    should = ['1:1', '4:4']
+    route_target_tester(v, af, opts, should, 'Test 2')
+
+    # Test 3: restore the removed entries
+    should = master.clone
+    route_target_tester(v, af, opts, should, 'Test 3')
+
+    # Test 4: 'default'
+    should = v.default_route_target_import
+    route_target_tester(v, af, opts, should, 'Test 4')
+  end
+
+  def route_target_tester(v, af, opts, should, test_id)
+    # First configure all four property types
+    opts.each do |opt|
+      # non-evpn
+      v.send("route_target_#{opt}=", should)
+      # evpn
+      v.send("route_target_#{opt}_evpn=", should)
+    end
+
+    # Now check the results
+    opts.each do |opt|
+      # non-evpn
+      result = v.send("route_target_#{opt}")
+      assert_equal(should, result,
+                   "#{test_id} : #{af} : route_target_#{opt}")
+      # evpn
+      result = v.send("route_target_#{opt}_evpn")
+      assert_equal(should, result,
+                   "#{test_id} : #{af} : route_target_#{opt}_evpn")
+    end
   end
 end

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -114,10 +114,6 @@ class TestVrf < CiscoTestCase
   end
 
   def test_route_distinguisher
-    if node.product_id[/N3/]
-      skip('Platform does not support nv overlay feature') unless
-        Feature.nv_overlay_supported?
-    end
     v = Vrf.new('blue')
     v.route_distinguisher = 'auto'
     assert_equal('auto', v.route_distinguisher)

--- a/tests/test_vxlan_vtep.rb
+++ b/tests/test_vxlan_vtep.rb
@@ -25,8 +25,6 @@ class TestVxlanVtep < CiscoTestCase
     super
     skip('Platform does not support MT-full or MT-lite') unless
       VxlanVtep.mt_full_support || VxlanVtep.mt_lite_support
-    skip('Platform does not support nv overlay feature') unless
-      Feature.nv_overlay_supported?
   end
 
   def teardown


### PR DESCRIPTION
- route-distinguisher is now supported in both vrf and bgp
- route-target props have moved completely into vrf_af (new provider)
- vrf.yaml now template-tized
- changed feature calls to use new Feature class
- minitests updated
- feature calls moved to feature.rb
