### PR TITLE
'rake test' cleanup for XR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,14 @@ Changelog
   * bgp_af
   * bgp_neighbor
   * bgp_neighbor_af
-  * interface
   * command_config
-  * platform (@glennmatthews)
+  * dns_domain (@glennmatthews)
+  * domain_name (@glennmatthews)
+  * interface
+  * name_server (@glennmatthews)
   * ntp_config (@jonnytpuppet)
   * ntp_server (@jonnytpuppet)
+  * platform (@glennmatthews)
 * `test_feature` minitest
 * Extend interface with attributes:
   * `ipv4_forwarding`

--- a/lib/cisco_node_utils/cmd_ref/aaa_auth_login_service.yaml
+++ b/lib/cisco_node_utils/cmd_ref/aaa_auth_login_service.yaml
@@ -1,5 +1,7 @@
 # aaa_auth_login_service
 ---
+_exclude: [ios_xr]
+
 groups:
   get_data_format: nxapi_structured
   get_command: "show aaa authentication"

--- a/lib/cisco_node_utils/cmd_ref/aaa_authentication_login.yaml
+++ b/lib/cisco_node_utils/cmd_ref/aaa_authentication_login.yaml
@@ -1,5 +1,7 @@
 # aaa_authentication_login
 ---
+_exclude: [ios_xr]
+
 ascii_authentication:
   get_command: "show run aaa all"
   get_value: '/^aaa authentication login ascii-authentication/'

--- a/lib/cisco_node_utils/cmd_ref/aaa_authorization_service.yaml
+++ b/lib/cisco_node_utils/cmd_ref/aaa_authorization_service.yaml
@@ -1,5 +1,7 @@
 # aaa_authorization_service
 ---
+_exclude: [ios_xr]
+
 groups:
   get_data_format: nxapi_structured
   get_command: "show aaa authorization all"

--- a/lib/cisco_node_utils/cmd_ref/dnsclient.yaml
+++ b/lib/cisco_node_utils/cmd_ref/dnsclient.yaml
@@ -5,15 +5,23 @@ _template:
 
 domain_list:
   multiple: true
-  get_value: '/^ip domain-list (\S+)$/'
-  set_value: '<state> ip domain-list <name>'
+  nexus:
+    get_value: '/^ip domain-list (\S+)$/'
+    set_value: '<state> ip domain-list <name>'
+  ios_xr:
+    get_value: '/^domain list (\S+)$/'
+    set_value: '<state> domain list <name>'
   default_value: []
 
 domain_list_vrf:
   multiple: true
-  context: ['vrf context <vrf>']
-  get_value: '/ip domain-list (\S+)/'
-  set_value: '<state> ip domain-list <name>'
+  nexus:
+    context: ['vrf context <vrf>']
+    get_value: '/ip domain-list (\S+)/'
+    set_value: '<state> ip domain-list <name>'
+  ios_xr:
+    get_value: '/^domain vrf <vrf> list (\S+)/'
+    set_value: '<state> domain vrf <vrf> list <name>'
   default_value: []
 
 domain_name:
@@ -26,14 +34,22 @@ domain_name:
     get_value: '/^domain name (\S+)$/'
 
 domain_name_vrf:
-  context: ['vrf context <vrf>']
-  get_value: '/ip domain-name (\S+)/'
-  set_value: '<state> ip domain-name <name>'
+  nexus:
+    context: ['vrf context <vrf>']
+    get_value: '/ip domain-name (\S+)/'
+    set_value: '<state> ip domain-name <name>'
+  ios_xr:
+    get_value: '/^domain vrf <vrf> name (\S+)$/'
+    set_value: '<state> domain vrf <vrf> name <name>'
   default_value: ''
 
 name_server:
   multiple: true
   default_value: []
-  get_command: "show running-config all | include 'ip name-server' | exclude 'use-vrf'"
-  get_value: '/^ip name-server ([\s\d\.:]+)$/'
-  set_value: '<state> ip name-server <ip>'
+  nexus:
+    get_command: "show running-config all | include 'ip name-server' | exclude 'use-vrf'"
+    get_value: '/^ip name-server ([\s\d\.:]+)$/'
+    set_value: '<state> ip name-server <ip>'
+  ios_xr:
+    get_value: '/^domain name-server (\S+)$/'
+    set_value: '<state> domain name-server <ip>'

--- a/lib/cisco_node_utils/cmd_ref/evpn_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/evpn_vni.yaml
@@ -1,5 +1,7 @@
 # evpn_vni.yaml
 ---
+_exclude: [ios_xr]
+
 _template:
   get_command: "show running bgp all"
   get_context:

--- a/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
+++ b/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
@@ -1,7 +1,7 @@
 # fabricpath
 ---
 # Fabricpath feature is not available on N3K and N9K
-_exclude: [N3k, N9k]
+_exclude: [N3k, N9k, ios_xr]
 
 aggregate_multicast_routes:
   _exclude: [N5k, N6k]

--- a/lib/cisco_node_utils/cmd_ref/fabricpath_topology.yaml
+++ b/lib/cisco_node_utils/cmd_ref/fabricpath_topology.yaml
@@ -1,7 +1,7 @@
 # fabricpath_topology
 ---
 # Fabricpath feature is not available on N3K and N9K
-_exclude: [N3k, N9k]
+_exclude: [N3k, N9k, ios_xr]
 
 _template:
   get_command: 'show running-config fabricpath all'

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -1,5 +1,7 @@
 # feature
 ---
+_exclude: [ios_xr]
+
 bgp:
   kind: boolean
   get_command: "show running | i ^feature"

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -16,6 +16,8 @@ access_vlan:
 
 all_interfaces:
   multiple:
+  ios_xr:
+    get_command: 'show running all-interfaces'
   get_context: ~
   get_value: '/^interface (.*)/'
 

--- a/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
@@ -1,5 +1,7 @@
 # interface_portchannel
 ---
+_exclude: [ios_xr]
+
 _template:
   get_command: "show running interface all"
   get_context: ['/^interface %s$/i']

--- a/lib/cisco_node_utils/cmd_ref/interface_service_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_service_vni.yaml
@@ -1,7 +1,8 @@
 # interface_service_vni
 ---
+_exclude: [N3k, N5k, N6k, N9k, ios_xr]
+
 _template:
-  _exclude: [N3k, N5k, N6k, N9k]
   get_command: 'show running interface all'
   get_context:
     - '/^interface <name>$/i'

--- a/lib/cisco_node_utils/cmd_ref/overlay_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/overlay_global.yaml
@@ -1,5 +1,7 @@
 # overlay_global
 ---
+_exclude: [ios_xr]
+
 anycast_gateway_mac:
   kind: string
   get_command: "show running all | inc 'fabric forwarding'"

--- a/lib/cisco_node_utils/cmd_ref/pim.yaml
+++ b/lib/cisco_node_utils/cmd_ref/pim.yaml
@@ -1,5 +1,7 @@
 # pim
 ---
+_exclude: [ios_xr]
+
 _template:
   get_command: "show run pim all"
   get_context:

--- a/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
@@ -1,5 +1,7 @@
 # portchannel_global
 ---
+_exclude: [ios_xr]
+
 _template:
   get_command: "show running all"
 

--- a/lib/cisco_node_utils/cmd_ref/radius_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/radius_global.yaml
@@ -1,5 +1,7 @@
 # radius_global.yaml
 ---
+_exclude: [ios_xr]
+
 key:
   get_command: "show running-config radius all"
   get_value: '/^radius-server key \d+\s+(\S+)/'

--- a/lib/cisco_node_utils/cmd_ref/radius_server.yaml
+++ b/lib/cisco_node_utils/cmd_ref/radius_server.yaml
@@ -1,5 +1,7 @@
 # radius_server.yaml
 ---
+_exclude: [ios_xr]
+
 accounting:
   auto_default: false
   kind: boolean

--- a/lib/cisco_node_utils/cmd_ref/radius_server_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/radius_server_group.yaml
@@ -1,5 +1,7 @@
 # radius_server_group
 ---
+_exclude: [ios_xr]
+
 _template:
   multiple: true
   default_value: []

--- a/lib/cisco_node_utils/cmd_ref/snmp_community.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_community.yaml
@@ -1,5 +1,7 @@
 # snmp_community
 ---
+_exclude: [ios_xr]
+
 acl:
   get_command: "show running snmp all"
   get_value: '/^snmp-server community %s use-acl (.*)$/'

--- a/lib/cisco_node_utils/cmd_ref/snmp_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_group.yaml
@@ -1,5 +1,7 @@
 # snmp_group
 ---
+_exclude: [ios_xr]
+
 group:
   multiple: true
   get_command: "show snmp group"

--- a/lib/cisco_node_utils/cmd_ref/snmp_notification_receiver.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_notification_receiver.yaml
@@ -1,5 +1,7 @@
 # snmp_notification_receiver
 ---
+_exclude: [ios_xr]
+
 port:
   get_command: "show running-config snmp all"
   get_value: '/^snmp-server host %s.*version.* udp-port (\d+).*$/'

--- a/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
@@ -1,5 +1,7 @@
 # snmp_server
 ---
+_exclude: [ios_xr]
+
 aaa_user_cache_timeout:
   nexus:
     kind: int

--- a/lib/cisco_node_utils/cmd_ref/snmp_user.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_user.yaml
@@ -1,5 +1,7 @@
 # snmp_user
 ---
+_exclude: [ios_xr]
+
 _template:
   multiple: true
 

--- a/lib/cisco_node_utils/cmd_ref/snmpnotification.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmpnotification.yaml
@@ -1,5 +1,7 @@
 # snmpnotification
 ---
+_exclude: [ios_xr]
+
 enable:
   get_command: "sh run snmp all | include 'snmp-server enable traps'"
   get_value: '/^snmp-server enable traps <trap_name> ?$/'

--- a/lib/cisco_node_utils/cmd_ref/stp_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/stp_global.yaml
@@ -1,5 +1,7 @@
 # stp_global
 ---
+_exclude: [ios_xr]
+
 _template:
   get_command: "show running-config spanning-tree"
 

--- a/lib/cisco_node_utils/cmd_ref/tacacs_server.yaml
+++ b/lib/cisco_node_utils/cmd_ref/tacacs_server.yaml
@@ -1,5 +1,7 @@
 # tacacs_server
 ---
+_exclude: [ios_xr]
+
 deadtime:
   kind: int
   get_command: "show run tacacs all"

--- a/lib/cisco_node_utils/cmd_ref/tacacs_server_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/tacacs_server_group.yaml
@@ -1,5 +1,7 @@
 # tacacs_server_group
 ---
+_exclude: [ios_xr]
+
 deadtime:
   get_command: "show run tacacs all"
   get_context: ['/^aaa group server tacacs\+ %s/']

--- a/lib/cisco_node_utils/cmd_ref/tacacs_server_host.yaml
+++ b/lib/cisco_node_utils/cmd_ref/tacacs_server_host.yaml
@@ -1,5 +1,7 @@
 # tacacs_server_host
 ---
+_exclude: [ios_xr]
+
 encryption:
   set_value: "%s tacacs-server host %s key %s %s"
 

--- a/lib/cisco_node_utils/cmd_ref/vdc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vdc.yaml
@@ -3,7 +3,7 @@
 # The current simplified implementation assumes no admin-vdc and that the
 # default vdc name uses id 1. Full multi-vdc support is TBD.
 ---
-_exclude: [N3k, N5k, N6k, N9k]
+_exclude: [N3k, N5k, N6k, N9k, ios_xr]
 
 _template:
   get_command: 'show run vdc all'

--- a/lib/cisco_node_utils/cmd_ref/vlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vlan.yaml
@@ -1,5 +1,7 @@
 # vlan
 ---
+_exclude: [ios_xr]
+
 all_vlans:
   multiple: true
   get_command: "show vlan brief"

--- a/lib/cisco_node_utils/cmd_ref/vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vni.yaml
@@ -1,6 +1,7 @@
 # vni
 ---
-_exclude: [N5k, N6k]
+_exclude: [N5k, N6k, ios_xr]
+
 all_vnis:
   multiple:
   N7k:

--- a/lib/cisco_node_utils/cmd_ref/vpc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vpc.yaml
@@ -1,5 +1,7 @@
 # vpc
 ---
+_exclude: [ios_xr]
+
 _template: 
   get_command:  'show running-config vpc all'
   get_context:  ['/^vpc domain\s*(\d+)$/']

--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
@@ -1,6 +1,6 @@
 # vxlan_vtep
 ---
-_exclude: [N3k, N5k, N6k]
+_exclude: [N3k, N5k, N6k, ios_xr]
 
 _template:
   get_command: "show running-config interface all | section 'interface nve'"

--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
@@ -1,6 +1,6 @@
 # vxlan_vtep_vni
 ---
-_exclude: [N3k, N5k, N6k]
+_exclude: [N3k, N5k, N6k, ios_xr]
 
 _template:
   get_command: "show running-config interface all | section 'interface nve'"

--- a/lib/cisco_node_utils/cmd_ref/yum.yaml
+++ b/lib/cisco_node_utils/cmd_ref/yum.yaml
@@ -1,5 +1,7 @@
 # yum
 ---
+_exclude: [ios_xr]
+
 install:
   set_value: "install add %s %s activate"
 

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -133,7 +133,6 @@ class TestCase < Minitest::Test
   def teardown
     @device.close unless @device.nil?
     @device = nil
-    GC.start
   end
 
   def config(*args)

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -39,7 +39,7 @@ class CiscoTestCase < TestCase
   @skip_unless_supported = nil
 
   class << self
-    attr_reader :skip_unless_supported
+    attr_accessor :skip_unless_supported
   end
 
   def self.runnable_methods
@@ -89,8 +89,12 @@ class CiscoTestCase < TestCase
     node.cmd_ref
   end
 
-  def platform
+  def self.platform
     node.client.platform
+  end
+
+  def platform
+    self.class.platform
   end
 
   def config(*args)

--- a/tests/test_aaa_authentication_login.rb
+++ b/tests/test_aaa_authentication_login.rb
@@ -17,6 +17,7 @@ require_relative '../lib/cisco_node_utils/aaa_authentication_login'
 
 # Test class for AAA Authentication Login
 class TestAaaAuthenticationLogin < CiscoTestCase
+  @skip_unless_supported = 'aaa_authentication_login'
   # DEFAULT(:ascii_authentication)
   # => false
   # rubocop:disable Style/MethodName

--- a/tests/test_aaa_authentication_login_service.rb
+++ b/tests/test_aaa_authentication_login_service.rb
@@ -21,6 +21,7 @@ AAA_AUTH_LOGIN_SERVICE_METHOD_UNSELECTED = :unselected
 
 # Test class for AAA Authentication Login Service
 class TestAaaAuthenticationLoginService < CiscoTestCase
+  @skip_unless_supported = 'aaa_auth_login_service'
   def unconfig_tacacs
     config('no feature tacacs+')
   end

--- a/tests/test_aaa_authorization_service.rb
+++ b/tests/test_aaa_authorization_service.rb
@@ -17,6 +17,8 @@ require_relative '../lib/cisco_node_utils/aaa_authorization_service'
 
 # TestAaaAuthorizationService - Minitest for AaaAuthorizationService util
 class TestAaaAuthorizationService < CiscoTestCase
+  @skip_unless_supported = 'aaa_authorization_service'
+
   def setup
     super
     feature_tacacs

--- a/tests/test_dns_domain.rb
+++ b/tests/test_dns_domain.rb
@@ -20,6 +20,8 @@ require_relative '../lib/cisco_node_utils/dns_domain'
 
 # TestDnsDomain - Minitest for DnsDomain node utility.
 class TestDnsDomain < CiscoTestCase
+  @skip_unless_supported = 'dnsclient'
+
   def setup
     # setup runs at the beginning of each test
     super
@@ -34,9 +36,15 @@ class TestDnsDomain < CiscoTestCase
 
   def no_dnsdomain_tests
     # Turn the feature off for a clean test.
-    config('no ip domain-list aoeu.com',
-           'no ip domain-list asdf.com',
-           'no vrf context test')
+    if platform == :ios_xr
+      config('no domain list aoeu.com',
+             'no domain list asdf.com',
+             'no vrf test')
+    else
+      config('no ip domain-list aoeu.com',
+             'no ip domain-list asdf.com',
+             'no vrf context test')
+    end
   end
 
   # TESTS

--- a/tests/test_domain_name.rb
+++ b/tests/test_domain_name.rb
@@ -20,6 +20,8 @@ require_relative '../lib/cisco_node_utils/domain_name'
 
 # TestDomainName - Minitest for DomainName node utility.
 class TestDomainName < CiscoTestCase
+  @skip_unless_supported = 'dnsclient'
+
   def setup
     # setup runs at the beginning of each test
     super
@@ -34,9 +36,15 @@ class TestDomainName < CiscoTestCase
 
   def no_domainname_test_xyz
     # Turn the feature off for a clean test.
-    config('no ip domain-name test.abc',
-           'no ip domain-name test.xyz',
-           'no vrf context test')
+    if platform == :ios_xr
+      config('no domain name test.abc',
+             'no domain name test.xyz',
+             'no vrf test')
+    else
+      config('no ip domain-name test.abc',
+             'no ip domain-name test.xyz',
+             'no vrf context test')
+    end
   end
 
   # TESTS

--- a/tests/test_evpn_vni.rb
+++ b/tests/test_evpn_vni.rb
@@ -21,6 +21,8 @@ require_relative '../lib/cisco_node_utils/evpn_vni'
 
 # TestEvpnVni - Minitest for EvpnVni class
 class TestEvpnVni < CiscoTestCase
+  @skip_unless_supported = 'evpn_vni'
+
   def setup
     # Disable feature bgp and no overlay evpn before each test to
     # ensure we are starting with a clean slate for each test.

--- a/tests/test_fabricpath_global.rb
+++ b/tests/test_fabricpath_global.rb
@@ -21,6 +21,8 @@ include Cisco
 
 # TestFabricpathGlobal - Minitest for Fabricpath Global node utils
 class TestFabricpathGlobal < CiscoTestCase
+  @skip_unless_supported = 'fabricpath'
+
   def setup
     # setup runs at the beginning of each test
     super

--- a/tests/test_fabricpath_topology.rb
+++ b/tests/test_fabricpath_topology.rb
@@ -20,6 +20,8 @@ include Cisco
 
 # TestFabricpathTopo - Minitest for Fabricpath Topo node utils
 class TestFabricpathTopo < CiscoTestCase
+  @skip_unless_supported = 'fabricpath_topology'
+
   def setup
     # setup runs at the beginning of each test
     super

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -20,10 +20,7 @@ include Cisco
 
 # TestFeature - Minitest for feature class
 class TestFeature < CiscoTestCase
-  def setup
-    super
-    # skip("Platform does not support 'feature' cli") if platform == :ios_xr
-  end
+  @skip_unless_supported = 'feature'
 
   ###########
   # Helpers #

--- a/tests/test_grpc.rb
+++ b/tests/test_grpc.rb
@@ -22,6 +22,17 @@ require_relative 'basetest'
 class TestGRPC < TestCase
   @@client = nil # rubocop:disable Style/ClassVars
 
+  def self.runnable_methods
+    # If we're pointed to an NXAPI node (as evidenced by lack of a port num)
+    # then these tests don't apply
+    return [:all_skipped] unless address[/:/]
+    super
+  end
+
+  def all_skipped
+    skip 'Node under test appears to be NXAPI, not gRPC'
+  end
+
   def client
     unless @@client
       client = Cisco::Client::GRPC.new(address, username, password)

--- a/tests/test_grpc.rb
+++ b/tests/test_grpc.rb
@@ -30,7 +30,7 @@ class TestGRPC < TestCase
   end
 
   def all_skipped
-    skip 'Node under test appears to be NXAPI, not gRPC'
+    skip 'Node under test does not appear to use the gRPC client'
   end
 
   def client

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -716,6 +716,7 @@ class TestInterface < CiscoTestCase
     assert(ref, 'Error, reference not found')
 
     # Create interface member of this group (required for XR)
+    interface_ethernet_default(interfaces_id[0])
     member = InterfaceChannelGroup.new(interfaces[0])
     begin
       member.channel_group = 10

--- a/tests/test_interface_portchannel.rb
+++ b/tests/test_interface_portchannel.rb
@@ -18,6 +18,7 @@ require_relative '../lib/cisco_node_utils/interface_portchannel'
 
 # TestX__CLASS_NAME__X - Minitest for X__CLASS_NAME__X node utility class
 class TestInterfacePortChannel < CiscoTestCase
+  @skip_unless_supported = 'interface_portchannel'
   # TESTS
 
   DEFAULT_NAME = 'port-channel134'

--- a/tests/test_interface_service_vni.rb
+++ b/tests/test_interface_service_vni.rb
@@ -33,6 +33,8 @@ include Cisco
 #      encapsulation profile vni_600_6000 default
 #
 class TestInterfaceServiceVni < CiscoTestCase
+  @skip_unless_supported = 'interface_service_vni'
+
   def setup
     super
   end

--- a/tests/test_interface_svi.rb
+++ b/tests/test_interface_svi.rb
@@ -22,9 +22,20 @@ class TestSvi < CiscoTestCase
   @@pre_clean_needed = true # rubocop:disable Style/ClassVars
   attr_reader :svi
 
+  def self.runnable_methods
+    # We don't have a separate YAML file to key off, so we check platform
+    return super unless platform == :ios_xr
+    remove_method :setup
+    remove_method :teardown
+    [:xr_unsupported]
+  end
+
+  def xr_unsupported
+    skip("Skipping #{self.class}; Vlan interfaces are not supported on IOS XR")
+  end
+
   def setup
     super
-    skip('No support for Vlan interfaces on IOS XR') if platform == :ios_xr
     remove_all_svis if @@pre_clean_needed
     @@pre_clean_needed = false # rubocop:disable Style/ClassVars
     @svi = Interface.new('Vlan23')

--- a/tests/test_name_server.rb
+++ b/tests/test_name_server.rb
@@ -20,6 +20,8 @@ require_relative '../lib/cisco_node_utils/name_server'
 
 # TestNameServer - Minitest for NameServer node utility.
 class TestNameServer < CiscoTestCase
+  @skip_unless_supported = 'dnsclient'
+
   def setup
     # setup runs at the beginning of each test
     super
@@ -34,8 +36,13 @@ class TestNameServer < CiscoTestCase
 
   def no_nameserver_google
     # Turn the feature off for a clean test.
-    config('no ip name-server 7.7.7.7',
-           'no ip name-server 2001:4860:4860::7777')
+    if platform == :ios_xr
+      config('no domain name-server 7.7.7.7',
+             'no domain name-server 2001:4860:4860::7777')
+    else
+      config('no ip name-server 7.7.7.7',
+             'no ip name-server 2001:4860:4860::7777')
+    end
   end
 
   # TESTS

--- a/tests/test_node.rb
+++ b/tests/test_node.rb
@@ -24,10 +24,19 @@ Node.lazy_connect = true # we'll specify the connection info later
 # TestNode - Minitest for core functionality of Node class
 class TestNode < TestCase
   def setup
+    # Load parameters for login
+    address
+    username
+    password
+    # Clear out the environment so we have control over which parameters
+    # we provide to Node to connect with.
+    @env_node = ENV['NODE']
+    ENV['NODE'] = nil
   end
 
   def teardown
-    GC.start
+    # Restore the environment
+    ENV['NODE'] = @env_node
   end
 
   # As Node is now a singleton, we cannot instantiate it.

--- a/tests/test_node_ext.rb
+++ b/tests/test_node_ext.rb
@@ -43,7 +43,7 @@ class TestNodeExt < CiscoTestCase
 
   def test_config_get_invalid
     assert_raises IndexError do # no entry
-      node.config_get('feature', 'name')
+      node.config_get('foobar', 'name')
     end
     assert_raises IndexError do # entry but no config_get
       node.config_get('show_system', 'resources')
@@ -60,7 +60,7 @@ class TestNodeExt < CiscoTestCase
       node.config_get_default('show_version', 'foobar')
     end
     assert_raises IndexError do # no feature entry
-      node.config_get_default('feature', 'name')
+      node.config_get_default('foobar', 'name')
     end
     assert_raises IndexError do # no default_value defined
       node.config_get_default('show_version', 'version')
@@ -81,7 +81,7 @@ class TestNodeExt < CiscoTestCase
 
   def test_config_set_invalid
     assert_raises IndexError do
-      node.config_set('feature', 'name')
+      node.config_set('foobar', 'name')
     end
     assert_raises(IndexError, Cisco::UnsupportedError) do
       # feature exists but no config_set

--- a/tests/test_nxapi.rb
+++ b/tests/test_nxapi.rb
@@ -28,7 +28,7 @@ class TestNxapi < TestCase
   end
 
   def all_skipped
-    skip 'Node under test appears to be gRPC, not NXAPI'
+    skip 'Node under test does not appear to use the NXAPI client'
   end
 
   def client

--- a/tests/test_nxapi.rb
+++ b/tests/test_nxapi.rb
@@ -20,6 +20,17 @@ require_relative 'basetest'
 class TestNxapi < TestCase
   @@client = nil # rubocop:disable Style/ClassVars
 
+  def self.runnable_methods
+    # If we're pointed to a gRPC node (as evidenced by presence of a port num)
+    # then these tests don't apply
+    return [:all_skipped] if address[/:/]
+    super
+  end
+
+  def all_skipped
+    skip 'Node under test appears to be gRPC, not NXAPI'
+  end
+
   def client
     unless @@client
       client = Cisco::Client::NXAPI.new(address, username, password)

--- a/tests/test_overlay_global.rb
+++ b/tests/test_overlay_global.rb
@@ -21,6 +21,8 @@ include Cisco
 
 # TestOverlayGlobal - Minitest for OverlayGlobal node utility
 class TestOverlayGlobal < CiscoTestCase
+  @skip_unless_supported = 'overlay_global'
+
   def setup
     super
     config('no feature fabric forwarding')

--- a/tests/test_pim.rb
+++ b/tests/test_pim.rb
@@ -45,6 +45,8 @@ include Cisco
 
 # TestPim - Minitest for Pim Feature
 class TestPim < CiscoTestCase
+  @skip_unless_supported = 'pim'
+
   @@pre_clean_needed = true # rubocop:disable Style/ClassVars
 
   # Enables feature pim

--- a/tests/test_pim_group_list.rb
+++ b/tests/test_pim_group_list.rb
@@ -32,6 +32,8 @@ include Cisco
 
 # TestPim - Minitest for PimGrouplist
 class TestPimGroupList < CiscoTestCase
+  @skip_unless_supported = 'pim'
+
   # Enables feature pim
   #--------------------
   def setup

--- a/tests/test_pim_rp_address.rb
+++ b/tests/test_pim_rp_address.rb
@@ -31,6 +31,8 @@ include Cisco
 
 # TestPimRpAddress - Minitest for PimRpAddress
 class TestPimRpAddress < CiscoTestCase
+  @skip_unless_supported = 'pim'
+
   # Enables feature pim
   #--------------------
   def setup

--- a/tests/test_portchannel_global.rb
+++ b/tests/test_portchannel_global.rb
@@ -17,6 +17,7 @@ require_relative '../lib/cisco_node_utils/portchannel_global'
 
 # TestX__CLASS_NAME__X - Minitest for X__CLASS_NAME__X node utility class
 class TestPortchannelGlobal < CiscoTestCase
+  @skip_unless_supported = 'portchannel_global'
   # TESTS
 
   DEFAULT_NAME = 'default'

--- a/tests/test_radius_global.rb
+++ b/tests/test_radius_global.rb
@@ -20,6 +20,8 @@ require_relative '../lib/cisco_node_utils/radius_global'
 
 # TestRadiusGlobal - Minitest for RadiusGlobal node utility.
 class TestRadiusGlobal < CiscoTestCase
+  @skip_unless_supported = 'radius_global'
+
   def setup
     # setup runs at the beginning of each test
     super

--- a/tests/test_radius_server.rb
+++ b/tests/test_radius_server.rb
@@ -20,6 +20,8 @@ require_relative '../lib/cisco_node_utils/radius_server'
 
 # TestRadiusServer - Minitest for RadiusServer node utility.
 class TestRadiusServer < CiscoTestCase
+  @skip_unless_supported = 'radius_server'
+
   def setup
     # setup runs at the beginning of each test
     super

--- a/tests/test_radius_server_group.rb
+++ b/tests/test_radius_server_group.rb
@@ -21,6 +21,8 @@ require File.expand_path('../../lib/cisco_node_utils/radius_server_group', \
 
 # TestRadiusServerGroup - Minitest for RadiusServerGroup node utility.
 class TestRadiusServerGroup < CiscoTestCase
+  @skip_unless_supported = 'radius_server_group'
+
   def setup
     # setup runs at the beginning of each test
     super

--- a/tests/test_snmp_notification_receiver.rb
+++ b/tests/test_snmp_notification_receiver.rb
@@ -21,6 +21,8 @@ require_relative '../lib/cisco_node_utils/snmp_notification_receiver'
 # TestSnmpNotificationReceiver - Minitest for SnmpNotificationReceiver
 # node utility.
 class TestSnmpNotificationReceiver < CiscoTestCase
+  @skip_unless_supported = 'snmp_notification_receiver'
+
   def setup
     # setup runs at the beginning of each test
     super

--- a/tests/test_snmpcommunity.rb
+++ b/tests/test_snmpcommunity.rb
@@ -25,6 +25,8 @@ end
 
 # TestSnmpCommunity - Minitest for SnmpCommunity node utility
 class TestSnmpCommunity < CiscoTestCase
+  @skip_unless_supported = 'snmp_community'
+
   SNMP_COMMUNITY_NAME_STR = 128
   SNMP_GROUP_NAME_STR = 128
   DEFAULT_SNMP_COMMUNITY_GROUP = 'network-operator'

--- a/tests/test_snmpgroup.rb
+++ b/tests/test_snmpgroup.rb
@@ -17,6 +17,8 @@ require_relative '../lib/cisco_node_utils/snmpgroup'
 
 # TestSnmpGroup - Minitest for SnmpGroup node utility.
 class TestSnmpGroup < CiscoTestCase
+  @skip_unless_supported = 'snmp_group'
+
   # NXOS snmp groups will not be empty
   def test_snmpgroup_collection_not_empty
     snmpgroups = SnmpGroup.groups

--- a/tests/test_snmpnotification.rb
+++ b/tests/test_snmpnotification.rb
@@ -18,8 +18,9 @@
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/snmpnotification'
 
-# TestRadiusGlobal - Minitest for RadiusGlobal node utility.
+# TestSnmpNotification - Minitest for SnmpNotification node utility.
 class TestSnmpNotification < CiscoTestCase
+  @skip_unless_supported = 'snmpnotification'
   def setup
     # setup runs at the beginning of each test
     super

--- a/tests/test_snmpserver.rb
+++ b/tests/test_snmpserver.rb
@@ -17,6 +17,8 @@ require_relative '../lib/cisco_node_utils/snmpserver'
 
 # TestSnmpServer - Minitest for SnmpServer node utility
 class TestSnmpServer < CiscoTestCase
+  @skip_unless_supported = 'snmp_server'
+
   DEFAULT_SNMP_SERVER_AAA_USER_CACHE_TIMEOUT = 3600
   DEFAULT_SNMP_SERVER_LOCATION = ''
   DEFAULT_SNMP_SERVER_CONTACT = ''

--- a/tests/test_snmpuser.rb
+++ b/tests/test_snmpuser.rb
@@ -21,6 +21,8 @@ DEFAULT_SNMP_USER_GROUP_NAME = 'network-operator'
 
 # TestSnmpUser - Minitest for SnmpUser node utility class
 class TestSnmpUser < CiscoTestCase
+  @skip_unless_supported = 'snmp_user'
+
   @@existing_users = nil # rubocop:disable Style/ClassVars
 
   def setup

--- a/tests/test_stp_global.rb
+++ b/tests/test_stp_global.rb
@@ -15,8 +15,9 @@
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/stp_global'
 
-# TestX__CLASS_NAME__X - Minitest for X__CLASS_NAME__X node utility class
+# TestStpGlobal - Minitest for StpGlobal node utility class
 class TestStpGlobal < CiscoTestCase
+  @skip_unless_supported = 'stp_global'
   # TESTS
 
   @@clean = false # rubocop:disable Style/ClassVars

--- a/tests/test_tacacs_server.rb
+++ b/tests/test_tacacs_server.rb
@@ -17,6 +17,8 @@ require_relative '../lib/cisco_node_utils/tacacs_server'
 
 # TestTacacsServer - Minitest for TacacsServer node utility
 class TestTacacsServer < CiscoTestCase
+  @skip_unless_supported = 'tacacs_server'
+
   def assert_tacacsserver_feature
     assert_show_match(command: 'show run all | no-more',
                       pattern: /feature tacacs\+/)

--- a/tests/test_tacacs_server_group.rb
+++ b/tests/test_tacacs_server_group.rb
@@ -18,6 +18,8 @@ require_relative '../lib/cisco_node_utils/tacacs_server_host'
 
 # Test class for Tacacs Server Group
 class TestTacacsServerGroup < CiscoTestCase
+  @skip_unless_supported = 'tacacs_server_group'
+
   def clean_tacacs_config
     config('no feature tacacs',
            'feature tacacs')

--- a/tests/test_tacacs_server_host.rb
+++ b/tests/test_tacacs_server_host.rb
@@ -23,6 +23,8 @@ DEFAULT_TACACS_SERVER_HOST_ENCRYPTION_PASSWORD = ''
 
 # TestTacacsServerHost - Minitest for TacacsServerHost node utility
 class TestTacacsServerHost < CiscoTestCase
+  @skip_unless_supported = 'tacacs_server_host'
+
   def setup
     super
     @host_name = 'testhost'

--- a/tests/test_vdc.rb
+++ b/tests/test_vdc.rb
@@ -23,6 +23,7 @@ class TestVdc < CiscoTestCase
   #  a) VDC support is limited to a narrow list of platforms.
   #  b) License restrictions may limit platforms to a single vdc
   #  c) Linecard restrictions may limit some tests to specific linecards
+  @skip_unless_supported = 'vdc'
 
   def setup
     super

--- a/tests/test_vlan.rb
+++ b/tests/test_vlan.rb
@@ -20,6 +20,8 @@ include Cisco
 
 # TestVlan - Minitest for Vlan node utility
 class TestVlan < CiscoTestCase
+  @skip_unless_supported = 'vlan'
+
   @@cleaned = false # rubocop:disable Style/ClassVars
   def cleanup
     Vlan.vlans.each do |vlan, obj|

--- a/tests/test_vni.rb
+++ b/tests/test_vni.rb
@@ -21,6 +21,8 @@ include Cisco
 
 # TestVni - Minitest for Vni node utility
 class TestVni < CiscoTestCase
+  @skip_unless_supported = 'vni'
+
   def setup
     super
     skip('Platform does not support MT-full or MT-lite') unless

--- a/tests/test_vpc.rb
+++ b/tests/test_vpc.rb
@@ -20,6 +20,8 @@ include Cisco
 
 # TestVpc - Minitest for Vpc node utility class
 class TestVpc < CiscoTestCase
+  @skip_unless_supported = 'vpc'
+
   def setup
     super
     no_feature_vpc

--- a/tests/test_vtp.rb
+++ b/tests/test_vtp.rb
@@ -17,6 +17,8 @@ require_relative '../lib/cisco_node_utils/vtp'
 
 # TestVtp - Minitest for Vtp node utility class
 class TestVtp < CiscoTestCase
+  @skip_unless_supported = 'vtp'
+
   def setup
     super
     no_feature_vtp

--- a/tests/test_vxlan_vtep.rb
+++ b/tests/test_vxlan_vtep.rb
@@ -19,8 +19,10 @@ require_relative '../lib/cisco_node_utils/vdc'
 
 include Cisco
 
-# TestVxlanGlobal - Minitest for VxlanGlobal node utility
+# TestVxlanVtep - Minitest for VxlanVtep node utility
 class TestVxlanVtep < CiscoTestCase
+  @skip_unless_supported = 'vxlan_vtep'
+
   def setup
     super
     skip('Platform does not support MT-full or MT-lite') unless

--- a/tests/test_vxlan_vtep_vni.rb
+++ b/tests/test_vxlan_vtep_vni.rb
@@ -18,8 +18,10 @@ require_relative '../lib/cisco_node_utils/vxlan_vtep_vni'
 
 include Cisco
 
-# TestVxlanGlobal - Minitest for VxlanGlobal node utility
+# TestVxlanVtepVni - Minitest for VxlanVtepVni node utility
 class TestVxlanVtepVni < CiscoTestCase
+  @skip_unless_supported = 'vxlan_vtep_vni'
+
   def setup
     super
     config('no feature nv overlay')

--- a/tests/test_yum.rb
+++ b/tests/test_yum.rb
@@ -28,6 +28,8 @@ class TestYum < CiscoTestCase
     'This test may fail with other versions.'
   # rubocop:enable Style/ClassVars
 
+  @skip_unless_supported = 'yum'
+
   def setup
     super
     # only run check once (can't use initialize because @device isn't ready)


### PR DESCRIPTION
Summary:

```
$ NODE="192.168.122.222:57799 admin admin" rake test
...
386 runs, 2175 assertions, 0 failures, 1 errors, 69 skips
Coverage report generated for MiniTest to /home/glmatthe/cisco-network-node-utils/coverage. 4114 / 7035 LOC (58.48%) covered.
```

(the 1 error needs investigation but seems to be intermittent)

Details:
- Add `_exclude: [ios_xr]` to all YAML files not supporting XR.
- Add `@skip_unless_supported = ...` to the corresponding minitests
- Fix some errors in test_node and test_node_ext.rb
- Add XR support for dns_domain, domain_name, and name_server types (it ended up being easier than figuring out how to disable the associated tests)
- Skip NXAPI test on gRPC node and vice versa.

Full log:

```
$ NODE="192.168.122.222:57799 admin admin" rake test/home/glmatthe/.rbenv/versions/2.2.3/bin/ruby -w -I"lib:lib:tests" -I"/home/glmatthe/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rake-10.5.0/lib" "/home/glmatthe/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rake-10.5.0/lib/rake/rake_test_loader.rb" "tests/test_*.rb" -v
/home/glmatthe/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/google-protobuf-3.0.0.alpha.5.0.3-x86_64-linux/lib/google/protobuf/repeated_field.rb:108: warning: method redefined; discarding old slice
/home/glmatthe/.rbenv/versions/2.2.3/lib/ruby/2.2.0/forwardable.rb:181: warning: previous definition of slice was here
Run options: -v --seed 56026

# Running:

TestCmdRef#test_getter_printf_substitution = 0.00 s = .
TestCmdRef#test_load_duplicate_param = 0.00 s = .
TestCmdRef#test_default_only = 0.00 s = .
TestCmdRef#test_exclude_whole_file = 0.00 s = .
TestCmdRef#test_getter_hash_substitution = 0.00 s = .
TestCmdRef#test_exclude_whole_item = 0.00 s = .
TestCmdRef#test_load_whitespace_only = 0.00 s = .
TestCmdRef#test_load_unsupported_key = 0.00 s = .
TestCmdRef#test_load_feature_name_default = 0.00 s = .
TestCmdRef#test_load_ios_xr_generic = 0.00 s = .
TestCmdRef#test_load_duplicate_name = 0.00 s = .
TestCmdRef#test_exclude_implicit = 0.00 s = .
TestCmdRef#test_load_feature_name_no_data = 0.00 s = .
TestCmdRef#test_load_types = 0.00 s = .
TestCmdRef#test_data_sanity = 1.78 s = .
TestCmdRef#test_load_ios_xr_xrv9k = 0.00 s = .
TestCmdRef#test_load_n9k = 0.00 s = .
TestCmdRef#test_load_unalphabetized = 0.00 s = .
TestCmdRef#test_load_n7k = 0.00 s = .
TestCmdRef#test_default_only_default_value = 0.00 s = .
TestCmdRef#test_exclude_no_exclusion = 0.00 s = .
TestCmdRef#test_load_not_valid_yaml = 0.00 s = .
TestCmdRef#test_filter_hash = 0.00 s = .
TestCmdRef#test_load_empty_file = 0.00 s = .
TestCmdRef#test_load_generic = 0.00 s = .
TestCmdRef#test_hash_merge_no_template = 0.00 s = .
TestCmdRef#test_load_n3k_3064 = 0.00 s = .
TestCmdRef#test_default_only_cleanup = 0.00 s = .

Node under test:
  - name  - sunstone-gfm
  - type  - R-IOSXRV9000-CH
TestInterfaceOspf#all_skipped = 1.03 s = S
TestVlan#all_skipped = 1.06 s = S
TestAcl#all_skipped = 1.10 s = S
TestPlatform#test_board = 1.14 s = .
TestPlatform#test_cpu = 1.14 s = .
TestPlatform#test_last_reset = 1.18 s = .
TestPlatform#test_packages = 1.00 s = .
TestPlatform#test_fans = 1.49 s = .
TestPlatform#test_virtual_services = 1.03 s = .
TestPlatform#test_hardware_type = 1.47 s = .
TestPlatform#test_chassis = 1.16 s = .
TestPlatform#test_slots = 1.43 s = .
TestPlatform#test_uptime = 1.46 s = .
TestPlatform#test_memory = 1.43 s = .
TestPlatform#test_reset_reason = 1.18 s = .
TestPlatform#test_system_image = 1.05 s = .
TestPlatform#test_power_supplies = 1.46 s = .
TestSnmpNotificationReceiver#all_skipped = 1.04 s = S
TestAaaAuthenticationLoginService#all_skipped = 1.04 s = S
TestSwitchport#test_switchport_autostate_disabled_feature_disabled_mgmt_intf = 6.46 s = .
TestSwitchport#test_switchport_autostate_disabled_unsupported_mode = 3.76 s = .
TestSwitchport#test_switchport_vtp_disabled_unsupported_mode_fex = 3.86 s = .
TestSwitchport#test_system_default_switchport_on_off = 3.69 s = .
TestSwitchport#test_raise_error_switchport_not_enabled = 3.77 s = .
TestSwitchport#test_interface_switchport_trunk_allowed_vlan = 3.65 s = .
TestSwitchport#test_interface_switchport_trunk_native_vlan = 3.68 s = .
TestSwitchport#test_switchport_autostate_disabled_feature_disabled_eth1_1 = 3.75 s = .
TestSwitchport#test_system_default_switchport_shutdown_on_off = 3.84 s = .
TestSwitchport#test_interface_switchport_mode_valid_fex = 3.81 s = S
TestSwitchport#test_interface_get_access_vlan = 3.78 s = .
TestSwitchport#test_switchport_vtp_disabled_feature_disabled_mgmt_intf = 5.29 s = .
TestSwitchport#test_interface_get_access_vlan_switchport_trunk = 3.79 s = .
TestSwitchport#test_interface_svi_command_on_non_vlan = 3.77 s = .
TestSwitchport#test_interface_switchport_mode_valid = 3.77 s = .
TestSwitchport#test_interface_switchport_mode_not_supported = 5.06 s = .
TestSwitchport#test_interface_get_access_vlan_switchport_disabled = 3.63 s = .
TestSwitchport#test_switchport_vtp_disabled_unsupported_mode_disabled = 3.72 s = .
TestSwitchport#test_interface_switchport_mode_invalid = 13.11 s = .
TestSwitchport#test_switchport_vtp_disabled_feature_disabled_eth1_1 = 3.74 s = .
TestClientUtils#test_filter_cli = 0.00 s = .
TestClientUtils#test_find_subconfig = 0.00 s = .
TestFeature#all_skipped = 0.99 s = S
Connection reset by peer? Try again
TestInterface#test_interface_ipv4_proxy_arp = 10.76 s = .
TestInterface#test_ipv6_acl = 23.41 s = .
TestInterface#test_interface_shutdown_valid = 7.04 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig = 21.13 s = .
TestInterface#test_speed = 3.22 s = .
TestInterface#test_svi_prop_nil_when_ethernet = 2.34 s = .
TestInterface#test_interface_ipv4_arp_timeout = 2.42 s = .
TestInterface#test_interface_create_does_not_exist = 2.13 s = .
TestInterface#test_encapsulation_dot1q = 11.12 s = .
TestInterface#test_interface_ipv4_redirects = 10.27 s = .
TestInterface#test_interface_create_valid = 2.41 s = .
TestInterface#test_interface_fabric_forwarding_anycast_gateway = 2.48 s = .
TestInterface#test_interface_vrf_empty = 4.20 s = .
TestInterface#test_interface_ipv4_address = 11.97 s = .
TestInterface#test_interface_create_name_invalid = 1.01 s = .
TestInterface#test_interface_mtu_invalid = 3.59 s = .
TestInterface#test_interface_vrf_default = 16.30 s = .
TestInterface#test_interface_description_valid = 5.14 s = .
TestInterface#test_interfaces_not_empty = 1.67 s = .
TestInterface#test_negotiate_auto_loopback = 4.45 s = .
TestInterface#test_interface_create_name_nil = 0.99 s = .
Connection reset by peer? Try again
TestInterface#test_interface_vrf_valid = 7.35 s = .
TestInterface#test_negotiate_auto_portchannel = 11.20 s = .
TestInterface#test_interface_ipv4_addr_mask_set_netmask_invalid = 4.08 s = .
TestInterface#test_interface_vrf_override = 8.37 s = .
TestInterface#test_mtu_invalid_loopback = 3.97 s = .
TestInterface#test_interface_vrf_invalid_type = 2.43 s = .
TestInterface#test_interface_vrf_exceeds_max_length = 4.00 s = .
TestInterface#test_vrf_change_with_ip_addr = 30.86 s = .
TestInterface#test_negotiate_auto_ethernet = 3.05 s = .
TestInterface#test_interface_description_zero_length = 4.36 s = .
TestInterface#test_interface_mtu_change = 8.98 s = .
TestInterface#test_interface_mtu_valid = 6.99 s = .
TestInterface#test_duplex = 3.34 s = .
TestInterface#test_interface_ipv4_addr_mask_set_address_invalid = 4.17 s = .
TestInterface#test_ipv4_acl = 34.62 s = .
TestInterface#test_interface_ipv4_all_interfaces = 77.51 s = .
TestInterface#test_ipv4_pim_sparse_mode = 2.41 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig_secondary = 6.48 s = .
TestInterface#test_interface_description_nil = 2.56 s = .
TestNtpConfig#test_ntpconfig_create_destroy_single = 3.49 s = .
TestNode#test_node_connect_one_argument = 0.00 s = .
TestNode#test_node_connect_username_zero_length = 0.00 s = .
TestNode#test_node_connect_nil_username = 0.00 s = .
TestNode#test_node_connect_invalid_username = 0.00 s = .
TestNode#test_node_connect_password_zero_length = 0.00 s = .
TestNode#test_node_connect_two_arguments = 0.00 s = .
TestNode#test_node_connect = 0.95 s = .
TestNode#test_node_connect_invalid_password = 0.00 s = .
TestNode#test_node_connect_nil_password = 0.00 s = .
TestNode#test_node_connect_zero_arguments = 0.00 s = .
TestNode#test_node_create_not_allowed = 0.00 s = .
TestSnmpUser#all_skipped = 1.05 s = S
TestRadiusGlobal#all_skipped = 1.01 s = S
TestNodeExt#test_config_get = 1.01 s = .
TestNodeExt#test_config_get_default = 1.04 s = .
TestNodeExt#test_config_get_invalid = 0.99 s = .
Connection reset by peer? Try again
TestNodeExt#test_config_get_regexp_tokens = 8.54 s = .
TestNodeExt#test_get_system_cpu_utilization = 1.02 s = .
TestNodeExt#test_cli_caching = 4.24 s = .
TestNodeExt#test_config_set_invalid = 1.02 s = .
TestNodeExt#test_get_boot = 1.01 s = .
TestNodeExt#test_get_system_uptime = 1.50 s = .
TestNodeExt#test_get_last_reset_reason = 1.01 s = .
TestNodeExt#test_get_os = 1.49 s = .
TestNodeExt#test_config_set = 5.14 s = .
TestNodeExt#test_get_product_version_id = 1.55 s = .
TestNodeExt#test_get_domain_name_when_set = 3.69 s = .
TestNodeExt#test_get_os_version = 1.41 s = .
TestNodeExt#test_get_host_name_when_not_set = 3.93 s = .
TestNodeExt#test_get_host_name_when_set = 4.24 s = .
TestNodeExt#test_get_product_id = 1.50 s = .
TestNodeExt#test_get_domain_name_when_not_set = 3.34 s = .
TestNodeExt#test_get_last_reset_time = 1.04 s = .
TestNodeExt#test_get_product_description = 1.54 s = .
TestNodeExt#test_get_system = 1.02 s = .
TestNodeExt#test_config_get_default_invalid = 1.00 s = .
TestNodeExt#test_get_product_serial_number = 1.48 s = .
TestPimRpAddress#all_skipped = 0.99 s = S
Connection reset by peer? Try again
TestInterfacePortChannel#all_skipped = 2.02 s = S
TestPimGroupList#all_skipped = 0.98 s = S
Connection reset by peer? Try again
TestTacacsServerHost#all_skipped = 1.96 s = S
Connection reset by peer? Try again
TestVxlanVtep#all_skipped = 2.01 s = S
TestOverlayGlobal#all_skipped = 1.06 s = S
TestAaaAuthenticationLogin#all_skipped = 1.04 s = S
TestNxapi#all_skipped = 1.05 s = S
TestInterfaceSwitchportVtp#test_set_switchport_vtp_default_trunk = 3.80 s = S
TestInterfaceSwitchportVtp#test_set_switchport_vtp_false_access = 3.79 s = S
TestInterfaceSwitchportVtp#test_set_switchport_vtp_true_access = 3.69 s = S
TestInterfaceSwitchportVtp#test_switchport_vtp_disabled_feature_enabled = 3.76 s = S
TestInterfaceSwitchportVtp#test_switchport_vtp_enabled_access = 3.88 s = S
TestInterfaceSwitchportVtp#test_set_switchport_vtp_true_unsupported_mgmt_intf = 3.84 s = S
TestInterfaceSwitchportVtp#test_switchport_vtp_disabled_access = 3.74 s = S
TestInterfaceSwitchportVtp#test_switchport_vtp_enabled_trunk = 3.83 s = S
TestInterfaceSwitchportVtp#test_set_switchport_vtp_true_trunk = 3.74 s = S
TestInterfaceSwitchportVtp#test_set_switchport_vtp_true_unsupported_mode_disabled = 3.86 s = S
TestInterfaceSwitchportVtp#test_switchport_vtp_disabled_trunk = 16.00 s = S
TestInterfaceSwitchportVtp#test_set_switchport_vtp_false_trunk = 3.60 s = S
TestInterfaceSwitchportVtp#test_set_switchport_vtp_default_access = 3.66 s = S
TestInterfaceSwitchportVtp#test_set_switchport_vtp_false_unsupported_mode_disabled = 3.64 s = S
TestAce#all_skipped = 1.03 s = S
TestInterfaceChannelGroup#test_description = 8.13 s = .
TestInterfaceChannelGroup#test_shutdown = 7.05 s = .
TestInterfaceChannelGroup#test_channel_group = 7.40 s = .
TestSyslogSettings#test_syslogsettings_create = 0.00 s = .
TestSyslogServer#test_create_destroy_single_vrf_ipv6 = 9.35 s = .
TestSyslogServer#test_create_destroy_multiple = 12.24 s = .
TestSyslogServer#test_create_destroy_single_vrf_ipv4 = 21.34 s = .
TestSyslogServer#test_create_destroy_single_ipv4 = 7.73 s = .
TestSyslogServer#test_create_destroy_single_ipv6 = 7.61 s = .
TestVlanMtFull#test_vlan_mode_fabricpath = 2.38 s = S
TestStpGlobal#all_skipped = 0.95 s = S
Connection reset by peer? Try again
TestDomainName#test_domainname_create_replace_destroy_vrf = 10.02 s = .
TestDomainName#test_domainname_create_replace_destroy = 8.95 s = .
TestRouterOspf#all_skipped = 1.03 s = S
TestSnmpCommunity#all_skipped = 1.06 s = S
TestPortchannelGlobal#all_skipped = 1.02 s = S
TestVtp#all_skipped = 1.02 s = S
TestLogger#test_logger_methods = 1.05 s = .
D, [2016-02-26T13:38:21.681801 #14493] DEBUG -- : Test default debug output
I, [2016-02-26T13:38:21.681931 #14493]  INFO -- : Test default info output
W, [2016-02-26T13:38:21.681978 #14493]  WARN -- : Test default warn output
E, [2016-02-26T13:38:21.682023 #14493] ERROR -- : Test default error output
TestLogger#test_default_logger_output = 1.12 s = .
TestBgpNeighbor#test_shutdown = 25.10 s = .
TestBgpNeighbor#test_create_destroy = 36.28 s = .
TestBgpNeighbor#test_transport_passive_only = 24.80 s = .
TestBgpNeighbor#test_capability_negotiation = 28.99 s = .
TestBgpNeighbor#test_collection_not_empty = 6.86 s = .
TestBgpNeighbor#test_remove_private_as_options = 13.72 s = .
TestBgpNeighbor#test_transport_passive_mode = 32.62 s = .
TestBgpNeighbor#test_default_password_type = 44.31 s = .
TestBgpNeighbor#test_local_as = 43.48 s = .
TestBgpNeighbor#test_low_memory_exempt = 13.69 s = .
TestBgpNeighbor#test_collection_empty = 6.07 s = .
TestBgpNeighbor#test_ebgp_multihop = 21.69 s = .
TestBgpNeighbor#test_multiple_descriptions = 49.84 s = .
TestBgpNeighbor#test_remote_as = 37.84 s = .
TestBgpNeighbor#test_suppress_4_byte_as = 24.64 s = .
TestBgpNeighbor#test_timers = 44.60 s = .
TestBgpNeighbor#test_update_source = 29.36 s = .
TestBgpNeighbor#test_dynamic_capability = 13.44 s = .
TestBgpNeighbor#test_connected_check = 35.78 s = .
TestBgpNeighbor#test_data = 5.28 s = .
TestBgpNeighbor#test_description = 24.80 s = .
TestBgpNeighbor#test_log_neighbor_changes = 28.81 s = .
TestBgpNeighbor#test_maximum_peers = 4.96 s = S
TestBgpNeighbor#test_password = 35.84 s = .
TestEvpnVni#all_skipped = 1.00 s = S
TestSnmpNotification#all_skipped = 0.98 s = S
Connection reset by peer? Try again
TestTacacsServer#all_skipped = 2.03 s = S
E0226 13:48:59.492623154   14493 parsing.c:472]              Unknown frame type 2d
W, [2016-02-26T13:48:59.492935 #14493]  WARN -- : gRPC error '14' during 'show_cmd_text_output' request: 
W, [2016-02-26T13:48:59.493018 #14493]  WARN -- :   with cli: 'show clock'
W, [2016-02-26T13:48:59.493059 #14493]  WARN -- :   ''
E, [2016-02-26T13:48:59.493129 #14493] ERROR -- : initial connect failed: Connection refused: 
E0226 13:48:59.493594813   14493 tcp_client_posix.c:171]     failed to connect to 'ipv4:127.0.0.1:0': socket error: connection refused
E0226 13:49:00.493896486   14493 tcp_client_posix.c:171]     failed to connect to 'ipv4:127.0.0.1:0': socket error: connection refused
E0226 13:49:02.086919995   14493 tcp_client_posix.c:171]     failed to connect to 'ipv4:127.0.0.1:0': socket error: connection refused
E0226 13:49:04.273666572   14493 tcp_client_posix.c:171]     failed to connect to 'ipv4:127.0.0.1:0': socket error: connection refused
W, [2016-02-26T13:49:04.494352 #14493]  WARN -- : gRPC error '4' during 'show_cmd_text_output' request: 
W, [2016-02-26T13:49:04.494461 #14493]  WARN -- :   with cli: 'show clock'
W, [2016-02-26T13:49:04.494500 #14493]  WARN -- :   'Deadline Exceeded'
E, [2016-02-26T13:49:04.494577 #14493] ERROR -- : initial connect failed: Deadline Exceeded
TestGRPC#test_connection_failure = 6.00 s = .
TestGRPC#test_get_cli_invalid = 1.64 s = .
TestGRPC#test_set_cli_string = 6.11 s = .
TestGRPC#test_get_cli_empty = 1.33 s = .
TestGRPC#test_new_nil_username = 1.00 s = .
Connection reset by peer? Try again
TestGRPC#test_smart_create = 2.28 s = .
TestGRPC#test_get_cli_default = 1.47 s = .
TestGRPC#test_set_cli_array = 3.11 s = .
TestGRPC#test_get_cli_cache = 3.42 s = .
TestGRPC#test_get_cli_incomplete = 1.24 s = .
E0226 13:49:28.046355676   14493 tcp_client_posix.c:189]     failed to connect to 'ipv4:127.0.0.1:0': timeout occurred
TestGRPC#test_set_cli_invalid = 2.07 s = .
TestGRPC#test_new_nil_password = 1.00 s = .
Connection reset by peer? Try again
E, [2016-02-26T13:49:31.165054 #14493] ERROR -- : initial connect failed: Failed authentication
TestGRPC#test_auth_failure = 2.00 s = .
Connection reset by peer? Try again
TestGRPC#test_get_cli_explicit = 2.45 s = .
TestGRPC#test_new_invalid_address = 0.99 s = .
Connection reset by peer? Try again
TestGRPC#test_new_nil_address = 1.97 s = .
Connection reset by peer? Try again
TestRadiusServer#all_skipped = 1.97 s = S
Connection reset by peer? Try again
TestPim#all_skipped = 1.97 s = S
Connection reset by peer? Try again
TestFabricpathTopo#all_skipped = 2.04 s = S
TestInterfaceSwitchportSvi#test_switchport_autostate_access = 4.01 s = S
TestInterfaceSwitchportSvi#test_switchport_autostate_disabled_feature_enabled = 3.74 s = S
TestInterfaceSwitchportSvi#test_switchport_autostate_enabled_trunk = 3.86 s = S
TestInterfaceSwitchportSvi#test_switchport_autostate_unsupported_mode_disabled = 3.84 s = S
TestInterfaceSwitchportSvi#test_switchport_autostate_disabled_access = 3.73 s = S
TestInterfaceSwitchportSvi#test_switchport_autostate_enabled_access = 3.88 s = S
TestInterfaceSwitchportSvi#test_switchport_autostate_disabled_trunk = 3.88 s = S
TestInterfaceSwitchportSvi#test_set_switchport_autostate_true_unsupported_mgmt_intf = 3.77 s = S
TestInterfaceSwitchportSvi#test_switchport_autostate_trunk = 3.90 s = S
TestBgpAF#test_distance = 21.97 s = .
TestBgpAF#test_collection_empty = 3.28 s = .
TestBgpAF#test_network = 425.08 s = .
TestBgpAF#test_utils_delta_add_remove_depth_1 = 2.85 s = .
TestBgpAF#test_redistribute = 232.05 s = .
TestBgpAF#test_respond_to? = 10.23 s = .
TestBgpAF#test_table_map = 34.70 s = .
TestBgpAF#test_collection_not_empty = 98.98 s = .
**************************************
******** default_information_originate, 55, default, ["ipv4", "unicast"]
         Unsupported
******** client_to_client, 55, default, ["ipv4", "unicast"]
******** additional_paths_send, 55, default, ["ipv4", "unicast"]
******** additional_paths_receive, 55, default, ["ipv4", "unicast"]
******** additional_paths_install, 55, default, ["ipv4", "unicast"]
         Unsupported
******** advertise_l2vpn_evpn, 55, default, ["ipv4", "unicast"]
         Unsupported
******** next_hop_route_map, 55, default, ["ipv4", "unicast"]
******** additional_paths_selection, 55, default, ["ipv4", "unicast"]
******** maximum_paths, 55, default, ["ipv4", "unicast"]
******** maximum_paths_ibgp, 55, default, ["ipv4", "unicast"]
******** dampen_igp_metric, 55, default, ["ipv4", "unicast"]
         Unsupported
******** default_metric, 55, default, ["ipv4", "unicast"]
         Unsupported
******** inject_map, 55, default, ["ipv4", "unicast"]
         Unsupported
**************************************
******** default_information_originate, 55, default, ["ipv6", "unicast"]
         Unsupported
******** client_to_client, 55, default, ["ipv6", "unicast"]
******** additional_paths_send, 55, default, ["ipv6", "unicast"]
******** additional_paths_receive, 55, default, ["ipv6", "unicast"]
******** additional_paths_install, 55, default, ["ipv6", "unicast"]
         Unsupported
******** advertise_l2vpn_evpn, 55, default, ["ipv6", "unicast"]
         Unsupported
******** next_hop_route_map, 55, default, ["ipv6", "unicast"]
******** additional_paths_selection, 55, default, ["ipv6", "unicast"]
******** maximum_paths, 55, default, ["ipv6", "unicast"]
******** maximum_paths_ibgp, 55, default, ["ipv6", "unicast"]
******** dampen_igp_metric, 55, default, ["ipv6", "unicast"]
         Unsupported
******** default_metric, 55, default, ["ipv6", "unicast"]
         Unsupported
******** inject_map, 55, default, ["ipv6", "unicast"]
         Unsupported
**************************************
******** default_information_originate, 55, default, ["ipv4", "multicast"]
         Unsupported
******** client_to_client, 55, default, ["ipv4", "multicast"]
******** additional_paths_send, 55, default, ["ipv4", "multicast"]
         CliError
******** additional_paths_receive, 55, default, ["ipv4", "multicast"]
         CliError
******** additional_paths_install, 55, default, ["ipv4", "multicast"]
         Unsupported
******** advertise_l2vpn_evpn, 55, default, ["ipv4", "multicast"]
         Unsupported
******** next_hop_route_map, 55, default, ["ipv4", "multicast"]
******** additional_paths_selection, 55, default, ["ipv4", "multicast"]
         CliError
******** maximum_paths, 55, default, ["ipv4", "multicast"]
******** maximum_paths_ibgp, 55, default, ["ipv4", "multicast"]
******** dampen_igp_metric, 55, default, ["ipv4", "multicast"]
         Unsupported
******** default_metric, 55, default, ["ipv4", "multicast"]
         Unsupported
******** inject_map, 55, default, ["ipv4", "multicast"]
         Unsupported
**************************************
******** default_information_originate, 55, default, ["ipv6", "multicast"]
         Unsupported
******** client_to_client, 55, default, ["ipv6", "multicast"]
******** additional_paths_send, 55, default, ["ipv6", "multicast"]
         CliError
******** additional_paths_receive, 55, default, ["ipv6", "multicast"]
         CliError
******** additional_paths_install, 55, default, ["ipv6", "multicast"]
         Unsupported
******** advertise_l2vpn_evpn, 55, default, ["ipv6", "multicast"]
         Unsupported
******** next_hop_route_map, 55, default, ["ipv6", "multicast"]
******** additional_paths_selection, 55, default, ["ipv6", "multicast"]
         CliError
******** maximum_paths, 55, default, ["ipv6", "multicast"]
******** maximum_paths_ibgp, 55, default, ["ipv6", "multicast"]
******** dampen_igp_metric, 55, default, ["ipv6", "multicast"]
         Unsupported
******** default_metric, 55, default, ["ipv6", "multicast"]
         Unsupported
******** inject_map, 55, default, ["ipv6", "multicast"]
         Unsupported
**************************************
******** default_information_originate, 55, default, ["l2vpn", "evpn"]
         Unsupported
******** client_to_client, 55, default, ["l2vpn", "evpn"]
******** additional_paths_send, 55, default, ["l2vpn", "evpn"]
******** additional_paths_receive, 55, default, ["l2vpn", "evpn"]
******** additional_paths_install, 55, default, ["l2vpn", "evpn"]
         Unsupported
******** advertise_l2vpn_evpn, 55, default, ["l2vpn", "evpn"]
         Unsupported
******** next_hop_route_map, 55, default, ["l2vpn", "evpn"]
******** additional_paths_selection, 55, default, ["l2vpn", "evpn"]
******** maximum_paths, 55, default, ["l2vpn", "evpn"]
         CliError
******** maximum_paths_ibgp, 55, default, ["l2vpn", "evpn"]
         CliError
******** dampen_igp_metric, 55, default, ["l2vpn", "evpn"]
         Unsupported
******** default_metric, 55, default, ["l2vpn", "evpn"]
         Unsupported
******** inject_map, 55, default, ["l2vpn", "evpn"]
         Unsupported
**************************************
******** default_information_originate, 55, red, ["ipv4", "unicast"]
         Unsupported
******** client_to_client, 55, red, ["ipv4", "unicast"]
         CliError
******** additional_paths_send, 55, red, ["ipv4", "unicast"]
******** additional_paths_receive, 55, red, ["ipv4", "unicast"]
******** additional_paths_install, 55, red, ["ipv4", "unicast"]
         Unsupported
******** advertise_l2vpn_evpn, 55, red, ["ipv4", "unicast"]
         Unsupported
******** next_hop_route_map, 55, red, ["ipv4", "unicast"]
         CliError
******** additional_paths_selection, 55, red, ["ipv4", "unicast"]
******** maximum_paths, 55, red, ["ipv4", "unicast"]
******** maximum_paths_ibgp, 55, red, ["ipv4", "unicast"]
******** dampen_igp_metric, 55, red, ["ipv4", "unicast"]
         Unsupported
******** default_metric, 55, red, ["ipv4", "unicast"]
         Unsupported
******** inject_map, 55, red, ["ipv4", "unicast"]
         Unsupported
**************************************
******** default_information_originate, 55, red, ["ipv6", "unicast"]
         Unsupported
******** client_to_client, 55, red, ["ipv6", "unicast"]
         CliError
******** additional_paths_send, 55, red, ["ipv6", "unicast"]
******** additional_paths_receive, 55, red, ["ipv6", "unicast"]
******** additional_paths_install, 55, red, ["ipv6", "unicast"]
         Unsupported
******** advertise_l2vpn_evpn, 55, red, ["ipv6", "unicast"]
         Unsupported
******** next_hop_route_map, 55, red, ["ipv6", "unicast"]
         CliError
******** additional_paths_selection, 55, red, ["ipv6", "unicast"]
******** maximum_paths, 55, red, ["ipv6", "unicast"]
******** maximum_paths_ibgp, 55, red, ["ipv6", "unicast"]
******** dampen_igp_metric, 55, red, ["ipv6", "unicast"]
         Unsupported
******** default_metric, 55, red, ["ipv6", "unicast"]
         Unsupported
******** inject_map, 55, red, ["ipv6", "unicast"]
         Unsupported
**************************************
******** default_information_originate, 55, red, ["ipv4", "multicast"]
         Unsupported
******** client_to_client, 55, red, ["ipv4", "multicast"]
         CliError
******** additional_paths_send, 55, red, ["ipv4", "multicast"]
         CliError
******** additional_paths_receive, 55, red, ["ipv4", "multicast"]
         CliError
******** additional_paths_install, 55, red, ["ipv4", "multicast"]
         Unsupported
******** advertise_l2vpn_evpn, 55, red, ["ipv4", "multicast"]
         Unsupported
******** next_hop_route_map, 55, red, ["ipv4", "multicast"]
         CliError
******** additional_paths_selection, 55, red, ["ipv4", "multicast"]
         CliError
******** maximum_paths, 55, red, ["ipv4", "multicast"]
******** maximum_paths_ibgp, 55, red, ["ipv4", "multicast"]
******** dampen_igp_metric, 55, red, ["ipv4", "multicast"]
         Unsupported
******** default_metric, 55, red, ["ipv4", "multicast"]
         Unsupported
******** inject_map, 55, red, ["ipv4", "multicast"]
         Unsupported
**************************************
******** default_information_originate, 55, red, ["ipv6", "multicast"]
         Unsupported
******** client_to_client, 55, red, ["ipv6", "multicast"]
         CliError
******** additional_paths_send, 55, red, ["ipv6", "multicast"]
         CliError
******** additional_paths_receive, 55, red, ["ipv6", "multicast"]
         CliError
******** additional_paths_install, 55, red, ["ipv6", "multicast"]
         Unsupported
******** advertise_l2vpn_evpn, 55, red, ["ipv6", "multicast"]
         Unsupported
******** next_hop_route_map, 55, red, ["ipv6", "multicast"]
         CliError
******** additional_paths_selection, 55, red, ["ipv6", "multicast"]
         CliError
******** maximum_paths, 55, red, ["ipv6", "multicast"]
******** maximum_paths_ibgp, 55, red, ["ipv6", "multicast"]
******** dampen_igp_metric, 55, red, ["ipv6", "multicast"]
         Unsupported
******** default_metric, 55, red, ["ipv6", "multicast"]
         Unsupported
******** inject_map, 55, red, ["ipv6", "multicast"]
         Unsupported
TestBgpAF#test_properties_matrix = 507.28 s = .
TestBgpAF#test_dampening = 31.78 s = .
TestBgpAF#test_utils_delta_add_remove = 2.73 s = .
TestSnmpGroup#all_skipped = 1.03 s = S
TestVpc#all_skipped = 1.01 s = S
TestRouterOspfVrf#all_skipped = 1.01 s = S
TestAaaAuthorizationService#all_skipped = 1.01 s = S
TestNtpServer#test_ntpserver_create_destroy_single_ipv4 = 6.91 s = .
TestNtpServer#test_ntpserver_create_destroy_multiple = 9.88 s = .
TestNtpServer#test_ntpserver_create_destroy_single_ipv6 = 7.06 s = .
TestRadiusServerGroup#all_skipped = 1.13 s = S
TestSnmpServer#all_skipped = 1.00 s = S
TestBgpNeighborAF#test_props_bool = 117.18 s = .
TestBgpNeighborAF#test_send_community = 296.60 s = .
TestBgpNeighborAF#test_soo = 66.51 s = .
TestBgpNeighborAF#test_advertise_map = 78.36 s = .
TestBgpNeighborAF#test_max_prefix = 157.90 s = .
TestBgpNeighborAF#test_default_originate = 129.62 s = .
TestBgpNeighborAF#test_tri_states = 134.77 s = .
TestBgpNeighborAF#test_nbrs_with_masks = 37.11 s = .
TestBgpNeighborAF#test_allowas_in = 140.47 s = .
TestBgpNeighborAF#test_props_string = 125.36 s = .
TestBgpNeighborAF#test_route_reflector_client = 103.50 s = .
TestBgpNeighborAF#test_weight = 98.89 s = .
TestBgpNeighborAF#test_nbr_af_create_destroy = 60.06 s = .
TestSvi#xr_unsupported = 1.01 s = S
TestVdc#all_skipped = 1.01 s = S
TestNameServer#test_nameserver_create_destroy_single_ipv6 = 7.21 s = .
TestNameServer#test_nameserver_create_destroy_single_ipv4 = 7.07 s = .
TestNameServer#test_router_create_destroy_multiple = 10.22 s = .
TestRouterBgp#test_confed_id_uu76828 = 7.07 s = .
TestRouterBgp#test_timer_bestpath_limit = 26.27 s = .
TestRouterBgp#test_create_invalid_multiple = 6.07 s = .
TestRouterBgp#test_default_maxas_limit = 4.52 s = .
TestRouterBgp#test_router_id_not_configured = 5.15 s = .
TestRouterBgp#test_default_cluster_id = 4.48 s = .
TestRouterBgp#test_default_timer_keepalive_hold_default = 5.21 s = .
TestRouterBgp#test_valid_asn = 121.61 s = .
TestRouterBgp#test_default_enforce_first_as = 4.92 s = .
TestRouterBgp#test_cluster_id_default = 10.40 s = .
TestRouterBgp#test_confederation_peers_not_configured = 20.27 s = .
TestRouterBgp#test_suppress_fib_pending = 13.29 s = .
TestRouterBgp#test_default_fast_external_fallover = 4.73 s = .
TestRouterBgp#test_log_neighbor_changes_vrf = 15.19 s = .
TestRouterBgp#test_default_neighbor_down_fib_accelerate = 4.43 s = .
TestRouterBgp#test_timer_bestpath_limit_always_default = 4.43 s = .
TestRouterBgp#test_asnum_dot = 21.64 s = .
TestRouterBgp#test_default_disable_policy_batching = 4.37 s = .
TestRouterBgp#test_bestpath_not_configured_vrf = 11.44 s = .
TestRouterBgp#test_graceful_restart_vrf = 10.65 s = .
TestRouterBgp#test_flush_routes = 4.44 s = .
TestRouterBgp#test_default_router_id = 4.57 s = .
TestRouterBgp#test_default_flush_routes = 4.48 s = .
TestRouterBgp#test_maxas_limit_vrf = 10.77 s = .
TestRouterBgp#test_bestpath_vrf = 42.73 s = .
TestRouterBgp#test_shutdown_not_configured = 4.49 s = .
TestRouterBgp#test_bestpath_not_configured_default = 4.88 s = .
TestRouterBgp#test_default_disable_policy_batching_ipv4 = 4.47 s = .
TestRouterBgp#test_cluster_id_vrf = 10.70 s = .
TestRouterBgp#test_default_log_neighbor_changes = 17.36 s = .
TestRouterBgp#test_reconnect_interval = 13.81 s = .
TestRouterBgp#test_confederation_peers_vrf = 10.76 s = .
TestRouterBgp#test_default_isolate = 4.34 s = .
TestRouterBgp#test_shutdown = 4.48 s = .
TestRouterBgp#test_asnum_invalid = 1.60 s = .
TestRouterBgp#test_graceful_restart_default = 28.40 s = .
TestRouterBgp#test_isolate = 4.41 s = .
TestRouterBgp#test_cluster_id_not_configured = 4.97 s = .
TestRouterBgp#test_create_vrfname_zero_length = 1.60 s = .
TestRouterBgp#test_log_neighbor_changes_default = 9.16 s = .
TestRouterBgp#test_vrf_invalid = 1.54 s = .
TestRouterBgp#test_confederation_id_default = 8.55 s = .
TestRouterBgp#test_maxas_limit_default = 4.30 s = .
TestRouterBgp#test_disable_policy_batching_ipv4 = 4.32 s = .
TestRouterBgp#test_event_history = 5.02 s = .
TestRouterBgp#test_timer_bestpath_limit_always_vrf = 25.98 s = .
TestRouterBgp#test_confederation_id_vrf = 10.81 s = .
TestRouterBgp#test_router_id = 21.14 s = .
TestRouterBgp#test_suppress_fib_pending_not_configured = 4.40 s = .
TestRouterBgp#test_bestpath_default = 40.44 s = .
TestRouterBgp#test_default_disable_policy_batching_ipv6 = 4.41 s = .
TestRouterBgp#test_default_bestpath = 4.54 s = .
TestRouterBgp#test_destroy = 5.81 s = .
TestRouterBgp#test_neighbor_down_fib_accelerate_not_configured = 4.44 s = .
TestRouterBgp#test_create_valid = 14.37 s = .
TestRouterBgp#test_enforce_first_as = 9.01 s = .
TestRouterBgp#test_default_confederation_id = 16.82 s = .
TestRouterBgp#test_nsr = 18.32 s = .
TestRouterBgp#test_reconnect_interval_default = 4.94 s = .
TestRouterBgp#test_collection_empty = 3.04 s = .
TestRouterBgp#test_default_shutdown = 4.59 s = .
TestRouterBgp#test_route_distinguisher = 33.02 s = .
TestRouterBgp#test_timer_bestpath_limit_always_not_configured = 4.43 s = .
TestRouterBgp#test_default_suppress_fib_pending = 4.44 s = .
TestRouterBgp#test_disable_policy_batching = 4.34 s = .
TestRouterBgp#test_disable_policy_batching_ipv6 = 4.38 s = .
TestRouterBgp#test_fast_external_fallover = 8.18 s = .
TestRouterBgp#test_timer_bestpath_limit_default = 4.44 s = .
TestRouterBgp#test_collection_not_empty = 6.14 s = .
TestRouterBgp#test_confederation_id_not_configured = 4.96 s = .
TestRouterBgp#test_neighbor_down_fib_accelerate = 28.90 s = .
TestRouterBgp#test_confederation_peers_default = 32.46 s = .
TestRouterBgp#test_timer_bgp_keepalive_hold = 37.49 s = .
TestRouterBgp#test_default_confederation_peers = 4.38 s = .
TestRouterBgp#test_default_graceful_restart = 4.51 s = .
TestRouterBgp#test_default_timer_bestpath_limit_always = 4.42 s = .
TestTacacsServerGroup#all_skipped = 1.04 s = S
TestDnsDomain#test_dnsdomain_create_destroy_multiple_vrf = 11.08 s = .
TestDnsDomain#test_dnsdomain_create_destroy_single = 6.91 s = .
TestDnsDomain#test_dnsdomain_create_destroy_multiple = 10.45 s = .
TestDnsDomain#test_dnsdomain_create_destroy_single_vrf = 10.17 s = .
TestVxlanVtepVni#all_skipped = 0.98 s = S
Connection reset by peer? Try again
TestYum#all_skipped = 1.99 s = S
Connection reset by peer? Try again
TestVrf#test_description = 21.96 s = .
TestVrf#test_route_distinguisher = 4.31 s = .
TestVrf#test_shutdown = 4.27 s = .
TestVrf#test_vrf_af_create_destroy = 21.32 s = .
TestVrf#test_collection_default = 2.08 s = .
TestVrf#test_name_type_invalid = 1.56 s = .
TestVrf#test_route_policy = 17.82 s = E
TestVrf#test_route_target = 260.39 s = .
TestVrf#test_vni = 1.57 s = S
TestVrf#test_name_too_long = 2.67 s = .
TestVrf#test_create_and_destroy = 14.78 s = .
TestVrf#test_name_zero_length = 2.62 s = .
TestCommandConfig#test_indent_with_tab = 1.00 s = .
Connection reset by peer? Try again
TestCommandConfig#test_valid_scale = 22.17 s = .
TestCommandConfig#test_invalid_config = 6.73 s = .
TestCommandConfig#test_valid_config = 9.05 s = .
TestCommandConfig#test_build_min_config_hash = 1.07 s = .
TestVni#all_skipped = 1.02 s = S
TestInterfaceServiceVni#all_skipped = 1.02 s = S
TestFabricpathGlobal#all_skipped = 1.03 s = S

Finished in 5771.251527s, 0.0669 runs/s, 0.3769 assertions/s.

  1) Skipped:
TestInterfaceOspf#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestInterfaceOspf; feature 'interface_ospf' is unsupported on this node


  2) Skipped:
TestVlan#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestVlan; feature 'vlan' is unsupported on this node


  3) Skipped:
TestAcl#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestAcl; feature 'acl' is unsupported on this node


  4) Skipped:
TestSnmpNotificationReceiver#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestSnmpNotificationReceiver; feature 'snmp_notification_receiver' is unsupported on this node


  5) Skipped:
TestAaaAuthenticationLoginService#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestAaaAuthenticationLoginService; feature 'aaa_auth_login_service' is unsupported on this node


  6) Skipped:
TestSwitchport#test_interface_switchport_mode_valid_fex [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:224]:
Not supported on IOS XR


  7) Skipped:
TestFeature#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestFeature; feature 'feature' is unsupported on this node


  8) Skipped:
TestSnmpUser#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestSnmpUser; feature 'snmp_user' is unsupported on this node


  9) Skipped:
TestRadiusGlobal#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestRadiusGlobal; feature 'radius_global' is unsupported on this node


 10) Skipped:
TestPimRpAddress#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestPimRpAddress; feature 'pim' is unsupported on this node


 11) Skipped:
TestInterfacePortChannel#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestInterfacePortChannel; feature 'interface_portchannel' is unsupported on this node


 12) Skipped:
TestPimGroupList#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestPimGroupList; feature 'pim' is unsupported on this node


 13) Skipped:
TestTacacsServerHost#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestTacacsServerHost; feature 'tacacs_server_host' is unsupported on this node


 14) Skipped:
TestVxlanVtep#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestVxlanVtep; feature 'vxlan_vtep' is unsupported on this node


 15) Skipped:
TestOverlayGlobal#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestOverlayGlobal; feature 'overlay_global' is unsupported on this node


 16) Skipped:
TestAaaAuthenticationLogin#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestAaaAuthenticationLogin; feature 'aaa_authentication_login' is unsupported on this node


 17) Skipped:
TestNxapi#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/test_nxapi.rb:31]:
Node under test appears to be gRPC, not NXAPI


 18) Skipped:
TestInterfaceSwitchportVtp#test_set_switchport_vtp_default_trunk [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:535]:
VTP is not supported on IOS XR


 19) Skipped:
TestInterfaceSwitchportVtp#test_set_switchport_vtp_false_access [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:535]:
VTP is not supported on IOS XR


 20) Skipped:
TestInterfaceSwitchportVtp#test_set_switchport_vtp_true_access [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:535]:
VTP is not supported on IOS XR


 21) Skipped:
TestInterfaceSwitchportVtp#test_switchport_vtp_disabled_feature_enabled [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:535]:
VTP is not supported on IOS XR


 22) Skipped:
TestInterfaceSwitchportVtp#test_switchport_vtp_enabled_access [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:535]:
VTP is not supported on IOS XR


 23) Skipped:
TestInterfaceSwitchportVtp#test_set_switchport_vtp_true_unsupported_mgmt_intf [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:535]:
VTP is not supported on IOS XR


 24) Skipped:
TestInterfaceSwitchportVtp#test_switchport_vtp_disabled_access [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:535]:
VTP is not supported on IOS XR


 25) Skipped:
TestInterfaceSwitchportVtp#test_switchport_vtp_enabled_trunk [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:535]:
VTP is not supported on IOS XR


 26) Skipped:
TestInterfaceSwitchportVtp#test_set_switchport_vtp_true_trunk [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:535]:
VTP is not supported on IOS XR


 27) Skipped:
TestInterfaceSwitchportVtp#test_set_switchport_vtp_true_unsupported_mode_disabled [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:535]:
VTP is not supported on IOS XR


 28) Skipped:
TestInterfaceSwitchportVtp#test_switchport_vtp_disabled_trunk [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:535]:
VTP is not supported on IOS XR


 29) Skipped:
TestInterfaceSwitchportVtp#test_set_switchport_vtp_false_trunk [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:535]:
VTP is not supported on IOS XR


 30) Skipped:
TestInterfaceSwitchportVtp#test_set_switchport_vtp_default_access [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:535]:
VTP is not supported on IOS XR


 31) Skipped:
TestInterfaceSwitchportVtp#test_set_switchport_vtp_false_unsupported_mode_disabled [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:535]:
VTP is not supported on IOS XR


 32) Skipped:
TestAce#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestAce; feature 'acl' is unsupported on this node


 33) Skipped:
TestVlanMtFull#test_vlan_mode_fabricpath [/home/glmatthe/cisco-network-node-utils/tests/test_vlan_mt_full.rb:68]:
Platform does not support MT-full


 34) Skipped:
TestStpGlobal#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestStpGlobal; feature 'stp_global' is unsupported on this node


 35) Skipped:
TestRouterOspf#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestRouterOspf; feature 'ospf' is unsupported on this node


 36) Skipped:
TestSnmpCommunity#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestSnmpCommunity; feature 'snmp_community' is unsupported on this node


 37) Skipped:
TestPortchannelGlobal#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestPortchannelGlobal; feature 'portchannel_global' is unsupported on this node


 38) Skipped:
TestVtp#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestVtp; feature 'vtp' is unsupported on this node


 39) Skipped:
TestBgpNeighbor#test_maximum_peers [/home/glmatthe/cisco-network-node-utils/tests/test_bgp_neighbor.rb:340]:
Maximum-peers does not apply to IOS XR


 40) Skipped:
TestEvpnVni#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestEvpnVni; feature 'evpn_vni' is unsupported on this node


 41) Skipped:
TestSnmpNotification#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestSnmpNotification; feature 'snmpnotification' is unsupported on this node


 42) Skipped:
TestTacacsServer#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestTacacsServer; feature 'tacacs_server' is unsupported on this node


 43) Skipped:
TestRadiusServer#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestRadiusServer; feature 'radius_server' is unsupported on this node


 44) Skipped:
TestPim#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestPim; feature 'pim' is unsupported on this node


 45) Skipped:
TestFabricpathTopo#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestFabricpathTopo; feature 'fabricpath_topology' is unsupported on this node


 46) Skipped:
TestInterfaceSwitchportSvi#test_switchport_autostate_access [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:403]:
VLAN interfaces are not supported on IOS XR


 47) Skipped:
TestInterfaceSwitchportSvi#test_switchport_autostate_disabled_feature_enabled [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:403]:
VLAN interfaces are not supported on IOS XR


 48) Skipped:
TestInterfaceSwitchportSvi#test_switchport_autostate_enabled_trunk [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:403]:
VLAN interfaces are not supported on IOS XR


 49) Skipped:
TestInterfaceSwitchportSvi#test_switchport_autostate_unsupported_mode_disabled [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:403]:
VLAN interfaces are not supported on IOS XR


 50) Skipped:
TestInterfaceSwitchportSvi#test_switchport_autostate_disabled_access [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:403]:
VLAN interfaces are not supported on IOS XR


 51) Skipped:
TestInterfaceSwitchportSvi#test_switchport_autostate_enabled_access [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:403]:
VLAN interfaces are not supported on IOS XR


 52) Skipped:
TestInterfaceSwitchportSvi#test_switchport_autostate_disabled_trunk [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:403]:
VLAN interfaces are not supported on IOS XR


 53) Skipped:
TestInterfaceSwitchportSvi#test_set_switchport_autostate_true_unsupported_mgmt_intf [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:403]:
VLAN interfaces are not supported on IOS XR


 54) Skipped:
TestInterfaceSwitchportSvi#test_switchport_autostate_trunk [/home/glmatthe/cisco-network-node-utils/tests/test_interface_switchport.rb:403]:
VLAN interfaces are not supported on IOS XR


 55) Skipped:
TestSnmpGroup#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestSnmpGroup; feature 'snmp_group' is unsupported on this node


 56) Skipped:
TestVpc#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestVpc; feature 'vpc' is unsupported on this node


 57) Skipped:
TestRouterOspfVrf#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestRouterOspfVrf; feature 'ospf' is unsupported on this node


 58) Skipped:
TestAaaAuthorizationService#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestAaaAuthorizationService; feature 'aaa_authorization_service' is unsupported on this node


 59) Skipped:
TestRadiusServerGroup#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestRadiusServerGroup; feature 'radius_server_group' is unsupported on this node


 60) Skipped:
TestSnmpServer#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestSnmpServer; feature 'snmp_server' is unsupported on this node


 61) Skipped:
TestSvi#xr_unsupported [/home/glmatthe/cisco-network-node-utils/tests/test_interface_svi.rb:34]:
Skipping TestSvi; Vlan interfaces are not supported on IOS XR


 62) Skipped:
TestVdc#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestVdc; feature 'vdc' is unsupported on this node


 63) Skipped:
TestTacacsServerGroup#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestTacacsServerGroup; feature 'tacacs_server_group' is unsupported on this node


 64) Skipped:
TestVxlanVtepVni#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestVxlanVtepVni; feature 'vxlan_vtep_vni' is unsupported on this node


 65) Skipped:
TestYum#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestYum; feature 'yum' is unsupported on this node


 66) Error:
TestVrf#test_route_policy:
Cisco::CliError: CliError: '(unknown, see error message)' rejected with message:
'The command '(unknown, see error message)' was rejected with error:
Policy [abc] must be defined before it can be attached.'
    /home/glmatthe/cisco-network-node-utils/lib/cisco_node_utils/node.rb:239:in `rescue in set'
    /home/glmatthe/cisco-network-node-utils/lib/cisco_node_utils/node.rb:237:in `set'
    /home/glmatthe/cisco-network-node-utils/lib/cisco_node_utils/node.rb:159:in `config_set'
    /home/glmatthe/cisco-network-node-utils/lib/cisco_node_utils/node_util.rb:66:in `config_set'
    /home/glmatthe/cisco-network-node-utils/lib/cisco_node_utils/vrf_af.rb:119:in `route_policy_import='
    /home/glmatthe/cisco-network-node-utils/tests/test_vrf.rb:194:in `block in route_policy'
    /home/glmatthe/cisco-network-node-utils/tests/test_vrf.rb:191:in `each'
    /home/glmatthe/cisco-network-node-utils/tests/test_vrf.rb:191:in `route_policy'
    /home/glmatthe/cisco-network-node-utils/tests/test_vrf.rb:177:in `block in test_route_policy'
    /home/glmatthe/cisco-network-node-utils/tests/test_vrf.rb:177:in `each'
    /home/glmatthe/cisco-network-node-utils/tests/test_vrf.rb:177:in `test_route_policy'


 67) Skipped:
TestVrf#test_vni [/home/glmatthe/cisco-network-node-utils/tests/test_vrf.rb:112]:
Platform does not support MT-lite


 68) Skipped:
TestVni#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestVni; feature 'vni' is unsupported on this node


 69) Skipped:
TestInterfaceServiceVni#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestInterfaceServiceVni; feature 'interface_service_vni' is unsupported on this node


 70) Skipped:
TestFabricpathGlobal#all_skipped [/home/glmatthe/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestFabricpathGlobal; feature 'fabricpath' is unsupported on this node

386 runs, 2175 assertions, 0 failures, 1 errors, 69 skips
Coverage report generated for MiniTest to /home/glmatthe/cisco-network-node-utils/coverage. 4114 / 7035 LOC (58.48%) covered.
```
