### PR TITLE
Fix invalid 'feature fabric forwarding' command

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -1,6 +1,7 @@
 # feature
 ---
 fabric:
+  _exclude: [/N3/]
   config_get: "show feature-set"
   config_get_token: '/^fabric[\s\d]+(\w+)/'
   config_set: "<state> feature-set fabric"
@@ -9,7 +10,7 @@ fabric_forwarding:
   _exclude: [/N3/]
   config_get: "show running | i ^feature"
   config_get_token: '/^feature fabric forwarding$/'
-  config_set: "<state> feature fabric forwarding"
+  config_set: "feature fabric forwarding"
 
 nv_overlay:
   _exclude: [/N(5|6)/]

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -1,7 +1,7 @@
 # feature
 ---
 fabric:
-  _exclude: [/N3/]
+  _exclude: [/N(3|9)/]
   config_get: "show feature-set"
   config_get_token: '/^fabric[\s\d]+(\w+)/'
   config_set: "<state> feature-set fabric"

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -1,5 +1,10 @@
 # feature
 ---
+fabric:
+  config_get: "show feature-set"
+  config_get_token: '/^fabric[\s\d]+(\w+)/'
+  config_set: "<state> feature-set fabric"
+
 fabric_forwarding:
   _exclude: [/N3/]
   config_get: "show running | i ^feature"

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -1,5 +1,11 @@
 # feature
 ---
+fabric_forwarding:
+  _exclude: [/N3/]
+  config_get: "show running | i ^feature"
+  config_get_token: '/^feature fabric forwarding$/'
+  config_set: "<state> feature fabric forwarding"
+
 nv_overlay:
   _exclude: [/N(5|6)/]
   kind: boolean

--- a/lib/cisco_node_utils/cmd_ref/vxlan_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_global.yaml
@@ -31,8 +31,3 @@ dup_host_mac_detection_host_moves:
 
 dup_host_mac_detection_timeout:
   default_value: 180
-
-feature:
-  config_get: "show running | i ^feature"
-  config_get_token: '/^feature fabric forwarding$/'
-  config_set: "<state> feature fabric forwarding"

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -34,9 +34,13 @@ module Cisco
       config_get('feature', 'fabric') !~ /^uninstalled/
     end
 
+    def self.fabric_supported?
+      config_get('feature', 'fabric')
+    end
+
     def self.fabric_forwarding_enable
       return if fabric_forwarding_enabled?
-      Feature.fabric_enable unless node.product_id =~ /N9/
+      Feature.fabric_enable if Feature.fabric_supported?
       config_set('feature', 'fabric_forwarding')
     end
 

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -21,8 +21,9 @@ module Cisco
   class Feature < NodeUtil
     def self.fabric_enable
       # install feature-set and enable it
+      return if fabric_enabled?
       config_set('feature', 'fabric', state: 'install') unless fabric_installed?
-      config_set('feature', 'fabric', state: '') unless fabric_enabled?
+      config_set('feature', 'fabric', state: '')
     end
 
     def self.fabric_enabled?
@@ -31,6 +32,16 @@ module Cisco
 
     def self.fabric_installed?
       config_get('feature', 'fabric') !~ /^uninstalled/
+    end
+
+    def self.fabric_forwarding_enable
+      return if fabric_forwarding_enabled?
+      Feature.fabric_enable unless node.product_id =~ /N9/
+      config_set('feature', 'fabric_forwarding')
+    end
+
+    def self.fabric_forwarding_enabled?
+      config_get('feature', 'fabric_forwarding')
     end
 
     def self.nv_overlay_enabled?

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -19,6 +19,20 @@ require_relative 'node_util'
 module Cisco
   # Feature - node util class for managing common features
   class Feature < NodeUtil
+    def self.fabric_enable
+      # install feature-set and enable it
+      config_set('feature', 'fabric', state: 'install') unless fabric_installed?
+      config_set('feature', 'fabric', state: '') unless fabric_enabled?
+    end
+
+    def self.fabric_enabled?
+      config_get('feature', 'fabric') =~ /^enabled/
+    end
+
+    def self.fabric_installed?
+      config_get('feature', 'fabric') !~ /^uninstalled/
+    end
+
     def self.nv_overlay_enabled?
       config_get('feature', 'nv_overlay')
     rescue Cisco::CliError => e

--- a/lib/cisco_node_utils/vxlan_global.rb
+++ b/lib/cisco_node_utils/vxlan_global.rb
@@ -26,29 +26,11 @@ module Cisco
   class VxlanGlobal < NodeUtil
     # Constructor for vxlan_global
     def initialize(instantiate=true)
-      enable if instantiate && !VxlanGlobal.enabled
-    end
-
-    def enable
-      Feature.fabric_enable unless Feature.fabric_enabled?
-      config_set('feature', 'fabric_forwarding', state: '')
+      Feature.fabric_forwarding_enable if instantiate
     end
 
     def disable
-      config_set('feature', 'fabric_forwarding', state: 'no') if
-        Feature.fabric_enabled?
       dup_host_mac_detection_default
-    end
-
-    # Check current state of the configuration
-    def self.enabled
-      feat = config_get('feature', 'fabric_forwarding')
-      return !(feat.nil? || feat.empty?)
-    rescue Cisco::CliError => e
-      # This cmd will syntax reject if feature is not
-      # enabled. Just catch the reject and return false.
-      return false if e.clierror =~ /Syntax error/
-      raise
     end
 
     # ----------

--- a/lib/cisco_node_utils/vxlan_global.rb
+++ b/lib/cisco_node_utils/vxlan_global.rb
@@ -29,17 +29,17 @@ module Cisco
     end
 
     def enable
-      config_set('vxlan_global', 'feature', state: '')
+      config_set('feature', 'fabric_forwarding', state: '')
     end
 
     def disable
-      config_set('vxlan_global', 'feature', state: 'no')
+      config_set('feature', 'fabric_forwarding', state: 'no')
       dup_host_mac_detection_default
     end
 
     # Check current state of the configuration
     def self.enabled
-      feat = config_get('vxlan_global', 'feature')
+      feat = config_get('feature', 'fabric_forwarding')
       return !(feat.nil? || feat.empty?)
     rescue Cisco::CliError => e
       # This cmd will syntax reject if feature is not

--- a/lib/cisco_node_utils/vxlan_global.rb
+++ b/lib/cisco_node_utils/vxlan_global.rb
@@ -18,6 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require_relative 'feature'
 require_relative 'node_util'
 
 module Cisco
@@ -29,11 +30,13 @@ module Cisco
     end
 
     def enable
+      Feature.fabric_enable unless Feature.fabric_enabled?
       config_set('feature', 'fabric_forwarding', state: '')
     end
 
     def disable
-      config_set('feature', 'fabric_forwarding', state: 'no')
+      config_set('feature', 'fabric_forwarding', state: 'no') if
+        Feature.fabric_enabled?
       dup_host_mac_detection_default
     end
 

--- a/tests/test_vxlan_global.rb
+++ b/tests/test_vxlan_global.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/feature'
 require_relative '../lib/cisco_node_utils/vxlan_global'
 
 include Cisco
@@ -33,13 +34,9 @@ class TestVxlanGlobal < CiscoTestCase
     config('no feature fabric forwarding')
   end
 
-  def test_on_off
+  def test_feature_on
     feat = VxlanGlobal.new
-    feat.enable
-    assert(VxlanGlobal.enabled)
-
-    feat.disable
-    refute(VxlanGlobal.enabled)
+    assert(Feature.fabric_forwarding_enabled?)
   end
 
   def test_dup_host_ip_addr_detection_set

--- a/tests/test_vxlan_global.rb
+++ b/tests/test_vxlan_global.rb
@@ -35,7 +35,7 @@ class TestVxlanGlobal < CiscoTestCase
   end
 
   def test_feature_on
-    feat = VxlanGlobal.new
+    VxlanGlobal.new
     assert(Feature.fabric_forwarding_enabled?)
   end
 


### PR DESCRIPTION
### Changes

`feature fabric forwarding` is not supported for 3k.

Additionally, `feature fabric forwarding` depends on `feature-set fabric` being installed.  VxlanGlobal provider now handles the case where `feature-set fabric` is not installed.
### Minitest Error

Currently only n9k fails minitest.

On my n9k-108, I get an error that says `install feature-set fabric` is an invalid command.  I thought that meant `fabric forwarding` is unsupported on 9k, but I found out I was still able to enable `feature fabric forwarding` while `feature-set fabric` was uninstalled.  Can anyone reproduce this on their n9k?

```
switch# show feature-set 
Feature Set Name      ID        State   
--------------------  --------  --------
fex                    3          disabled
fabric                 7          uninstalled
mpls                   4          uninstalled


switch(config)# install feature-set ?
  fex   FEX
  mpls  MPLS

switch(config)# feature fabric forwarding 
switch(config)#
```
