### PR TITLE
Fixes for interface minitests

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -339,7 +339,7 @@ svi_autostate:
   kind: boolean
   get_value: '/^(?:no )?autostate$/'
   set_value: "<state> autostate"
-  default_value: true
+  default_value: false
 
 svi_management:
   _exclude: [ios_xr]

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -339,7 +339,7 @@ svi_autostate:
   kind: boolean
   get_value: '/^(?:no )?autostate$/'
   set_value: "<state> autostate"
-  default_value: false
+  default_value: true
 
 svi_management:
   _exclude: [ios_xr]

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -1026,11 +1026,12 @@ module Cisco
     end
 
     def switchport_vtp
-      return nil unless switchport_vtp_mode_capable?
+      return default_switchport_vtp unless switchport_vtp_mode_capable?
       config_get('interface', 'vtp', name: @name)
     end
 
     def switchport_vtp=(vtp_set)
+      # TODO: throw UnsupportedError instead of returning false?
       return false unless switchport_vtp_mode_capable?
       no_cmd = (vtp_set) ? '' : 'no'
       config_set('interface', 'vtp', name: @name, state: no_cmd)

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -1026,7 +1026,7 @@ module Cisco
     end
 
     def switchport_vtp
-      return default_switchport_vtp unless switchport_vtp_mode_capable?
+      return nil unless switchport_vtp_mode_capable?
       config_get('interface', 'vtp', name: @name)
     end
 
@@ -1086,6 +1086,7 @@ module Cisco
     end
 
     def default_switchport_vtp
+      return nil unless switchport_vtp_mode_capable?
       config_get_default('interface', 'vtp')
     end
 

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -185,4 +185,20 @@ class CiscoTestCase < TestCase
       obj.destroy
     end
   end
+
+  # Remove all configurations from an interface.
+  def interface_cleanup(intf_name)
+    cfg = get_interface_cleanup_config(intf_name)
+    config(*cfg)
+  end
+
+  # Returns an array of commands to remove all configurations from
+  # an interface.
+  def get_interface_cleanup_config(intf_name)
+    if platform == :ios_xr
+      ["no interface #{intf_name}", "interface #{intf_name} shutdown"]
+    else
+      ["default interface #{intf_name}"]
+    end
+  end
 end

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -156,7 +156,7 @@ class CiscoTestCase < TestCase
       # rubocop:disable Style/ClassVars
       @@interfaces_id = []
       interfaces.each do |interface|
-        id = interface.split('Ethernet')[1]
+        id = interface.split('ethernet')[1]
         @@interfaces_id << id
       end
       # rubocop:enable Style/ClassVars

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1043,15 +1043,15 @@ class TestInterface < CiscoTestCase
   def test_interface_ipv4_forwarding
     intf = interfaces[0]
     interface_ethernet_default(intf)
+    i = Interface.new(intf)
 
     if platform == :ios_xr
-      assert_nil(intf.default_ipv4_forwarding)
-      assert_nil(intf.ipv4_forwarding)
-      assert_raises(Cisco::UnsupportedError) { intf.ipv4_forwarding = false }
+      assert_nil(i.default_ipv4_forwarding)
+      assert_nil(i.ipv4_forwarding)
+      assert_raises(Cisco::UnsupportedError) { i.ipv4_forwarding = false }
       return
     end
 
-    i = Interface.new(intf)
     assert_equal(i.default_ipv4_forwarding, i.ipv4_forwarding)
     begin
       i.switchport_mode = :disabled
@@ -1224,9 +1224,7 @@ class TestInterface < CiscoTestCase
     inttype_h
   end
 
-  # NOTE - Changes to this method may require new validation methods
-  #        to be created or existing ones to be modified.
-  def test_interface_ipv4_all_interfaces
+  def interface_test_data
     inttype_h = {}
     inttype_h[interfaces[0]] = {
       address_len:         '8.7.1.1/15',
@@ -1299,6 +1297,13 @@ class TestInterface < CiscoTestCase
     }
     # Skipping mgmt0 interface since that interface is our 'path' to
     # master should revisit this later
+    inttype_h
+  end
+
+  # NOTE - Changes to this method may require new validation methods
+  #        to be created or existing ones to be modified.
+  def test_interface_ipv4_all_interfaces
+    inttype_h = interface_test_data
 
     # Set system defaults to "factory" values prior to initial test.
     config(*
@@ -1318,9 +1323,15 @@ class TestInterface < CiscoTestCase
     # Steps to cleanup the preload configuration
     cfg = []
     inttype_h.each_key do |k|
-      cfg << "#{/^Ethernet/.match(k) ? 'default' : 'no'} interface #{k}"
+      if /ethernet/.match(k)
+        # leave interface there, but unconfigure it
+        cfg.push(*get_interface_cleanup_config(k))
+      else
+        # remove interface
+        cfg << "no interface #{k}"
+      end
     end
-    cfg << 'no feature interface-vlan'
+    cfg << 'no feature interface-vlan' unless platform == :ios_xr
 
     begin
       # Validate the collection
@@ -1334,6 +1345,7 @@ class TestInterface < CiscoTestCase
       validate_interface_shutdown(inttype_h)
       validate_vrf(inttype_h)
       config(*cfg)
+      InterfaceChannelGroup.new(interfaces[1]).channel_group = false
     rescue Minitest::Assertion
       # clean up before failing
       config(*cfg)

--- a/tests/test_interface_channel_group.rb
+++ b/tests/test_interface_channel_group.rb
@@ -23,7 +23,6 @@ class TestInterfaceChannelGroup < CiscoTestCase
     @intf = InterfaceChannelGroup.new(interfaces[1])
 
     # Only pre-clean interface on initial setup
-
     interface_cleanup(@intf.name) unless @@clean
     @@clean = true # rubocop:disable Style/ClassVars
   end

--- a/tests/test_interface_channel_group.rb
+++ b/tests/test_interface_channel_group.rb
@@ -23,12 +23,13 @@ class TestInterfaceChannelGroup < CiscoTestCase
     @intf = InterfaceChannelGroup.new(interfaces[1])
 
     # Only pre-clean interface on initial setup
-    config("default interface #{@intf}") unless @@clean
+
+    interface_cleanup(@intf.name) unless @@clean
     @@clean = true # rubocop:disable Style/ClassVars
   end
 
   def teardown
-    config("default interface #{@intf}")
+    interface_cleanup(@intf.name)
   end
 
   def test_channel_group

--- a/tests/test_interface_switchport.rb
+++ b/tests/test_interface_switchport.rb
@@ -23,6 +23,11 @@ include Cisco
 class TestInterfaceSwitchport < CiscoTestCase
   attr_reader :interface
 
+  def platform_supports_vtp_switchport_access?
+    skip('Platform does not support VTP when switchport mode is access') if
+      node.product_id =~ /N(5|6|7)/
+  end
+
   def setup
     super
     config('no feature vtp', 'no feature interface-vlan')
@@ -48,11 +53,6 @@ class TestSwitchport < TestInterfaceSwitchport
   DEFAULT_IF_ACCESS_VLAN = 1
   DEFAULT_IF_SWITCHPORT_ALLOWED_VLAN = '1-4094'
   DEFAULT_IF_SWITCHPORT_NATIVE_VLAN = 1
-
-  def platform_supports_vtp_switchport_access?
-    skip('Platform does not support VTP when switchport mode is access') if
-      node.product_id =~ /N(5|6|7)/
-  end
 
   def system_default_switchport(state='')
     config("#{state} system default switchport")
@@ -427,7 +427,7 @@ class TestInterfaceSwitchportSvi < TestInterfaceSwitchport
            'switchport autostate exclude')
 
     cmd_ref = cmd_ref_switchport_autostate_exclude
-    if cmd_ref.config_set?
+    if cmd_ref.setter?
       assert(interface.switchport_autostate_exclude,
              'Error: interface, access, autostate exclude not enabled')
     else
@@ -448,7 +448,7 @@ class TestInterfaceSwitchportSvi < TestInterfaceSwitchport
            'switchport autostate exclude')
 
     cmd_ref = cmd_ref_switchport_autostate_exclude
-    if cmd_ref.config_set?
+    if cmd_ref.setter?
       assert(interface.switchport_autostate_exclude,
              'Error: interface, access, autostate exclude not enabled')
     else

--- a/tests/test_interface_switchport.rb
+++ b/tests/test_interface_switchport.rb
@@ -658,4 +658,14 @@ class TestInterfaceSwitchportVtp < TestInterfaceSwitchport
     refute(interface.switchport_vtp,
            'Error: mode :disabled, vtp should be false')
   end
+
+  def test_default_switchport_vtp
+    [:access, :disabled].each do |mode|
+      interface.switchport_mode = mode
+      interface.switchport_vtp = interface.default_switchport_vtp
+      assert_equal(interface.switchport_vtp, interface.default_switchport_vtp,
+                   "Error: mode :#{mode}, "\
+                   'switchport_vtp should equal default_switchport_vtp')
+    end
+  end
 end


### PR DESCRIPTION
Various fixes to the test_interface, test_interface_channel_group and test_interface_switchport minitests on both nx and xr.
