### PR TITLE
BGP minitest fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/bgp_neighbor.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp_neighbor.yaml
@@ -56,7 +56,7 @@ local_as:
   default_value: 0
 
 log_neighbor_changes:
-  _exclude: [/N(6|7)/]
+  _exclude: [/N(5|6|7)/]
   multiple: true # not actually, but we get an array of matches
   auto_default: false
   config_get_token_append: '/^log-neighbor-changes\s+??(\S+)?\s+??$/'

--- a/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
@@ -147,7 +147,7 @@ send_community:
 soft_reconfiguration_in:
   auto_default: false
   default_value: 'inherit'
-  /N9K/:
+  /(N3K|N9K)/:
     config_get_token_append: '/^soft-reconfiguration inbound(?: always)?/'
     config_set_append: '<state> soft-reconfiguration inbound <always>'
   else:

--- a/lib/cisco_node_utils/cmd_ref/pim.yaml
+++ b/lib/cisco_node_utils/cmd_ref/pim.yaml
@@ -13,7 +13,7 @@ all_group_lists:
 
 all_rp_addresses:
   multiple:
-  config_get_token_append: '/^<afi> pim rp-address (.*)$/'
+  config_get_token_append: '/^<afi> pim rp-address ([0-9\.]+)/'
 
 all_ssm_ranges:
   multiple:

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -113,4 +113,26 @@ class CiscoTestCase < TestCase
     end
     @@interfaces_id
   end
+
+  # Remove all router bgps.
+  def remove_all_bgps
+    require_relative '../lib/cisco_node_utils/bgp'
+    RouterBgp.routers.each do |_asn, vrfs|
+      vrfs.each do |vrf, obj|
+        if vrf == 'default'
+          obj.destroy
+          break
+        end
+      end
+    end
+  end
+
+  # Remove all user vrfs.
+  def remove_all_vrfs
+    require_relative '../lib/cisco_node_utils/vrf'
+    Vrf.vrfs.each do |vrf, obj|
+      next if vrf[/management/]
+      obj.destroy
+    end
+  end
 end

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -25,11 +25,17 @@ require_relative '../lib/cisco_node_utils/feature'
 
 # TestBgpAF - Minitest for RouterBgpAF class
 class TestBgpAF < CiscoTestCase
+  @@pre_clean_needed = true # rubocop:disable Style/ClassVars
+
   def setup
     super
-    # Disable and enable feature bgp before each test to ensure we
-    # are starting with a clean slate for each test.
-    config('no feature bgp', 'feature bgp')
+    remove_all_bgps if @@pre_clean_needed
+    @@pre_clean_needed = false # rubocop:disable Style/ClassVars
+  end
+
+  def teardown
+    super
+    remove_all_bgps
   end
 
   def get_bgp_af_cfg(asn, vrf, af)

--- a/tests/test_bgp_neighbor.rb
+++ b/tests/test_bgp_neighbor.rb
@@ -26,17 +26,20 @@ class TestBgpNeighbor < CiscoTestCase
   # rubocop:disable Style/ClassVars
   @@asn = 55
   @@addr = '1.1.1.1'
+  @@pre_clean_needed = true
   # rubocop:enable Style/ClassVars
 
   def setup
-    # Disable feature bgp before each test to ensure we
-    # are starting with a clean slate for each test.
     super
-    config('no feature bgp', 'feature bgp', 'router bgp 55')
+    remove_all_bgps if @@pre_clean_needed
+    @@pre_clean_needed = false # rubocop:disable Style/ClassVars
+    # BGP Neighbor requires the presence of a basic bgp global config
+    RouterBgp.new(@@asn)
   end
 
   def teardown
-    config('no feature bgp')
+    super
+    remove_all_bgps
   end
 
   def get_bgpneighbor_match_line(addr, vrf='default')
@@ -52,13 +55,13 @@ class TestBgpNeighbor < CiscoTestCase
     line
   end
 
-  def test_bgpneighbor_collection_empty
+  def test_collection_empty
     config('no feature bgp')
     neighbors = RouterBgpNeighbor.neighbors
     assert_empty(neighbors, 'BGP neighbor collection is not empty')
   end
 
-  def test_bgpneighbor_collection_not_empty
+  def test_collection_not_empty
     config('router bgp 55',
            'neighbor 1.1.1.1',
            'vrf red',
@@ -84,7 +87,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_create_destroy
+  def test_create_destroy
     address = { '1.1.1.1'            => '1.1.1.1',
                 '2.2.2.2/24'         => '2.2.2.0/24',
                 '2000::2'            => '2000::2',
@@ -103,7 +106,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_description
+  def test_description
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       description = "tested by mini test for vrf #{vrf}"
@@ -117,7 +120,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_multiple_descriptions
+  def test_multiple_descriptions
     # First create multiple routers with multiple desriptions.
     address = ['1.1.1.1', '2.2.2.0/24', '2000::2', '2000:123:38::/64']
     vrfs = %w(default red)
@@ -142,7 +145,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_connected_check
+  def test_connected_check
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       check = [true, false, neighbor.default_connected_check]
@@ -154,7 +157,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_capability_negotiation
+  def test_capability_negotiation
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       check = [true, false, neighbor.default_capability_negotiation]
@@ -166,7 +169,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_dynamic_capability
+  def test_dynamic_capability
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       check = [true, false, neighbor.default_dynamic_capability]
@@ -178,7 +181,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_ebgp_multihop
+  def test_ebgp_multihop
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       ttls = [24, neighbor.default_ebgp_multihop]
@@ -190,7 +193,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_local_as
+  def test_local_as
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       local_asnum = [42, '52', '1.1', neighbor.default_local_as]
@@ -210,7 +213,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_log_neighbor_changes
+  def test_log_neighbor_changes
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       check = [:enable, :disable, :inherit, 'enable', 'disable', 'inherit',
@@ -223,7 +226,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_low_memory_exempt
+  def test_low_memory_exempt
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       check = [true, false, neighbor.default_low_memory_exempt]
@@ -235,7 +238,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_maximum_peers
+  def test_maximum_peers
     # only "address/prefix" type of neighbor address will accept
     # maximum_peers command
     addr = '1.1.1.0/24'
@@ -250,7 +253,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_password
+  def test_password
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       passwords = {}
@@ -278,7 +281,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_default_password_type
+  def test_set_default_password_type
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       password = 'test'
@@ -304,7 +307,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_remote_as
+  def test_remote_as
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       remote_asnum = [42, '1.1', neighbor.default_remote_as]
@@ -316,7 +319,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_remove_private_as_options
+  def test_remove_private_as_options
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       options = [:enable, :disable, :all, :"replace-as", 'enable', 'disable',
@@ -333,7 +336,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_shutdown
+  def test_shutdown
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       check = [true, false, neighbor.default_shutdown]
@@ -345,7 +348,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_suppress_4_byte_as
+  def test_suppress_4_byte_as
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       check = [true, false, neighbor.default_suppress_4_byte_as]
@@ -357,7 +360,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_timers
+  def test_timers
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       timers = [{ keep: 40, hold: 90 },
@@ -376,7 +379,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_transport_passive_only
+  def test_transport_passive_only
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       check = [true, false, neighbor.default_transport_passive_only]
@@ -388,7 +391,7 @@ class TestBgpNeighbor < CiscoTestCase
     end
   end
 
-  def test_bgpneighbor_set_get_update_source
+  def test_update_source
     %w(default test_vrf).each do |vrf|
       neighbor = RouterBgpNeighbor.new(@@asn, vrf, @@addr)
       interfaces = ['loopback1', 'Ethernet1/1', 'ethernet1/1',

--- a/tests/test_bgp_neighbor_af.rb
+++ b/tests/test_bgp_neighbor_af.rb
@@ -246,12 +246,9 @@ class TestBgpNeighborAF < CiscoTestCase
   #   additional_paths_send
   #   soft_reconfiguration_in
 
-  def n6k_platform?
-    /N6K/ =~ node.product_id
-  end
-
-  def n7k_platform?
-    /N7K/ =~ node.product_id
+  def supports_soft_reconfig_always?
+    return true if node.product_id[/N(3|9)K/]
+    false
   end
 
   def test_tri_states
@@ -270,11 +267,11 @@ class TestBgpNeighborAF < CiscoTestCase
 
       # The 'always' keyword is not supported on N6K / N7K
       %w(soft_reconfiguration_in).each do |k|
-        if n6k_platform? || n7k_platform?
-          array = [:enable, :inherit, 'enable', 'inherit',
+        if supports_soft_reconfig_always?
+          array = [:enable, :always, :inherit, 'enable', 'always', 'inherit',
                    af.send("default_#{k}")]
         else
-          array = [:enable, :always, :inherit, 'enable', 'always', 'inherit',
+          array = [:enable, :inherit, 'enable', 'inherit',
                    af.send("default_#{k}")]
         end
 

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -22,23 +22,17 @@ include Cisco
 # TestVrf - Minitest for Vrf node utility class
 class TestVrf < CiscoTestCase
   VRF_NAME_SIZE = 33
+  @@pre_clean_needed = true # rubocop:disable Style/ClassVars
 
   def setup
     super
-    vrf_clean
+    remove_all_vrfs if @@pre_clean_needed
+    @@pre_clean_needed = false # rubocop:disable Style/ClassVars
   end
 
   def teardown
     super
-    vrf_clean
-  end
-
-  def vrf_clean
-    vrfs = Vrf.vrfs
-    vrfs.keys do |vrf|
-      next if vrf[/management/]
-      config("no vrf context #{vrf}")
-    end
+    remove_all_vrfs
   end
 
   def test_collection_not_empty


### PR DESCRIPTION
- pim all_rp_addresses had a greedy regexp
- added conditional, non config() cleanups to test_\* setup/teardowns
- added l2vpn evpn checks to neighbor af
