### PR TITLE
Fix zero_pad issue in overlay_global

### DIFF
--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -134,5 +134,12 @@ module Cisco
       end
       delta
     end # delta_add_remove
+
+    # Helper to 0-pad a mac address.
+    def self.zero_pad_macaddr(mac)
+      return nil if mac.nil? || mac.empty?
+      o1, o2, o3 = mac.split('.').map { |o| o.to_i(16).to_s(10) }
+      sprintf('%04x.%04x.%04x', o1, o2, o3)
+    end
   end # class Utils
 end   # module Cisco

--- a/lib/cisco_node_utils/overlay_global.rb
+++ b/lib/cisco_node_utils/overlay_global.rb
@@ -18,6 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require_relative 'cisco_cmn_utils'
 require_relative 'feature'
 require_relative 'node_util'
 
@@ -125,7 +126,9 @@ module Cisco
     # anycast-gateway-mac
     def anycast_gateway_mac
       return nil unless Feature.nv_overlay_evpn_enabled?
-      config_get('overlay_global', 'anycast_gateway_mac')
+      mac = config_get('overlay_global', 'anycast_gateway_mac')
+      # This value gets 0-padded when nvgened, so we need to convert it.
+      Utils.zero_pad_macaddr(mac).nil? ? default_anycast_gateway_mac : mac
     end
 
     def anycast_gateway_mac=(mac_addr)

--- a/tests/test_overlay_global.rb
+++ b/tests/test_overlay_global.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/cisco_cmn_utils'
 require_relative '../lib/cisco_node_utils/feature'
 require_relative '../lib/cisco_node_utils/overlay_global'
 
@@ -91,9 +92,11 @@ class TestOverlayGlobal < CiscoTestCase
                  overlay_global.anycast_gateway_mac)
     assert(Feature.nv_overlay_evpn_enabled?)
 
-    # Set to non-default value
-    mac_addr = '1223.3445.5668'
-    overlay_global.anycast_gateway_mac = mac_addr
-    assert_equal(mac_addr, overlay_global.anycast_gateway_mac)
+    # Set to various non-default values
+    %w(1.1.1 55.a10.ffff 1223.3445.5668).each do |mac|
+      overlay_global.anycast_gateway_mac = mac
+      assert_equal(Utils.zero_pad_macaddr(mac),
+                   overlay_global.anycast_gateway_mac)
+    end
   end
 end


### PR DESCRIPTION
The anycast_gateway_mac property gets zero_padded when it nvgens.  Fixes the getter to return a zero-padded value.

```
Node under test:
  - name  - dt-n9k5-1
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I3.1.bin

0001.0001.0001
0055.0a10.ffff
1223.3445.5668
TestOverlayGlobal#test_anycast_gateway_mac = 6.54 s = .
TestOverlayGlobal#test_dup_host_ip_addr_detection = 4.11 s = .
TestOverlayGlobal#test_dup_host_mac_detection = 3.94 s = .

Finished in 14.593847s, 0.2056 runs/s, 1.5075 assertions/s.
```
