### PR TITLE
Adding destroy method for pim, needed for resource=absent

### DIFF
--- a/lib/cisco_node_utils/pim.rb
+++ b/lib/cisco_node_utils/pim.rb
@@ -111,5 +111,14 @@ module Cisco
       set_args_keys(state: state, ssm_range: range)
       config_set('pim', 'ssm_range', @set_args)
     end
+
+    # This destroy method is different than most because pim does not have a
+    # "container" for properties, they simply exist in a given vrf context.
+    # For that reason destroy needs to explicitly set each property
+    # to its default state.
+    def destroy
+      set_args_keys(state: 'no', ssm_range: 'none')
+      config_set('pim', 'ssm_range', @set_args)
+    end
   end  # Class
 end    # Module


### PR DESCRIPTION
# Description:

Adding destroy method for pim, needed for resource=absent
# Resource Testing:

———————————
site.pp:
node default {
    cisco_pim { 'ipv4' :
      ensure         => present,
      vrf            => 'default',
      ssm_range      => '224.0.0.0/8 225.0.0.0/8'
    }
}

root@agent-lab11-nx#puppet agent -t --trace
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for agent-lab11-nx.cisco.com
Info: Applying configuration version '1455193624'
Notice: /Stage[main]/Main/Node[default]/Cisco_pim[ipv4]/ensure: created
Notice: Applied catalog in 0.51 seconds

site.pp:
node default {
    cisco_pim { 'ipv4' :
      ensure         => absent,
      vrf            => 'default',
      ssm_range      => '224.0.0.0/8 225.0.0.0/8'
    }
}

root@agent-lab11-nx#puppet agent -t --trace
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for agent-lab11-nx.cisco.com
Info: Applying configuration version '1455193650'
Notice: /Stage[main]/Main/Node[default]/Cisco_pim[ipv4]/ensure: removed
Notice: Applied catalog in 1.00 seconds
root@agent-lab11-nx#
# Rubocop:

——————
rtpfe1@agent-lab11-ws:~/smigopal/feb_pim/cisco-network-node-utils$ rubocop lib/cisco_node_utils/pim.rb
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.3-compliant syntax, but you are running 2.2.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 1 file
.

1 file inspected, no offenses detected
# Minitests:

——————
rtpfe1@agent-lab11-ws:~/smigopal/feb_pim/cisco-network-node-utils$ ruby tests/test_pim.rb -v  -- 10.122.197.125 admin admin
Run options: -v -- --seed 23435

 Running:

Node under test:
- name  - agent-lab11-nx
- type  - N9K-NXOSV
- image - bootflash:///nxos.7.0.3.I2.1.bin

conf : ["feature pim"]
conf : [" ip pim ssm range 1.1.1.1/8"]
TestPim#test_single_invalid_ssm_range_single_vrf = 2.72 s = .
conf : ["feature pim"]
conf : ["feature pim"]
conf : ["feature pim"]
conf : [" ip pim ssm range 229.0.0.0/8 225.0.0.0/8 224.0.0.0/8"]
conf : ["vrf context red", " ip pim ssm range 230.0.0.0/8 228.0.0.0/8 224.0.0.0/8"]
conf : ["vrf context black", " ip pim ssm range none"]
TestPim#test_multiple_ssm_range_multiple_vrfs = 1.99 s = .
conf : ["feature pim"]
conf : ["feature pim"]
conf : [" ip pim ssm range 229.0.0.0/8 225.0.0.0/8 224.0.0.0/8"]
conf : ["vrf context red", " ip pim ssm range 230.0.0.0/8 228.0.0.0/8 224.0.0.0/8"]
conf : ["vrf context red", " ip pim ssm range none"]
TestPim#test_multiple_ssm_range_overwrite_multiple_vrfs = 2.14 s = .
conf : ["feature pim"]
conf : [" ip pim ssm range none"]
TestPim#test_single_ssm_range_none_single_vrf = 1.81 s = .
conf : ["feature pim"]
conf : [" ip pim ssm range 229.0.0.0/8"]
TestPim#test_single_ssm_range_single_vrf = 1.72 s = .

Finished in 10.379273s, 0.4817 runs/s, 0.8671 assertions/s.

5 runs, 9 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /home/rtpfe1/smigopal/feb_pim/cisco-network-node-utils/coverage. 590 / 1161 LOC (50.82%) covered.
rtpfe1@agent-lab11-ws:~/smigopal/feb_pim/cisco-network-node-utils$
