### PR TITLE
Fix test_node failure

### DIFF
--- a/tests/test_node.rb
+++ b/tests/test_node.rb
@@ -50,7 +50,7 @@ class TestNode < TestCase
   def test_node_connect_zero_arguments
     node = Node.instance
     # No UDS present on the test host, so default logic fails to connect
-    assert_raises(RuntimeError) do
+    assert_raises(Cisco::Client::ConnectionRefused) do
       node.connect
     end
   end


### PR DESCRIPTION
The latest `develop` code expects this test to raise `Cisco::Client::ConnectionRefused`

Tests pass on (XR, N8K, N9K (I2 and I3), N7K, N6K)
