### PR TITLE
fix route_distinguisher

### DIFF
--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -808,6 +808,7 @@ module Cisco
     end
 
     def default_route_distinguisher
+      return nil if @vrf.nil? || @vrf == 'default'
       config_get_default('bgp', 'route_distinguisher')
     end
 

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -786,11 +786,7 @@ module Cisco
     # route_distinguisher
     # Note that this property is supported by both bgp and vrf providers.
     def route_distinguisher
-      if @vrf.nil? || @vrf == 'default'
-        fail Cisco::UnsupportedError.new('bgp', 'route_distinguisher', 'get',
-                                         'route_distinguisher is not ' \
-                                         'configurable on a default VRF')
-      end
+      return nil if @vrf.nil? || @vrf == 'default'
       config_get('bgp', 'route_distinguisher', @get_args)
     end
 
@@ -816,12 +812,7 @@ module Cisco
     end
 
     def default_route_distinguisher
-      if @vrf.nil? || @vrf == 'default'
-        fail Cisco::UnsupportedError.new('bgp', 'default_route_distinguisher',
-                                         'get',
-                                         'route_distinguisher is not ' \
-                                         'configurable on a default VRF')
-      end
+      return nil if @vrf.nil? || @vrf == 'default'
       config_get_default('bgp', 'route_distinguisher')
     end
 

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -786,16 +786,24 @@ module Cisco
     # route_distinguisher
     # Note that this property is supported by both bgp and vrf providers.
     def route_distinguisher
-      return nil if @vrf.nil? || @vrf == 'default'
+      if @vrf.nil? || @vrf == 'default'
+        fail Cisco::UnsupportedError.new('bgp', 'route_distinguisher', 'get',
+                                         'route_distinguisher is not ' \
+                                         'configurable on a default VRF')
+      end
       config_get('bgp', 'route_distinguisher', @get_args)
     end
 
     def route_distinguisher=(rd)
+      if @vrf.nil? || @vrf == 'default'
+        fail Cisco::UnsupportedError.new('bgp', 'route_distinguisher', 'set',
+                                         'route_distinguisher is not ' \
+                                         'configurable on a default VRF')
+      end
       if platform == :nexus
         Feature.nv_overlay_enable
         Feature.nv_overlay_evpn_enable
       end
-      return nil if @vrf.nil? || @vrf == 'default'
       if rd == default_route_distinguisher
         @set_args[:state] = 'no'
         @set_args[:rd] = ''
@@ -808,7 +816,11 @@ module Cisco
     end
 
     def default_route_distinguisher
-      return nil if @vrf.nil? || @vrf == 'default'
+      if @vrf.nil? || @vrf == 'default'
+        fail Cisco::UnsupportedError.new('bgp', 'route_distinguisher', 'set',
+                                         'route_distinguisher is not ' \
+                                         'configurable on a default VRF')
+      end
       config_get_default('bgp', 'route_distinguisher')
     end
 

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -786,6 +786,7 @@ module Cisco
     # route_distinguisher
     # Note that this property is supported by both bgp and vrf providers.
     def route_distinguisher
+      return nil if @vrf.nil? || @vrf == 'default'
       config_get('bgp', 'route_distinguisher', @get_args)
     end
 
@@ -794,6 +795,7 @@ module Cisco
         Feature.nv_overlay_enable
         Feature.nv_overlay_evpn_enable
       end
+      return nil if @vrf.nil? || @vrf == 'default'
       if rd == default_route_distinguisher
         @set_args[:state] = 'no'
         @set_args[:rd] = ''

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -817,7 +817,8 @@ module Cisco
 
     def default_route_distinguisher
       if @vrf.nil? || @vrf == 'default'
-        fail Cisco::UnsupportedError.new('bgp', 'route_distinguisher', 'set',
+        fail Cisco::UnsupportedError.new('bgp', 'default_route_distinguisher',
+                                         'get',
                                          'route_distinguisher is not ' \
                                          'configurable on a default VRF')
       end

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -289,7 +289,7 @@ route_distinguisher:
     set_value: '<state> rd <rd>'
   nexus:
     context:
-      - "vrf context <vrf>"
+      - "(?)vrf context <vrf>"
     get_value: 'rd (\S+)'
     set_value: "<state> rd <rd>"
 

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -289,7 +289,7 @@ route_distinguisher:
     set_value: '<state> rd <rd>'
   nexus:
     context:
-      - "(?)vrf context <vrf>"
+      - "vrf context <vrf>"
     get_value: 'rd (\S+)'
     set_value: "<state> rd <rd>"
 


### PR DESCRIPTION
make vrf context optional for route_distinguisher
All mini tests passed for nexus, and ios_xr
