### PR TITLE
Feature pim fixes (n8|9k)

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -34,6 +34,12 @@ nv_overlay_evpn:
   get_value: '/^nv overlay evpn$/'
   set_value: "nv overlay evpn"
 
+pim:
+  kind: boolean
+  get_command: 'show running | section feature'
+  get_value: '/^feature pim$/' # TBD pim6
+  set_value: 'feature pim'
+
 vn_segment_vlan_based:
   # MT-lite only
   N3k: &vn_segment_vlan_based_mt_lite

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -36,7 +36,7 @@ nv_overlay_evpn:
 
 pim:
   kind: boolean
-  get_command: 'show running | section feature'
+  get_command: "show running | i ^feature"
   get_value: '/^feature pim$/' # TBD pim6
   set_value: 'feature pim'
 

--- a/lib/cisco_node_utils/cmd_ref/pim.yaml
+++ b/lib/cisco_node_utils/cmd_ref/pim.yaml
@@ -21,13 +21,6 @@ all_ssm_ranges:
   multiple:
   get_value : '/^<afi> pim ssm range (.*)$/'
 
-feature:
-  get_command: 'show running | section feature'
-  get_context: ~
-  get_value: '/^feature pim$/' # TBD pim6
-  set_context: ~
-  set_value: 'feature pim'
-
 group_list:
   default_value: ~
   get_value: '/^<afi> pim rp-address (\S+) group-list (\S+)/'

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -97,6 +97,16 @@ module Cisco
     end
 
     # ---------------------------
+    def self.pim_enable
+      return if pim_enabled?
+      config_set('feature', 'pim')
+    end
+
+    def self.pim_enabled?
+      config_get('feature', 'pim')
+    end
+
+    # ---------------------------
     def self.vn_segment_vlan_based_enable
       return if vn_segment_vlan_based_enabled?
       result = config_set('feature', 'vn_segment_vlan_based')

--- a/lib/cisco_node_utils/pim.rb
+++ b/lib/cisco_node_utils/pim.rb
@@ -32,19 +32,7 @@ module Cisco
       @afi = Pim.afi_cli(afi)
       set_args_keys_default
 
-      Pim.feature_enable if instantiate
-    end
-
-    def self.feature_enabled
-      config_get('pim', 'feature')
-    rescue Cisco::CliError => e
-      # cmd will syntax reject when feature is not enabled
-      raise unless e.clierror =~ /Syntax error/
-      return false
-    end
-
-    def self.feature_enable
-      config_set('pim', 'feature')
+      Feature.pim_enable if instantiate
     end
 
     # self.pims returns a hash of all current pim objects.
@@ -99,6 +87,7 @@ module Cisco
     # For that reason destroy needs to explicitly set each property
     # to its default state.
     def destroy
+      return unless Feature.pim_enabled?
       self.ssm_range = ''
     end
 

--- a/lib/cisco_node_utils/pim_group_list.rb
+++ b/lib/cisco_node_utils/pim_group_list.rb
@@ -93,7 +93,7 @@ module Cisco
     # Create pim grouplist instance
     # ---------------------------------
     def create
-      Pim.feature_enable unless Pim.feature_enabled
+      Feature.pim_enable
       set_args_keys(state: '')
       config_set('pim', 'group_list', @set_args)
     end

--- a/lib/cisco_node_utils/pim_rp_address.rb
+++ b/lib/cisco_node_utils/pim_rp_address.rb
@@ -87,7 +87,7 @@ module Cisco
     # Create pim rp_addr instance
     # ------------------------------
     def create
-      Pim.feature_enable unless Pim.feature_enabled
+      Feature.pim_enable
       set_args_keys(state: '')
       config_set('pim', 'rp_address', @set_args)
     end

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -129,6 +129,10 @@ class TestFeature < CiscoTestCase
     vdc_lc_state(vdc_current) if vdc_current
   end
 
+  def test_pim
+    feature('pim')
+  end
+
   def test_vn_segment_vlan_based
     if node.product_id[/N(5|6|7)/]
       assert_nil(Feature.vn_segment_vlan_based_enabled?)


### PR DESCRIPTION
- Added `pim` to various `feature` files.
- Updated `pim` objects to make use of `Feature.pim_enable`

**Tests:**
- tests/test_feature.rb  `n8k, n9k(I2 & I3)` :white_check_mark: 
- tests/test_pim*.rb `n8k, n9k(I2 & I3)` :white_check_mark: 
- Support for `n5|6|6k` is beyond the scope of this commit.
- Note: PIM is currently excluded on XR
