### PR TITLE
l4 ace node utils

### DIFF
--- a/lib/cisco_node_utils/ace.rb
+++ b/lib/cisco_node_utils/ace.rb
@@ -154,7 +154,7 @@ module Cisco
       return nil unless ace_match.names.include?(prop)
 
       # extract and return value that follows prefix + <space>
-      regexp = Regexp.new("#{Regexp.escape(prefix)} (?<extracted>.\S+)")
+      regexp = Regexp.new("#{Regexp.escape(prefix)} (?<extracted>.*)")
       value_match = regexp.match(ace_match[prop])
       return nil if value_match.nil?
       value_match[:extracted]
@@ -247,21 +247,22 @@ module Cisco
     def tcp_flags
       match = ace_get
       return nil if match.nil?
-      match.names.include?('tcp_flags') ? match[:tcp_flags] : nil
+      match.names.include?('tcp_flags') ? match[:tcp_flags].strip: nil
     end
 
     def tcp_flags=(tcp_flags)
-      @set_args[:tcp_flags] = tcp_flags
+      @set_args[:tcp_flags] = tcp_flags.strip
     end
 
     def established
       match = ace_get
       return nil if match.nil?
-      match.names.include?('established') ? true : false
+      return nil unless match.names.include?('established')
+      match[:established] == 'established' ? true : nil 
     end
 
     def established=(established)
-      @set_args[:established] = established == true ? 'established' : ''
+      @set_args[:established] = established.to_s == 'true' ? 'established' : ''
     end
 
     def precedence
@@ -331,11 +332,12 @@ module Cisco
     def log
       match = ace_get
       return nil if match.nil?
-      match.names.include?('log') ? true : false
+      return nil unless match.names.include?('log')
+      match[:log] == 'log' ? true : nil
     end
 
     def log=(log)
-      @set_args[:log] = log == true ? 'log' : ''
+      @set_args[:log] = log.to_s == 'true' ? 'log' : ''
     end
   end
 end


### PR DESCRIPTION
fix in node utils  to make beaker tests work

rtpfe1@agent-lab9-ws:~/saraza/cisco-network-node-utils/tests$ unset https_proxy
rtpfe1@agent-lab9-ws:~/saraza/cisco-network-node-utils/tests$ ruby test_ace.rb -v -- 10.122.197.168 admin admin
Run options: -v -- --seed 11618
# Running:

Node under test:
- name  - agent-lab9-nx
- type  - N9K-NXOSV
- image - bootflash:///nxos.7.0.3.I2.1.bin

TestAce#test_ace_update = 3.91 s = .
TestAce#test_create_destroy_ace_one = 19.38 s = .

Finished in 23.288936s, 0.0859 runs/s, 8.5878 assertions/s.

2 runs, 200 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /home/rtpfe1/saraza/cisco-network-node-utils/tests/coverage. 0.0 / 0.0 LOC (100.0%) covered.
