### PR TITLE
svi interface fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -207,6 +207,7 @@ speed:
   default_value: "auto"
 
 svi_autostate:
+  _exclude: [/N(5|6)/]
   kind: boolean
   config_get_token_append: '/^(?:no )?autostate$/'
   config_set_append: "%s autostate"
@@ -263,10 +264,19 @@ switchport_trunk_native_vlan:
   default_value: 1
 
 system_default_svi_autostate:
+  _exclude: [/N(5|6)/]
   kind: boolean
   config_get: "show running all | include 'system default'"
-  config_get_token: ['/^system default interface-vlan autostate$/']
-  # default_value: n/a. This is a user-configurable system default.
+  /N7K/:
+    # When enabled:  Property does not nvgen.
+    # When disabled: Property nvgens as 'system default interface-vlan no autostate'
+    config_get_token: ['/^system default interface-vlan no autostate$/']
+    # default_value: n/a. This is a user-configurable system default.
+  else:
+    # When enabled:  Property nvgens as 'system default interface-vlan autostate' 
+    # When disabled: Property nvgens as 'no system default interface-vlan autostate'
+    config_get_token: ['/^system default interface-vlan autostate$/']
+    # default_value: n/a. This is a user-configurable system default.
 
 system_default_switchport:
   # Note: This is a simple boolean state but there is a bug on some

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -738,7 +738,17 @@ module Cisco
 
     def system_default_svi_autostate
       # This command is a user-configurable system default.
-      config_get('interface', 'system_default_svi_autostate')
+      #
+      # This property behaves differently on an n7k vs ni(3|9)k and therefore
+      # needs special handling.
+      # N7K: When enabled, does not nvgen.
+      #      When disabled, does nvgen, but differently then n(3|9)k.
+      #      Return true for the disabled case, false otherwise.
+      # N(3|9)K: When enabled, does nvgen.
+      #          When disabled, does nvgen.
+      #          Return true for the enabled case, false otherwise.
+      result = config_get('interface', 'system_default_svi_autostate')
+      /N7K/.match(node.product_id) ? !result : result
     end
 
     def switchport_vtp_mode_capable?


### PR DESCRIPTION
- Skip svi autostate test cases on n(5|6)k as they are not supported.
- Modify `system_default_svi_autostate` to handle Nexus platform differences.
- Refactored `test_svi_get_svis` to handle platform differences.

```
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils> ruby tests/test_interface_svi.rb -v -- n6k-92 admin admin
Run options: -v -- --seed 41328

# Running:


Node under test:
  - name  - n6k-92
  - type  - N6K-C6001-64P
  - image - bootflash:///n6000-uk9-kickstart.7.3.0.N1.0.270.bin

TestSvi#test_svi_set_management_default = 6.37 s = .
TestSvi#test_svi_create_vlan_invalid = 1.66 s = .
TestSvi#test_svi_get_autostate_true = 1.34 s = S
TestSvi#test_svi_get_management_true = 2.67 s = .
TestSvi#test_system_default_svi_autostate_on_off = 1.31 s = S
TestSvi#test_svi_prop_nil_when_ethernet = 1.04 s = S
TestSvi#test_svi_set_autostate_true = 1.04 s = S
TestSvi#test_svi_get_autostate_false = 1.04 s = S
TestSvi#test_svi_create_valid = 3.11 s = .
TestSvi#test_svi_create_vlan_invalid_value = 2.02 s = .
TestSvi#test_svi_create_vlan_nil = 1.03 s = .
TestSvi#test_svi_name = 2.08 s = .
TestSvi#test_svi_create_interface_description = 2.65 s = .
TestSvi#test_svi_set_management_true = 2.66 s = .
TestSvi#test_svi_set_management_false = 2.73 s = .
TestSvi#test_svi_set_autostate_false = 1.35 s = S
TestSvi#test_svi_assignment = 2.69 s = .
TestSvi#test_svi_set_autostate_default = 1.37 s = S
TestSvi#test_svi_get_svis = 12.18 s = .

Finished in 50.368257s, 0.3772 runs/s, 0.4963 assertions/s.

  1) Skipped:
TestSvi#test_svi_get_autostate_true [tests/test_interface_svi.rb:60]:
svi autostate properties are not supported on this platform


  2) Skipped:
TestSvi#test_system_default_svi_autostate_on_off [tests/test_interface_svi.rb:60]:
svi autostate properties are not supported on this platform


  3) Skipped:
TestSvi#test_svi_prop_nil_when_ethernet [tests/test_interface_svi.rb:60]:
svi autostate properties are not supported on this platform


  4) Skipped:
TestSvi#test_svi_set_autostate_true [tests/test_interface_svi.rb:60]:
svi autostate properties are not supported on this platform


  5) Skipped:
TestSvi#test_svi_get_autostate_false [tests/test_interface_svi.rb:60]:
svi autostate properties are not supported on this platform


  6) Skipped:
TestSvi#test_svi_set_autostate_false [tests/test_interface_svi.rb:60]:
svi autostate properties are not supported on this platform


  7) Skipped:
TestSvi#test_svi_set_autostate_default [tests/test_interface_svi.rb:60]:
svi autostate properties are not supported on this platform

19 runs, 25 assertions, 0 failures, 0 errors, 7 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/coverage. 615 / 1158 LOC (53.11%) covered.
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils> 
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils> ruby tests/test_interface_svi.rb -v -- n7k-j admin admin
Run options: -v -- --seed 3095

# Running:


Node under test:
  - name  - n7k-j
  - type  - N7K-C7009
  - image - bootflash:///n7000-s2-dk9.7.3.0.D1.0.202.bin

TestSvi#test_svi_create_vlan_nil = 2.70 s = .
TestSvi#test_svi_create_interface_description = 2.83 s = .
TestSvi#test_svi_set_management_default = 3.08 s = .
TestSvi#test_system_default_svi_autostate_on_off = 3.51 s = .
TestSvi#test_svi_create_vlan_invalid = 1.55 s = .
TestSvi#test_svi_set_autostate_false = 2.45 s = .
TestSvi#test_svi_get_autostate_false = 2.81 s = .
TestSvi#test_svi_set_management_true = 2.55 s = .
TestSvi#test_svi_prop_nil_when_ethernet = 1.94 s = .
TestSvi#test_svi_assignment = 2.53 s = .
TestSvi#test_svi_create_vlan_invalid_value = 1.97 s = .
TestSvi#test_svi_create_valid = 2.32 s = .
TestSvi#test_svi_get_svis = 12.41 s = .
TestSvi#test_svi_set_management_false = 2.58 s = .
TestSvi#test_svi_get_management_true = 2.61 s = .
TestSvi#test_svi_set_autostate_true = 2.41 s = .
TestSvi#test_svi_name = 2.07 s = .
TestSvi#test_svi_set_autostate_default = 2.77 s = .
TestSvi#test_svi_get_autostate_true = 2.81 s = .

Finished in 57.917181s, 0.3281 runs/s, 0.8115 assertions/s.

19 runs, 47 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/coverage. 632 / 1158 LOC (54.58%) covered.
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils> ruby tests/test_interface_svi.rb -v -- n8k-136 admin admin
Run options: -v -- --seed 611

# Running:


Node under test:
  - name  - n8k-136
  - type  - N5K-C56128P
  - image - bootflash:///n6000-uk9-kickstart.7.3.0.N1.0.281.bin

TestSvi#test_svi_create_vlan_invalid_value = 4.57 s = .
TestSvi#test_svi_set_autostate_false = 1.34 s = S
TestSvi#test_svi_prop_nil_when_ethernet = 0.95 s = S
TestSvi#test_svi_set_autostate_default = 0.96 s = S
TestSvi#test_svi_set_management_false = 2.83 s = .
TestSvi#test_svi_set_management_default = 3.53 s = .
TestSvi#test_svi_name = 2.19 s = .
TestSvi#test_svi_get_autostate_true = 1.25 s = S
TestSvi#test_svi_set_management_true = 2.82 s = .
TestSvi#test_svi_create_vlan_invalid = 1.58 s = .
TestSvi#test_svi_create_interface_description = 3.03 s = .
TestSvi#test_svi_get_management_true = 2.84 s = .
TestSvi#test_svi_assignment = 2.81 s = .
TestSvi#test_svi_get_svis = 12.78 s = .
TestSvi#test_svi_set_autostate_true = 1.84 s = S
TestSvi#test_svi_get_autostate_false = 0.97 s = S
TestSvi#test_system_default_svi_autostate_on_off = 1.01 s = S
TestSvi#test_svi_create_vlan_nil = 0.95 s = .
TestSvi#test_svi_create_valid = 2.76 s = .

Finished in 51.007167s, 0.3725 runs/s, 0.4901 assertions/s.

  1) Skipped:
TestSvi#test_svi_set_autostate_false [tests/test_interface_svi.rb:60]:
svi autostate properties are not supported on this platform


  2) Skipped:
TestSvi#test_svi_prop_nil_when_ethernet [tests/test_interface_svi.rb:60]:
svi autostate properties are not supported on this platform


  3) Skipped:
TestSvi#test_svi_set_autostate_default [tests/test_interface_svi.rb:60]:
svi autostate properties are not supported on this platform


  4) Skipped:
TestSvi#test_svi_get_autostate_true [tests/test_interface_svi.rb:60]:
svi autostate properties are not supported on this platform


  5) Skipped:
TestSvi#test_svi_set_autostate_true [tests/test_interface_svi.rb:60]:
svi autostate properties are not supported on this platform


  6) Skipped:
TestSvi#test_svi_get_autostate_false [tests/test_interface_svi.rb:60]:
svi autostate properties are not supported on this platform


  7) Skipped:
TestSvi#test_system_default_svi_autostate_on_off [tests/test_interface_svi.rb:60]:
svi autostate properties are not supported on this platform

19 runs, 25 assertions, 0 failures, 0 errors, 7 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/coverage. 615 / 1158 LOC (53.11%) covered.
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils> 
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils> ruby tests/test_interface_svi.rb -v -- dt-n9k5-1 admin admin
Run options: -v -- --seed 26258

# Running:


Node under test:
  - name  - dt-n9k5-1
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I2.1.69.bin

TestSvi#test_svi_set_management_default = 4.27 s = .
TestSvi#test_svi_create_vlan_nil = 0.80 s = .
TestSvi#test_svi_get_autostate_true = 2.77 s = .
TestSvi#test_svi_set_autostate_default = 1.54 s = .
TestSvi#test_svi_prop_nil_when_ethernet = 1.25 s = .
TestSvi#test_svi_name = 1.44 s = .
TestSvi#test_svi_get_svis = 6.24 s = .
TestSvi#test_svi_set_management_false = 1.72 s = .
TestSvi#test_svi_create_vlan_invalid_value = 1.25 s = .
TestSvi#test_system_default_svi_autostate_on_off = 2.06 s = .
TestSvi#test_svi_set_autostate_false = 1.43 s = .
TestSvi#test_svi_get_autostate_false = 2.78 s = .
TestSvi#test_svi_create_valid = 1.91 s = .
TestSvi#test_svi_create_interface_description = 1.82 s = .
TestSvi#test_svi_set_autostate_true = 1.60 s = .
TestSvi#test_svi_create_vlan_invalid = 1.07 s = .
TestSvi#test_svi_set_management_true = 1.75 s = .
TestSvi#test_svi_get_management_true = 2.67 s = .
TestSvi#test_svi_assignment = 1.75 s = .

Finished in 40.120416s, 0.4736 runs/s, 1.1715 assertions/s.

19 runs, 47 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/coverage. 635 / 1158 LOC (54.84%) covered.
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils> ruby tests/test_interface_svi.rb -v -- 10.122.84.101 admin admin
Run options: -v -- --seed 24780

# Running:


Node under test:
  - name  - n31x-101
  - type  - N3K-C3132Q-40GX
  - image - bootflash:///nxos.7.0.3.I2.1.bin

TestSvi#test_svi_get_autostate_false = 3.24 s = .
TestSvi#test_svi_assignment = 1.86 s = .
TestSvi#test_svi_prop_nil_when_ethernet = 1.34 s = .
TestSvi#test_svi_name = 1.52 s = .
TestSvi#test_system_default_svi_autostate_on_off = 2.13 s = .
TestSvi#test_svi_create_vlan_invalid = 1.19 s = .
TestSvi#test_svi_get_management_true = 1.84 s = .
TestSvi#test_svi_create_vlan_nil = 0.90 s = .
TestSvi#test_svi_get_svis = 6.55 s = .
TestSvi#test_svi_get_autostate_true = 2.06 s = .
TestSvi#test_svi_set_autostate_false = 1.65 s = .
TestSvi#test_svi_create_vlan_invalid_value = 1.36 s = .
TestSvi#test_svi_set_management_true = 1.84 s = .
TestSvi#test_svi_create_valid = 1.96 s = .
TestSvi#test_svi_set_management_default = 2.23 s = .
TestSvi#test_svi_set_autostate_true = 1.63 s = .
TestSvi#test_svi_set_management_false = 1.89 s = .
TestSvi#test_svi_create_interface_description = 1.91 s = .
TestSvi#test_svi_set_autostate_default = 2.41 s = .

Finished in 39.508266s, 0.4809 runs/s, 1.1896 assertions/s.

19 runs, 47 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/coverage. 635 / 1158 LOC (54.84%) covered.
```
