### PR TITLE
Additional ipv4_addr and ipv4_arp_timeout updates

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -91,6 +91,9 @@ ipv4_arp_timeout:
   config_set_append: "%s ip arp timeout %s"
   default_value: 700
 
+ipv4_arp_timeout_non_vlan_interfaces:
+  default_only: ~
+
 ipv4_netmask_length:
   default_value: ~
 

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -326,12 +326,29 @@ module Cisco
       config_get_default('interface', 'ipv4_address')
     end
 
+    def default_ipv4_address_secondary
+      default_ipv4_address
+    end
+
     def default_ipv4_netmask_length
       config_get_default('interface', 'ipv4_netmask_length')
     end
 
+    def default_ipv4_netmask_length_secondary
+      default_ipv4_netmask_length
+    end
+
+    def ipv4_arp_timeout_lookup_string
+      case @name
+      when /vlan/i
+        return 'ipv4_arp_timeout'
+      else
+        return 'ipv4_arp_timeout_non_vlan_interfaces'
+      end
+    end
+
     def ipv4_arp_timeout
-      config_get('interface', 'ipv4_arp_timeout', @name)
+      config_get('interface', ipv4_arp_timeout_lookup_string, @name)
     end
 
     def ipv4_arp_timeout=(timeout)
@@ -342,7 +359,7 @@ module Cisco
     end
 
     def default_ipv4_arp_timeout
-      config_get_default('interface', 'ipv4_arp_timeout')
+      config_get_default('interface', ipv4_arp_timeout_lookup_string)
     end
 
     def ipv4_pim_sparse_mode


### PR DESCRIPTION
`interface.rb` was missing a few things for secondary ip address and ip arp timeout support.
1. default methods for `ipv4_address_secondary` and `ipv4_netmask_length_secondary`
2. added lookup string for `ipv4_arp_timeout` to return `nil` on unsupported interfaces.

```
Node under test:
  - name  - dt-n9k5-1
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I2.1.69.bin

TestInterface#test_interface_description_nil = 1.65 s = .
TestInterface#test_interface_get_access_vlan = 5.35 s = .
TestInterface#test_interface_create_name_invalid = 0.71 s = .
TestInterface#test_ipv4_pim_sparse_mode = 4.91 s = .
TestInterface#test_interface_create_valid = 0.76 s = .
TestInterface#test_interface_ipv4_redirects = 5.25 s = .
TestInterface#test_negotiate_auto_ethernet = 3.68 s = S
TestInterface#test_interface_description_valid = 3.75 s = .
TestInterface#test_negotiate_auto_portchannel = 5.05 s = .
TestInterface#test_ipv4_acl = 4.40 s = .
TestInterface#test_interface_get_access_vlan_switchport_disabled = 3.72 s = .
TestInterface#test_interface_shutdown_valid = 4.88 s = .
TestInterface#test_interface_encapsulation_dot1q_invalid = 3.79 s = .
TestInterface#test_interface_encapsulation_dot1q_valid = 4.26 s = .
TestInterface#test_interfaces_not_empty = 1.06 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig_secondary = 5.10 s = .
TestInterface#test_interface_ipv4_proxy_arp = 5.25 s = .
TestInterface#test_interface_encapsulation_dot1q_change = 4.54 s = .
TestInterface#test_interface_ipv4_addr_mask_set_netmask_invalid = 3.75 s = .
TestInterface#test_interface_duplex_change = 4.45 s = .
TestInterface#test_interface_speed_valid = 3.99 s = .
TestInterface#test_interface_duplex_valid = 4.01 s = .
TestInterface#test_interface_vrf_invalid_type = 0.76 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig = 5.00 s = .
TestInterface#test_interface_ipv4_address = 5.84 s = .
TestInterface#test_interface_ipv4_all_interfaces = 56.13 s = .
TestInterface#test_interface_duplex_invalid = 3.77 s = .
TestInterface#test_interface_vrf_default = 2.24 s = .
TestInterface#test_interface_mtu_valid = 4.13 s = .
TestInterface#test_interface_create_does_not_exist = 0.80 s = .
TestInterface#test_ipv6_acl = 4.89 s = .
TestInterface#test_interface_speed_change = 0.96 s = S
TestInterface#test_interface_ipv4_arp_timeout = 3.67 s = .
TestInterface#test_interface_mtu_change = 4.39 s = .
TestInterface#test_interface_vrf_exceeds_max_length = 0.76 s = .
TestInterface#test_interface_vrf_valid = 1.21 s = .
TestInterface#test_interface_vrf_override = 1.39 s = .
TestInterface#test_interface_ipv4_addr_mask_set_address_invalid = 3.69 s = .
TestInterface#test_interface_mtu_invalid = 1.18 s = .
TestInterface#test_interface_description_too_long = 3.40 s = .
TestInterface#test_interface_vrf_empty = 2.24 s = .
TestInterface#test_interface_get_access_vlan_switchport_trunk = 4.21 s = .
TestInterface#test_interface_create_name_nil = 0.74 s = .
TestInterface#test_interface_speed_invalid = 0.90 s = .
TestInterface#test_interface_description_zero_length = 1.13 s = .
TestInterface#test_interface_channel_group_add_delete = 1.63 s = .
TestInterface#test_negotiate_auto_loopback = 1.81 s = .

Finished in 201.213847s, 0.2336 runs/s, 1.6947 assertions/s.

  1) Skipped:
TestInterface#test_negotiate_auto_ethernet [tests/test_interface.rb:718]:
Skip test: Interface type does not allow config change


  2) Skipped:
TestInterface#test_interface_speed_change [tests/test_interface.rb:84]:
Skip test: Interface type does not allow config change

47 runs, 341 assertions, 0 failures, 0 errors, 2 skips
```
