### PR TITLE
Adding fabric forwarding mode anycast-gateway property for Interface

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -18,6 +18,11 @@ fabric_forwarding:
   config_get_token: '/^feature fabric forwarding$/'
   config_set: "feature fabric forwarding"
 
+fabric_frwd_anycast_mac:
+  config_get: "show running | i ^fabric"
+  config_get_token: '/^fabric forwarding anycast-gateway-mac (\S+)/'
+  config_set: "%s fabric forwarding anycast-gateway-mac %s"
+
 nv_overlay:
   _exclude: [/N(3|5|6)/]
   kind: boolean

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -46,6 +46,12 @@ encapsulation_dot1q:
   config_set_append: "%s encapsulation dot1q %s"
   default_value: ""
 
+fabric_frwd_anycast:
+  kind: boolean
+  config_get_token_append: '/^fabric forwarding mode anycast-gateway$/'
+  config_set_append: "%s fabric forwarding mode anycast-gateway"
+  default_value: false
+
 feature_lacp:
   kind: boolean
   config_get: "show running | i ^feature"

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -108,5 +108,23 @@ module Cisco
     end
 
     # ---------------------------
+    def self.fabric_frwd_anycast_mac
+      config_get('feature', 'fabric_frwd_anycast_mac')
+    end
+
+    def self.fabric_frwd_anycast_mac=(val)
+      puts 'S:Entered Setter:fabric_frwd_anycast_mac='
+      if val
+        state = ''
+      else
+        state = 'no'
+        val = ''
+      end
+      config_set('feature',
+                 'fabric_frwd_anycast_mac', state, val)
+    rescue Cisco::CliError => e
+      raise " '#{e.command}' : #{e.clierror}"
+    end
+    # ---------------------------
   end
 end

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -205,6 +205,28 @@ module Cisco
       FabricpathGlobal.fabricpath_feature_set(fabricpath_set)
     end
 
+    def fabric_frwd_anycast
+      config_get('interface', 'fabric_frwd_anycast', @name)
+    end
+
+    def fabric_frwd_anycast=(state)
+      begin
+        unless Feature.fabric_forwarding_enabled?
+          config_set('feature', 'fabric_forwarding')
+        end
+        return unless Feature.fabric_frwd_anycast_mac
+        no_cmd = (state ? '' : 'no')
+        config_set('interface',
+                   'fabric_frwd_anycast', @name, no_cmd)
+      end
+    rescue Cisco::CliError => e
+      raise "[#{@name}] '#{e.command}' : #{e.clierror}"
+    end
+
+    def default_fabric_frwd_anycast
+      config_get_default('interface', 'fabric_frwd_anycast')
+    end
+
     def fex_feature
       fex = config_get('fex', 'feature')
       fail 'fex_feature not found' if fex.nil?

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -958,6 +958,31 @@ class TestInterface < CiscoTestCase
     assert_raises(RuntimeError) { nonvlanint.ipv4_arp_timeout = 300 }
   end
 
+  def test_interface_fabric_frwd_anycast
+    # Setup
+    config('no interface vlan11')
+    int = Interface.new('vlan11')
+    config('feature fabric forwarding')
+    Feature.fabric_frwd_anycast_mac = '2.2.2'
+    # 1. Testing default
+    assert_equal(int.default_fabric_frwd_anycast, int.fabric_frwd_anycast)
+    # 2. Testing non-default
+    int.fabric_frwd_anycast = true
+    assert_equal(true, int.fabric_frwd_anycast)
+    # 3. Setting back to default
+    int.fabric_frwd_anycast = int.default_fabric_frwd_anycast
+    assert_equal(int.default_fabric_frwd_anycast, int.fabric_frwd_anycast)
+
+    # 4. Removing feature fabric forwarding anycast mac
+    config('no fabric forwarding mode')
+    Feature.fabric_frwd_anycast_mac = '1.1.1'
+    int.fabric_frwd_anycast = true
+    assert_equal(true, int.fabric_frwd_anycast)
+    # 5. Attempting to configure on a non-vlan interface
+    nonvlanint = create_interface
+    assert_raises(RuntimeError) { nonvlanint.fabric_frwd_anycast = true }
+  end
+
   def test_interface_ipv4_proxy_arp
     interface = create_interface
     interface.switchport_mode = :disabled


### PR DESCRIPTION
# Description:

Adding fabric forwarding mode anycast-gateway property for Interface
# Rubocop:

---

rtpfe1@agent-lab11-ws:~/smigopal/28_int_nu/cisco-network-node-utils$ rubocop lib/cisco_node_utils/feature.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/smigopal/28_int_nu/cisco-network-node-utils$ rubocop lib/cisco_node_utils/interface.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/smigopal/28_int_nu/cisco-network-node-utils$ rubocop tests/test_interface.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
rtpfe1@agent-lab11-ws:~/smigopal/28_int_nu/cisco-network-node-utils$
# Minitests:

---

rtpfe1@agent-lab11-ws:~/smigopal/28_int_nu/cisco-network-node-utils$ ruby tests/test_interface.rb -v -n test_interface_fabric_frwd_anycast -- 10.122.197.125 admin admin
Run options: -v -n test_interface_fabric_frwd_anycast -- --seed 1547

 Running:

Node under test:
- name  - agent-lab11-nx
- type  - N9K-NXOSV
- image - bootflash:///nxos.7.0.3.I2.1.bin

conf : ["interface vlan11"]
conf : [" fabric forwarding anycast-gateway-mac 2.2.2"]
conf : ["interface vlan11", " fabric forwarding mode anycast-gateway"]
conf : ["interface vlan11", "no fabric forwarding mode anycast-gateway"]
conf : [" fabric forwarding anycast-gateway-mac 1.1.1"]
conf : ["interface vlan11", " fabric forwarding mode anycast-gateway"]
conf : ["interface ethernet1/1"]
conf : ["interface ethernet1/1", " fabric forwarding mode anycast-gateway"]
TestInterface#test_interface_fabric_frwd_anycast = 7.64 s = .

Finished in 7.639177s, 0.1309 runs/s, 0.6545 assertions/s.

1 runs, 5 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /home/rtpfe1/smigopal/28_int_nu/cisco-network-node-utils/coverage. 625 / 1224 LOC (51.06%) covered.
rtpfe1@agent-lab11-ws:~/smigopal/28_int_nu/cisco-network-node-utils$
