### PR TITLE
Explicitly exclude platforms and skip minitest

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
@@ -1,5 +1,7 @@
 # vxlan_vtep
 ---
+_exclude: [/N(3|5|6)/]
+
 _template:
   config_get: "show running-config interface all | section 'interface nve'"
   config_get_token: '/^interface <name>$/i'

--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
@@ -29,7 +29,7 @@ mt_full_support:
 mt_lite_support:
   # This is only used for determining support for Multi-Tenancy Lite
   kind: boolean
-  /N(3|9)/:
+  /N9/:
     default_only: true
   else:
     # this feature is always off on these platforms and cannot be changed

--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
@@ -1,5 +1,7 @@
 # vxlan_vtep_vni
 ---
+_exclude: [/N(3|5|6)/]
+
 _template:
   config_get: "show running-config interface all | section 'interface nve'"
   config_get_token: '/^interface <name>$/i'

--- a/tests/test_vxlan_vtep_vni.rb
+++ b/tests/test_vxlan_vtep_vni.rb
@@ -49,6 +49,8 @@ class TestVxlanVtepVni < CiscoTestCase
   end
 
   def test_vnis
+    skip('Platform does not support vnis') if VxlanVtepVni.vnis['nve1'].nil?
+
     # Test empty case
     assert_empty(VxlanVtepVni.vnis['nve1'])
 


### PR DESCRIPTION
TestVxlanVtep and TestVxlanVtepVni skip for 3k, 5k, and 6k.
