### PR TITLE
Skip switchport mode access vtp tests for 5/6/7k

### DIFF
--- a/tests/test_interface_switchport.rb
+++ b/tests/test_interface_switchport.rb
@@ -49,6 +49,11 @@ class TestInterfaceSwitchport < CiscoTestCase
     end
   end
 
+  def platform_supports_vtp_switchport_access?
+    skip('Platform does not support VTP when switchport mode is access') if
+      node.product_id =~ /N(5|6|7)/
+  end
+
   def system_default_switchport(state='')
     config("#{state} system default switchport")
   end
@@ -100,8 +105,7 @@ class TestInterfaceSwitchport < CiscoTestCase
   end
 
   def test_switchport_vtp_enabled_access
-    skip('Cannot apply VTP config because port mode is access') if
-      node.product_id =~ /N(5|6|7)/
+    platform_supports_vtp_switchport_access?
     vtp = Vtp.new(true)
     interface = Interface.new(interfaces[0])
     interface.switchport_mode = :access
@@ -149,8 +153,7 @@ class TestInterfaceSwitchport < CiscoTestCase
   end
 
   def test_set_switchport_vtp_default_access
-    skip('Cannot apply VTP config because port mode is access') if
-      node.product_id =~ /N(5|6|7)/
+    platform_supports_vtp_switchport_access?
     vtp = Vtp.new(true)
     interface = Interface.new(interfaces[0])
     interface.switchport_mode = :access
@@ -192,8 +195,7 @@ class TestInterfaceSwitchport < CiscoTestCase
   end
 
   def test_set_switchport_vtp_true_access
-    skip('Cannot apply VTP config because port mode is access') if
-      node.product_id =~ /N(5|6|7)/
+    platform_supports_vtp_switchport_access?
     vtp = Vtp.new(true)
     interface = Interface.new(interfaces[0])
 

--- a/tests/test_interface_switchport.rb
+++ b/tests/test_interface_switchport.rb
@@ -100,6 +100,8 @@ class TestInterfaceSwitchport < CiscoTestCase
   end
 
   def test_switchport_vtp_enabled_access
+    skip('Cannot apply VTP config because port mode is access') if
+      node.product_id =~ /N(5|6|7)/
     vtp = Vtp.new(true)
     interface = Interface.new(interfaces[0])
     interface.switchport_mode = :access
@@ -147,6 +149,8 @@ class TestInterfaceSwitchport < CiscoTestCase
   end
 
   def test_set_switchport_vtp_default_access
+    skip('Cannot apply VTP config because port mode is access') if
+      node.product_id =~ /N(5|6|7)/
     vtp = Vtp.new(true)
     interface = Interface.new(interfaces[0])
     interface.switchport_mode = :access
@@ -188,6 +192,8 @@ class TestInterfaceSwitchport < CiscoTestCase
   end
 
   def test_set_switchport_vtp_true_access
+    skip('Cannot apply VTP config because port mode is access') if
+      node.product_id =~ /N(5|6|7)/
     vtp = Vtp.new(true)
     interface = Interface.new(interfaces[0])
 


### PR DESCRIPTION
## Fix

5k, 6k, and 7k cannot configure `switchport_vtp` while in `switchport mode access`:

```
n8k-136(config-if)# vtp
Can not apply VTP configuration on interface Ethernet1/1 because the port mode is access
```

N7k is still failing a couple tests due to hardcoded interfaces.  #201 should fix this issue.
## Testing
### 5k/6k

```
~/cisco-network-node-utils$ ruby tests/test_interface_switchport.rb -v
Run options: -v --seed 63188

# Running:


Node under test:
  - name  - n6k-77
  - type  - N6K-C6001-64P
  - image - bootflash:///n6000-uk9-kickstart.7.3.0.ZN.0.234.bin

TestInterfaceSwitchport#test_switchport_autostate_enabled_access = 9.62 s = .
TestInterfaceSwitchport#test_switchport_autostate_enabled_trunk = 8.02 s = .
TestInterfaceSwitchport#test_switchport_vtp_disabled_feature_disabled_eth1_1 = 3.40 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_invalid = 3.06 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_false_trunk = 7.99 s = .
TestInterfaceSwitchport#test_switchport_vtp_enabled_trunk = 7.46 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_native_vlan_default = 3.54 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_true_unsupported_mgmt0 = 4.63 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_default_access = 1.38 s = S
TestInterfaceSwitchport#test_set_switchport_autostate_false_trunk = 6.60 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_true_unsupported_mgmt0 = 5.42 s = .
TestInterfaceSwitchport#test_switchport_autostate_disabled_unsupported_mode = 5.17 s = .
TestInterfaceSwitchport#test_interface_switchport_mode_valid = 21.43 s = .
TestInterfaceSwitchport#test_switchport_vtp_disabled_access = 7.50 s = .
TestInterfaceSwitchport#test_switchport_vtp_disabled_unsupported_mode_fex = 3.92 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_default = 3.37 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_default_trunk = 6.78 s = .
TestInterfaceSwitchport#test_switchport_autostate_disabled_feature_enabled = 5.20 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_native_vlan_change = 5.84 s = .
TestInterfaceSwitchport#test_switchport_vtp_disabled_unsupported_mode_disabled = 2.94 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_true_trunk = 6.70 s = .
TestInterfaceSwitchport#test_switchport_vtp_disabled_trunk = 9.35 s = .
TestInterfaceSwitchport#test_interface_svi_command_on_non_vlan = 2.93 s = .
TestInterfaceSwitchport#test_interface_switchport_mode_valid_fex = 3.73 s = .
TestInterfaceSwitchport#test_switchport_autostate_disabled_trunk = 6.23 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_true_trunk = 9.57 s = .
TestInterfaceSwitchport#test_switchport_vtp_enabled_access = 1.30 s = S
TestInterfaceSwitchport#test_set_switchport_vtp_true_access = 1.30 s = S
TestInterfaceSwitchport#test_switchport_autostate_disabled_feature_disabled_mgmt0 = 1.54 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_none = 3.37 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_false_unsupported_mode_disabled = 5.04 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_valid = 5.31 s = .
TestInterfaceSwitchport#test_raise_error_switchport_not_enabled = 1.60 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_true_access = 6.06 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_default_trunk = 11.75 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_false_unsupported_mode_disabled = 6.53 s = .
TestInterfaceSwitchport#test_system_default_switchport_on_off = 3.69 s = .
TestInterfaceSwitchport#test_interface_switchport_mode_not_supported = 2.13 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_native_vlan_valid = 3.40 s = .
TestInterfaceSwitchport#test_switchport_vtp_disabled_feature_disabled_mgmt0 = 1.06 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_true_unsupported_mode_disabled = 5.00 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_false_access = 9.93 s = .
TestInterfaceSwitchport#test_switchport_vtp_disabled_feature_enabled = 5.04 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_default_access = 5.99 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_change = 5.86 s = .
TestInterfaceSwitchport#test_interface_switchport_mode_invalid = 2.45 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_all = 3.41 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_false_access = 5.98 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_true_unsupported_mode_disabled = 8.50 s = .
TestInterfaceSwitchport#test_switchport_autostate_disabled_access = 3.53 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_native_vlan_invalid = 4.74 s = .
TestInterfaceSwitchport#test_switchport_autostate_disabled_feature_disabled_eth1_1 = 1.55 s = .
TestInterfaceSwitchport#test_system_default_switchport_shutdown_on_off = 2.85 s = .

Finished in 280.709957s, 0.1888 runs/s, 0.3242 assertions/s.

  1) Skipped:
TestInterfaceSwitchport#test_set_switchport_vtp_default_access [tests/test_interface_switchport.rb:152]:
Cannot apply VTP config because port mode is access


  2) Skipped:
TestInterfaceSwitchport#test_switchport_vtp_enabled_access [tests/test_interface_switchport.rb:103]:
Cannot apply VTP config because port mode is access


  3) Skipped:
TestInterfaceSwitchport#test_set_switchport_vtp_true_access [tests/test_interface_switchport.rb:195]:
Cannot apply VTP config because port mode is access

53 runs, 91 assertions, 0 failures, 0 errors, 3 skips
```
### N7k

```
~/cisco-network-node-utils$ ruby tests/test_interface_switchport.rb -v
Run options: -v --seed 57986

# Running:


Node under test:
  - name  - n7k-j
  - type  - N7K-C7009
  - image - bootflash:///n7000-s2-dk9.7.3.0.D1.0.202.bin

TestInterfaceSwitchport#test_switchport_autostate_disabled_feature_disabled_mgmt0 = 3.29 s = .
TestInterfaceSwitchport#test_switchport_vtp_disabled_feature_disabled_eth1_1 = 2.04 s = .
TestInterfaceSwitchport#test_switchport_vtp_enabled_trunk = 5.35 s = .
TestInterfaceSwitchport#test_interface_switchport_mode_valid_fex = 5.76 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_change = 4.43 s = .
TestInterfaceSwitchport#test_switchport_autostate_disabled_feature_enabled = 3.50 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_true_trunk = 7.65 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_true_unsupported_mode_disabled = 5.67 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_native_vlan_valid = 4.64 s = .
TestInterfaceSwitchport#test_switchport_autostate_disabled_trunk = 6.83 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_valid = 4.35 s = .
TestInterfaceSwitchport#test_switchport_autostate_disabled_access = 3.48 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_default_trunk = 7.84 s = .
TestInterfaceSwitchport#test_switchport_vtp_disabled_feature_disabled_mgmt0 = 1.59 s = .
TestInterfaceSwitchport#test_switchport_vtp_disabled_trunk = 6.40 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_true_unsupported_mgmt0 = 3.63 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_false_trunk = 7.49 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_native_vlan_change = 5.02 s = .
TestInterfaceSwitchport#test_switchport_vtp_disabled_unsupported_mode_disabled = 3.24 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_native_vlan_default = 3.93 s = .
TestInterfaceSwitchport#test_raise_error_switchport_not_enabled = 1.60 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_true_access = 7.60 s = .
TestInterfaceSwitchport#test_switchport_autostate_disabled_unsupported_mode = 3.71 s = .
TestInterfaceSwitchport#test_interface_switchport_mode_valid = 20.68 s = .
TestInterfaceSwitchport#test_switchport_vtp_disabled_access = 6.58 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_default_access = 1.36 s = S
TestInterfaceSwitchport#test_set_switchport_autostate_false_access = 6.42 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_invalid = 3.87 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_default_access = 6.25 s = .
TestInterfaceSwitchport#test_switchport_autostate_enabled_trunk = 7.35 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_all = 5.00 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_none = 4.09 s = .
TestInterfaceSwitchport#test_switchport_autostate_enabled_access = 6.17 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_native_vlan_invalid = 4.09 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_false_trunk = 6.69 s = .
TestInterfaceSwitchport#test_system_default_switchport_shutdown_on_off = 1.12 s = E
TestInterfaceSwitchport#test_interface_switchport_mode_not_supported = 2.25 s = .
TestInterfaceSwitchport#test_switchport_vtp_disabled_feature_enabled = 3.29 s = .
TestInterfaceSwitchport#test_switchport_autostate_disabled_feature_disabled_eth1_1 = 1.59 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_default_trunk = 8.24 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_true_unsupported_mode_disabled = 5.25 s = .
TestInterfaceSwitchport#test_interface_svi_command_on_non_vlan = 3.31 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_false_access = 6.53 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_false_unsupported_mode_disabled = 5.03 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_true_access = 1.39 s = S
TestInterfaceSwitchport#test_system_default_switchport_on_off = 1.14 s = F
TestInterfaceSwitchport#test_switchport_vtp_enabled_access = 1.37 s = S
TestInterfaceSwitchport#test_interface_switchport_mode_invalid = 2.96 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_true_trunk = 6.93 s = .
TestInterfaceSwitchport#test_set_switchport_vtp_true_unsupported_mgmt0 = 2.92 s = .
TestInterfaceSwitchport#test_set_switchport_autostate_false_unsupported_mode_disabled = 5.01 s = .
TestInterfaceSwitchport#test_switchport_vtp_disabled_unsupported_mode_fex = 5.37 s = .
TestInterfaceSwitchport#test_interface_switchport_trunk_allowed_vlan_default = 3.83 s = .

Finished in 255.117442s, 0.2077 runs/s, 0.3489 assertions/s.

  1) Skipped:
TestInterfaceSwitchport#test_set_switchport_vtp_default_access [tests/test_interface_switchport.rb:152]:
Cannot apply VTP config because port mode is access


  2) Error:
TestInterfaceSwitchport#test_system_default_switchport_shutdown_on_off:
Cisco::CliError: CliError: 'interface eth1/1' rejected with message:
'Error: Invalid range: Ethernet1/1'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node.rb:266:in `rescue in config'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node.rb:263:in `config'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node.rb:161:in `config_set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node_util.rb:58:in `config_set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/interface.rb:60:in `create'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/interface.rb:43:in `initialize'
    tests/test_interface_switchport.rb:741:in `new'
    tests/test_interface_switchport.rb:741:in `test_system_default_switchport_shutdown_on_off'


  3) Skipped:
TestInterfaceSwitchport#test_set_switchport_vtp_true_access [tests/test_interface_switchport.rb:195]:
Cannot apply VTP config because port mode is access


  4) Failure:
TestInterfaceSwitchport#test_system_default_switchport_on_off [tests/test_interface_switchport.rb:737]:
CliError: 'interface eth1/1' rejected with message:
'Error: Invalid range: Ethernet1/1'


  5) Skipped:
TestInterfaceSwitchport#test_switchport_vtp_enabled_access [tests/test_interface_switchport.rb:103]:
Cannot apply VTP config because port mode is access

53 runs, 89 assertions, 1 failures, 1 errors, 3 skips
```
