### PR TITLE
vlan fix and cleanup

### DIFF
--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -58,7 +58,7 @@ module Cisco
       # instead just displays a STDOUT error message; thus NXAPI does not detect
       # the failure and we must catch it by inspecting the "body" hash entry
       # returned by NXAPI. This vlan cli behavior is unlikely to change.
-      fail result[2]['body'] unless result[2]['body'].to_s.empty?
+      fail result[2]['body'] if /ERROR:/.match(result[2]['body'].to_s)
     end
 
     def fabricpath_feature

--- a/tests/test_vlan.rb
+++ b/tests/test_vlan.rb
@@ -26,10 +26,9 @@ class TestVlan < CiscoTestCase
   def setup
     super
     # Cleanup any non-default vlans prior to each test.
-    s = @device.cmd("show run | i '^vlan 1'")
-    s.split(',').each do |v|
-      vlan = v.match(/(\d+)/).to_s
-      config("no vlan #{vlan}") unless vlan.to_s == '1'
+    Vlan.vlans.each do |vlan_id, obj|
+      next if vlan_id == '1'
+      obj.destroy
     end
     # Only pre-clean interface on initial setup
     interface_ethernet_default(interfaces_id[0]) unless @@interface_cleaned

--- a/tests/test_vlan.rb
+++ b/tests/test_vlan.rb
@@ -22,20 +22,23 @@ include Cisco
 
 # TestVlan - Minitest for Vlan node utility
 class TestVlan < CiscoTestCase
-  @@interface_cleaned = false # rubocop:disable Style/ClassVars
-  def setup
-    super
-    # Cleanup any non-default vlans prior to each test.
+  @@cleaned = false # rubocop:disable Style/ClassVars
+  def cleanup
     Vlan.vlans.each do |vlan_id, obj|
       next if vlan_id == '1'
       obj.destroy
     end
-    # Only pre-clean interface on initial setup
-    interface_ethernet_default(interfaces_id[0]) unless @@interface_cleaned
-    @@interface_cleaned = true # rubocop:disable Style/ClassVars
+    interface_ethernet_default(interfaces_id[0])
+  end
+
+  def setup
+    super
+    cleanup unless @@cleaned
+    @@cleaned = true # rubocop:disable Style/ClassVars
   end
 
   def teardown
+    cleanup
     return unless Vdc.vdc_support
     # Reset the vdc module type back to default
     v = Vdc.new('default')


### PR DESCRIPTION
**Couple of updates for vlan:**
- Fixes improper handling of the results hash in a test helper method.  There are cases where the existing logic would result in `false` even when there was no error in the results hash.  Change to explicitly look for an ERROR.
- Added cleanup logic to remove existing non-default vlans and clean ethernet interfaces used by the tests.

**Beaker Tests**
- No longer see error related to improper handling of the results hash.

**N9k Mini Tests**

```
Node under test:
  - name  - dt-n9k5-1
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I2.1.69.bin

TestVlan#test_vlan_state_invalid = 4.75 s = .
TestVlan#test_vlan_shutdown_extended = 1.09 s = F
TestVlan#test_vlan_mode_fabricpath = 1.98 s = S
TestVlan#test_vlan_state_extended = 1.19 s = .
TestVlan#test_vlan_remove_interface_invalid = 2.21 s = .
TestVlan#test_vlan_add_remove_interface_valid = 3.49 s = .
TestVlan#test_vlan_create_and_destroy = 1.33 s = .
TestVlan#test_vlan_name_duplicate = 2.50 s = .
TestVlan#test_vlan_name_too_long = 1.62 s = .
TestVlan#test_vlan_name_default_1000 = 1.57 s = .
TestVlan#test_vlan_name_invalid = 1.26 s = .
TestVlan#test_vlan_mapped_vnis = 5.95 s = .
TestVlan#test_vlan_shutdown_valid = 3.42 s = .
TestVlan#test_vlan_name_nil = 1.16 s = .
TestVlan#test_vlan_collection_not_empty = 1.23 s = .
TestVlan#test_vlan_add_interface_invalid = 1.76 s = .
TestVlan#test_vlan_name_default_40 = 1.53 s = .
TestVlan#test_vlan_state_valid = 2.36 s = .
TestVlan#test_vlan_create_invalid_non_numeric_vlan = 1.15 s = .
TestVlan#test_vlan_name_zero_length = 1.41 s = .
TestVlan#test_vlan_create_invalid = 1.24 s = .
TestVlan#test_vlan_name_length_valid = 1.28 s = .

Finished in 45.462019s, 0.4839 runs/s, 1.1218 assertions/s.

  1) Failure:
TestVlan#test_vlan_shutdown_extended [tests/test_vlan.rb:247]:
vlan misconfig did not raise RuntimeError.
RuntimeError expected but nothing was raised.


  2) Skipped:
TestVlan#test_vlan_mode_fabricpath [tests/test_vlan.rb:187]:
Platform does not support MT-full

22 runs, 51 assertions, 1 failures, 0 errors, 1 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/coverage. 808 / 1566 LOC (51.6%) covered.
```

Failure unrelated to this change.

**N6K Minitests**

```
Node under test:
  - name  - n6k-92
  - type  - N6K-C6001-64P
  - image - bootflash:///n6000-uk9-kickstart.7.3.0.N1.0.270.bin

TestVlan#test_vlan_state_invalid = 5.59 s = .
TestVlan#test_vlan_name_invalid = 1.40 s = .
TestVlan#test_vlan_add_interface_invalid = 3.21 s = .
TestVlan#test_vlan_state_extended = 1.41 s = E
TestVlan#test_vlan_mapped_vnis = 1.33 s = S
TestVlan#test_vlan_state_valid = 4.50 s = .
TestVlan#test_vlan_name_zero_length = 1.78 s = .
TestVlan#test_vlan_name_nil = 1.60 s = .
TestVlan#test_vlan_name_duplicate = 1.92 s = .
TestVlan#test_vlan_name_default_1000 = 2.58 s = .
TestVlan#test_vlan_name_length_valid = 1.92 s = .
TestVlan#test_vlan_create_invalid_non_numeric_vlan = 1.43 s = .
TestVlan#test_vlan_create_invalid = 1.57 s = .
TestVlan#test_vlan_shutdown_valid = 4.62 s = .
TestVlan#test_vlan_name_too_long = 1.51 s = .
TestVlan#test_vlan_shutdown_extended = 1.53 s = .
TestVlan#test_vlan_name_default_40 = 2.63 s = .
TestVlan#test_vlan_create_and_destroy = 2.18 s = .
TestVlan#test_vlan_mode_fabricpath = 2.21 s = S
TestVlan#test_vlan_remove_interface_invalid = 3.38 s = .
TestVlan#test_vlan_add_remove_interface_valid = 5.53 s = .
TestVlan#test_vlan_collection_not_empty = 1.96 s = .

Finished in 55.801677s, 0.3943 runs/s, 0.8064 assertions/s.

  1) Error:
TestVlan#test_vlan_state_extended:
RuntimeError: ERROR: Can t modify state for extended VLAN

ERROR : cli_process_vlan_config_exit(302), command state suspend FAILED
Cannot run commands in the mode at this moment. Please try again.

    /nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/lib/cisco_node_utils/vlan.rb:61:in `cli_error_check'
    /nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/lib/cisco_node_utils/vlan.rb:141:in `state='
    tests/test_vlan.rb:218:in `test_vlan_state_extended'


  2) Skipped:
TestVlan#test_vlan_mapped_vnis [/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/tests/basetest.rb:103]:
Feature 'feature', attribute 'vn_segment_vlan_based', operation 'config_set' is unsupported on this node


  3) Skipped:
TestVlan#test_vlan_mode_fabricpath [tests/test_vlan.rb:187]:
Platform does not support MT-full

22 runs, 45 assertions, 0 failures, 1 errors, 2 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/coverage. 807 / 1566 LOC (51.53%) covered.
```

Error is an actual error on this N6K.  Problem in the image and reported correctly by our cli_error_check method.

**N7K Minitests**

```
Node under test:
  - name  - n7k-j
  - type  - N7K-C7009
  - image - bootflash:///n7000-s2-dk9.7.3.0.D1.0.202.bin

TestVlan#test_vlan_name_default_40 = 6.28 s = .
TestVlan#test_vlan_remove_interface_invalid = 3.12 s = .
TestVlan#test_vlan_state_valid = 4.46 s = .
TestVlan#test_vlan_mode_fabricpath = 1.28 s = S
TestVlan#test_vlan_name_too_long = 1.80 s = .
TestVlan#test_vlan_add_interface_invalid = 2.30 s = .
TestVlan#test_vlan_state_extended = 1.80 s = .
TestVlan#test_vlan_state_invalid = 1.77 s = .
TestVlan#test_vlan_create_and_destroy = 2.27 s = .
TestVlan#test_vlan_create_invalid_non_numeric_vlan = 1.28 s = .
TestVlan#test_vlan_add_remove_interface_valid = 4.33 s = .
TestVlan#test_vlan_mapped_vnis = 1.68 s = S
TestVlan#test_vlan_name_default_1000 = 2.84 s = .
TestVlan#test_vlan_shutdown_extended = 1.81 s = F
TestVlan#test_vlan_name_duplicate = 2.39 s = .
TestVlan#test_vlan_name_length_valid = 2.23 s = .
TestVlan#test_vlan_name_nil = 1.80 s = .
TestVlan#test_vlan_name_zero_length = 2.15 s = .
TestVlan#test_vlan_shutdown_valid = 4.64 s = .
TestVlan#test_vlan_create_invalid = 1.71 s = .
TestVlan#test_vlan_name_invalid = 1.88 s = .
TestVlan#test_vlan_collection_not_empty = 1.66 s = .

Finished in 55.482247s, 0.3965 runs/s, 0.8111 assertions/s.

  1) Skipped:
TestVlan#test_vlan_mode_fabricpath [tests/test_vlan.rb:181]:
Unable to find a compatible interface in chassis


  2) Skipped:
TestVlan#test_vlan_mapped_vnis [/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/tests/basetest.rb:103]:
Feature 'feature', attribute 'vn_segment_vlan_based', operation 'config_set' is unsupported on this node


  3) Failure:
TestVlan#test_vlan_shutdown_extended [tests/test_vlan.rb:247]:
vlan misconfig did not raise RuntimeError.
RuntimeError expected but nothing was raised.

22 runs, 45 assertions, 1 failures, 0 errors, 2 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/coverage. 818 / 1566 LOC (52.23%) covered.
```
