### PR TITLE
route_distinguisher fixes for I2 vs I3

### DIFF
--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -778,10 +778,16 @@ module Cisco
                                          'route_distinguisher is not ' \
                                          'configurable on a default VRF')
       end
-      Feature.nv_overlay_evpn_enable if platform == :nexus
+
+      # NX I2 images require 'nv overlay evpn' for rd and also require
+      # explicit values when removing the rd command. These restrictions are
+      # not not needed in I3 and newer images.
+      Feature.nv_overlay_evpn_enable if Utils.nexus_i2_image
+
       if rd == default_route_distinguisher
+        return if route_distinguisher.empty?
         @set_args[:state] = 'no'
-        @set_args[:rd] = ''
+        @set_args[:rd] = route_distinguisher
       else
         @set_args[:state] = ''
         @set_args[:rd] = rd

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -779,7 +779,7 @@ module Cisco
                                          'configurable on a default VRF')
       end
 
-      # NX I2 images require 'nv overlay evpn' for rd and also require
+      # N3k I2 images require 'nv overlay evpn' for rd and also require
       # explicit values when removing the rd command. These restrictions are
       # not not needed in I3 and newer images.
       Feature.nv_overlay_evpn_enable if Utils.nexus_i2_image

--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -96,6 +96,13 @@ module Cisco
   # General utility class
   class Utils
     require 'ipaddr'
+
+    # Helper utility to check for older Nexus I2 images
+    def self.nexus_i2_image
+      require_relative 'platform'
+      true if Platform.image_version[/7.0.3.I2.*/]
+    end
+
     # Helper utility method for ip/prefix format networks.
     # For ip/prefix format '1.1.1.1/24' or '2000:123:38::34/64',
     # we need to mask the address using the prefix length so that they

--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -100,7 +100,7 @@ module Cisco
     # Helper utility to check for older Nexus I2 images
     def self.nexus_i2_image
       require_relative 'platform'
-      true if Platform.image_version[/7.0.3.I2.*/]
+      true if Platform.image_version[/7.0.3.I2/]
     end
 
     # Helper utility method for ip/prefix format networks.

--- a/lib/cisco_node_utils/platform.rb
+++ b/lib/cisco_node_utils/platform.rb
@@ -19,6 +19,13 @@ require_relative 'node_util'
 module Cisco
   # Platform - class for gathering platform hardware and software information
   class Platform < NodeUtil
+    #
+    # NX: 7.0(3)I2(3) [build 7.0(3)I2(2.118)]
+    # XR: 6.1.1.04I
+    def self.image_version
+      config_get('show_version', 'version')
+    end
+
     # ex: 'n3500-uk9.6.0.2.A3.0.40.bin'
     def self.system_image
       config_get('show_version', 'boot_image')

--- a/tests/test_platform.rb
+++ b/tests/test_platform.rb
@@ -17,6 +17,27 @@ require_relative '../lib/cisco_node_utils/platform'
 
 # TestPlatform - Minitest for Platform class
 class TestPlatform < CiscoTestCase
+  def test_image_version
+    case platform
+    when :ios_xr
+      refute_empty(Platform.image_version)
+
+    when :nexus
+      # Supported Images:
+      # N3/9k: 7.0(3)I2(*), 7.0(3)I3(1)
+      # N7k:   7.3(1)D1(1)
+      # N5/6k: 7.3(0)N1(1)
+
+      in_pat = '(^  NXOS: version |^  system:    version)'
+      s = @device.cmd("show version | i '#{in_pat}'")
+
+      out_pat = %r{/(\d\.\d\(\d\)[IDN])\d\(\d\)/}
+      show = s.match(out_pat).to_s
+      plat = Platform.image_version.match(out_pat).to_s
+      assert_equal(show, plat)
+    end
+  end
+
   def test_system_image
     if platform == :ios_xr
       assert_nil(Platform.system_image)

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -1049,6 +1049,9 @@ class TestRouterBgp < CiscoTestCase
     remove_all_vrfs
 
     bgp = setup_vrf
+    assert_empty(bgp.route_distinguisher,
+                 'bgp route_distinguisher should *NOT* be configured')
+
     bgp.route_distinguisher = 'auto'
     assert_equal('auto', bgp.route_distinguisher)
 


### PR DESCRIPTION
- We were forcing Feature.nv_overlay_evpn_enable for all nexus devices but this is actually only necessary on N3k/N9k platforms running the older 7.0(3)I2 images. The I3 images do not require overlay to use route_distinguisher.
- I added a check in cmn utils to help look for I2 images.
- Tested on N3,5,6,7k,N9kI2, N9kI3
