### PR TITLE
Add `ipv4_arp_timeout` and `ipv4_address_secondary` properties to interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Changelog
 * Extend interface with attributes:
   * `channel_group`
   * `ipv4_acl_in`, `ipv4_acl_out`, `ipv6_acl_in`, `ipv6_acl_out`
+  * `ipv4_address_secondary`, `ipv4_arp_timeout`
   * `vlan_mapping`
   * switchport mode `fabricpath`
 * Extend vrf with attributes:

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -80,10 +80,16 @@ ipv4_addr_mask:
   multiple:
   cli_nexus:
     config_get_token_append: '/^ip address ([0-9\.]+)[\s\/](.*)/'
-    config_set_append: "%s ip address %s"
+    config_set_append: "%s ip address %s %s"
 
 ipv4_address:
   default_value: ~
+
+ipv4_arp_timeout:
+  kind: int
+  config_get_token_append: '/^ip arp timeout (\d+)$/'
+  config_set_append: "%s ip arp timeout %s"
+  default_value: 700
 
 ipv4_netmask_length:
   default_value: ~

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -331,6 +331,8 @@ module Cisco
     end
 
     def ipv4_arp_timeout=(timeout)
+      fail "'ipv4 arp timeout' can ony be configured on a vlan interface" unless
+        /vlan/.match(@name)
       state = (timeout == default_ipv4_arp_timeout) ? 'no' : ''
       config_set('interface', 'ipv4_arp_timeout', @name, state, timeout)
     end

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -269,9 +269,9 @@ module Cisco
         state = 'no'
         if secondary
           # We need address and mask to remove.
-          am = "#{ipv4_address_secondary}/#{ipv4_netmask_secondary}"
+          am = "#{ipv4_address_secondary}/#{ipv4_netmask_length_secondary}"
         else
-          am = "#{ipv4_address}/#{ipv4_netmask}"
+          am = "#{ipv4_address}/#{ipv4_netmask_length}"
         end
       else
         state = ''
@@ -293,11 +293,15 @@ module Cisco
       when :v4_addr
         v = d.nil? ? default_ipv4_address : d[0]
       when :v4_mask
-        v = d.nil? ? default_ipv4_netmask : d[1].to_i
+        v = d.nil? ? default_ipv4_netmask_length : d[1].to_i
       when :v4_addr_secondary
         v = (d.nil? || d.size < 4) ? default_ipv4_address : d[2]
       when :v4_mask_secondary
-        v = (d.nil? || d.size < 4) ? default_ipv4_netmask : d[3][0, 2].to_i
+        if d.nil? || d.size < 4
+          v = default_ipv4_netmask_length
+        else
+          v = d[3][0, 2].to_i
+        end
       end
       v
     end
@@ -310,11 +314,11 @@ module Cisco
       select_ipv4_attribute(:v4_addr_secondary)
     end
 
-    def ipv4_netmask
+    def ipv4_netmask_length
       select_ipv4_attribute(:v4_mask)
     end
 
-    def ipv4_netmask_secondary
+    def ipv4_netmask_length_secondary
       select_ipv4_attribute(:v4_mask_secondary)
     end
 
@@ -322,7 +326,7 @@ module Cisco
       config_get_default('interface', 'ipv4_address')
     end
 
-    def default_ipv4_netmask
+    def default_ipv4_netmask_length
       config_get_default('interface', 'ipv4_netmask_length')
     end
 

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -262,42 +262,81 @@ module Cisco
       raise "[#{@name}] '#{e.command}' : #{e.clierror}"
     end
 
-    def ipv4_addr_mask
-      config_get('interface', 'ipv4_addr_mask', @name)
-    end
-
-    def ipv4_addr_mask_set(addr, mask)
+    def ipv4_addr_mask_set(addr, mask, secondary=false)
       check_switchport_disabled
+      sec = secondary ? 'secondary' : ''
       if addr.nil? || addr == default_ipv4_address
-        config_set('interface', 'ipv4_addr_mask', @name, 'no', '')
+        state = 'no'
+        if secondary
+          # We need address and mask to remove.
+          am = "#{ipv4_address_secondary}/#{ipv4_netmask_secondary}"
+        else
+          am = "#{ipv4_address}/#{ipv4_netmask}"
+        end
       else
-        config_set('interface', 'ipv4_addr_mask', @name, '',
-                   "#{addr}/#{mask}")
+        state = ''
+        am = "#{addr}/#{mask}"
       end
+      config_set('interface', 'ipv4_addr_mask', @name, state, am, sec)
     rescue Cisco::CliError => e
       raise "[#{@name}] '#{e.command}' : #{e.clierror}"
     end
 
+    def ipv4_addr_mask
+      config_get('interface', 'ipv4_addr_mask', @name)
+    end
+
+    def select_ipv4_attribute(attribute)
+      d = ipv4_addr_mask.flatten unless ipv4_addr_mask.nil?
+      # (d)ata format after flatten: ['addr', 'mask', 'addr', 'mask secondary']
+      case attribute
+      when :v4_addr
+        v = d.nil? ? default_ipv4_address : d[0]
+      when :v4_mask
+        v = d.nil? ? default_ipv4_netmask : d[1].to_i
+      when :v4_addr_secondary
+        v = (d.nil? || d.size < 4) ? default_ipv4_address : d[2]
+      when :v4_mask_secondary
+        v = (d.nil? || d.size < 4) ? default_ipv4_netmask : d[3][0, 2].to_i
+      end
+      v
+    end
+
     def ipv4_address
-      val = ipv4_addr_mask
-      return default_ipv4_address if val.nil?
-      # val is [[addr, mask], [addr, mask secondary]] - we just want the addr
-      val.shift.first
+      select_ipv4_attribute(:v4_addr)
+    end
+
+    def ipv4_address_secondary
+      select_ipv4_attribute(:v4_addr_secondary)
+    end
+
+    def ipv4_netmask
+      select_ipv4_attribute(:v4_mask)
+    end
+
+    def ipv4_netmask_secondary
+      select_ipv4_attribute(:v4_mask_secondary)
     end
 
     def default_ipv4_address
       config_get_default('interface', 'ipv4_address')
     end
 
-    def ipv4_netmask_length
-      val = ipv4_addr_mask
-      return default_ipv4_netmask_length if val.nil?
-      # val is [[addr, mask], [addr, mask secondary]] - we just want the mask
-      val.shift.last.to_i
+    def default_ipv4_netmask
+      config_get_default('interface', 'ipv4_netmask_length')
     end
 
-    def default_ipv4_netmask_length
-      config_get_default('interface', 'ipv4_netmask_length')
+    def ipv4_arp_timeout
+      config_get('interface', 'ipv4_arp_timeout', @name)
+    end
+
+    def ipv4_arp_timeout=(timeout)
+      state = (timeout == default_ipv4_arp_timeout) ? 'no' : ''
+      config_set('interface', 'ipv4_arp_timeout', @name, state, timeout)
+    end
+
+    def default_ipv4_arp_timeout
+      config_get_default('interface', 'ipv4_arp_timeout')
     end
 
     def ipv4_pim_sparse_mode

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -231,7 +231,7 @@ class TestInterface < CiscoTestCase
                         pattern: pattern)
       assert_equal(address, interface.ipv4_address,
                    "Error: ipv4 address get value mismatch for #{k}")
-      assert_equal(length, interface.ipv4_netmask,
+      assert_equal(length, interface.ipv4_netmask_length,
                    "Error: ipv4 netmask length get value mismatch for #{k}")
 
       # Get default
@@ -240,12 +240,12 @@ class TestInterface < CiscoTestCase
 
       # get_default_netmask
       assert_equal(DEFAULT_IF_IP_NETMASK_LEN,
-                   interface.default_ipv4_netmask,
+                   interface.default_ipv4_netmask_length,
                    "Error: ipv4 netmask length default mismatch for #{k}")
 
       # Unconfigure ipaddress
       interface.ipv4_addr_mask_set(interface.default_ipv4_address,
-                                   interface.default_ipv4_netmask)
+                                   interface.default_ipv4_netmask_length)
       pattern = %r{^\s+ip address #{address}/#{length}}
       refute_show_match(command: show_cmd(interface.name),
                         pattern: pattern,
@@ -253,7 +253,7 @@ class TestInterface < CiscoTestCase
       assert_equal(DEFAULT_IF_IP_ADDRESS, interface.ipv4_address,
                    "Error: ipv4 address value mismatch after unconfig for #{k}")
       assert_equal(DEFAULT_IF_IP_NETMASK_LEN,
-                   interface.ipv4_netmask,
+                   interface.ipv4_netmask_length,
                    "Error: ipv4 netmask length default mismatch for #{k}")
     end
   end
@@ -866,7 +866,7 @@ class TestInterface < CiscoTestCase
                       msg:     'Error: ipv4 address missing in CLI')
     assert_equal(address, interface.ipv4_address,
                  'Error: ipv4 address get value mismatch')
-    assert_equal(length, interface.ipv4_netmask,
+    assert_equal(length, interface.ipv4_netmask_length,
                  'Error: ipv4 netmask length get value mismatch')
 
     # Secondary: setter, getter
@@ -876,7 +876,7 @@ class TestInterface < CiscoTestCase
                       msg:     'Error: ipv4 address missing in CLI')
     assert_equal(sec_addr, interface.ipv4_address_secondary,
                  'Error: ipv4 address get value mismatch')
-    assert_equal(length, interface.ipv4_netmask,
+    assert_equal(length, interface.ipv4_netmask_length,
                  'Error: ipv4 netmask length get value mismatch')
 
     # get default
@@ -885,7 +885,7 @@ class TestInterface < CiscoTestCase
 
     # get_default_netmask
     assert_equal(DEFAULT_IF_IP_NETMASK_LEN,
-                 interface.default_ipv4_netmask,
+                 interface.default_ipv4_netmask_length,
                  'Error: ipv4 netmask length get default value mismatch')
 
     # unconfigure ipaddress - secondary must be removed first
@@ -898,7 +898,7 @@ class TestInterface < CiscoTestCase
     assert_equal(DEFAULT_IF_IP_ADDRESS, interface.ipv4_address,
                  'Error: ipv4 address value mismatch after unconfig')
     assert_equal(DEFAULT_IF_IP_NETMASK_LEN,
-                 interface.ipv4_netmask,
+                 interface.ipv4_netmask_length,
                  'Error: ipv4 netmask length default get value mismatch')
 
     interface_ethernet_default(interfaces_id[0])
@@ -915,7 +915,7 @@ class TestInterface < CiscoTestCase
     # getter
     assert_equal(address, interface.ipv4_address,
                  'Error: ipv4 address get value mismatch')
-    assert_equal(length, interface.ipv4_netmask,
+    assert_equal(length, interface.ipv4_netmask_length,
                  'Error: ipv4 netmask length get value mismatch')
     # unconfigure ipaddress
     interface_ipv4_config(ifname, address, length, false)
@@ -937,7 +937,7 @@ class TestInterface < CiscoTestCase
     # getter
     assert_equal(address, interface.ipv4_address,
                  'Error: ipv4 address get value mismatch')
-    assert_equal(length, interface.ipv4_netmask,
+    assert_equal(length, interface.ipv4_netmask_length,
                  'Error: ipv4 netmask length get value mismatch')
     # unconfigure ipaddress includign secondary
     interface_ipv4_config(ifname, address, length, false, false)

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -231,7 +231,7 @@ class TestInterface < CiscoTestCase
                         pattern: pattern)
       assert_equal(address, interface.ipv4_address,
                    "Error: ipv4 address get value mismatch for #{k}")
-      assert_equal(length, interface.ipv4_netmask_length,
+      assert_equal(length, interface.ipv4_netmask,
                    "Error: ipv4 netmask length get value mismatch for #{k}")
 
       # Get default
@@ -240,12 +240,12 @@ class TestInterface < CiscoTestCase
 
       # get_default_netmask
       assert_equal(DEFAULT_IF_IP_NETMASK_LEN,
-                   interface.default_ipv4_netmask_length,
+                   interface.default_ipv4_netmask,
                    "Error: ipv4 netmask length default mismatch for #{k}")
 
       # Unconfigure ipaddress
       interface.ipv4_addr_mask_set(interface.default_ipv4_address,
-                                   interface.default_ipv4_netmask_length)
+                                   interface.default_ipv4_netmask)
       pattern = %r{^\s+ip address #{address}/#{length}}
       refute_show_match(command: show_cmd(interface.name),
                         pattern: pattern,
@@ -253,7 +253,7 @@ class TestInterface < CiscoTestCase
       assert_equal(DEFAULT_IF_IP_ADDRESS, interface.ipv4_address,
                    "Error: ipv4 address value mismatch after unconfig for #{k}")
       assert_equal(DEFAULT_IF_IP_NETMASK_LEN,
-                   interface.ipv4_netmask_length,
+                   interface.ipv4_netmask,
                    "Error: ipv4 netmask length default mismatch for #{k}")
     end
   end
@@ -855,27 +855,42 @@ class TestInterface < CiscoTestCase
     interface = create_interface
     interface.switchport_mode = :disabled
     address = '8.7.1.1'
+    sec_addr = '10.5.5.1'
+    secondary = true
     length = 15
 
-    # setter, getter
+    # Primary: setter, getter
     interface.ipv4_addr_mask_set(address, length)
     pattern = %r{^\s+ip address #{address}/#{length}}
     assert_show_match(pattern: pattern,
                       msg:     'Error: ipv4 address missing in CLI')
     assert_equal(address, interface.ipv4_address,
                  'Error: ipv4 address get value mismatch')
-    assert_equal(length, interface.ipv4_netmask_length,
+    assert_equal(length, interface.ipv4_netmask,
                  'Error: ipv4 netmask length get value mismatch')
+
+    # Secondary: setter, getter
+    interface.ipv4_addr_mask_set(sec_addr, length, secondary)
+    pattern = %r{^\s+ip address #{sec_addr}/#{length} secondary}
+    assert_show_match(pattern: pattern,
+                      msg:     'Error: ipv4 address missing in CLI')
+    assert_equal(sec_addr, interface.ipv4_address_secondary,
+                 'Error: ipv4 address get value mismatch')
+    assert_equal(length, interface.ipv4_netmask,
+                 'Error: ipv4 netmask length get value mismatch')
+
     # get default
     assert_equal(DEFAULT_IF_IP_ADDRESS, interface.default_ipv4_address,
                  'Error: ipv4 address get default value mismatch')
 
     # get_default_netmask
     assert_equal(DEFAULT_IF_IP_NETMASK_LEN,
-                 interface.default_ipv4_netmask_length,
+                 interface.default_ipv4_netmask,
                  'Error: ipv4 netmask length get default value mismatch')
 
-    # unconfigure ipaddress
+    # unconfigure ipaddress - secondary must be removed first
+    interface.ipv4_addr_mask_set(interface.default_ipv4_address, length,
+                                 secondary)
     interface.ipv4_addr_mask_set(interface.default_ipv4_address, length)
     pattern = (/^\s+ip address (.*)/)
     refute_show_match(pattern: pattern,
@@ -883,7 +898,7 @@ class TestInterface < CiscoTestCase
     assert_equal(DEFAULT_IF_IP_ADDRESS, interface.ipv4_address,
                  'Error: ipv4 address value mismatch after unconfig')
     assert_equal(DEFAULT_IF_IP_NETMASK_LEN,
-                 interface.ipv4_netmask_length,
+                 interface.ipv4_netmask,
                  'Error: ipv4 netmask length default get value mismatch')
 
     interface_ethernet_default(interfaces_id[0])
@@ -900,7 +915,7 @@ class TestInterface < CiscoTestCase
     # getter
     assert_equal(address, interface.ipv4_address,
                  'Error: ipv4 address get value mismatch')
-    assert_equal(length, interface.ipv4_netmask_length,
+    assert_equal(length, interface.ipv4_netmask,
                  'Error: ipv4 netmask length get value mismatch')
     # unconfigure ipaddress
     interface_ipv4_config(ifname, address, length, false)
@@ -922,11 +937,26 @@ class TestInterface < CiscoTestCase
     # getter
     assert_equal(address, interface.ipv4_address,
                  'Error: ipv4 address get value mismatch')
-    assert_equal(length, interface.ipv4_netmask_length,
+    assert_equal(length, interface.ipv4_netmask,
                  'Error: ipv4 netmask length get value mismatch')
     # unconfigure ipaddress includign secondary
     interface_ipv4_config(ifname, address, length, false, false)
     interface_ethernet_default(interfaces_id[0])
+  end
+
+  def test_interface_ipv4_arp_timeout
+    # Setup
+    config('no interface vlan11')
+    int = Interface.new('vlan11')
+
+    # Test default
+    assert_equal(int.default_ipv4_arp_timeout, int.ipv4_arp_timeout)
+    # Test non-default
+    int.ipv4_arp_timeout = 300
+    assert_equal(300, int.ipv4_arp_timeout)
+    # Set back to default
+    int.ipv4_arp_timeout = int.default_ipv4_arp_timeout
+    assert_equal(int.default_ipv4_arp_timeout, int.ipv4_arp_timeout)
   end
 
   def test_interface_ipv4_proxy_arp

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -957,6 +957,10 @@ class TestInterface < CiscoTestCase
     # Set back to default
     int.ipv4_arp_timeout = int.default_ipv4_arp_timeout
     assert_equal(int.default_ipv4_arp_timeout, int.ipv4_arp_timeout)
+
+    # Attempt to configure on a non-vlan interface
+    nonvlanint = create_interface
+    assert_raises(RuntimeError) { nonvlanint.ipv4_arp_timeout = 300 }
   end
 
   def test_interface_ipv4_proxy_arp


### PR DESCRIPTION
NOTE: `ipv4 arp timeout` can only be configured under a vlan interface.

Known failure below, not related to my changes.

```
Run options: -v -- --seed 63021

# Running:


Node under test:
  - name  - n3k-103
  - type  - N3K-C3048TP-1GE
  - image - 

TestInterface#test_interface_create_name_invalid = 2.37 s = .
TestInterface#test_interface_vrf_valid = 1.53 s = .
TestInterface#test_interface_vrf_invalid_type = 0.96 s = .
TestInterface#test_interface_speed_invalid = 2.20 s = .
TestInterface#test_interfaces_not_empty = 1.32 s = .
TestInterface#test_interface_ipv4_all_interfaces = 10.00 s = F
TestInterface#test_interface_duplex_invalid = 4.54 s = .
TestInterface#test_interface_duplex_change = 6.38 s = .
TestInterface#test_interface_mtu_valid = 4.40 s = .
TestInterface#test_ipv6_acl = 4.51 s = .
TestInterface#test_interface_description_valid = 3.91 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig_secondary = 4.64 s = .
TestInterface#test_interface_ipv4_arp_timeout = 3.95 s = .
TestInterface#test_interface_get_access_vlan_switchport_disabled = 3.79 s = .
TestInterface#test_interface_ipv4_addr_mask_set_address_invalid = 3.91 s = .
TestInterface#test_interface_vrf_override = 1.64 s = .
TestInterface#test_interface_encapsulation_dot1q_invalid = 3.96 s = .
TestInterface#test_interface_encapsulation_dot1q_valid = 4.39 s = .
TestInterface#test_interface_create_does_not_exist = 0.93 s = .
TestInterface#test_interface_description_too_long = 3.42 s = .
TestInterface#test_interface_ipv4_addr_mask_set_netmask_invalid = 3.89 s = .
TestInterface#test_negotiate_auto_ethernet = 3.51 s = S
TestInterface#test_interface_speed_valid = 4.77 s = .
TestInterface#test_interface_vrf_default = 1.62 s = .
TestInterface#test_interface_create_name_nil = 0.90 s = .
TestInterface#test_interface_ipv4_redirects = 6.11 s = .
TestInterface#test_interface_create_valid = 0.96 s = .
TestInterface#test_interface_mtu_invalid = 1.52 s = .
TestInterface#test_interface_get_access_vlan_switchport_trunk = 4.98 s = .
TestInterface#test_interface_get_access_vlan = 4.90 s = .
TestInterface#test_interface_encapsulation_dot1q_change = 4.93 s = .
TestInterface#test_negotiate_auto_loopback = 1.05 s = .
TestInterface#test_interface_description_nil = 0.95 s = .
TestInterface#test_ipv4_pim_sparse_mode = 6.85 s = .
TestInterface#test_interface_shutdown_valid = 4.84 s = .
TestInterface#test_interface_ipv4_proxy_arp = 6.05 s = .
TestInterface#test_interface_ipv4_address = 6.66 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig = 4.58 s = .
TestInterface#test_interface_description_zero_length = 1.49 s = .
TestInterface#test_interface_vrf_empty = 1.55 s = .
TestInterface#test_interface_mtu_change = 4.92 s = .
TestInterface#test_negotiate_auto_portchannel = 6.39 s = .
TestInterface#test_interface_channel_group_add_delete = 2.35 s = .
TestInterface#test_interface_vrf_exceeds_max_length = 0.98 s = .
TestInterface#test_ipv4_acl = 4.49 s = .
TestInterface#test_interface_duplex_valid = 5.72 s = .
TestInterface#test_interface_speed_change = 5.78 s = .

Finished in 175.521079s, 0.2678 runs/s, 0.9970 assertions/s.

  1) Failure:
TestInterface#test_interface_ipv4_all_interfaces [tests/test_interface.rb:230]:
Expected /^\s+ip address 9.7.1.1\/15/ to match output of '"show run interface vlan45 all | no-more"':
show run interface vlan45 all | no-more

!Command: show running-config interface Vlan45 all
!Time: Fri Jan 15 20:33:33 2016

version 7.0(3)I2(2)

interface Vlan45
  description Mini Me
  shutdown
  mtu 1500
  bandwidth 1000000
  autostate
  delay 1
  medium broadcast
  snmp trap link-status
  carrier-delay msec 100
  load-interval counter 1 60
  load-interval counter 2 300
  no load-interval counter 3
  mac-address 6c41.6a33.eec1 
  no management
  ip proxy-arp

n3k-103# .


  2) Skipped:
TestInterface#test_negotiate_auto_ethernet [tests/test_interface.rb:718]:
Skip test: Interface type does not allow config change

47 runs, 175 assertions, 1 failures, 0 errors, 1 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils/coverage. 795 / 1185 LOC (67.09%) covered.
```

```
Run options: -v -- --seed 28079

# Running:


Node under test:
  - name  - dt-n9k5-1
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I2.1.69.bin

TestInterface#test_interface_vrf_empty = 9.02 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig = 5.54 s = .
TestInterface#test_interface_get_access_vlan = 4.09 s = .
TestInterface#test_interface_encapsulation_dot1q_invalid = 3.71 s = .
TestInterface#test_negotiate_auto_ethernet = 3.53 s = S
TestInterface#test_negotiate_auto_portchannel = 5.70 s = .
TestInterface#test_interface_duplex_change = 4.35 s = .
TestInterface#test_ipv4_pim_sparse_mode = 4.70 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig_secondary = 5.00 s = .
TestInterface#test_interface_shutdown_valid = 4.41 s = .
TestInterface#test_interface_mtu_change = 4.40 s = .
TestInterface#test_interface_ipv4_redirects = 5.21 s = .
TestInterface#test_interface_encapsulation_dot1q_valid = 4.00 s = .
TestInterface#test_interface_description_zero_length = 1.07 s = .
TestInterface#test_interface_duplex_invalid = 3.70 s = .
TestInterface#test_interface_encapsulation_dot1q_change = 4.36 s = .
TestInterface#test_negotiate_auto_loopback = 1.78 s = .
TestInterface#test_ipv6_acl = 4.18 s = .
TestInterface#test_interface_ipv4_addr_mask_set_netmask_invalid = 3.59 s = .
TestInterface#test_interface_get_access_vlan_switchport_disabled = 3.78 s = .
TestInterface#test_interface_ipv4_all_interfaces = 54.72 s = .
TestInterface#test_interface_description_too_long = 3.59 s = .
TestInterface#test_interface_get_access_vlan_switchport_trunk = 5.26 s = .
TestInterface#test_interface_description_nil = 0.69 s = .
TestInterface#test_interface_speed_valid = 3.88 s = .
TestInterface#test_interface_create_name_nil = 0.67 s = .
TestInterface#test_interface_create_valid = 0.73 s = .
TestInterface#test_interface_duplex_valid = 4.02 s = .
TestInterface#test_interface_channel_group_add_delete = 1.74 s = .
TestInterface#test_interface_create_does_not_exist = 0.81 s = .
TestInterface#test_interface_mtu_invalid = 1.04 s = .
TestInterface#test_interface_vrf_invalid_type = 0.70 s = .
TestInterface#test_ipv4_acl = 4.09 s = .
TestInterface#test_interface_ipv4_proxy_arp = 5.94 s = .
TestInterface#test_interface_vrf_exceeds_max_length = 0.72 s = .
TestInterface#test_interface_speed_change = 0.91 s = S
TestInterface#test_interfaces_not_empty = 0.95 s = .
TestInterface#test_interface_speed_invalid = 0.82 s = .
TestInterface#test_interface_ipv4_addr_mask_set_address_invalid = 3.67 s = .
TestInterface#test_interface_mtu_valid = 3.95 s = .
TestInterface#test_interface_vrf_default = 2.12 s = .
TestInterface#test_interface_description_valid = 3.84 s = .
TestInterface#test_interface_ipv4_arp_timeout = 3.53 s = .
TestInterface#test_interface_vrf_override = 1.23 s = .
TestInterface#test_interface_ipv4_address = 5.60 s = .
TestInterface#test_interface_vrf_valid = 1.19 s = .
TestInterface#test_interface_create_name_invalid = 0.72 s = .

Finished in 203.262360s, 0.2312 runs/s, 1.6727 assertions/s.

  1) Skipped:
TestInterface#test_negotiate_auto_ethernet [tests/test_interface.rb:718]:
Skip test: Interface type does not allow config change


  2) Skipped:
TestInterface#test_interface_speed_change [tests/test_interface.rb:84]:
Skip test: Interface type does not allow config change

47 runs, 340 assertions, 0 failures, 0 errors, 2 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils/coverage. 809 / 1185 LOC (68.27%) covered.

```
