### PR TITLE
Initial commit interface_channel_group provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,15 @@ Changelog
 * Feature
   * feature (@robert-w-gries)
 * Interface
+  * interface_channel_group (@chrisvanheuveln)
+  * interface_portchannel (@saichint)
   * interface_service_vni (@chrisvanheuveln)
 * PIM
   * pim (@smigopal)
   * pim_group_list (@smigopal)
   * pim_rp_address (@smigopal)
 * Port Channel
+  * interface_channel_group (@chrisvanheuveln)
   * interface_portchannel (@saichint)
   * portchannel_global (@saichint)
 * SNMP
@@ -53,7 +56,6 @@ Changelog
   * `suppress_inactive`
   * `table_map`
 * Extend interface with attributes:
-  * `channel_group`
   * `ipv4_acl_in`, `ipv4_acl_out`, `ipv6_acl_in`, `ipv6_acl_out`
   * `ipv4_address_secondary`, `ipv4_arp_timeout`
   * `vlan_mapping`

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -22,12 +22,6 @@ all_interfaces:
   multiple:
   config_get_token: '/^interface (.*)/'
 
-channel_group:
-  kind: int
-  config_get_token_append: '/^channel-group (\d+)$/'
-  config_set_append: "%s channel-group %s %s"
-  default_value: false
-
 create:
   config_set: "interface %s"
 

--- a/lib/cisco_node_utils/cmd_ref/interface_channel_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_channel_group.yaml
@@ -1,0 +1,28 @@
+# interface_channel_group
+---
+_template:
+  config_get: "show running interface all"
+  config_get_token: '/^interface <name>$/i'
+  config_set: 'interface <name>'
+
+all_interfaces:
+  multiple:
+  config_get_token: '/^interface (Ethernet.*)/i'
+
+channel_group:
+  kind: int
+  config_get_token_append: '/^channel-group (\d+)$/'
+  config_set_append: '<state> channel-group <group> <force>'
+  default_value: false
+
+description:
+  kind: string
+  config_get_token_append: '/^description (.*)/'
+  config_set_append: '<state> description <desc>'
+  default_value: ''
+
+shutdown:
+  kind: boolean
+  config_get_token_append: '/^(?:no )?shutdown$/'
+  config_set_append: '<state> shutdown'
+  default_value: true

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -160,36 +160,6 @@ module Cisco
       config_get_default('interface', 'access_vlan')
     end
 
-    def channel_group
-      config_get('interface', 'channel_group', @name)
-    end
-
-    def channel_group=(val)
-      fail "channel_group is not supported on #{@name}" unless
-        @name[/Ethernet/i]
-      # 'force' is needed by cli_nxos to handle the case where a port-channel
-      # interface is created prior to the channel-group cli; in which case
-      # the properties of the port-channel interface will be different from
-      # the ethernet interface. 'force' is not needed if the port-channel is
-      # created as a result of the channel-group cli but since it does no
-      # harm we will use it every time.
-      if val
-        state = ''
-        force = 'force'
-      else
-        state = 'no'
-        val = force = ''
-      end
-      config_set('interface',
-                 'channel_group', @name, state, val, force)
-    rescue Cisco::CliError => e
-      raise "[#{@name}] '#{e.command}' : #{e.clierror}"
-    end
-
-    def default_channel_group
-      config_get_default('interface', 'channel_group')
-    end
-
     def description
       config_get('interface', 'description', @name)
     end

--- a/lib/cisco_node_utils/interface_channel_group.rb
+++ b/lib/cisco_node_utils/interface_channel_group.rb
@@ -1,0 +1,124 @@
+# January 2016, Chris Van Heuveln
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'node_util'
+
+# Add some interface-specific constants to the Cisco namespace
+module Cisco
+  # Interface - node utility class for general interface config management
+  class InterfaceChannelGroup < NodeUtil
+    attr_reader :name
+
+    def initialize(name)
+      validate_args(name)
+    end
+
+    def self.interfaces
+      hash = {}
+      all = config_get('interface_channel_group', 'all_interfaces')
+      return hash if all.nil?
+
+      all.each do |id|
+        id = id.downcase
+        hash[id] = InterfaceChannelGroup.new(id)
+      end
+      hash
+    end
+
+    def validate_args(name)
+      fail TypeError unless name.is_a?(String)
+      fail ArgumentError unless name.length > 0
+      fail "channel_group is not supported on #{name}" unless
+        name[/Ethernet/i]
+      @name = name.downcase
+      set_args_keys
+    end
+
+    def set_args_keys(hash={}) # rubocop:disable Style/AccessorMethodName
+      @get_args = { name: @name }
+      @set_args = @get_args.merge!(hash) unless hash.empty?
+    end
+
+    def fail_cli(e)
+      fail "[#{@name}] '#{e.command}' : #{e.clierror}"
+    end
+
+    ########################################################
+    #                      PROPERTIES                      #
+    ########################################################
+
+    def channel_group
+      config_get('interface_channel_group', 'channel_group', @get_args)
+    end
+
+    def channel_group=(group)
+      # 'force' is needed by cli_nxos to handle the case where a port-channel
+      # interface is created prior to the channel-group cli; in which case
+      # the properties of the port-channel interface will be different from
+      # the ethernet interface. 'force' is not needed if the port-channel is
+      # created as a result of the channel-group cli but since it does no
+      # harm we will use it every time.
+      if group
+        state = ''
+        force = 'force'
+      else
+        state = 'no'
+        group = force = ''
+      end
+      config_set('interface_channel_group', 'channel_group',
+                 set_args_keys(state: state, group: group, force: force))
+    rescue Cisco::CliError => e
+      fail_cli(e)
+    end
+
+    def default_channel_group
+      config_get_default('interface_channel_group', 'channel_group')
+    end
+
+    # ----------------------------
+    def description
+      config_get('interface_channel_group', 'description', @get_args)
+    end
+
+    def description=(desc)
+      state = desc.strip.empty? ? 'no' : ''
+      config_set('interface_channel_group', 'description',
+                 set_args_keys(state: state, desc: desc))
+    rescue Cisco::CliError => e
+      fail_cli(e)
+    end
+
+    def default_description
+      config_get_default('interface_channel_group', 'description')
+    end
+
+    # ----------------------------
+    def shutdown
+      config_get('interface_channel_group', 'shutdown', @get_args)
+    end
+
+    def shutdown=(state)
+      config_set('interface_channel_group', 'shutdown',
+                 set_args_keys(state: state ? '' : 'no'))
+    rescue Cisco::CliError => e
+      fail_cli(e)
+    end
+
+    def default_shutdown
+      config_get_default('interface_channel_group', 'shutdown')
+    end
+  end  # Class
+end    # Module

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1206,15 +1206,6 @@ class TestInterface < CiscoTestCase
     interface.destroy
   end
 
-  def test_interface_channel_group_add_delete
-    interface = Interface.new(interfaces[0])
-    pc = 100
-    interface.channel_group = pc
-    assert_equal(pc.to_i, interface.channel_group)
-    interface.channel_group = interface.default_channel_group
-    assert_equal(interface.default_channel_group, interface.channel_group)
-  end
-
   def test_ipv4_pim_sparse_mode
     # Sample cli:
     #

--- a/tests/test_interface_channel_group.rb
+++ b/tests/test_interface_channel_group.rb
@@ -1,0 +1,74 @@
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/interface_channel_group'
+
+# TestInterface - Minitest for general functionality of the Interface class.
+class TestInterfaceChannelGroup < CiscoTestCase
+  @@clean = false # rubocop:disable Style/ClassVars
+  def setup
+    super
+    @intf = InterfaceChannelGroup.new(interfaces[1])
+
+    # Only pre-clean interface on initial setup
+    config("default interface #{@intf}") unless @@clean
+    @@clean = true # rubocop:disable Style/ClassVars
+  end
+
+  def teardown
+    config("default interface #{@intf}")
+  end
+
+  def test_channel_group
+    i = @intf
+    group = 200
+    i.channel_group = group
+    assert_equal(group, i.channel_group)
+
+    group = 201
+    i.channel_group = group
+    assert_equal(group, i.channel_group)
+
+    group = i.default_channel_group
+    i.channel_group = group
+    assert_equal(group, i.channel_group)
+  end
+
+  def test_description
+    i = @intf
+    desc = 'test desc'
+    i.description = desc
+    assert_equal(desc, i.description)
+
+    desc = 'test desc changed'
+    i.description = desc
+    assert_equal(desc, i.description)
+
+    desc = i.default_description
+    i.description = desc
+    assert_equal(desc, i.description)
+  end
+
+  def test_shutdown
+    i = @intf
+    i.shutdown = true
+    assert(i.shutdown)
+    i.shutdown = false
+    refute(i.shutdown)
+
+    i.shutdown = i.default_shutdown
+    assert(i.shutdown)
+  end
+end


### PR DESCRIPTION
- moved channel_group property out of interface provider, into new interface_channel_group provider
  - channel-group causes problems in nxos when it is present on an interface; e.g. you cannot change switchport modes, etc
  - moving it into its own provider allows the manifest to explicitly remove it while allowing new (non-channel-group) properties to be added to the interface
