### PR TITLE
Fix for feature fabric forwarding exception for n9k I3 images

### DIFF
--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -80,7 +80,12 @@ module Cisco
 
     # ---------------------------
     def self.nv_overlay_evpn_enable
-      return if nv_overlay_evpn_enabled?
+      begin
+        return if nv_overlay_evpn_enabled? && fabric_forwarding_enabled?
+        config_set('feature', 'fabric_forwarding')
+        config_set('feature', 'nv_overlay_evpn')
+      end
+    rescue
       config_set('feature', 'nv_overlay_evpn')
     end
 

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -80,8 +80,11 @@ module Cisco
 
     # ---------------------------
     def self.nv_overlay_evpn_enable
+    # The feature fabric-forwarding cli is required in some older nxos images but is not 
+    # present in newer images because nv_overlay_evpn handles both features; therefore
+    # feature fabric-forwarding is best-effort and ignored on cli failure.
       begin
-        return if nv_overlay_evpn_enabled? && fabric_forwarding_enabled?
+        return if nv_overlay_evpn_enabled?
         config_set('feature', 'fabric_forwarding')
         config_set('feature', 'nv_overlay_evpn')
       end

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -80,9 +80,10 @@ module Cisco
 
     # ---------------------------
     def self.nv_overlay_evpn_enable
-    # The feature fabric-forwarding cli is required in some older nxos images but is not 
-    # present in newer images because nv_overlay_evpn handles both features; therefore
-    # feature fabric-forwarding is best-effort and ignored on cli failure.
+      # The feature fabric-forwarding cli is required in some older nxos images
+      # but is not present in newer images because nv_overlay_evpn handles
+      # both features; therefore feature fabric-forwarding is best-effort
+      # and ignored on cli failure.
       begin
         return if nv_overlay_evpn_enabled?
         config_set('feature', 'fabric_forwarding')

--- a/lib/cisco_node_utils/vxlan_global.rb
+++ b/lib/cisco_node_utils/vxlan_global.rb
@@ -26,7 +26,7 @@ module Cisco
   class VxlanGlobal < NodeUtil
     # Constructor for vxlan_global
     def initialize(instantiate=true)
-      Feature.fabric_forwarding_enable if instantiate
+      Feature.nv_overlay_evpn_enable if instantiate
     end
 
     def disable

--- a/tests/test_vxlan_global.rb
+++ b/tests/test_vxlan_global.rb
@@ -20,23 +20,21 @@ include Cisco
 
 # TestVxlanGlobal - Minitest for VxlanGlobal node utility
 class TestVxlanGlobal < CiscoTestCase
+  @@clean = false # rubocop:disable Style/ClassVars
   def setup
     super
-    no_vxlan_global
-  end
-
-  def teardown
-    no_vxlan_global
-    super
+    no_vxlan_global unless @@clean
+    @@clean = true # rubocop:disable Style/ClassVars
   end
 
   def no_vxlan_global
-    config('no feature fabric forwarding')
-  end
-
-  def test_feature_on
-    VxlanGlobal.new
-    assert(Feature.fabric_forwarding_enabled?)
+    begin
+      return if !(nv_overlay_evpn_enabled?) && !(fabric_forwarding_enabled?)
+      config('no feature fabric forwarding')
+      config('no nv overlay evpn')
+    end
+  rescue
+    config('no nv overlay evpn')
   end
 
   def test_dup_host_ip_addr_detection_set

--- a/tests/test_vxlan_global.rb
+++ b/tests/test_vxlan_global.rb
@@ -28,12 +28,7 @@ class TestVxlanGlobal < CiscoTestCase
   end
 
   def no_vxlan_global
-    begin
-      return if !(nv_overlay_evpn_enabled?) && !(fabric_forwarding_enabled?)
-      config('no feature fabric forwarding')
-      config('no nv overlay evpn')
-    end
-  rescue
+    config('no feature fabric forwarding')
     config('no nv overlay evpn')
   end
 


### PR DESCRIPTION
# Description:

Fix for feature fabric forwarding exception for n9k I3 images
# MiniTests:
# I2:

——
rtpfe1@agent-lab11-ws:~/smigopal/28_final_nve/cisco-network-node-utils$ ruby tests/test_vxlan_global.rb -v  -- 10.122.197.125 admin admin
Run options: -v -- --seed 28415

Running:

Node under test:
- name  - agent-lab11-nx
- type  - N9K-NXOSV
- image - bootflash:///nxos.7.0.3.I2.1.bin

conf : ["feature fabric forwarding"]
conf : ["nv overlay evpn"]
conf : [" fabric forwarding anycast-gateway-mac 1223.3445.5668"]
TestVxlanGlobal#test_anycast_gateway_mac_set = 4.86 s = .
conf : ["no fabric forwarding dup-host-ip-addr-detection 5 180"]
TestVxlanGlobal#test_dup_host_ip_addr_detection_clear = 1.80 s = .
conf : ["l2rib dup-host-mac-detection 160 16"]
TestVxlanGlobal#test_dup_host_mac_detection_set = 1.47 s = .
conf : [" fabric forwarding dup-host-ip-addr-detection 200 20"]
TestVxlanGlobal#test_dup_host_ip_addr_detection_set = 1.41 s = .
conf : ["no fabric forwarding anycast-gateway-mac "]
TestVxlanGlobal#test_anycast_gateway_mac_clear = 1.36 s = .
conf : ["l2rib dup-host-mac-detection default"]
TestVxlanGlobal#test_dup_host_mac_detection_default = 1.36 s = .

Finished in 12.272599s, 0.4889 runs/s, 0.4889 assertions/s.

6 runs, 6 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /home/rtpfe1/smigopal/28_final_nve/cisco-network-node-utils/coverage. 435 / 572 LOC (76.05%) covered.
rtpfe1@agent-lab11-ws:~/smigopal/28_final_nve/cisco-network-node-utils$
# I3:

——
rtpfe1@agent-lab11-ws:~/smigopal/28_final_nve/cisco-network-node-utils$ ruby tests/test_vxlan_global.rb -v -- 10.122.84.109 admin admin
Run options: -v -- --seed 14916

Running:

Node under test:
- name  - n9k-109
- type  - N9K-C9504
- image - bootflash:///nxos.7.0.3.I3.0.285.bin

conf : ["feature fabric forwarding"]
conf : ["nv overlay evpn"]
conf : ["l2rib dup-host-mac-detection default"]
TestVxlanGlobal#test_dup_host_mac_detection_default = 5.53 s = .
conf : ["feature fabric forwarding"]
conf : ["nv overlay evpn"]
conf : ["no fabric forwarding anycast-gateway-mac "]
TestVxlanGlobal#test_anycast_gateway_mac_clear = 2.16 s = .
conf : ["feature fabric forwarding"]
conf : ["nv overlay evpn"]
conf : ["l2rib dup-host-mac-detection 160 16"]
TestVxlanGlobal#test_dup_host_mac_detection_set = 1.79 s = .
conf : ["feature fabric forwarding"]
conf : ["nv overlay evpn"]
conf : [" fabric forwarding anycast-gateway-mac 1223.3445.5668"]
TestVxlanGlobal#test_anycast_gateway_mac_set = 2.09 s = .
conf : ["feature fabric forwarding"]
conf : ["nv overlay evpn"]
conf : ["no fabric forwarding dup-host-ip-addr-detection 5 180"]
TestVxlanGlobal#test_dup_host_ip_addr_detection_clear = 2.11 s = .
conf : ["feature fabric forwarding"]
conf : ["nv overlay evpn"]
conf : [" fabric forwarding dup-host-ip-addr-detection 200 20"]
TestVxlanGlobal#test_dup_host_ip_addr_detection_set = 2.13 s = .

Finished in 15.827843s, 0.3791 runs/s, 0.3791 assertions/s.

6 runs, 6 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /home/rtpfe1/smigopal/28_final_nve/cisco-network-node-utils/coverage. 439 / 572 LOC (76.75%) covered.
rtpfe1@agent-lab11-ws:~/smigopal/28_final_nve/cisco-network-node-utils$
# Rubocop:

rtpfe1@agent-lab11-ws:~/smigopal/28_final_nve/cisco-network-node-utils$ rubocop lib/cisco_node_utils/feature.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/smigopal/28_final_nve/cisco-network-node-utils$ rubocop lib/cisco_node_utils/vxlan_global.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/smigopal/28_final_nve/cisco-network-node-utils$ rubocop tests/test_vxlan_global.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/smigopal/28_final_nve/cisco-network-node-utils$
