### PR TITLE
vdc template fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vdc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vdc.yaml
@@ -7,8 +7,8 @@ _exclude: [N3k, N5k, N6k, N9k]
 
 _template:
   get_command: 'show run vdc all'
-  get_context: ['/^vdc <vdc>/']
-  set_context: ['vdc <vdc>']
+  get_context: ['(?)/^vdc <vdc>/']
+  set_context: ['terminal dont-ask ; vdc <vdc>']
 
 all_vdcs:
   multiple:

--- a/lib/cisco_node_utils/cmd_ref/vdc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vdc.yaml
@@ -7,8 +7,8 @@ _exclude: [N3k, N5k, N6k, N9k]
 
 _template:
   get_command: 'show run vdc all'
-  get_context: ['(?)/^vdc <vdc>/']
-  set_context: ['terminal dont-ask ; vdc <vdc>']
+  get_context: ['/^vdc <vdc>/']
+  set_context: ['terminal dont-ask', 'vdc <vdc>']
 
 all_vdcs:
   multiple:
@@ -22,6 +22,7 @@ allocate_interface_unallocated:
 
 default_vdc_name:
   # Name of the default vdc. Assumes no admin-vdc.
+  get_context: ~
   get_value: '/^vdc (\S+) id 1$/' # Assumes id 1 for default vdc
 
 limit_resource_module_type:


### PR DESCRIPTION
- vdc get_context should be optional
- vdc set_context needs terminal dont-ask for prompt-less mode
- test_vdc minitest now passes 100% on N7k (the only platform currently supporting the vdc provider)
