### PR TITLE
Cisco::Logger backtrace on N5k

### DIFF
--- a/lib/cisco_node_utils.rb
+++ b/lib/cisco_node_utils.rb
@@ -12,5 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Declare module here as files referenced in glob-order below may assume
+# module already exists.
+module Cisco
+end
+
 # Automatically load all Ruby files in the cisco_node_utils subdirectory
 Dir.glob(__dir__ + '/cisco_node_utils/*.rb') { |file| require file }


### PR DESCRIPTION
Symptom: I loaded the post-merge NU gem on my N5k, ran puppet agent and saw:
 `Error: Facter: error while resolving custom fact "cisco_node_utils": uninitialized constant Cisco`
- backtrace showed logger.rb:24, which does:
  
  `module Cisco::Logger`
- Glenn noticed that we're sourcing our files in glob order, which on the n5k platform results in logger.rb before the other files
- Problem wasn't seen on N9k, but glob order there is reverse alpha, which picked up yum.rb first, which does `module Cisco`, so it works fine
