### PR TITLE
Putting back terminal dont-ask in interactive cli

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vpc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vpc.yaml
@@ -60,8 +60,6 @@ dual_active_exclude_interface_vlan_bridge_domain:
 fabricpath_emulated_switch_id: 
   _exclude: [N3k, N5k, N6k, N9k]
   kind: int
-  get_command:  'show running-config vpc all'
-  get_context:  ['/^vpc domain\s*(\d+)$/']
   set_context:  ['terminal dont-ask', 'vpc domain <domain>']
   get_value: '/^fabricpath switch-id\s+(\d+)$/'
   set_value: '<state> fabricpath switch-id <swid>'
@@ -109,7 +107,6 @@ peer_gateway:
 peer_gateway_exclude_bridge_domain: 
   kind: string
   _exclude: [N3k, N5k, N6k, N7k, N9k]
-  get_context:  ['/^vpc domain\s*(\d+)$/']
   set_context:  ['terminal dont-ask', 'vpc domain <domain>']
   get_value: '/^peer-gateway exclude bridge-domain\s+(\S+)/'
   set_value: "peer-gateway exclude-bridge-domain <range>"
@@ -118,7 +115,6 @@ peer_gateway_exclude_bridge_domain:
 peer_gateway_exclude_vlan: 
   _exclude: [N3k, N9k]
   kind: string
-  get_context:  ['/^vpc domain\s*(\d+)$/']
   set_context:  ['terminal dont-ask', 'vpc domain <domain>']
   get_value: '/^peer-gateway exclude-vlan\s(\S+)/'
   set_value: "peer-gateway exclude-vlan <range>"

--- a/lib/cisco_node_utils/cmd_ref/vpc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vpc.yaml
@@ -97,7 +97,6 @@ layer3_peer_routing:
 
 peer_gateway: 
   kind: boolean
-  get_context:  ['/^vpc domain\s*(\d+)$/']
   set_context:  ['terminal dont-ask', 'vpc domain <domain>']
   get_value: '/^peer-gateway/'
   set_value: "<state> peer-gateway"

--- a/lib/cisco_node_utils/cmd_ref/vpc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vpc.yaml
@@ -5,13 +5,13 @@ _exclude: [ios_xr]
 _template: 
   get_command:  'show running-config vpc all'
   get_context:  ['/^vpc domain\s*(\d+)$/']
-  set_context:  ["vpc domain <domain>"]
+  set_context:  ['vpc domain <domain>']
 
 auto_recovery: 
   kind: boolean
   _exclude: [N5k, N6k]
   auto_default: false
-  get_value: '/^auto\-recovery/'
+  get_value: '/^auto-recovery/'
   set_value: "<state> auto-recovery"
   N3k:
     default_value: false
@@ -22,7 +22,7 @@ auto_recovery:
 
 auto_recovery_reload_delay: 
   kind: int
-  get_value: '/auto\-recovery reload\-delay (\d+)/'
+  get_value: '/^auto-recovery reload-delay (\d+)/'
   set_value: "auto-recovery reload-delay <delay>"
   default_value: 240
 
@@ -34,7 +34,7 @@ delay_restore:
 
 delay_restore_interface_vlan: 
   kind: int
-  get_value: '/^delay restore interface\-vlan\s+(\d+)/'
+  get_value: '/^delay restore interface-vlan\s+(\d+)/'
   set_value: "delay restore interface-vlan <delay>"
   default_value: 10
 
@@ -50,16 +50,19 @@ domain:
 dual_active_exclude_interface_vlan_bridge_domain: 
   kind: string
   N7k:
-    get_value: '/^dual\-active exclude interface\-vlan\-bridge\-domain\s+(\S+)/'
+    get_value: '/^dual-active exclude interface-vlan-bridge-domain\s+(\S+)/'
     set_value: "<state> dual-active exclude interface-vlan-bridge-domain <range>"
   else:
-    get_value: '/^dual\-active exclude interface\-vlan\s+(\S+)/'
+    get_value: '/^dual-active exclude interface-vlan\s+(\S+)/'
     set_value: "<state> dual-active exclude interface-vlan <range>"
   default_value: 'none'
 
 fabricpath_emulated_switch_id: 
   _exclude: [N3k, N5k, N6k, N9k]
   kind: int
+  get_command:  'show running-config vpc all'
+  get_context:  ['/^vpc domain\s*(\d+)$/']
+  set_context:  ['terminal dont-ask', 'vpc domain <domain>']
   get_value: '/^fabricpath switch-id\s+(\d+)$/'
   set_value: '<state> fabricpath switch-id <swid>'
   default_value: false
@@ -76,14 +79,14 @@ feature:
   get_command: "show feature | section vpc"
   get_context: ~
   get_value: '/^vpc\s+\d+\s+enabled\s*$/'
-  set_context: ~
+  set_context: ['terminal dont-ask']
   set_value: "<state> feature vpc"
   default_value: false
 
 graceful_consistency_check: 
   auto_default: false
   kind: boolean
-  get_value: '/^graceful consistency\-check/'
+  get_value: '/^graceful consistency-check/'
   set_value: "<state> graceful consistency-check"
   default_value: true
 
@@ -96,7 +99,9 @@ layer3_peer_routing:
 
 peer_gateway: 
   kind: boolean
-  get_value: '/^peer\-gateway/'
+  get_context:  ['/^vpc domain\s*(\d+)$/']
+  set_context:  ['terminal dont-ask', 'vpc domain <domain>']
+  get_value: '/^peer-gateway/'
   set_value: "<state> peer-gateway"
   default_value: false
 
@@ -104,63 +109,67 @@ peer_gateway:
 peer_gateway_exclude_bridge_domain: 
   kind: string
   _exclude: [N3k, N5k, N6k, N7k, N9k]
-  get_value: '/^peer\-gateway exclude bridge\-domain\s+(\S+)/'
+  get_context:  ['/^vpc domain\s*(\d+)$/']
+  set_context:  ['terminal dont-ask', 'vpc domain <domain>']
+  get_value: '/^peer-gateway exclude bridge-domain\s+(\S+)/'
   set_value: "peer-gateway exclude-bridge-domain <range>"
   default_value: ''
 
 peer_gateway_exclude_vlan: 
   _exclude: [N3k, N9k]
   kind: string
-  get_value: '/^peer\-gateway exclude-vlan\s(\S+)/'
+  get_context:  ['/^vpc domain\s*(\d+)$/']
+  set_context:  ['terminal dont-ask', 'vpc domain <domain>']
+  get_value: '/^peer-gateway exclude-vlan\s(\S+)/'
   set_value: "peer-gateway exclude-vlan <range>"
   default_value: ''
 
 # Peer-keep-alive
 peer_keepalive_dest:
-  get_value:  '/^peer\-keepalive destination (\S+)/'
+  get_value:  '/^peer-keepalive destination (\S+)/'
   default_value: ''
 
 peer_keepalive_hold_timeout: 
   kind: int
-  get_value:  '/^peer\-keepalive .*hold\-timeout (\S+)/'
+  get_value:  '/^peer-keepalive .*hold-timeout (\S+)/'
   default_value: 3
 
 peer_keepalive_interval: 
   kind: int
-  get_value:  '/^peer\-keepalive .*interval (\S+)/'
+  get_value:  '/^peer-keepalive .*interval (\S+)/'
   default_value: 1000
 
 peer_keepalive_precedence: 
   kind: int
-  get_value:  '/^peer\-keepalive .*precedence (\S+)/'
+  get_value:  '/^peer-keepalive .*precedence (\S+)/'
   default_value: 6
 
 peer_keepalive_set: 
   set_value:  "peer-keepalive destination <dest> source <src> udp-port <port_num> vrf <vrf> interval <interval> timeout <timeout> precedence <precedence> hold-timeout <hold_timeout>"
 
 peer_keepalive_src:
-  get_value:  '/^peer\-keepalive .*source (\S+)/'
+  get_value:  '/^peer-keepalive .*source (\S+)/'
   default_value: ''
 
 peer_keepalive_timeout: 
   kind: int
-  get_value:  '/^peer\-keepalive .* timeout (\S+)/'
+  get_value:  '/^peer-keepalive .* timeout (\S+)/'
   default_value: 5
 
 peer_keepalive_udp_port: 
   kind: int
-  get_value:  '/^peer\-keepalive .*udp\-port (\S+)/'
+  get_value:  '/^peer-keepalive .*udp-port (\S+)/'
   default_value: 3200
 
 peer_keepalive_vrf:
-  get_value:  '/^peer\-keepalive .*vrf (\S+)/'
+  get_value:  '/^peer-keepalive .*vrf (\S+)/'
   default_value: 'management'
 
 port_channel_limit: 
   _exclude: [N3k, N5k, N6k, N9k]
   auto_default: false
   kind: boolean    
-  get_value: '/^port\-channel limit/'
+  get_value: '/^port-channel limit/'
   set_value: "<state> port-channel limit"
   default_value: true
 
@@ -173,7 +182,7 @@ role_priority:
 self_isolation: 
   kind: boolean
   _exclude: [N5k, N6k, N9k]
-  get_value: '/^self\-isolation/'
+  get_value: '/^self-isolation/'
   set_value: "<state> self-isolation"
   default_value: false
 
@@ -186,13 +195,13 @@ shutdown:
 
 system_mac:
   kind: string
-  get_value: '/^system\-mac (\S+)$/'
+  get_value: '/^system-mac (\S+)$/'
   set_value: "<state> system-mac <mac_addr>"
   default_value: ''
 
 system_priority: 
   kind: int
-  get_value: '/^system\-priority\s+(\d+)/'
+  get_value: '/^system-priority\s+(\d+)/'
   set_value: "system-priority <priority>"
   default_value: 32667
 

--- a/tests/test_vpc.rb
+++ b/tests/test_vpc.rb
@@ -293,7 +293,7 @@ class TestVpc < CiscoTestCase
                            6, 3)
     # init channel group as none first, to test phy-port vPC link
     interface = InterfaceChannelGroup.new(interfaces[0])
-    interface.channel_group = false
+    interface.channel_group = false if interface.channel_group
     # Phy port vPC is supported only on N7K
     if /N7/ =~ node.product_id
       phy_interface = Interface.new(interfaces[0])

--- a/tests/test_vpc.rb
+++ b/tests/test_vpc.rb
@@ -288,31 +288,32 @@ class TestVpc < CiscoTestCase
   #
   def test_interface_vpc_id
     vpc = Vpc.new(100)
-    # test phy port vpc
-    interface = Interface.new(interfaces[0])
-    assert_equal(interface.vpc_id, interface.default_vpc_id,
-                 'default vpc_id should be null')
     # Make sure PKA is set
     vpc.peer_keepalive_set('1.1.1.2', '1.1.1.1', 3800, 'management', 400, 3,
                            6, 3)
+    # init channel group as none first, to test phy-port vPC link
+    interface = InterfaceChannelGroup.new(interfaces[0])
+    interface.channel_group = false
     # Phy port vPC is supported only on N7K
     if /N7/ =~ node.product_id
-      interface.switchport_mode = :trunk
-      interface.vpc_id = 10
-      assert_equal(10, interface.vpc_id, 'vpc_id should be 10')
+      phy_interface = Interface.new(interfaces[0])
+      assert_equal(phy_interface.vpc_id, phy_interface.default_vpc_id,
+                   'default vpc_id should be null')
+      phy_interface.switchport_mode = :trunk
+      phy_interface.vpc_id = 10
+      assert_equal(10, phy_interface.vpc_id, 'vpc_id should be 10')
 
       # negative - cannot config peer link on this
       e = assert_raises(CliError) do
-        interface.vpc_peer_link = true
+        phy_interface.vpc_peer_link = true
       end
       assert_match(/Invalid number/i, e.message)
 
       # turn off vpc id
-      interface.vpc_id = false
-      refute(interface.vpc_id, 'vpc_id should be unset')
+      phy_interface.vpc_id = false
+      refute(phy_interface.vpc_id, 'vpc_id should be unset')
     end
     # test port-channel vpc
-    interface = InterfaceChannelGroup.new(interfaces[0])
     interface.channel_group = 10
     interface_pc = Interface.new('port-channel10')
     interface_pc.switchport_mode = :trunk


### PR DESCRIPTION
1. removed the un-necessary escaped '-' from YAML regexes
2. addded back terminal dont-ask in YAML which were removed with the grpc-merge
