### PR TITLE
[git-hooks] Run rubocop against staged ruby files only

### DIFF
--- a/bin/git/hooks/pre-commit/rubocop
+++ b/bin/git/hooks/pre-commit/rubocop
@@ -9,12 +9,17 @@
 # rubocop run of all checks as part of the pre-push hook
 
 step_name "Running RuboCop lint checks"
-rubocop --lint
+staged_ruby_files=$(git diff --name-only --staged | grep .*.rb)
+if [ -z "$staged_ruby_files" ]; then
+  # quit since there are no ruby files to check
+  exit 0
+fi
+rubocop --lint $staged_ruby_files
 check_rc "Please fix RuboCop lint failures before committing."
 
 # Do a full rubocop run to warn the user, but don't block a commit by it.
 step_name "Running all RuboCop checks"
-rubocop
+rubocop $staged_ruby_files
 check_rc_optional "Fix all RuboCop failures before pushing upstream"
 
 exit 0

--- a/bin/git/hooks/pre-push/rubocop
+++ b/bin/git/hooks/pre-push/rubocop
@@ -3,5 +3,10 @@
 [ -n "$GIT_DIR" ] || export GIT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)/.git"
 . "$GIT_DIR"/hooks/hook_lib
 
-rubocop
+staged_ruby_files=$(git diff --name-only --staged | grep .*.rb)
+if [ -z "$staged_ruby_files" ]; then
+  # quit since there are no ruby files to check
+  exit 0
+fi
+rubocop $staged_ruby_files
 check_rc "Please fix RuboCop failures before pushing code upstream."


### PR DESCRIPTION
### Motivation

I've run into this problem a few times where I stage a file for commit, find out that there's a rubocop error in the file, fix the issue, then re-commit the change while forgetting to stage the file again.

This causes rubocop to report a false-positive for my commit because it can't tell that my staged changes include rubocop errors.

With this change, the git-hook will only run rubocop against staged `*.rb` files.
### Tests

Insert rubocop errors into random `*.rb` files:

```
diff --git a/lib/cisco_node_utils/vdc.rb b/lib/cisco_node_utils/vdc.rb
index 2d54829..5f5c2fc 100644
--- a/lib/cisco_node_utils/vdc.rb
+++ b/lib/cisco_node_utils/vdc.rb
@@ -1,4 +1,4 @@
-#
+#ljsk
 # NXAPI implementation of VDC class
 #
 # December 2015, Chris Van Heuveln
diff --git a/lib/cisco_node_utils/vni.rb b/lib/cisco_node_utils/vni.rb
index f2b9dc2..d0a5e58 100644
--- a/lib/cisco_node_utils/vni.rb
+++ b/lib/cisco_node_utils/vni.rb
@@ -1,4 +1,6 @@
-# VNI provider class
+laksdjf;asdkfasdf
+lsdfj
+asdfalsd# VNI provider class
 #
 # Deepak Cherian, September 2015
 #
diff --git a/lib/cisco_node_utils/yum.rb b/lib/cisco_node_utils/yum.rb
index 8807f75..41e2b6d 100644
--- a/lib/cisco_node_utils/yum.rb
+++ b/lib/cisco_node_utils/yum.rb
@@ -1,3 +1,4 @@
+#test
 #
 # NX
```

Attempt to stage and commit the ruby files:

```
~/cisco-network-node-utils/bin/git$ git status
On branch feature/git-hooks-staged-only
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

    modified:   hooks/pre-commit/rubocop
    modified:   hooks/pre-push/rubocop
    modified:   ../../lib/cisco_node_utils/vdc.rb
    modified:   ../../lib/cisco_node_utils/vni.rb
    modified:   ../../lib/cisco_node_utils/yum.rb

~/cisco-network-node-utils/bin/git$ git commit -m "This should fail"
*** Running Git hook script: pre-commit-rubocop...
    Running RuboCop lint checks
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 3 files
...

3 files inspected, no offenses detected
    Running all RuboCop checks
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 3 files
CCC

Offenses:

lib/cisco_node_utils/vdc.rb:1:1: C: Missing space after #.
#ljsk
^^^^^
lib/cisco_node_utils/vni.rb:1:8: C: Do not use semicolons to terminate expressions.
laksdjf;asdkfasdf
       ^
lib/cisco_node_utils/vni.rb:1:8: C: Space missing after semicolon.
laksdjf;asdkfasdf
       ^
lib/cisco_node_utils/vni.rb:3:9: C: Put a space before an end-of-line comment.
asdfalsd# VNI provider class
        ^^^^^^^^^^^^^^^^^^^^
lib/cisco_node_utils/yum.rb:1:1: C: Missing space after #.
#test
^^^^^

3 files inspected, 5 offenses detected
    ...[ WARNING ] Fix all RuboCop failures before pushing upstream
Continue anyway? [y/N] N
*** Running Git hook script: pre-commit-validate-diffs...
0
    ...[ OK ]
    ...[ FAIL ] One or more hook scripts reported an error
```

Unstage the ruby files with errors and commit just the git-hooks:

```
~/cisco-network-node-utils/bin/git$ git reset
Unstaged changes after reset:
M   bin/git/hooks/pre-commit/rubocop
M   bin/git/hooks/pre-push/rubocop
M   lib/cisco_node_utils/vdc.rb
M   lib/cisco_node_utils/vni.rb
M   lib/cisco_node_utils/yum.rb

robgrie@puppetmaster:~/cisco-network-node-utils/bin/git$ git add hooks/

robgrie@puppetmaster:~/cisco-network-node-utils/bin/git$ git commit -m "Run rubocop against staged ruby files only"
*** Running Git hook script: pre-commit-rubocop...
    Running RuboCop lint checks
    ...[ OK ]
*** Running Git hook script: pre-commit-validate-diffs...
0
    ...[ OK ]
*** Running Git hook script: commit-msg-enforce_style...
    ...[ OK ]
```
