### PR TITLE
ipv4_addr_mask_set unset idempotence

### DIFF
--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -238,9 +238,11 @@ module Cisco
       if addr.nil? || addr == default_ipv4_address
         state = 'no'
         if secondary
+          return if ipv4_address_secondary == default_ipv4_address_secondary
           # We need address and mask to remove.
           am = "#{ipv4_address_secondary}/#{ipv4_netmask_length_secondary}"
         else
+          return if ipv4_address == default_ipv4_address
           am = "#{ipv4_address}/#{ipv4_netmask_length}"
         end
       else

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -883,6 +883,10 @@ class TestInterface < CiscoTestCase
     interface.ipv4_addr_mask_set(interface.default_ipv4_address, length,
                                  secondary)
     interface.ipv4_addr_mask_set(interface.default_ipv4_address, length)
+    # unconfigure should be safely idempotent
+    interface.ipv4_addr_mask_set(interface.default_ipv4_address, length,
+                                 secondary)
+    interface.ipv4_addr_mask_set(interface.default_ipv4_address, length)
     pattern = (/^\s+ip address (.*)/)
     refute_show_match(pattern: pattern,
                       msg:     'Error: ipv4 address still present in CLI')


### PR DESCRIPTION
In doing some testing in the gRPC branch I found that ipv4_addr_mask_set is not safe when attempting to unset an IP address that is already unset - you get a CliError because it's trying to do something like 'no ip address /'. This looks to also be an issue in the release branch so I'm opening this PR to double-commit it to release_1.2.0.

```
Run options: -n test_interface_ipv4_address -- --seed 45791

# Running:


Node under test:
  - name  - n9k-108
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I2.1.bin

.

Finished in 12.178028s, 0.0821 runs/s, 1.3960 assertions/s.

1 runs, 17 assertions, 0 failures, 0 errors, 0 skips
```
