### PR TITLE
fabric_forwarding_anycast fixes

### DIFF
--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -56,7 +56,15 @@ module Cisco
     def self.fabric_forwarding_enable
       return if fabric_forwarding_enabled?
       Feature.fabric_enable if Feature.fabric_supported?
-      config_set('feature', 'fabric_forwarding')
+      # The feature fabric-forwarding cli is required in some older nxos images
+      # but is not present in newer images because nv_overlay_evpn handles
+      # both features; therefore feature fabric-forwarding is best-effort
+      # and ignored on cli failure.
+      begin
+        config_set('feature', 'fabric_forwarding')
+      rescue Cisco::CliError
+        CiscoLogger.debug '"feature fabric forwarding" CLI was rejected'
+      end
     end
 
     def self.fabric_forwarding_enabled?
@@ -80,15 +88,7 @@ module Cisco
 
     # ---------------------------
     def self.nv_overlay_evpn_enable
-      # The feature fabric-forwarding cli is required in some older nxos images
-      # but is not present in newer images because nv_overlay_evpn handles
-      # both features; therefore feature fabric-forwarding is best-effort
-      # and ignored on cli failure.
-      begin
-        config_set('feature', 'fabric_forwarding')
-      rescue Cisco::CliError
-        CiscoLogger.debug '"feature fabric forwarding" CLI was rejected'
-      end
+      return if nv_overlay_evpn_enabled?
       config_set('feature', 'nv_overlay_evpn')
     end
 

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -216,12 +216,15 @@ module Cisco
                  'fabric_forwarding_anycast_gateway', @name, no_cmd)
       fail if fabric_forwarding_anycast_gateway.to_s != state.to_s
     rescue Cisco::CliError => e
+      info = "[#{@name}] '#{e.command}' : #{e.clierror}"
+      raise "#{info} 'fabric_forwarding_anycast_gateway' can ony be " \
+        'configured on a vlan interface' unless /vlan/.match(@name)
       anycast_gateway_mac = OverlayGlobal.new.anycast_gateway_mac
       if anycast_gateway_mac.nil? || anycast_gateway_mac.empty?
-        raise "[#{@name}] '#{e.command}' : #{e.clierror}
-               Anycast gateway mac needs to be configured
-               before configuring forwarding mode under interface"
+        raise "#{info} Anycast gateway mac needs to be configured " \
+               'before configuring forwarding mode under interface'
       end
+      raise info
     end
 
     def default_fabric_forwarding_anycast_gateway

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -221,7 +221,7 @@ module Cisco
         'configured on a vlan interface' unless /vlan/.match(@name)
       anycast_gateway_mac = OverlayGlobal.new.anycast_gateway_mac
       if anycast_gateway_mac.nil? || anycast_gateway_mac.empty?
-        raise "#{info} Anycast gateway mac must to be configured " \
+        raise "#{info} Anycast gateway mac must be configured " \
                'before configuring forwarding mode under interface'
       end
       raise info

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -217,11 +217,11 @@ module Cisco
       fail if fabric_forwarding_anycast_gateway.to_s != state.to_s
     rescue Cisco::CliError => e
       info = "[#{@name}] '#{e.command}' : #{e.clierror}"
-      raise "#{info} 'fabric_forwarding_anycast_gateway' can ony be " \
+      raise "#{info} 'fabric_forwarding_anycast_gateway' can only be " \
         'configured on a vlan interface' unless /vlan/.match(@name)
       anycast_gateway_mac = OverlayGlobal.new.anycast_gateway_mac
       if anycast_gateway_mac.nil? || anycast_gateway_mac.empty?
-        raise "#{info} Anycast gateway mac needs to be configured " \
+        raise "#{info} Anycast gateway mac must to be configured " \
                'before configuring forwarding mode under interface'
       end
       raise info

--- a/lib/cisco_node_utils/overlay_global.rb
+++ b/lib/cisco_node_utils/overlay_global.rb
@@ -50,7 +50,7 @@ module Cisco
     end
 
     def dup_host_ip_addr_detection_set(host_moves, timeout)
-      Feature.nv_overlay_evpn_enable unless Feature.nv_overlay_evpn_enabled?
+      Feature.nv_overlay_evpn_enable
       if host_moves == default_dup_host_ip_addr_detection_host_moves &&
          timeout == default_dup_host_ip_addr_detection_timeout
         state = 'no'
@@ -131,9 +131,8 @@ module Cisco
     def anycast_gateway_mac=(mac_addr)
       fail TypeError unless mac_addr.is_a?(String)
 
-      Feature.nv_overlay_evpn_enable unless Feature.nv_overlay_evpn_enabled?
-      Feature.fabric_forwarding_enable unless
-        Feature.fabric_forwarding_enabled?
+      Feature.nv_overlay_evpn_enable
+      Feature.fabric_forwarding_enable
       if mac_addr == default_anycast_gateway_mac
         state = 'no'
         mac_addr = ''

--- a/lib/cisco_node_utils/overlay_global.rb
+++ b/lib/cisco_node_utils/overlay_global.rb
@@ -131,7 +131,9 @@ module Cisco
     def anycast_gateway_mac=(mac_addr)
       fail TypeError unless mac_addr.is_a?(String)
 
-      Feature.nv_overlay_evpn_enable
+      Feature.nv_overlay_evpn_enable unless Feature.nv_overlay_evpn_enabled?
+      Feature.fabric_forwarding_enable unless
+        Feature.fabric_forwarding_enabled?
       if mac_addr == default_anycast_gateway_mac
         state = 'no'
         mac_addr = ''

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -961,14 +961,14 @@ class TestInterface < CiscoTestCase
 
   def test_interface_fabric_forwarding_anycast_gateway
     # Setup
+    config('no nv overlay evpn')
+    config('no feature fabric forwarding')
     config('no interface vlan11')
     int = Interface.new('vlan11')
     foo = OverlayGlobal.new
     foo.anycast_gateway_mac = '1223.3445.5668'
 
-    # 1. Testing default
-    int.fabric_forwarding_anycast_gateway =
-      int.default_fabric_forwarding_anycast_gateway
+    # 1. Testing default for newly created vlan
     assert_equal(int.default_fabric_forwarding_anycast_gateway,
                  int.fabric_forwarding_anycast_gateway)
 
@@ -980,19 +980,15 @@ class TestInterface < CiscoTestCase
     int.fabric_forwarding_anycast_gateway = false
     refute(int.fabric_forwarding_anycast_gateway)
 
-    # 4. Removing fabric forwarding anycast gateway mac
-    foo.anycast_gateway_mac = foo.default_anycast_gateway_mac
-    assert_raises(RuntimeError) { int.fabric_forwarding_anycast_gateway = true }
-
-    # 5. Removing feature fabric forwarding
-    config('no feature fabric forwarding')
-    assert_raises(RuntimeError) { int.fabric_forwarding_anycast_gateway = true }
-
-    # 6. Attempting to configure on a non-vlan interface
+    # 4. Attempt to configure on a non-vlan interface
     nonvlanint = create_interface
     assert_raises(RuntimeError) do
       nonvlanint.fabric_forwarding_anycast_gateway = true
     end
+
+    # 5. Removing fabric forwarding anycast gateway mac
+    foo.anycast_gateway_mac = foo.default_anycast_gateway_mac
+    assert_raises(RuntimeError) { int.fabric_forwarding_anycast_gateway = true }
   end
 
   def test_interface_ipv4_proxy_arp

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -961,8 +961,6 @@ class TestInterface < CiscoTestCase
 
   def test_interface_fabric_forwarding_anycast_gateway
     # Setup
-    config('no nv overlay evpn')
-    config('no feature fabric forwarding')
     config('no interface vlan11')
     int = Interface.new('vlan11')
     foo = OverlayGlobal.new
@@ -986,7 +984,8 @@ class TestInterface < CiscoTestCase
       nonvlanint.fabric_forwarding_anycast_gateway = true
     end
 
-    # 5. Removing fabric forwarding anycast gateway mac
+    # 5. Attempt to set 'fabric forwarding anycast gateway' while the
+    #    overlay gateway mac is not set.
     foo.anycast_gateway_mac = foo.default_anycast_gateway_mac
     assert_raises(RuntimeError) { int.fabric_forwarding_anycast_gateway = true }
   end


### PR DESCRIPTION
- De-couples `nv overlay evpn` from `feature fabric fowarding`.
- Add call in `overlay_global.rb`, `anycast_gateway_mac` setter method to enable both `nv overlay evpn` and `feature fabric forwarding` but `feature fabric forwarding` is a no-op on images that don't support it.
- Refactored tests.

**TESTS**

```
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils> ruby tests/test_interface.rb -n test_interface_fabric_forwarding_anycast_gateway -v -- dt-n9k5-1 admin admin
Run options: -n test_interface_fabric_forwarding_anycast_gateway -v -- --seed 21871

# Running:


Node under test:
  - name  - dt-n9k5-1
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I3.1.bin

TestInterface#test_interface_fabric_forwarding_anycast_gateway = 13.94 s = .

Finished in 13.939495s, 0.0717 runs/s, 0.3587 assertions/s.

1 runs, 5 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/coverage. 689 / 1290 LOC (53.41%) covered.
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils> ruby tests/test_interface.rb -n test_interface_fabric_forwarding_anycast_gateway -v -- agent-lab10-nx admin admin
Run options: -n test_interface_fabric_forwarding_anycast_gateway -v -- --seed 35363

# Running:


Node under test:
  - name  - agent-lab10-nx
  - type  - N9K-NXOSV
  - image - bootflash:///nxos.7.0.3.I2.1.bin

TestInterface#test_interface_fabric_forwarding_anycast_gateway = 9.49 s = .

Finished in 9.493716s, 0.1053 runs/s, 0.5267 assertions/s.

1 runs, 5 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/coverage. 687 / 1290 LOC (53.26%) covered.
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils> 
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils> ruby tests/test_overlay_global.rb  -v -- dt-n9k5-1 admin admin
Run options: -v -- --seed 6791

# Running:


Node under test:
  - name  - dt-n9k5-1
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I3.1.bin

TestOverlayGlobal#test_dup_host_ip_addr_detection = 10.44 s = .
TestOverlayGlobal#test_anycast_gateway_mac = 10.66 s = .
TestOverlayGlobal#test_dup_host_mac_detection = 6.55 s = .

Finished in 27.649013s, 0.1085 runs/s, 0.7234 assertions/s.

3 runs, 20 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/coverage. 655 / 1244 LOC (52.65%) covered.
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils> 
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils> ruby tests/test_overlay_global.rb  -v -- agent-lab10-nx admin admin
Run options: -v -- --seed 21989

# Running:


Node under test:
  - name  - agent-lab10-nx
  - type  - N9K-NXOSV
  - image - bootflash:///nxos.7.0.3.I2.1.bin

TestOverlayGlobal#test_dup_host_mac_detection = 4.62 s = .
TestOverlayGlobal#test_dup_host_ip_addr_detection = 3.56 s = .
TestOverlayGlobal#test_anycast_gateway_mac = 4.76 s = .

Finished in 12.937798s, 0.2319 runs/s, 1.5459 assertions/s.

3 runs, 20 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils/coverage. 649 / 1244 LOC (52.17%) covered.
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release120/cisco-network-node-utils> 

```
