### PR TITLE
Added IPv6 support for syslog_server

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/syslog_server.yaml
+++ b/lib/cisco_node_utils/cmd_ref/syslog_server.yaml
@@ -9,7 +9,7 @@ level:
 server:
   multiple: true
   config_get: "show running-config all | include '^logging server'"
-  config_get_token: '/^logging server ((?:[0-9]{1,3}\.){3}[0-9]{1,3}).*/'
+  config_get_token: '/^logging server (\S+).*/'
   config_set: '<state> logging server <ip> <level> <vrf>'
 
 vrf:

--- a/tests/test_syslog_server.rb
+++ b/tests/test_syslog_server.rb
@@ -35,36 +35,48 @@ class TestSyslogServer < CiscoTestCase
   def no_syslogserver
     # Turn the feature off for a clean test.
     config('no logging server 1.2.3.4',
-           'no logging server 2.3.4.5',
+           'no logging server 2003::2',
            'no vrf context red')
   end
 
   # TESTS
 
-  def test_syslogserver_create_destroy_single
+  def test_create_destroy_single_ipv4
     id = '1.2.3.4'
     refute_includes(Cisco::SyslogServer.syslogservers, id)
 
     server = Cisco::SyslogServer.new(id, 2, 'default', true)
     assert_includes(Cisco::SyslogServer.syslogservers, id)
-    assert_equal(Cisco::SyslogServer.syslogservers[id], server)
+    assert_equal(server, Cisco::SyslogServer.syslogservers[id])
 
     server.destroy
     refute_includes(Cisco::SyslogServer.syslogservers, id)
   end
 
-  def test_syslogserver_create_destroy_multiple
+  def test_create_destroy_single_ipv6
+    id = '2003::2'
+    refute_includes(Cisco::SyslogServer.syslogservers, id)
+
+    server = Cisco::SyslogServer.new(id, 2, 'default', true)
+    assert_includes(Cisco::SyslogServer.syslogservers, id)
+    assert_equal(server, Cisco::SyslogServer.syslogservers[id])
+
+    server.destroy
+    refute_includes(Cisco::SyslogServer.syslogservers, id)
+  end
+
+  def test_create_destroy_multiple
     id = '1.2.3.4'
-    id2 = '2.3.4.5'
+    id2 = '2003::2'
     refute_includes(Cisco::SyslogServer.syslogservers, id)
     refute_includes(Cisco::SyslogServer.syslogservers, id2)
 
     server = Cisco::SyslogServer.new(id, 2, 'default', true)
     server2 = Cisco::SyslogServer.new(id2, 2, 'default', true)
     assert_includes(Cisco::SyslogServer.syslogservers, id)
-    assert_equal(Cisco::SyslogServer.syslogservers[id], server)
+    assert_equal(server, Cisco::SyslogServer.syslogservers[id])
     assert_includes(Cisco::SyslogServer.syslogservers, id2)
-    assert_equal(Cisco::SyslogServer.syslogservers[id2], server2)
+    assert_equal(server2, Cisco::SyslogServer.syslogservers[id2])
 
     server.destroy
     server2.destroy
@@ -72,7 +84,7 @@ class TestSyslogServer < CiscoTestCase
     refute_includes(Cisco::SyslogServer.syslogservers, id2)
   end
 
-  def test_syslogserver_create_destroy_single_vrf
+  def test_create_destroy_single_vrf_ipv4
     config('vrf context red')
     id = '1.2.3.4'
 
@@ -80,7 +92,21 @@ class TestSyslogServer < CiscoTestCase
 
     server = Cisco::SyslogServer.new(id, 2, 'red', true)
     assert_includes(Cisco::SyslogServer.syslogservers, id)
-    assert_equal(Cisco::SyslogServer.syslogservers[id], server)
+    assert_equal(server, Cisco::SyslogServer.syslogservers[id])
+
+    server.destroy
+    refute_includes(Cisco::SyslogServer.syslogservers, id)
+  end
+
+  def test_create_destroy_single_vrf_ipv6
+    config('vrf context red')
+    id = '2003::2'
+
+    refute_includes(Cisco::SyslogServer.syslogservers, id)
+
+    server = Cisco::SyslogServer.new(id, 2, 'red', true)
+    assert_includes(Cisco::SyslogServer.syslogservers, id)
+    assert_equal(server, Cisco::SyslogServer.syslogservers[id])
 
     server.destroy
     refute_includes(Cisco::SyslogServer.syslogservers, id)


### PR DESCRIPTION
TestSyslogServer#test_create_destroy_single_ipv6 = 13.91 s = .
TestSyslogServer#test_create_destroy_single = 12.78 s = .
TestSyslogServer#test_create_destroy_multiple = 12.90 s = .
TestSyslogServer#test_create_destroy_single_vrf = 13.75 s = .

Finished in 53.347300s, 0.0750 runs/s, 0.6561 assertions/s.

4 runs, 35 assertions, 0 failures, 0 errors, 0 skips
