### PR TITLE
cisco_vxlan_vtep: added property source-interface hold-down-time

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
@@ -46,6 +46,12 @@ source_intf:
   config_set_append: '<state> source-interface <lpbk_intf>'
   default_value: ''
 
+source_intf_hold_down_time:
+  kind: int
+  config_get_token_append: '/^source-interface hold-down-time (\d+)$/'
+  config_set_append: '<state> source-interface hold-down-time <time>'
+  default_value: ''
+
 vni:
   config_set_append: '<state> member vni <vni> <assoc_vrf>'
 

--- a/lib/cisco_node_utils/vxlan_vtep.rb
+++ b/lib/cisco_node_utils/vxlan_vtep.rb
@@ -140,9 +140,6 @@ module Cisco
     end
 
     def source_interface_hold_down_time=(time)
-      # Source interface should be configured before hold down time
-      # is configured.
-      return if source_interface == default_source_interface
       state = time == default_source_interface_hold_down_time ? 'no' : ''
       # Cli rejects removing hold-down-time without an argument, so make
       # sure it is configured before attempting to remove it

--- a/lib/cisco_node_utils/vxlan_vtep.rb
+++ b/lib/cisco_node_utils/vxlan_vtep.rb
@@ -135,6 +135,33 @@ module Cisco
       config_get_default('vxlan_vtep', 'source_intf')
     end
 
+    def source_interface_hold_down_time
+      config_get('vxlan_vtep', 'source_intf_hold_down_time', name: @name)
+    end
+
+    def source_interface_hold_down_time=(time)
+      # Source interface should be configured before hold down time
+      # is configured.
+      return if source_interface == default_source_interface
+      state = time == default_source_interface_hold_down_time ? 'no' : ''
+      # Cli rejects removing hold-down-time without an argument, so make
+      # sure it is configured before attempting to remove it
+      if state == 'no'
+        time = source_interface_hold_down_time
+        unless time == default_source_interface_hold_down_time
+          config_set('vxlan_vtep', 'source_intf_hold_down_time', name: @name,
+                             state: state, time: time)
+        end
+      else
+        config_set('vxlan_vtep', 'source_intf_hold_down_time', name: @name,
+                               state: state, time: time)
+      end
+    end
+
+    def default_source_interface_hold_down_time
+      config_get_default('vxlan_vtep', 'source_intf_hold_down_time')
+    end
+
     def shutdown
       config_get('vxlan_vtep', 'shutdown', name: @name)
     end

--- a/tests/test_vxlan_vtep.rb
+++ b/tests/test_vxlan_vtep.rb
@@ -211,4 +211,26 @@ class TestVxlanVtep < CiscoTestCase
     vtep.source_interface = val
     assert_equal(val, vtep.source_interface)
   end
+
+  def test_source_interface_hold_down_time
+    mt_full_env_setup if VxlanVtep.mt_full_support
+    mt_lite_env_setup if VxlanVtep.mt_lite_support
+
+    vtep = VxlanVtep.new('nve1')
+
+    # Set source_interface to non-default value
+    val = 'loopback55'
+    vtep.source_interface = val
+    assert_equal(val, vtep.source_interface)
+
+    # Set source_interface_hold_down_time
+    time = 50
+    vtep.source_interface_hold_down_time = time
+    assert_equal(time, vtep.source_interface_hold_down_time)
+
+    # Set source_interface_hold_down_time to default value
+    val = vtep.default_source_interface_hold_down_time
+    vtep.source_interface_hold_down_time = val
+    assert_equal(val, vtep.source_interface_hold_down_time)
+  end
 end


### PR DESCRIPTION
Rubocop passes:

Minitest passes:

```
# Running:


Node under test:
  - name  - agent-lab7-nx
  - type  - N9K-NXOSV
  - image - bootflash:///nxos.7.0.3.I2.2.22.bin

TestVxlanVtep#test_host_reachability = 142.06 s = .
TestVxlanVtep#test_create_negative = 142.10 s = .
TestVxlanVtep#test_create_destroy_one = 134.90 s = .
TestVxlanVtep#test_mt_full_create_destroy_multiple = 1.58 s = S
TestVxlanVtep#test_source_interface_hold_down_time = 135.70 s = .
TestVxlanVtep#test_shutdown = 135.42 s = .
TestVxlanVtep#test_source_interface = 137.44 s = .
TestVxlanVtep#test_description = 134.57 s = .

Finished in 963.759647s, 0.0083 runs/s, 0.0259 assertions/s.

  1) Skipped:
TestVxlanVtep#test_mt_full_create_destroy_multiple [tests/test_vxlan_vtep.rb:89]:
Platform does not support MT-full
```
