### PR TITLE
Fix BGP minitest errors/warnings.

### DIFF
--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -162,7 +162,7 @@ class TestCase < Minitest::Test
       # NX-OS has a space after '#', IOS XR does not
       'Match'  => /^[^()]+[$%#>] *\z/n)
 
-    if !warn_match.nil? && warn_match.match(result)
+    if warn_match && warn_match.match(result)
       Cisco::Logger.warn("Config result:\n#{result}")
     else
       Cisco::Logger.debug("Config result:\n#{result}")

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -140,7 +140,7 @@ class TestCase < Minitest::Test
   # Execute the specified config commands and warn if the
   # output matches the default "warning" regex.
   def config(*args)
-    config_and_warn_on_match(/invalid|^%/i, *args)
+    config_and_warn_on_match(/^invalid|^%/i, *args)
   end
 
   # Execute the specified config commands. Use this version

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -138,20 +138,20 @@ class TestCase < Minitest::Test
   end
 
   # Execute the specified config commands and warn if the
-  # ouput matches the following regex: /invalid|^%/i
+  # output matches the default "warning" regex.
   def config(*args)
-     config_and_warn_on_match(/invalid|^%/i, *args)
+    config_and_warn_on_match(/invalid|^%/i, *args)
   end
 
   # Execute the specified config commands. Use this version
   # of the config method if you expect possible config errors
   # and do not wish to log them as a warning.
   def config_no_warn(*args)
-     config_and_warn_on_match(nil, *args)
+    config_and_warn_on_match(nil, *args)
   end
 
   # Execute the specified config commands and warn if the
-  # ouput matches the specified regex.5  Specifying nil for
+  # ouput matches the specified regex.  Specifying nil for
   # warn_match means "do not warn".
   def config_and_warn_on_match(warn_match, *args)
     # Send the entire config as one string but be sure not to return until

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -137,7 +137,23 @@ class TestCase < Minitest::Test
     @device = nil
   end
 
+  # Execute the specified config commands and warn if the
+  # ouput matches the following regex: /invalid|^%/i
   def config(*args)
+     config_and_warn_on_match(/invalid|^%/i, *args)
+  end
+
+  # Execute the specified config commands. Use this version
+  # of the config method if you expect possible config errors
+  # and do not wish to log them as a warning.
+  def config_no_warn(*args)
+     config_and_warn_on_match(nil, *args)
+  end
+
+  # Execute the specified config commands and warn if the
+  # ouput matches the specified regex.5  Specifying nil for
+  # warn_match means "do not warn".
+  def config_and_warn_on_match(warn_match, *args)
     # Send the entire config as one string but be sure not to return until
     # we are safely back out of config mode, i.e. prompt is
     # 'switch#' not 'switch(config)#' or 'switch(config-if)#' etc.
@@ -146,11 +162,12 @@ class TestCase < Minitest::Test
       # NX-OS has a space after '#', IOS XR does not
       'Match'  => /^[^()]+[$%#>] *\z/n)
 
-    if /invalid|^%/i.match(result)
+    if !warn_match.nil? && warn_match.match(result)
       Cisco::Logger.warn("Config result:\n#{result}")
     else
       Cisco::Logger.debug("Config result:\n#{result}")
     end
+    result
   rescue Net::ReadTimeout => e
     raise "Timeout when configuring:\n#{args.join("\n")}\n\n#{e}"
   end

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -96,9 +96,9 @@ class CiscoTestCase < TestCase
     self.class.platform
   end
 
-  def config(*args)
+  def config_and_warn_on_match(warn_match, *args)
     if node.client.platform == :ios_xr
-      result = super(*args, 'commit best-effort')
+      result = super(warn_match, *args, 'commit best-effort')
     else
       result = super
     end

--- a/tests/test_bgp_neighbor.rb
+++ b/tests/test_bgp_neighbor.rb
@@ -133,7 +133,7 @@ class TestBgpNeighbor < CiscoTestCase
       test_data_hash[d[:vrf]] = d[:neighbors]
       cmds << "vrf #{d[:vrf]}" unless d[:vrf] == 'default'
       d[:neighbors].each do |neighbor|
-        cmds << "neighbor #{neighbor}"
+        cmds << "neighbor #{neighbor}" << "remote-as #{REMOTE_ASN}"
       end
     end
 
@@ -161,7 +161,7 @@ class TestBgpNeighbor < CiscoTestCase
   def test_create_destroy
     test_data.each do |d|
       d[:neighbors].each do |addr|
-        neighbor = RouterBgpNeighbor.new(ASN, d[:vrf], addr)
+        neighbor = create_neighbor(d[:vrf], addr)
         exists = neighbor_exists?(addr, d[:vrf])
         assert(exists, "Failed to create bgp neighbor #{addr}")
         line = get_bgpneighbor_match_line(addr, d[:vrf])
@@ -295,7 +295,7 @@ class TestBgpNeighbor < CiscoTestCase
   end
 
   def test_log_neighbor_changes
-    if node.product_id[/ios_xr|N(5|6|7)/]
+    if node.product_id[/IOSXR|N(5|6|7)/]
       b = create_neighbor('blue')
       assert_nil(b.log_neighbor_changes)
       assert_nil(b.default_log_neighbor_changes)

--- a/tests/test_bgp_neighbor.rb
+++ b/tests/test_bgp_neighbor.rb
@@ -295,7 +295,7 @@ class TestBgpNeighbor < CiscoTestCase
   end
 
   def test_log_neighbor_changes
-    if node.product_id[/IOSXR|N(5|6|7)/]
+    if platform == :ios_xr || node.product_id[/N(5|6|7)/]
       b = create_neighbor('blue')
       assert_nil(b.log_neighbor_changes)
       assert_nil(b.default_log_neighbor_changes)

--- a/tests/test_bgp_neighbor_af.rb
+++ b/tests/test_bgp_neighbor_af.rb
@@ -106,6 +106,13 @@ class TestBgpNeighborAF < CiscoTestCase
     cfg << "vrf #{vrf} address-family #{af_v4}"
     cfg << 'rd-set auto' << 'end-set'
 
+    # If any of the route-policies already exist, the config output
+    # will match our magic "warning regex" (due to the presence of a '%'),
+    # so just execute this part of the config without checking for errors.
+    config_no_warn(*cfg)
+
+    cfg = []
+
     # router-id and address-family under the global bgp
     # remote-as under the neighbor
     # VRF statements
@@ -115,16 +122,13 @@ class TestBgpNeighborAF < CiscoTestCase
     cfg << "router bgp #{asn} address-family #{af_v4}"
     cfg << "router bgp #{asn} address-family #{af_v6}"
     cfg << "router bgp #{asn} address-family #{vpn}"
+    cfg << "router bgp #{asn} address-family vpnv6 unicast"
     cfg << "router bgp #{asn} address-family #{evpn}"
     cfg << "router bgp #{asn} vrf #{vrf} rd auto"
     cfg << "router bgp #{asn} vrf #{vrf} address-family #{af_v4}"
-    cfg << "router bgp #{asn} vrf #{vrf} address-family #{af_v6}"
-    cfg << "router bgp #{asn} vrf #{vrf} address-family #{evpn}"
     cfg << "router bgp #{asn} vrf #{vrf} neighbor #{nbr} remote-as #{asn}"
-    cfg << "router bgp #{asn} vrf #{vrf} neighbor #{nbr} " \
-           "address-family #{af_v4}"
 
-    config_no_warn(*cfg)
+    config(*cfg)
   end
 
   def cleanup

--- a/tests/test_bgp_neighbor_af.rb
+++ b/tests/test_bgp_neighbor_af.rb
@@ -101,14 +101,11 @@ class TestBgpNeighborAF < CiscoTestCase
     cfg << "route-policy #{str2.reverse}" << 'end-policy'
     cfg << 'route-policy foo_bar' << 'end-policy'
     cfg << 'route-policy baz_inga' << 'end-policy'
-
-    # vpn stuff - possibly not needed
-    cfg << "vrf #{vrf} address-family #{af_v4}"
     cfg << 'rd-set auto' << 'end-set'
 
-    # If any of the route-policies already exist, the config output
-    # will match our magic "warning regex" (due to the presence of a '%'),
-    # so just execute this part of the config without checking for errors.
+    # If any of the above config already exists, the output will contain
+    # a warning that matches our magic "warning regex" (due to the presence
+    # of a '%'), so just execute without checking for errors.
     config_no_warn(*cfg)
 
     cfg = []

--- a/tests/test_bgp_neighbor_af.rb
+++ b/tests/test_bgp_neighbor_af.rb
@@ -89,57 +89,72 @@ class TestBgpNeighborAF < CiscoTestCase
     vpn   = 'vpnv4 unicast'
     evpn  = 'l2vpn evpn'
 
+    cfg = []
+
     # Global requirements
     # route policies
     str1 = 'route-map-in-name'
     str2 = 'route-map-out-name'
-    config("route-policy #{str1}", 'end-policy')
-    config("route-policy #{str2}", 'end-policy')
-    config("route-policy #{str1.reverse}", 'end-policy')
-    config("route-policy #{str2.reverse}", 'end-policy')
-    config('route-policy foo_bar', 'end-policy')
-    config('route-policy baz_inga', 'end-policy')
+    cfg << "route-policy #{str1}" << 'end-policy'
+    cfg << "route-policy #{str2}" << 'end-policy'
+    cfg << "route-policy #{str1.reverse}" << 'end-policy'
+    cfg << "route-policy #{str2.reverse}" << 'end-policy'
+    cfg << 'route-policy foo_bar' << 'end-policy'
+    cfg << 'route-policy baz_inga' << 'end-policy'
 
     # vpn stuff - possibly not needed
-    config("vrf #{vrf} address-family #{af_v4}")
-    config('rd-set auto', 'end-set')
+    cfg << "vrf #{vrf} address-family #{af_v4}"
+    cfg << 'rd-set auto' << 'end-set'
 
     # router-id and address-family under the global bgp
     # remote-as under the neighbor
     # VRF statements
-    config("router bgp #{asn}")
-    config("router bgp #{asn} bgp router-id 1.1.1.1")
-    config("router bgp #{asn} neighbor #{nbr} remote-as #{asn}")
-    config("router bgp #{asn} address-family #{af_v4}")
-    config("router bgp #{asn} address-family #{af_v6}")
-    config("router bgp #{asn} address-family #{vpn}")
-    config("router bgp #{asn} address-family #{evpn}")
-    config("router bgp #{asn} vrf #{vrf} rd auto")
-    config("router bgp #{asn} vrf #{vrf} address-family #{af_v4}")
-    config("router bgp #{asn} vrf #{vrf} address-family #{af_v6}")
-    config("router bgp #{asn} vrf #{vrf} address-family #{evpn}")
-    config("router bgp #{asn} vrf #{vrf} neighbor #{nbr} remote-as #{asn}")
-    config("router bgp #{asn} vrf #{vrf} neighbor #{nbr} " \
-           "address-family #{af_v4}")
+    cfg << "router bgp #{asn}"
+    cfg << "router bgp #{asn} bgp router-id 1.1.1.1"
+    cfg << "router bgp #{asn} neighbor #{nbr} remote-as #{asn}"
+    cfg << "router bgp #{asn} address-family #{af_v4}"
+    cfg << "router bgp #{asn} address-family #{af_v6}"
+    cfg << "router bgp #{asn} address-family #{vpn}"
+    cfg << "router bgp #{asn} address-family #{evpn}"
+    cfg << "router bgp #{asn} vrf #{vrf} rd auto"
+    cfg << "router bgp #{asn} vrf #{vrf} address-family #{af_v4}"
+    cfg << "router bgp #{asn} vrf #{vrf} address-family #{af_v6}"
+    cfg << "router bgp #{asn} vrf #{vrf} address-family #{evpn}"
+    cfg << "router bgp #{asn} vrf #{vrf} neighbor #{nbr} remote-as #{asn}"
+    cfg << "router bgp #{asn} vrf #{vrf} neighbor #{nbr} " \
+           "address-family #{af_v4}"
+
+    config_no_warn(*cfg)
   end
 
   def cleanup
+    cfg = []
     if platform == :nexus
-      config('no feature bgp', 'feature bgp')
-      config('no nv overlay evpn', 'nv overlay evpn')
+      cfg << 'no feature bgp' << 'feature bgp'
+      cfg << 'no nv overlay evpn' << 'nv overlay evpn'
     else
-      config('no router bgp')
-      config('no vrf aa address-family ipv4 unicast')
-      config('no vrf aa')
+      cfg << 'no router bgp'
+      cfg << 'no vrf aa address-family ipv4 unicast'
+      cfg << 'no vrf aa'
 
       str1 = 'route-map-in-name'
       str2 = 'route-map-out-name'
-      config("no route-policy #{str1}")
-      config("no route-policy #{str2}")
-      config("no route-policy #{str1.reverse}")
-      config("no route-policy #{str2.reverse}")
-      config('no route-policy foo_bar')
-      config('no route-policy baz_inga')
+      cfg << "no route-policy #{str1}"
+      cfg << "no route-policy #{str2}"
+      cfg << "no route-policy #{str1.reverse}"
+      cfg << "no route-policy #{str2.reverse}"
+      cfg << 'no route-policy foo_bar'
+      cfg << 'no route-policy baz_inga'
+    end
+
+    config(*cfg)
+  end
+
+  def cleanup_bgp
+    if platform == :ios_xr
+      config('no router bgp')
+    else
+      config('no feature bgp', 'feature bgp')
     end
   end
 
@@ -196,7 +211,8 @@ class TestBgpNeighborAF < CiscoTestCase
 
   # ---------------------------------
   def test_nbrs_with_masks
-    config('no feature bgp', 'feature bgp')
+
+    cleanup_bgp
 
     # Creates
     obj = {}

--- a/tests/test_bgp_neighbor_af.rb
+++ b/tests/test_bgp_neighbor_af.rb
@@ -103,9 +103,9 @@ class TestBgpNeighborAF < CiscoTestCase
     cfg << 'route-policy baz_inga' << 'end-policy'
     cfg << 'rd-set auto' << 'end-set'
 
-    # If any of the above config already exists, the output will contain
-    # a warning that matches our magic "warning regex" (due to the presence
-    # of a '%'), so just execute without checking for errors.
+    # If any of the above config already exists, we will get a
+    # CLI warning message about replacing existing configuration.
+    # Ignore these warnings, as they're intentional.
     config_no_warn(*cfg)
 
     cfg = []

--- a/tests/test_bgp_neighbor_af.rb
+++ b/tests/test_bgp_neighbor_af.rb
@@ -211,7 +211,6 @@ class TestBgpNeighborAF < CiscoTestCase
 
   # ---------------------------------
   def test_nbrs_with_masks
-
     cleanup_bgp
 
     # Creates

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -471,7 +471,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_disable_policy_batching_ipv4
-    if node.product_id[/IOSXR|N(5|6|7)/]
+    if platform == :ios_xr || node.product_id[/N(5|6|7)/]
       b = RouterBgp.new(1)
       assert_nil(b.disable_policy_batching_ipv4)
       assert_nil(b.default_disable_policy_batching_ipv4)
@@ -500,7 +500,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_disable_policy_batching_ipv6
-    if node.product_id[/IOSXR|N(5|6|7)/]
+    if platform == :ios_xr || node.product_id[/N(5|6|7)/]
       b = RouterBgp.new(1)
       assert_nil(b.disable_policy_batching_ipv6)
       assert_nil(b.default_disable_policy_batching_ipv6)
@@ -968,7 +968,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_neighbor_down_fib_accelerate
-    if node.product_id[/IOSXR|N(5|6|7)/]
+    if platform == :ios_xr || node.product_id[/N(5|6|7)/]
       b = RouterBgp.new(1)
       assert_nil(b.neighbor_down_fib_accelerate)
       assert_nil(b.default_neighbor_down_fib_accelerate)
@@ -1004,7 +1004,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_reconnect_interval
-    if node.product_id[/IOSXR|N(5|6|7)/]
+    if platform == :ios_xr || node.product_id[/N(5|6|7)/]
       b = RouterBgp.new(1)
       assert_nil(b.reconnect_interval)
       assert_nil(b.default_reconnect_interval)

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -194,14 +194,16 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
 
     if platform == :ios_xr
-      s = config('show run router bgp')
-      line = /"router bgp"/.match(s)
-      assert_nil(line, "Error: 'router bgp' still configured")
+      command = 'show run router bgp'
+      pattern = /"router bgp"/
     else
-      s = config('show run all | no-more')
-      line = /"feature bgp"/.match(s)
-      assert_nil(line, "Error: 'feature bgp' still configured")
+      command = 'show run all | no-more'
+      pattern = /"feature bgp"/
     end
+
+    refute_show_match(
+      command: command, pattern: pattern,
+      msg: "Error: 'router bgp' still configured")
   end
 
   def test_create_invalid_multiple
@@ -469,7 +471,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_disable_policy_batching_ipv4
-    if node.product_id[/ios_xr|N(5|6|7)/]
+    if node.product_id[/IOSXR|N(5|6|7)/]
       b = RouterBgp.new(1)
       assert_nil(b.disable_policy_batching_ipv4)
       assert_nil(b.default_disable_policy_batching_ipv4)
@@ -498,7 +500,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_disable_policy_batching_ipv6
-    if node.product_id[/ios_xr|N(5|6|7)/]
+    if node.product_id[/IOSXR|N(5|6|7)/]
       b = RouterBgp.new(1)
       assert_nil(b.disable_policy_batching_ipv6)
       assert_nil(b.default_disable_policy_batching_ipv6)
@@ -966,7 +968,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_neighbor_down_fib_accelerate
-    if node.product_id[/ios_xr|N(5|6|7)/]
+    if node.product_id[/IOSXR|N(5|6|7)/]
       b = RouterBgp.new(1)
       assert_nil(b.neighbor_down_fib_accelerate)
       assert_nil(b.default_neighbor_down_fib_accelerate)
@@ -1002,7 +1004,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_reconnect_interval
-    if node.product_id[/ios_xr|N(5|6|7)/]
+    if node.product_id[/IOSXR|N(5|6|7)/]
       b = RouterBgp.new(1)
       assert_nil(b.reconnect_interval)
       assert_nil(b.default_reconnect_interval)

--- a/tests/test_snmpuser.rb
+++ b/tests/test_snmpuser.rb
@@ -185,7 +185,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_snmpuser_auth_password_equal_invalid_param
-    name = 'testV3PwEqualInv2'
+    name = 'testV3PwEqualInvalid2'
     auth_pw = 'TeSt297534'
     create_user(name, "network-admin auth md5 #{auth_pw}")
 
@@ -194,7 +194,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_snmpuser_auth_priv_password_equal_invalid_param
-    name = 'testV3PwEqualInv'
+    name = 'testV3PwEqualInvalid'
     auth_pw = 'XXWWPass0wrf'
     create_user(name, "network-admin auth md5 #{auth_pw} priv #{auth_pw}")
 
@@ -205,7 +205,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_snmpuser_auth_password_equal_priv_invalid_param
-    name = 'testV3PwEqualInv'
+    name = 'testV3PwEqualInvalid'
     auth_pw = 'XXWWPass0wrf'
     create_user(name, "network-operator auth md5 #{auth_pw} priv #{auth_pw}")
 

--- a/tests/test_snmpuser.rb
+++ b/tests/test_snmpuser.rb
@@ -185,7 +185,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_snmpuser_auth_password_equal_invalid_param
-    name = 'testV3PwEqualInvalid2'
+    name = 'testV3PwEqualInv2'
     auth_pw = 'TeSt297534'
     create_user(name, "network-admin auth md5 #{auth_pw}")
 
@@ -194,7 +194,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_snmpuser_auth_priv_password_equal_invalid_param
-    name = 'testV3PwEqualInvalid'
+    name = 'testV3PwEqualInv'
     auth_pw = 'XXWWPass0wrf'
     create_user(name, "network-admin auth md5 #{auth_pw} priv #{auth_pw}")
 
@@ -205,7 +205,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_snmpuser_auth_password_equal_priv_invalid_param
-    name = 'testV3PwEqualInvalid'
+    name = 'testV3PwEqualInv'
     auth_pw = 'XXWWPass0wrf'
     create_user(name, "network-operator auth md5 #{auth_pw} priv #{auth_pw}")
 


### PR DESCRIPTION
Fixes for errors/warnings in minitests, mostly BGP related.
Improved flexibility of config method with regards to warning on error.
