### PR TITLE
Fix casing issue for anycast gateway mac

### DIFF
--- a/lib/cisco_node_utils/overlay_global.rb
+++ b/lib/cisco_node_utils/overlay_global.rb
@@ -127,8 +127,7 @@ module Cisco
     def anycast_gateway_mac
       return nil unless Feature.nv_overlay_evpn_enabled?
       mac = config_get('overlay_global', 'anycast_gateway_mac')
-      # This value gets 0-padded when nvgened, so we need to convert it.
-      Utils.zero_pad_macaddr(mac).nil? ? default_anycast_gateway_mac : mac
+      mac.nil? || mac.empty? ? default_anycast_gateway_mac : mac.downcase
     end
 
     def anycast_gateway_mac=(mac_addr)


### PR DESCRIPTION
**Issues resolved:**
- On fretta(n8k) the anycast gateway mac is displayed in uppercase instead of lowercase like it is on n9k.  This fix normalizes the getter to return the mac downcased.  This change will also be made to puppet in a subsequent commit to downcase the manifest data.
- Removes an incorrect call to Utils.zero_pad_macaddr() since the mac is already zero-padded.

N9K and N8K tests: :white_check_mark: 
