### PR TITLE
Skip entire test case if feature is excluded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changelog
 
 * Added client support for gRPC on IOS XR.
 * Smart dependency installation - installing this gem will install `grpc` on IOS XR and Linux environments, but not on NX-OS environments.
+* Minitests can declare the YAML feature they are exercising, and if the feature is `_exclude`d on the node under test, the test case will automatically be skipped in full.
 * Add IOS XR support for the following classes:
   * bgp
   * bgp_af

--- a/lib/cisco_node_utils/cmd_ref/interface_ospf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_ospf.yaml
@@ -1,5 +1,7 @@
 # interface_ospf
 ---
+_exclude: [ios_xr]
+
 _template:
   get_command: 'show running interface all'
   context: ["interface %s"]

--- a/lib/cisco_node_utils/cmd_ref/ospf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf.yaml
@@ -1,10 +1,12 @@
 # ospf
 ---
+_exclude: [ios_xr]
+
 _template:
   get_command: "show running ospf all"
   context:
     - "router ospf <name>"
-    - "vrf <vrf>"
+    - "(?)vrf <vrf>"
 
 auto_cost:
   get_value: '/^auto-cost reference-bandwidth (\d+)\s*(\S+)?$/'

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -426,6 +426,11 @@ module Cisco
       end
     end
 
+    def supports?(feature)
+      value = @hash[feature]
+      !(value.is_a?(UnsupportedCmdRef) || value.nil?)
+    end
+
     # Get the command reference
     def lookup(feature, name)
       value = @hash[feature]

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -51,7 +51,7 @@ class TestCase < Minitest::Test
   @@username = nil
   @@password = nil
 
-  def address
+  def self.address
     @@address ||= ARGV[0]
     @@address ||= ENV['NODE'].split(' ')[0] if ENV['NODE']
     unless @@address
@@ -61,7 +61,11 @@ class TestCase < Minitest::Test
     @@address
   end
 
-  def username
+  def address
+    self.class.address
+  end
+
+  def self.username
     @@username ||= ARGV[1]
     @@username ||= ENV['NODE'].split(' ')[1] if ENV['NODE']
     unless @@username
@@ -71,7 +75,11 @@ class TestCase < Minitest::Test
     @@username
   end
 
-  def password
+  def username
+    self.class.username
+  end
+
+  def self.password
     @@password ||= ARGV[2]
     @@password ||= ENV['NODE'].split(' ')[2] if ENV['NODE']
     unless @@password
@@ -79,6 +87,10 @@ class TestCase < Minitest::Test
       @@password = gets.chomp
     end
     @@password
+  end
+
+  def password
+    self.class.password
   end
 
   def setup

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -31,7 +31,32 @@ class CiscoTestCase < TestCase
   @@interfaces_id = nil
   # rubocop:enable Style/ClassVars
 
-  def node
+  # The feature (lib/cisco_node_utils/cmd_ref/<feature>.yaml) that this
+  # test case is primarily focused on exercising, if applicable.
+  # If the YAML file excludes this entire feature for this platform
+  # (top-level _exclude statement, not individual attributes), then
+  # this entire test case will be skipped.
+  @feature = nil
+
+  class << self
+    attr_reader :feature
+  end
+
+  def self.runnable_methods
+    return super if feature.nil? || node.cmd_ref.supports?(feature)
+    # If the entire feature under test is unsupported,
+    # undefine the setup/teardown methods and skip the whole test case
+    remove_method :setup
+    remove_method :teardown
+    [:all_skipped]
+  end
+
+  def all_skipped
+    skip("Skipping #{self.class}; feature '#{self.class.feature}' " \
+         'is unsupported on this node')
+  end
+
+  def self.node
     unless @@node
       @@node = Node.instance # rubocop:disable Style/ClassVars
       @@node.connect(address, username, password)
@@ -48,6 +73,10 @@ class CiscoTestCase < TestCase
     abort "Unauthorized to connect as #{username}:#{password}@#{address}"
   rescue Cisco::Client::ClientError, TypeError, ArgumentError => e
     abort "Error in establishing connection: #{e}"
+  end
+
+  def node
+    self.class.node
   end
 
   def setup

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -32,18 +32,19 @@ class CiscoTestCase < TestCase
   # rubocop:enable Style/ClassVars
 
   # The feature (lib/cisco_node_utils/cmd_ref/<feature>.yaml) that this
-  # test case is primarily focused on exercising, if applicable.
+  # test case is associated with, if applicable.
   # If the YAML file excludes this entire feature for this platform
   # (top-level _exclude statement, not individual attributes), then
-  # this entire test case will be skipped.
-  @feature = nil
+  # all tests in this test case will be skipped.
+  @skip_unless_supported = nil
 
   class << self
-    attr_reader :feature
+    attr_reader :skip_unless_supported
   end
 
   def self.runnable_methods
-    return super if feature.nil? || node.cmd_ref.supports?(feature)
+    return super if skip_unless_supported.nil?
+    return super if node.cmd_ref.supports?(skip_unless_supported)
     # If the entire feature under test is unsupported,
     # undefine the setup/teardown methods and skip the whole test case
     remove_method :setup
@@ -52,8 +53,8 @@ class CiscoTestCase < TestCase
   end
 
   def all_skipped
-    skip("Skipping #{self.class}; feature '#{self.class.feature}' " \
-         'is unsupported on this node')
+    skip("Skipping #{self.class}; feature " \
+         "'#{self.class.skip_unless_supported}' is unsupported on this node")
   end
 
   def self.node

--- a/tests/test_interface_ospf.rb
+++ b/tests/test_interface_ospf.rb
@@ -21,6 +21,8 @@ include Cisco
 
 # TestInterfaceOspf - Minitest for InterfaceOspf node utility class.
 class TestInterfaceOspf < CiscoTestCase
+  @feature = 'interface_ospf'
+
   def setup
     super
     config 'no feature ospf'

--- a/tests/test_interface_ospf.rb
+++ b/tests/test_interface_ospf.rb
@@ -21,7 +21,7 @@ include Cisco
 
 # TestInterfaceOspf - Minitest for InterfaceOspf node utility class.
 class TestInterfaceOspf < CiscoTestCase
-  @feature = 'interface_ospf'
+  @skip_unless_supported = 'interface_ospf'
 
   def setup
     super

--- a/tests/test_router_ospf.rb
+++ b/tests/test_router_ospf.rb
@@ -17,7 +17,7 @@ require_relative '../lib/cisco_node_utils/router_ospf'
 
 # TestRouterOspf - Minitest for the RouterOspf node utility class.
 class TestRouterOspf < CiscoTestCase
-  @feature = 'ospf'
+  @skip_unless_supported = 'ospf'
 
   def setup
     super

--- a/tests/test_router_ospf.rb
+++ b/tests/test_router_ospf.rb
@@ -17,6 +17,8 @@ require_relative '../lib/cisco_node_utils/router_ospf'
 
 # TestRouterOspf - Minitest for the RouterOspf node utility class.
 class TestRouterOspf < CiscoTestCase
+  @feature = 'ospf'
+
   def setup
     super
     @default_show_command = "show run | include '^router ospf .*'"

--- a/tests/test_router_ospf_vrf.rb
+++ b/tests/test_router_ospf_vrf.rb
@@ -18,7 +18,7 @@ require_relative '../lib/cisco_node_utils/router_ospf_vrf'
 
 # TestRouterOspfVrf - Minitest for RouterOspfVrf node utility class
 class TestRouterOspfVrf < CiscoTestCase
-  @feature = 'ospf'
+  @skip_unless_supported = 'ospf'
 
   def setup
     # Disable feature ospf before each test to ensure we

--- a/tests/test_router_ospf_vrf.rb
+++ b/tests/test_router_ospf_vrf.rb
@@ -18,6 +18,8 @@ require_relative '../lib/cisco_node_utils/router_ospf_vrf'
 
 # TestRouterOspfVrf - Minitest for RouterOspfVrf node utility class
 class TestRouterOspfVrf < CiscoTestCase
+  @feature = 'ospf'
+
   def setup
     # Disable feature ospf before each test to ensure we
     # are starting with a clean slate for each test.


### PR DESCRIPTION
Looking for feedback on this approach. It adds the following functionality:
- If you have a top-level `_exclude` statement in `foo.yaml`, and
- your minitest defines the class variable `@feature = 'foo'`, and
- you run your minitest against an excluded node

then the test will report a single Skipped result and exit. 

This doesn't let us do the more fine-grained negative testing that would be done for a 'partially supported' feature, but it lets us cleanly silence entire tests for features we haven't yet begun to work on.
# Example - test_router_ospf_vrf:
## IOS XR is excluded:

```
Node under test:
  - name  - ios
  - type  - R-IOSXRV9000-CH
TestRouterOspfVrf#all_skipped = 1.22 s = S

Fabulous run in 3.430676s, 0.2915 runs/s, 0.0000 assertions/s.

  1) Skipped:
TestRouterOspfVrf#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:55]:
Skipping TestRouterOspfVrf; feature 'ospf' is unsupported on this node

1 runs, 0 assertions, 0 failures, 0 errors, 1 skips
```
## NX-OS is not excluded and runs in full:

```
Node under test:
  - name  - n9k-108
  - type  - N9K-C9396PX
TestRouterOspfVrf#test_routerospfvrf_auto_cost = 7.63 s = .
TestRouterOspfVrf#test_routerospfvrf_router_id_multiple_vrf = 11.30 s = .
TestRouterOspfVrf#test_routerospfvrf_collection_not_empty_valid = 11.84 s = .
TestRouterOspfVrf#test_routerospfvrf_get_parent_name = 3.72 s = .
TestRouterOspfVrf#test_routerospfvrf_timer_throttle_spf_multiple_vrf = 11.09 s = .
TestRouterOspfVrf#test_routerospfvrf_router_id = 7.41 s = .
TestRouterOspfVrf#test_routerospfvrf_log_adjacency_multiple_vrf = 11.31 s = .
TestRouterOspfVrf#test_routerospfvrf_timer_throttle_lsa = 9.60 s = .
TestRouterOspfVrf#test_routerospfvrf_auto_cost_multiple_vrf = 6.07 s = .
TestRouterOspfVrf#test_routerospfvrf_collection_router_multi_vrfs = 11.89 s = .
TestRouterOspfVrf#test_routerospfvrf_log_adjacency_changes = 6.55 s = .
TestRouterOspfVrf#test_routerospfvrf_collection_size = 6.94 s = .
TestRouterOspfVrf#test_routerospfvrf_create_name_zero_length = 3.19 s = .
TestRouterOspfVrf#test_routerospfvrf_create_valid = 3.97 s = .
TestRouterOspfVrf#test_routerospfvrf_create_valid_destroy_default = 4.19 s = .
TestRouterOspfVrf#test_routerospfvrf_destroy = 4.12 s = .
TestRouterOspfVrf#test_routerospfvrf_get_default_timer_throttle_spf = 4.00 s = .
TestRouterOspfVrf#test_routerospfvrf_timer_throttle_lsa_start_hold_max = 7.07 s = .
TestRouterOspfVrf#test_routerospfvrf_timer_throttle_spf = 12.58 s = .
TestRouterOspfVrf#test_routerospfvrf_default_metric = 8.07 s = .
TestRouterOspfVrf#test_routerospfvrf_get_name = 4.03 s = .
TestRouterOspfVrf#test_routerospfvrf_timer_throttle_spf_start_hold_max = 12.11 s = .
TestRouterOspfVrf#test_routerospfvrf_create_vrf_nil = 0.80 s = .
TestRouterOspfVrf#test_routerospfvrf_noninstantiated = 9.09 s = .
TestRouterOspfVrf#test_routerospfvrf_get_default_auto_cost = 4.02 s = .
TestRouterOspfVrf#test_routerospfvrf_default_metric_multiple_vrf = 6.25 s = .
TestRouterOspfVrf#test_routerospfvrf_get_default_timer_throttle_lsa = 4.01 s = .
TestRouterOspfVrf#test_routerospfvrf_timer_throttle_lsa_multiple_vrf = 6.26 s = .
TestRouterOspfVrf#test_routerospfvrf_log_adjacency_multiple_vrf_2 = 10.03 s = .

Fabulous run in 209.903750s, 0.1382 runs/s, 3.2920 assertions/s.

29 runs, 691 assertions, 0 failures, 0 errors, 0 skips
```
