### PR TITLE
Suppress and fix warnings

### DIFF
--- a/lib/.rubocop.yml
+++ b/lib/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: ../.rubocop.yml
 # Baseline code complexity metrics for the lib/ subdirectory:
 
 Metrics/AbcSize:
-  Max: 48
+  Max: 49
 
 Metrics/CyclomaticComplexity:
   Max: 23

--- a/lib/cisco_node_utils/ace.rb
+++ b/lib/cisco_node_utils/ace.rb
@@ -17,7 +17,7 @@ require_relative 'node_util'
 module Cisco
   # Ace - node utility class for Ace Configuration
   class Ace < NodeUtil
-    attr_reader :afi, :acl_name, :seqno
+    attr_reader :afi, :acl_name
 
     def initialize(afi, acl_name, seqno)
       @afi = Acl.afi_cli(afi)

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -17,7 +17,6 @@
 require_relative 'cisco_cmn_utils'
 require_relative 'node_util'
 require_relative 'feature'
-require_relative 'bgp_af'
 require_relative 'logger'
 
 module Cisco

--- a/lib/cisco_node_utils/client/grpc.rb
+++ b/lib/cisco_node_utils/client/grpc.rb
@@ -17,7 +17,9 @@ require_relative 'client_errors'
 
 # Fail gracefully if submodule dependencies are not met
 begin
-  require 'grpc'
+  Cisco::Client.silence_warnings do
+    require 'grpc'
+  end
 rescue LoadError => e
   raise unless e.message =~ /-- grpc/
   # If grpc is not installed, raise an error that client understands.

--- a/lib/cisco_node_utils/client/grpc/client.rb
+++ b/lib/cisco_node_utils/client/grpc/client.rb
@@ -17,7 +17,9 @@
 # limitations under the License.
 
 require_relative '../client'
-require 'grpc'
+Cisco::Client.silence_warnings do
+  require 'grpc'
+end
 require 'json'
 require_relative 'ems_services'
 require_relative 'client_errors'
@@ -142,19 +144,20 @@ class Cisco::Client::GRPC < Cisco::Client
     if args.is_a?(ShowCmdArgs) || args.is_a?(CliConfigArgs)
       debug "  with cli: '#{args.cli}'"
     end
-    response = stub.send(type, args,
-                         timeout:  @timeout,
-                         username: @username,
-                         password: @password)
-    output = ''
-    # gRPC server may split the response into multiples
-    response = response.is_a?(Enumerator) ? response.to_a : [response]
-    debug "Got responses: #{response.map(&:class).join(', ')}"
-    # Check for errors first
-    handle_errors(args, response.select { |r| !r.errors.empty? })
+    output = Client.silence_warnings do
+      response = stub.send(type, args,
+                           timeout:  @timeout,
+                           username: @username,
+                           password: @password)
+      # gRPC server may split the response into multiples
+      response = response.is_a?(Enumerator) ? response.to_a : [response]
+      debug "Got responses: #{response.map(&:class).join(', ')}"
+      # Check for errors first
+      handle_errors(args, response.select { |r| !r.errors.empty? })
 
-    # If we got here, no errors occurred
-    output = handle_response(args, response)
+      # If we got here, no errors occurred
+      handle_response(args, response)
+    end
 
     @cache_hash[type][args.cli] = output if cache_enable? && !output.empty?
     return output

--- a/lib/cisco_node_utils/client/utils.rb
+++ b/lib/cisco_node_utils/client/utils.rb
@@ -152,4 +152,13 @@ class Cisco::Client
     end
     data
   end
+
+  # Helper method for require - suppress Ruby warnings for the given block
+  def self.silence_warnings(&block)
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    result = block.call
+    $VERBOSE = warn_level
+    result
+  end
 end


### PR DESCRIPTION
When running 'rake test', Ruby interpreter warnings are enabled (this can also be manually done by running 'ruby -w tests/test_name_goes_here...'). Unfortunately this results in a lot of noise from warnings in the core grpc gem. Use a bit of Ruby magic to suppress warnings when calling out to the grpc gem.

Once the grpc noise is suppressed, there are two valid Ruby warnings:

1) redefinition of `seqno` getter method in ace.rb (we define it as an attr_reader then follow up by declaring it as a separate function)
2) circular dependency between bgp.rb and bgp_af.rb - this was added when bgp was relying on bgp_af's feature logic; now that that has been moved into feature.rb, the dependency is no longer needed.
