### PR TITLE
Add missing get_data_format yaml entries

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/aaa_auth_login_service.yaml
+++ b/lib/cisco_node_utils/cmd_ref/aaa_auth_login_service.yaml
@@ -1,6 +1,7 @@
 # aaa_auth_login_service
 ---
 groups:
+  get_data_format: nxapi_structured
   get_command: "show aaa authentication"
   get_context: ["TABLE_AuthenMethods", "ROW_AuthenMethods"]
   # this set is only used when there are groups to configure

--- a/lib/cisco_node_utils/cmd_ref/aaa_authorization_service.yaml
+++ b/lib/cisco_node_utils/cmd_ref/aaa_authorization_service.yaml
@@ -1,6 +1,7 @@
 # aaa_authorization_service
 ---
 groups:
+  get_data_format: nxapi_structured
   get_command: "show aaa authorization all"
   get_context: ["TABLE_cmd_methods", "ROW_cmd_methods"]
   # this set is only used when there are groups to configure

--- a/lib/cisco_node_utils/cmd_ref/show_version.yaml
+++ b/lib/cisco_node_utils/cmd_ref/show_version.yaml
@@ -56,11 +56,12 @@ last_reset_time:
   get_value: "rr_ctime"
 
 system_image:
-  _exclude: [ios_xr]
+  nexus:
+    get_value: "kick_file_name"
+  ios_xr:
+    get_value: '/IOS XR.*Version (.*)$/' 
   N7k:
     get_value: "isan_file_name"
-  else:
-    get_value: "kick_file_name"
 
 uptime:
   # TODO: redundant with show_system, uptime?

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -67,7 +67,7 @@ class CiscoTestCase < TestCase
       puts "\nNode under test:"
       puts "  - name  - #{@@node.host_name}"
       puts "  - type  - #{@@node.product_id}"
-      # puts "  - image - #{@@node.system}\n\n"
+      puts "  - image - #{@@node.system}\n\n"
     end
     @@node
   rescue Cisco::Client::AuthenticationFailed


### PR DESCRIPTION
# Fixes the following
- The `test_aaa_authorization_service.rb` and `test_aaa_authentication_login_service.rb` tests did not have the correct `get_data_format` entries as they use `nxapi_structured` output for show commands.
- The `node under test` image version information was commented out.  I un-commented the line and updated the XR case to display the version which is quasi-more-meaningful then showing nothing.
## Test Details:

NOTE: All or most of the `test_aaa_auth*` tests were failing without this fix.  With the fix there are still issues that need to be investigated on certain platforms, but this at least unblocks the ability to debug the other failures which are beyond the scope of this PR but will be fixed in a future PR.
### N9K I2 Results: :white_check_mark:  All Pass
### N9K I3 Results: :children_crossing: Some failures
### N8K Fretta Camden Results: :children_crossing: Some failures
## XR Output Now Shows This For `image`:

```
root@rtp-puppetmaster1:~/github/cisco-network-node-utils# ruby tests/test_router_bgp.rb -v -- 10.122.197.144:57777 root lab 
Run options: -v -- --seed 34444

# Running:


Node under test:
  - name  - agent-lab22-xr
  - type  - R-IOSXRV9000-CH
  - image - 6.0.0.21I

TestRouterBgp#test_valid_asn = 57.59 s = .
TestRouterBgp#test_cluster_id_not_configured = 15.11 s = .
```
