### PR TITLE
Remove private-vlan test (not supported on fretta)

### DIFF
--- a/tests/cmd_config.yaml
+++ b/tests/cmd_config.yaml
@@ -8,7 +8,6 @@ nexus:
             feature bgp
             feature pim
             feature msdp
-            feature private-vlan
             feature udld
             feature interface-vlan
             feature hsrp
@@ -23,7 +22,6 @@ nexus:
             no feature bgp
             no feature pim
             no feature msdp
-            no feature private-vlan
             no feature udld
             no feature interface-vlan
             no feature hsrp


### PR DESCRIPTION
The test_command_config.rb enables and disables a list of features using command_config.  One of the features in that list, `private-vlan` is not supported on fretta(n8k).  Rather then add logic to skip fretta for this case, I simply removed the feature since the presence or absence of this test does not add significant value.

**Test Results** (n9k(I2 and I3), n8k, n6k): :white_check_mark: 
