### PR TITLE
Add missing nxapi_structured entries

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/README_YAML.md
+++ b/lib/cisco_node_utils/cmd_ref/README_YAML.md
@@ -230,10 +230,10 @@ CLI is the lowest common denominator, so YAML entries not otherwise flagged as a
 description:
   get_command: 'show version'
   nexus:
-    data_model: nxapi_structured
+    data_format: nxapi_structured
     get_value: 'chassis_id'
   else:
-    data_model: cli
+    data_format: cli
     get_value: '/Hardware\n  cisco (([^(\n]+|\(\d+ Slot\))+\w+)/'
 ```
 
@@ -320,10 +320,10 @@ Using `_template` in combination with platform and data format variants:
 _template:
   ios_xr:
     get_command: 'show inventory | begin "Rack 0"'
-    get_data_model: cli
+    get_data_format: cli
   nexus:
     get_command: 'show inventory'
-    get_data_model: nxapi_structured
+    get_data_format: nxapi_structured
 
 productid:
   ios_xr:
@@ -360,7 +360,7 @@ The `get_data_format` key is optionally used to specify which data format a give
 productid:
   get_command: 'show inventory'
   nexus:
-    get_data_model: nxapi_structured
+    get_data_format: nxapi_structured
     get_context: ['TABLE_inv', 'ROW_inv', 0]
 ```
 
@@ -386,7 +386,7 @@ area:
 productid:
   get_command: 'show inventory'
   nexus:
-    get_data_model: nxapi_structured
+    get_data_format: nxapi_structured
     get_context: ['TABLE_inv', 'ROW_inv', 0]
     get_value: 'productid'
     # config_get('inventory', 'productid') returns

--- a/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
@@ -11,6 +11,7 @@ aaa_user_cache_timeout:
     default_value: 3600
 
 contact:
+  get_data_format: nxapi_structured
   get_command: "show snmp"
   get_value: "sys_contact"
   set_value: "%s snmp-server contact %s"
@@ -24,6 +25,7 @@ global_enforce_priv:
   default_value: false
 
 location:
+  get_data_format: nxapi_structured
   get_command: "show snmp"
   get_value: "sys_location"
   set_value: "%s snmp-server location %s"


### PR DESCRIPTION
- Adds missing `get_data_format: nxapi_structured` yaml entries
- Fixed incorrect references to `data_model` in `lib/cisco_node_utils/cmd_ref/README_YAML.md`

**TESTING**
:white_check_mark:  on `N9K(I2 and I3), N8K, N7K, N6K`
