### PR TITLE
Fix interface regressions for nexus platforms 3k, 5k, 6k, 7k, 9k

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -48,7 +48,7 @@ duplex:
 
 encapsulation_dot1q:
   kind: int
-  config_get_token_append: '/^encapsulation dot1q (.*)/'
+  config_get_token_append: '/^encapsulation dot1q (.*)/i'
   config_set_append: "%s encapsulation dot1q %s"
   default_value: ""
 

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -475,11 +475,7 @@ module Cisco
     def negotiate_auto=(negotiate_auto)
       lookup = negotiate_auto_lookup_string
       no_cmd = (negotiate_auto ? '' : 'no')
-      begin
-        config_set('interface', lookup, @name, no_cmd)
-      rescue Cisco::CliError => e
-        raise "[#{@name}] '#{e.command}' : #{e.clierror}"
-      end
+      config_set('interface', lookup, @name, no_cmd)
     end
 
     def default_negotiate_auto

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -714,7 +714,7 @@ class TestInterface < CiscoTestCase
     # Some platforms/interfaces/versions do not support negotiation changes
     begin
       interface.negotiate_auto = false
-    rescue RuntimeError => e
+    rescue CliError => e
       skip('Skip test: Interface type does not allow config change') if
         e.message[/requested config change not allowed/]
       flunk(e.message)

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -40,8 +40,6 @@ class TestInterface < CiscoTestCase
   DEFAULT_IF_IP_PROXY_ARP = false
   DEFAULT_IF_IP_REDIRECTS = true
   DEFAULT_IF_VRF = ''
-  IF_DESCRIPTION_VALID_SIZE = 68 # SIZE = VSH Max 80 - "description " keyword
-  IF_DESCRIPTION_INVALID_SIZE = 255
   IF_VRF_MAX_LENGTH = 32
 
   def interface_ipv4_config(ifname, address, length,
@@ -401,24 +399,11 @@ class TestInterface < CiscoTestCase
     assert_equal('', interface.description)
   end
 
-  def test_interface_description_too_long
-    interface = Interface.new(interfaces[0])
-    description = 'a' * (IF_DESCRIPTION_INVALID_SIZE)
-    assert_raises(RuntimeError) { interface.description = description }
-    interface_ethernet_default(interfaces_id[0])
-  end
-
   def test_interface_description_valid
     interface = Interface.new(interfaces[0])
-    alphabet = 'abcdefghijklmnopqrstuvwxyz 0123456789'
-    description = ''
-    1.upto(IF_DESCRIPTION_VALID_SIZE) do |i|
-      description += alphabet[i % alphabet.size, 1]
-      next unless i == IF_DESCRIPTION_VALID_SIZE
-      # puts("description (#{i}): #{description}")
-      interface.description = description
-      assert_equal(description.rstrip, interface.description)
-    end
+    description = 'This is a test description ! '
+    interface.description = description
+    assert_equal(description.rstrip, interface.description)
     interface_ethernet_default(interfaces_id[0])
   end
 

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -455,6 +455,7 @@ class TestInterface < CiscoTestCase
 
   def test_interface_mtu_change
     interface = Interface.new(interfaces[0])
+    interface.switchport_mode = :disabled
     interface.mtu = 1520
     assert_equal(1520, interface.mtu)
     interface.mtu = 1580
@@ -464,11 +465,13 @@ class TestInterface < CiscoTestCase
 
   def test_interface_mtu_invalid
     interface = Interface.new(interfaces[0])
+    interface.switchport_mode = :disabled
     assert_raises(RuntimeError) { interface.mtu = 'hello' }
   end
 
   def test_interface_mtu_valid
     interface = Interface.new(interfaces[0])
+    interface.switchport_mode = :disabled
     interface.mtu = 1550
     assert_equal(1550, interface.mtu)
     interface_ethernet_default(interfaces_id[0])

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -64,7 +64,7 @@ class TestInterface < CiscoTestCase
   end
 
   def show_cmd(name)
-    all = node.product_id =~ /N7/ ? '' : 'all'
+    all = (name =~ /port-channel\d/ && node.product_id =~ /N7/) ? '' : 'all'
     "show run interface #{name} #{all} | no-more"
   end
 

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -78,11 +78,12 @@ class TestInterface < CiscoTestCase
 
   # Helper to check for misc speed change disallowed error messages.
   def speed_change_disallowed(message)
-    pattern = Regexp.new('(port doesn t support this speed|' \
-                         'Changing interface speed is not permitted|' \
-                         'requested config change not allowed)')
+    patterns = %w(port doesn t support this speed
+                  Changing interface speed is not permitted
+                  requested config change not allowed
+                  Configuration does not match the transceiver speed)
     skip('Skip test: Interface type does not allow config change') if
-         message[pattern]
+         message[Regexp.union(patterns)]
     flunk(message)
   end
 

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -80,10 +80,10 @@ class TestInterface < CiscoTestCase
 
   # Helper to check for misc speed change disallowed error messages.
   def speed_change_disallowed(message)
-    patterns = %w(port doesn t support this speed
-                  Changing interface speed is not permitted
-                  requested config change not allowed
-                  Configuration does not match the transceiver speed)
+    patterns = ['port doesn t support this speed',
+                'Changing interface speed is not permitted',
+                'requested config change not allowed',
+                /does not match the (transceiver speed|port capability)/]
     skip('Skip test: Interface type does not allow config change') if
          message[Regexp.union(patterns)]
     flunk(message)

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -40,7 +40,8 @@ class TestInterface < CiscoTestCase
   DEFAULT_IF_IP_PROXY_ARP = false
   DEFAULT_IF_IP_REDIRECTS = true
   DEFAULT_IF_VRF = ''
-  IF_DESCRIPTION_SIZE = 243 # SIZE = VSH Max 255 - "description " keyword
+  IF_DESCRIPTION_VALID_SIZE = 68 # SIZE = VSH Max 80 - "description " keyword
+  IF_DESCRIPTION_INVALID_SIZE = 255
   IF_VRF_MAX_LENGTH = 32
 
   def interface_ipv4_config(ifname, address, length,
@@ -401,7 +402,7 @@ class TestInterface < CiscoTestCase
 
   def test_interface_description_too_long
     interface = Interface.new(interfaces[0])
-    description = 'a' * (IF_DESCRIPTION_SIZE + 1)
+    description = 'a' * (IF_DESCRIPTION_INVALID_SIZE)
     assert_raises(RuntimeError) { interface.description = description }
     interface_ethernet_default(interfaces_id[0])
   end
@@ -410,9 +411,9 @@ class TestInterface < CiscoTestCase
     interface = Interface.new(interfaces[0])
     alphabet = 'abcdefghijklmnopqrstuvwxyz 0123456789'
     description = ''
-    1.upto(IF_DESCRIPTION_SIZE) do |i|
+    1.upto(IF_DESCRIPTION_VALID_SIZE) do |i|
       description += alphabet[i % alphabet.size, 1]
-      next unless i == IF_DESCRIPTION_SIZE
+      next unless i == IF_DESCRIPTION_VALID_SIZE
       # puts("description (#{i}): #{description}")
       interface.description = description
       assert_equal(description.rstrip, interface.description)

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -64,7 +64,8 @@ class TestInterface < CiscoTestCase
   end
 
   def show_cmd(name)
-    "show run interface #{name} all | no-more"
+    all = node.product_id =~ /N7/ ? '' : 'all'
+    "show run interface #{name} #{all} | no-more"
   end
 
   def interface_count


### PR DESCRIPTION
### Fixed errors
- Add another CliError message to `speed_change_disallowed` skip pattern
- Handle uppercase letter in `encapsulation dot1Q` for 5k and 6k
- Change max valid interface description size to `80` to fix error for 5k and 6k
- Handle `switchport mode` being enabled before `mtu` tests
- Remove `all` keyword from `show_cmd` for 7k because it is unsupported for that platform
### Changes
- Removed interface description length tests
### N3k Minitest Results

```
  1) Skipped:
TestInterface#test_negotiate_auto_ethernet [tests/test_interface.rb:709]:
Skip test: Interface type does not allow config change

46 runs, 342 assertions, 0 failures, 0 errors, 1 skips
```
### N5k Minitest Results

```
  1) Skipped:
TestInterface#test_interface_speed_change [tests/test_interface.rb:85]:
Skip test: Interface type does not allow config change

46 runs, 382 assertions, 0 failures, 0 errors, 1 skips
```
### N6k Minitest Results

```
  1) Skipped:
TestInterface#test_interface_speed_change [tests/test_interface.rb:87]:
Skip test: Interface type does not allow config change

47 runs, 383 assertions, 0 failures, 0 errors, 1 skips
```
### N7k Minitest Results

```
  1) Skipped:
TestInterface#test_interface_speed_valid [tests/test_interface.rb:87]:
Skip test: Interface type does not allow config change


  2) Skipped:
TestInterface#test_negotiate_auto_portchannel [/home/robgrie/cisco-network-node-utils/tests/basetest.rb:103]:
Feature 'interface', attribute 'negotiate_auto_portchannel', operation 'config_set' is unsupported on this node


  3) Skipped:
TestInterface#test_interface_duplex_valid [tests/test_interface.rb:87]:
Skip test: Interface type does not allow config change


  4) Skipped:
TestInterface#test_negotiate_auto_ethernet [/home/robgrie/cisco-network-node-utils/tests/basetest.rb:103]:
Feature 'interface', attribute 'negotiate_auto_ethernet', operation 'config_set' is unsupported on this node


  5) Skipped:
TestInterface#test_interface_speed_change [tests/test_interface.rb:87]:
Skip test: Interface type does not allow config change


  6) Skipped:
TestInterface#test_interface_duplex_change [tests/test_interface.rb:87]:
Skip test: Interface type does not allow config change


  7) Skipped:
TestInterface#test_interface_duplex_invalid [tests/test_interface.rb:87]:
Skip test: Interface type does not allow config change

47 runs, 323 assertions, 0 failures, 0 errors, 7 skips
```
### N9k Minitest Results

```
  1) Skipped:
TestInterface#test_interface_speed_change [tests/test_interface.rb:87]:
Skip test: Interface type does not allow config change


  2) Skipped:
TestInterface#test_negotiate_auto_ethernet [tests/test_interface.rb:724]:
Skip test: Interface type does not allow config change

47 runs, 341 assertions, 0 failures, 0 errors, 2 skips
```
