### PR TITLE
Better minitest logging CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ Changelog
   - Individual token values can be explicitly marked as optional (e.g., VRF context); tokens not marked as optional are mandatory.
   - Data format (CLI, NXAPI structured) is now assumed to be CLI unless explicitly specified otherwise using the new `(get_|set_)?data_format` YAML key. No more guessing based on whether a key looks like a hash key or a Regexp.
 * `cisco_nxapi` Gem is no longer a dependency as the NXAPI client code has been merged into this Gem under the `Cisco::Client` namespace.
+* Improved minitest logging CLI.
+  - `ruby test_foo.rb -l debug` instead of `ruby test_foo.rb -- <host> <user> <pass> debug`
+  - `rake test TESTOPTS='--log-level=debug'`
 
 ### Fixed
 

--- a/lib/cisco_node_utils/logger.rb
+++ b/lib/cisco_node_utils/logger.rb
@@ -43,12 +43,12 @@ module Cisco::Logger
       @@logger = Logger.new(STDOUT) # rubocop:disable Style/ClassVars
       @@logger.level = Logger::INFO
 
-      def debug_enable
-        @@logger.level = Logger::DEBUG
+      def level
+        @@logger.level
       end
 
-      def debug_disable
-        @@logger.level = Logger::INFO
+      def level=(level)
+        @@logger.level = level
       end
     end
 

--- a/lib/minitest/log_level_plugin.rb
+++ b/lib/minitest/log_level_plugin.rb
@@ -1,0 +1,41 @@
+# March 2016, Glenn F. Matthews
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'logger'
+require_relative '../cisco_node_utils/logger'
+
+# Add logging level option to minitest
+module Minitest
+  LEVEL_ALIASES = {
+    'debug'   => Logger::DEBUG,
+    'info'    => Logger::INFO,
+    'warning' => Logger::WARN,
+    'error'   => Logger::ERROR,
+  }
+  def self.plugin_log_level_options(opts, options)
+    opts.on(
+      '-l', '--log-level LEVEL', LEVEL_ALIASES,
+      'Configure logging level for tests',
+      "(#{LEVEL_ALIASES.keys.join(', ')})"
+    ) do |level|
+      options[:log_level] = level
+    end
+  end
+
+  def self.plugin_log_level_init(options)
+    Cisco::Logger.level = options[:log_level] if options[:log_level]
+  end
+end

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -17,6 +17,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Minitest needs to have this path in order to discover our logging plugin
+$LOAD_PATH.push File.expand_path('../../lib', __FILE__)
+
 require 'simplecov'
 SimpleCov.start do
   # Don't calculate coverage of our test code itself!
@@ -122,7 +125,6 @@ class TestCase < Minitest::Test
                    )
     end
     @device.cmd('term len 0')
-    Cisco::Logger.debug_enable if ARGV[3] == 'debug' || ENV['DEBUG'] == '1'
   rescue Errno::ECONNREFUSED
     puts 'Telnet login refused - please check that the IP address is correct'
     puts "  and that you have configured 'feature telnet' (NX-OS) or "

--- a/tests/test_logger.rb
+++ b/tests/test_logger.rb
@@ -30,11 +30,14 @@ class TestLogger < TestCase
   # will never fail. But it will print out all the messages that the tested
   # functions are supposed to print. So I still keep this test here
   def test_default_logger_output
-    Cisco::Logger.debug_enable
+    level = Cisco::Logger.level
+    Cisco::Logger.level = Logger::DEBUG
+    assert_equal(Logger::DEBUG, Cisco::Logger.level)
     assert_output { Cisco::Logger.debug('Test default debug output') }
     assert_output { Cisco::Logger.info('Test default info output') }
     assert_output { Cisco::Logger.warn('Test default warn output') }
     assert_output { Cisco::Logger.error('Test default error output') }
-    Cisco::Logger.debug_disable
+    Cisco::Logger.level = level
+    assert_equal(level, Cisco::Logger.level)
   end
 end


### PR DESCRIPTION
Remove the magic 'debug' positional argument from minitest (`ruby test_foo.rb -- <node> <user> <pass> [debug]`). Instead, define a proper minitest plugin that adds a `-l`/`--logging` option to our tests:

```
$ ruby tests/test_grpc.rb -h
minitest options:
    -h, --help                       Display this help.
    -s, --seed SEED                  Sets random seed. Also via env. Eg: SEED=n rake
    -v, --verbose                    Verbose. Show progress processing files.
    -n, --name PATTERN               Filter run on /regexp/ or string.

Known extensions: pride, logging
    -p, --pride                      Pride. Show your testing pride!
    -l, --logging LEVEL              Configure logging level for tests
                                     (debug, info, warning, error)
```

Can now run minitest with debugs enabled by either `ruby test_foo.rb -l debug -- <host> <user> <pass>` or `rake test TESTOPTS="--logging=debug" ...`.

```
$ ruby tests/test_logger.rb 
Run options: --seed 52010

# Running:

D, [2016-03-03T13:46:11.670734 #26742] DEBUG -- : Test default debug output
I, [2016-03-03T13:46:11.670834 #26742]  INFO -- : Test default info output
W, [2016-03-03T13:46:11.670868 #26742]  WARN -- : Test default warn output
E, [2016-03-03T13:46:11.670899 #26742] ERROR -- : Test default error output
..

Finished in 1.369195s, 1.4607 runs/s, 4.3821 assertions/s.

2 runs, 6 assertions, 0 failures, 0 errors, 0 skips
```

```
glmatthe@fe-ucs36:~/cisco-network-node-utils$ ruby tests/test_command_reference.rb -n test_data_sanity -l debug
Run options: -n test_data_sanity -l debug --seed 44134

# Running:

D, [2016-03-03T13:47:22.618384 #28786] DEBUG -- : Exclude this product (, nexus)
D, [2016-03-03T13:47:22.618482 #28786] DEBUG -- : Exclude this product (, nexus)
D, [2016-03-03T13:47:22.669743 #28786] DEBUG -- : Exclude this product (, nexus)
D, [2016-03-03T13:47:22.814565 #28786] DEBUG -- : Exclude this product (N9K-C9396PX, N9k)
D, [2016-03-03T13:47:22.821313 #28786] DEBUG -- : Exclude this product (N9K-C9396PX, N9k)
D, [2016-03-03T13:47:22.851770 #28786] DEBUG -- : Exclude this product (N9K-C9396PX, N9k)
D, [2016-03-03T13:47:22.851828 #28786] DEBUG -- : Exclude this product (N9K-C9396PX, N9k)
D, [2016-03-03T13:47:22.859915 #28786] DEBUG -- : Exclude this product (N9K-C9396PX, nexus)
D, [2016-03-03T13:47:22.859978 #28786] DEBUG -- : Exclude this product (N9K-C9396PX, nexus)
...
```

```
glmatthe@fe-ucs36:~/cisco-network-node-utils$ ruby tests/test_command_reference.rb -n test_data_sanity -l info
Run options: -n test_data_sanity -l info --seed 58144

# Running:

.
```
