### PR TITLE
config() method changes to show output.

### DIFF
--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -141,7 +141,7 @@ class TestCase < Minitest::Test
     # Send the entire config as one string but be sure not to return until
     # we are safely back out of config mode, i.e. prompt is
     # 'switch#' not 'switch(config)#' or 'switch(config-if)#' etc.
-   result = @device.cmd(
+    result = @device.cmd(
       'String' => "configure terminal\n" + args.join("\n") + "\nend",
       # NX-OS has a space after '#', IOS XR does not
       'Match'  => /^[^()]+[$%#>] *\z/n)

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -141,9 +141,10 @@ class TestCase < Minitest::Test
     # Send the entire config as one string but be sure not to return until
     # we are safely back out of config mode, i.e. prompt is
     # 'switch#' not 'switch(config)#' or 'switch(config-if)#' etc.
-    result = @device.cmd('String' => "configure terminal\n" + args.join("\n") + "\nend",
-                # NX-OS has a space after '#', IOS XR does not
-                'Match'  => /^[^()]+[$%#>] *\z/n)
+    result = @device.cmd('String' => "configure terminal\n" + args.join("\n") +
+                         "\nend",
+                         # NX-OS has a space after '#', IOS XR does not
+                         'Match'  => /^[^()]+[$%#>] *\z/n)
 
     if /invalid/i.match(result)
       Cisco::Logger.warn("Config result:\n#{result}")

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -141,9 +141,15 @@ class TestCase < Minitest::Test
     # Send the entire config as one string but be sure not to return until
     # we are safely back out of config mode, i.e. prompt is
     # 'switch#' not 'switch(config)#' or 'switch(config-if)#' etc.
-    @device.cmd('String' => "configure terminal\n" + args.join("\n") + "\nend",
+    result = @device.cmd('String' => "configure terminal\n" + args.join("\n") + "\nend",
                 # NX-OS has a space after '#', IOS XR does not
                 'Match'  => /^[^()]+[$%#>] *\z/n)
+
+    if /invalid/i.match(result)
+      Cisco::Logger.warn("Config result:\n#{result}")
+    else
+      Cisco::Logger.debug("Config result:\n#{result}")
+    end
   rescue Net::ReadTimeout => e
     raise "Timeout when configuring:\n#{args.join("\n")}\n\n#{e}"
   end

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -141,12 +141,12 @@ class TestCase < Minitest::Test
     # Send the entire config as one string but be sure not to return until
     # we are safely back out of config mode, i.e. prompt is
     # 'switch#' not 'switch(config)#' or 'switch(config-if)#' etc.
-    result = @device.cmd('String' => "configure terminal\n" + args.join("\n") +
-                         "\nend",
-                         # NX-OS has a space after '#', IOS XR does not
-                         'Match'  => /^[^()]+[$%#>] *\z/n)
+   result = @device.cmd(
+      'String' => "configure terminal\n" + args.join("\n") + "\nend",
+      # NX-OS has a space after '#', IOS XR does not
+      'Match'  => /^[^()]+[$%#>] *\z/n)
 
-    if /invalid/i.match(result)
+    if /invalid|^%/i.match(result)
       Cisco::Logger.warn("Config result:\n#{result}")
     else
       Cisco::Logger.debug("Config result:\n#{result}")


### PR DESCRIPTION
This does two things:
1. In debug mode, the output of all calls to `config()` will be logged.
2. No matter that the log-level, if the output of config() contains "invalid", the output will be logged as a warning.

If there are other matches I should be looking for, let me know.  I imagine this change will uncover a lot of errors that have previously been hidden.
