### PR TITLE
Remove bgp dot-notation handlers

### DIFF
--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -26,7 +26,7 @@ module Cisco
     def initialize(asnum, vrf='default', instantiate=true)
       fail ArgumentError unless vrf.is_a? String
       fail ArgumentError unless vrf.length > 0
-      @asnum = RouterBgp.process_asnum(asnum)
+      @asnum = asnum.to_s
       @vrf = vrf
       if @vrf == 'default'
         @get_args = @set_args = { asnum: @asnum }
@@ -34,19 +34,6 @@ module Cisco
         @get_args = @set_args = { asnum: @asnum, vrf: @vrf }
       end
       create if instantiate
-    end
-
-    def self.process_asnum(asnum)
-      err_msg = "BGP asnum must be either a 'String' or an" \
-                " 'Integer' object"
-      fail ArgumentError, err_msg unless asnum.is_a?(Integer) ||
-                                         asnum.is_a?(String)
-      if asnum.is_a? String
-        # Match ASDOT '1.5' or ASPLAIN '55' strings
-        fail ArgumentError unless /^(\d+|\d+\.\d+)$/.match(asnum)
-        asnum = RouterBgp.dot_to_big(asnum) if /\d+\.\d+/.match(asnum)
-      end
-      asnum.to_i
     end
 
     # Create a hash of all router bgp default and non-default
@@ -72,20 +59,6 @@ module Cisco
       # cmd will syntax reject when feature is not enabled
       raise unless e.clierror =~ /Syntax error/
       return {}
-    end
-
-    # Convert BGP ASN ASDOT+ to ASPLAIN
-    def self.dot_to_big(dot_str)
-      fail ArgumentError unless dot_str.is_a? String
-      return dot_str unless /\d+\.\d+/.match(dot_str)
-      mask = 0b1111111111111111
-      high = dot_str.to_i
-      low = 0
-      low_match = dot_str.match(/\.(\d+)/)
-      low = low_match[1].to_i if low_match
-      high_bits = (mask & high) << 16
-      low_bits = mask & low
-      high_bits + low_bits
     end
 
     def router_bgp(state='')
@@ -384,9 +357,11 @@ module Cisco
     def event_history_detail
       match = config_get('bgp', 'event_history_detail', @get_args)
       # This property requires auto_default=false
-      return default_event_history_detail if match.nil?
-      return 'false' if match[0] == 'no '
-      return 'size_' + match[1] if match[1]
+      if match.is_a?(Array)
+        return 'false' if match[0] == 'no '
+        return 'size_' + match[1] if match[1]
+      end
+      default_event_history_detail
     end
 
     def event_history_detail=(val)

--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -27,7 +27,7 @@ module Cisco
       err_msg = '"af" argument must be an array of two string values ' \
         'containing an afi + safi tuple'
       fail ArgumentError, err_msg unless af.is_a?(Array) || af.length == 2
-      @asn = asn.to_s
+      @asn = RouterBgp.validate_asnum(asn)
       @vrf = vrf
       @afi, @safi = af
       set_args_keys_default

--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -27,7 +27,7 @@ module Cisco
       err_msg = '"af" argument must be an array of two string values ' \
         'containing an afi + safi tuple'
       fail ArgumentError, err_msg unless af.is_a?(Array) || af.length == 2
-      @asn = RouterBgp.process_asnum(asn)
+      @asn = asn.to_s
       @vrf = vrf
       @afi, @safi = af
       set_args_keys_default

--- a/lib/cisco_node_utils/bgp_neighbor.rb
+++ b/lib/cisco_node_utils/bgp_neighbor.rb
@@ -32,7 +32,7 @@ module Cisco
       # we need to mask the address using prefix length, so that it becomes
       # something like "1.1.1.0/24" or "2000:123:38::/64"
       @nbr = Utils.process_network_mask(nbr)
-      @asn = asn
+      @asn = RouterBgp.validate_asnum(asn)
       @vrf = vrf
       @get_args = @set_args = { asnum: @asn, nbr: @nbr }
       @get_args[:vrf] = @set_args[:vrf] = vrf if vrf != 'default'

--- a/lib/cisco_node_utils/bgp_neighbor.rb
+++ b/lib/cisco_node_utils/bgp_neighbor.rb
@@ -164,8 +164,7 @@ module Cisco
     end
 
     def local_as=(val)
-      asnum = RouterBgp.process_asnum(val)
-      if asnum == default_local_as
+      if val == default_local_as
         set_args_keys(state: 'no', local_as: '')
       else
         set_args_keys(state: '', local_as: val)
@@ -269,8 +268,7 @@ module Cisco
     end
 
     def remote_as=(val)
-      asnum = RouterBgp.process_asnum(val)
-      if asnum == default_remote_as
+      if val == default_remote_as
         set_args_keys(state: 'no', remote_as: '')
       else
         set_args_keys(state: '', remote_as: val)

--- a/lib/cisco_node_utils/bgp_neighbor_af.rb
+++ b/lib/cisco_node_utils/bgp_neighbor_af.rb
@@ -62,7 +62,6 @@ module Cisco
     end
 
     def validate_args(asn, vrf, nbr, af)
-      asn = RouterBgp.process_asnum(asn)
       fail ArgumentError unless
         vrf.is_a?(String) && (vrf.length > 0)
       fail ArgumentError unless
@@ -71,7 +70,7 @@ module Cisco
         af.is_a?(Array) || af.length == 2
 
       nbr = Utils.process_network_mask(nbr)
-      @asn = asn
+      @asn = asn.to_s
       @vrf = vrf
       @nbr = nbr
       @afi, @safi = af

--- a/lib/cisco_node_utils/bgp_neighbor_af.rb
+++ b/lib/cisco_node_utils/bgp_neighbor_af.rb
@@ -70,7 +70,7 @@ module Cisco
         af.is_a?(Array) || af.length == 2
 
       nbr = Utils.process_network_mask(nbr)
-      @asn = asn.to_s
+      @asn = RouterBgp.validate_asnum(asn)
       @vrf = vrf
       @nbr = nbr
       @afi, @safi = af

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -192,7 +192,7 @@ route_distinguisher:
 
 router:
   config_get: "show running bgp"
-  config_get_token: '/^router bgp (\d+)$/'
+  config_get_token: '/^router bgp ([\d.]+)$/'
   config_set: "<state> router bgp <asnum>"
 
 router_id:

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -23,8 +23,8 @@ require_relative '../lib/cisco_node_utils/bgp'
 require_relative '../lib/cisco_node_utils/bgp_af'
 require_relative '../lib/cisco_node_utils/feature'
 
-# TestRouterBgpAF - Minitest for RouterBgpAF class
-class TestRouterBgpAF < CiscoTestCase
+# TestBgpAF - Minitest for RouterBgpAF class
+class TestBgpAF < CiscoTestCase
   def setup
     super
     # Disable and enable feature bgp before each test to ensure we

--- a/tests/test_bgp_neighbor.rb
+++ b/tests/test_bgp_neighbor.rb
@@ -21,8 +21,8 @@ require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/bgp'
 require_relative '../lib/cisco_node_utils/bgp_neighbor'
 
-# TestRouterBgpNeighbor - Minitest for RouterBgpNeighbor node utility class
-class TestRouterBgpNeighbor < CiscoTestCase
+# TestBgpNeighbor - Minitest for RouterBgpNeighbor node utility class
+class TestBgpNeighbor < CiscoTestCase
   # rubocop:disable Style/ClassVars
   @@asn = 55
   @@addr = '1.1.1.1'
@@ -203,7 +203,7 @@ class TestRouterBgpNeighbor < CiscoTestCase
         end
       end
       # test a negative value
-      assert_raises(ArgumentError) do
+      assert_raises(CliError) do
         neighbor.local_as = '52 15'
       end
       neighbor.destroy

--- a/tests/test_bgp_neighbor_af.rb
+++ b/tests/test_bgp_neighbor_af.rb
@@ -23,8 +23,8 @@ require_relative '../lib/cisco_node_utils/bgp'
 require_relative '../lib/cisco_node_utils/bgp_neighbor'
 require_relative '../lib/cisco_node_utils/bgp_neighbor_af'
 
-# TestRouterBgpNeighborAF - Minitest for RouterBgpNeighborAF class
-class TestRouterBgpNeighborAF < CiscoTestCase
+# TestBgpNeighborAF - Minitest for RouterBgpNeighborAF class
+class TestBgpNeighborAF < CiscoTestCase
   @@reset_feat = true # rubocop:disable Style/ClassVars
 
   def setup

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -23,10 +23,10 @@ require_relative '../lib/cisco_node_utils/bgp'
 # TestRouterBgp - Minitest for RouterBgp class
 class TestRouterBgp < CiscoTestCase
   def setup
-    # Disable feature bgp before each test to ensure we
-    # are starting with a clean slate for each test.
     super
-    config('no feature bgp')
+    # Remove the bgp config
+    bgp = RouterBgp.routers.values.shift
+    bgp['default'].destroy unless bgp.nil?
   end
 
   def get_routerbgp_match_line(as_number, vrf='default')
@@ -69,7 +69,7 @@ class TestRouterBgp < CiscoTestCase
 
   def test_asnum_invalid
     ['', 'Fifty_Five'].each do |test|
-      assert_raises(CliError, "#{test} not a valid asn") do
+      assert_raises(ArgumentError, "#{test} not a valid asn") do
         RouterBgp.new(test)
       end
     end
@@ -104,7 +104,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_create_valid_asn
+  def test_valid_asn
     [1, 4_294_967_295, '55', '1.0', '1.65535',
      '65535.0', '65535.65535'].each do |test|
       rtr_bgp = RouterBgp.new(test)
@@ -146,14 +146,15 @@ class TestRouterBgp < CiscoTestCase
     bgp1.destroy
   end
 
-  def test_routerbgp_get_asnum
-    asnum = 55
+  def test_asnum_dot
+    asnum = 65_540
     bgp = RouterBgp.new(asnum)
-    line = get_routerbgp_match_line(asnum)
-    asnum = line.to_s.split(' ').last.to_i
-    assert_equal(asnum, bgp.asnum,
-                 'Error: router asnum not correct')
-    bgp.destroy
+    assert_equal(asnum.to_s, bgp.asnum, 'Error: router asnum incorrect')
+
+    # Create a new object with the same ASN value but using AS_DOT notation
+    assert_raises(CliError) do
+      RouterBgp.new('1.4')
+    end
   end
 
   def test_routerbgp_destroy
@@ -686,33 +687,21 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
-  def test_routerbgp_set_get_maxas_limit
-    %w(test_default test_vrf).each do |t|
-      if t == 'test_default'
-        asnum = 55
-        vrf = 'default'
-        bgp = RouterBgp.new(asnum)
-      else
-        asnum = 99
-        vrf = 'yamllll'
-        bgp = RouterBgp.new(asnum, vrf)
-      end
-      bgp.maxas_limit = 50
-      assert_equal(50, bgp.maxas_limit,
-                   "vrf #{vrf}: bgp maxas-limit should be set to '50'")
-      bgp.maxas_limit = bgp.default_maxas_limit
-      assert_equal(bgp.default_maxas_limit, bgp.maxas_limit,
-                   "vrf #{vrf}: bgp maxas-limit should be set to default value")
-      bgp.destroy
-    end
+  def maxas_limit(vrf)
+    bgp = RouterBgp.new(55, vrf)
+    limit = 20
+    bgp.maxas_limit = limit
+    assert_equal(limit, bgp.maxas_limit, "vrf #{vrf}: maxas-limit invalid")
+
+    limit = bgp.default_maxas_limit
+    bgp.maxas_limit = limit
+    assert_equal(limit, bgp.maxas_limit, "vrf #{vrf}: maxas-limit not default")
   end
 
-  def test_routerbgp_default_maxas_limit
-    asnum = 55
-    bgp = RouterBgp.new(asnum)
-    assert_equal(bgp.default_maxas_limit, bgp.maxas_limit,
-                 'bgp maxas-limit should be default value')
-    bgp.destroy
+  def test_maxas_limit
+    %w(default cyan).each do |vrf|
+      maxas_limit(vrf)
+    end
   end
 
   def test_routerbgp_set_get_neighbor_down_fib_accelerate


### PR DESCRIPTION
I discovered a few issues while rewriting the bgp global beaker test:
- Our BGP providers were normalizing the ASN to AS-PLAIN but the nxos cli doesn't support switching between AS-PLAIN and AS-DOT notations, even when the asn is equivalent; ie. once a tag syntax is used you must continue using it:

```
n7k8(config)# router bgp 1.4
n7k8(config-router)# router bgp 65540
bgp is already running; tag is 1.4.
```

Thus, I'm removing the asnum normalizer methods `process_asnum` and `dot_to_big`
- Fixed a day 1 problem with the yaml regexp which failed to match against AS-DOT notation
- Fixed event_history_detail. We use `auto_default: false` with this one because the N7k doesn't show a value with show run all, which means config_get returns [nil, nil].
- Misc minitest fixes. All of the bgp minitests are now passing.
