### PR TITLE
Change NU dependency to nxapi 1.0.1

### DIFF
--- a/cisco_node_utils.gemspec
+++ b/cisco_node_utils.gemspec
@@ -32,5 +32,5 @@ Currently supports NX-OS nodes.
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '= 0.35.1'
   spec.add_development_dependency 'simplecov', '~> 0.9'
-  spec.add_runtime_dependency 'cisco_nxapi', '~> 1.0'
+  spec.add_runtime_dependency 'cisco_nxapi', '~> 1.0', '>= 1.0.1'
 end


### PR DESCRIPTION
I ran into a null hash problem with one of the new providers; the RC was traced back to an nxapi problem that was fixed with 1.0.1: https://github.com/cisco/cisco-nxapi/pull/2/files
