### PR TITLE
Add n8k(fretta) excludes + validate_property_excluded? method

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/acl.yaml
+++ b/lib/cisco_node_utils/cmd_ref/acl.yaml
@@ -24,7 +24,7 @@ acl:
   context: ~
   get_value: '/^<afi> access-list (\S+)$/'
   set_value: '<state> <afi> access-list <acl_name>'
-                      
+
 all_aces:
   multiple:
   get_value: '/^(\d+) .+$/'

--- a/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
+++ b/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
@@ -1,7 +1,7 @@
 # fabricpath
 ---
 # Fabricpath feature is not available on N3K and N9K
-_exclude: [N3k, N9k, ios_xr]
+_exclude: [N3k, N8k, N9k, ios_xr]
 
 aggregate_multicast_routes:
   _exclude: [N5k, N6k]
@@ -10,7 +10,7 @@ aggregate_multicast_routes:
   get_value: '/^fabricpath multicast aggregate\-routes\s*$/'
   set_value: "<state> fabricpath multicast aggregate-routes"
   default_value: false
-  
+
 allocate_delay:
   kind: int
   get_command: "show run fabricpath all"
@@ -18,7 +18,7 @@ allocate_delay:
   set_value: "<state> fabricpath timers allocate-delay <delay>"
   default_value: 10
 
-auto_switch_id: 
+auto_switch_id:
   kind: int
   get_command: "show fabricpath switch-id"
   get_value: '/^\*\s+(\d+).*No\s*$/'
@@ -54,7 +54,7 @@ linkup_delay_always:
   get_value: '/^fabricpath timers linkup\-delay always\s*$/'
   set_value: "<state> fabricpath timers linkup-delay always"
   default_value: false
-  
+
 linkup_delay_enable:
   _exclude: [N5k, N6k]
   auto_default: false
@@ -63,7 +63,7 @@ linkup_delay_enable:
   get_value: '/^fabricpath linkup\-delay\s*$/'
   set_value: "<state> fabricpath linkup-delay"
   default_value: true
-  
+
 loadbalance_algorithm:
   kind: string
   get_command: "show run fabricpath all"
@@ -92,7 +92,7 @@ loadbalance_multicast_rotate:
   get_command: "show fabricpath load-balance | begin Ftag"
   get_value: '/^Rotate amount: (\d+)/'
   default_value: 1
- 
+
 loadbalance_multicast_set:
   _exclude: [N5k, N6k]
   set_value: 'fabricpath load-balance multicast <rotate_amt> <inc_vlan>'

--- a/lib/cisco_node_utils/cmd_ref/fabricpath_topology.yaml
+++ b/lib/cisco_node_utils/cmd_ref/fabricpath_topology.yaml
@@ -1,7 +1,7 @@
 # fabricpath_topology
 ---
 # Fabricpath feature is not available on N3K and N9K
-_exclude: [N3k, N9k, ios_xr]
+_exclude: [N3k, N8k, N9k, ios_xr]
 
 _template:
   get_command: 'show running-config fabricpath all'

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -9,7 +9,7 @@ bgp:
   set_value: "feature bgp"
 
 fabric:
-  _exclude: [N3k, N9k]
+  _exclude: [N3k, N8k, N9k]
   get_command: "show feature-set"
   get_value: '/^fabric[\s\d]+(\w+)/'
   set_value: "<state> feature-set fabric"

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -441,14 +441,14 @@ system_default_switchport_shutdown:
     default_only: true
 
 vlan_mapping:
-  _exclude: [N3k, N5k, N6k, N9k]
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   multiple:
   get_value: '/^switchport vlan mapping (\d+) (\d+)/'
   set_value: '<state> switchport vlan mapping <original> <translated>'
   default_value: []
 
 vlan_mapping_enable:
-  _exclude: [N3k, N5k, N6k, N9k]
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   kind: boolean
   get_value: '/^(no )?switchport vlan mapping enable/'
   set_value: '<state> switchport vlan mapping enable'

--- a/lib/cisco_node_utils/cmd_ref/interface_service_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_service_vni.yaml
@@ -1,6 +1,6 @@
 # interface_service_vni
 ---
-_exclude: [N3k, N5k, N6k, N9k, ios_xr]
+_exclude: [N3k, N5k, N6k, N8k, N9k, ios_xr]
 
 _template:
   get_command: 'show running interface all'

--- a/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
@@ -6,52 +6,50 @@ _template:
   get_command: "show running all"
 
 asymmetric:
-  _exclude: [N6k, N5k, N3k, N9k]
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   default_value: false
 
 bundle_hash:
-  N3k:
+  N3k: &bundle_hash_ip_l4port
     default_value: 'ip-l4port'
-  N5k:
+  N5k: &bundle_hash_ip
     default_value: 'ip'
-  N6k:
-    default_value: 'ip'
-  N7k:
-    default_value: 'ip'
-  N9k:
-    default_value: 'ip-l4port'
+  N6k: *bundle_hash_ip
+  N7k: *bundle_hash_ip
+  N8k: *bundle_hash_ip_l4port
+  N9k: *bundle_hash_ip_l4port
 
 bundle_select:
   default_value: 'src-dst'
 
 concatenation:
-  _exclude: [N7k, N5k, N6k]
+  _exclude: [N5k, N6k, N7k]
   default_value: false
 
 hash_distribution:
-  _exclude: [N6k, N5k, N3k, N9k]
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   get_value: '/^port.channel hash.distribution (.*)$/'
   set_value: "port-channel hash-distribution %s"
   default_value: 'adaptive'
 
 hash_poly:
-  _exclude: [N7k, N3k, N9k]
+  _exclude: [N3k, N7k, N8k, N9k]
+  default_value: ~
 
 load_balance_type:
   kind: string
-  N3k:
+  N3k: &load_balance_type_symmetry
     default_only: "symmetry"
-  N5k:
+  N5k: &load_balance_type_ethernet
     default_only: "ethernet"
-  N6k:
-    default_only: "ethernet"
-  N7k:
+  N6k: *load_balance_type_ethernet
+  N7k: &load_balance_type_asymmetric
     default_only: "asymmetric"
-  N9k:
-    default_only: "symmetry"
+  N8k: *load_balance_type_symmetry
+  N9k: *load_balance_type_symmetry
 
 load_defer:
-  _exclude: [N6k, N5k, N3k, N9k]
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   kind: int
   get_value: '/^port.channel load.defer (\d+)$/'
   set_value: "port-channel load-defer %s"
@@ -63,7 +61,7 @@ port_channel_load_balance:
   set_value: "port-channel load-balance %s %s %s %s %s %s"
 
 resilient:
-  _exclude: [N6k, N5k, N7k]
+  _exclude: [N5k, N6k, N8k, N7k]
   kind: boolean
   get_value: '/^port-channel load-balance resilient$/'
   set_value: "%s port-channel load-balance resilient"
@@ -75,5 +73,5 @@ rotate:
   default_value: 0
 
 symmetry:
-  _exclude: [N7k, N5k, N6k]
+  _exclude: [N5k, N6k, N7k]
   default_value: false

--- a/lib/cisco_node_utils/cmd_ref/stp_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/stp_global.yaml
@@ -1,3 +1,4 @@
+
 # stp_global
 ---
 _exclude: [ios_xr]
@@ -6,7 +7,7 @@ _template:
   get_command: "show running-config spanning-tree"
 
 bd_designated_priority:
-  _exclude: [N3k, N5k, N6k, N9k]
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   multiple:
   get_context: ['/^spanning-tree pseudo-information$/']
   get_value: '/^bridge-domain (.*) designated priority (.*)$/'
@@ -15,40 +16,40 @@ bd_designated_priority:
   default_value: []
 
 bd_forward_time:
-  _exclude: [N3k, N5k, N6k, N9k]
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   multiple:
   get_value: '/^spanning-tree bridge-domain (.*) forward-time (.*)$/'
   set_value: "<state> spanning-tree bridge-domain <range> forward-time <val>"
   default_value: []
 
 bd_hello_time:
-  _exclude: [N3k, N5k, N6k, N9k]
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   multiple:
   get_value: '/^spanning-tree bridge-domain (.*) hello-time (.*)$/'
   set_value: "<state> spanning-tree bridge-domain <range> hello-time <val>"
   default_value: []
 
 bd_max_age:
-  _exclude: [N3k, N5k, N6k, N9k]
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   multiple:
   get_value: '/^spanning-tree bridge-domain (.*) max-age (.*)$/'
   set_value: "<state> spanning-tree bridge-domain <range> max-age <val>"
   default_value: []
 
 bd_priority:
-  _exclude: [N3k, N5k, N6k, N9k]
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   multiple:
   get_value: '/^spanning-tree bridge-domain (.*) priority (.*)$/'
   set_value: "<state> spanning-tree bridge-domain <range> priority <val>"
   default_value: []
 
 bd_range:
-  _exclude: [N3k, N5k, N6k, N9k]
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   kind: string
   default_only: "2-3967"
 
 bd_root_priority:
-  _exclude: [N3k, N5k, N6k, N9k]
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   multiple:
   get_context: ['/^spanning-tree pseudo-information$/']
   get_value: '/^bridge-domain (.*) root priority (.*)$/'
@@ -77,7 +78,7 @@ bridge_assurance:
   default_value: true
 
 domain:
-  _exclude: [N3k, N9k]
+  _exclude: [N3k, N8k, N9k]
   kind: int
   get_value: '/^spanning-tree domain (\d+)$/'
   set_value: "<state> spanning-tree domain <domain>"

--- a/lib/cisco_node_utils/cmd_ref/vdc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vdc.yaml
@@ -3,7 +3,7 @@
 # The current simplified implementation assumes no admin-vdc and that the
 # default vdc name uses id 1. Full multi-vdc support is TBD.
 ---
-_exclude: [N3k, N5k, N6k, N9k, ios_xr]
+_exclude: [N3k, N5k, N6k, N8k, N9k, ios_xr]
 
 _template:
   get_command: 'show run vdc all'

--- a/lib/cisco_node_utils/cmd_ref/vpc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vpc.yaml
@@ -2,12 +2,12 @@
 ---
 _exclude: [ios_xr]
 
-_template: 
+_template:
   get_command:  'show running-config vpc all'
   get_context:  ['/^vpc domain\s*(\d+)$/']
   set_context:  ['vpc domain <domain>']
 
-auto_recovery: 
+auto_recovery:
   kind: boolean
   _exclude: [N5k, N6k]
   auto_default: false
@@ -20,25 +20,25 @@ auto_recovery:
   else:
     default_value: true
 
-auto_recovery_reload_delay: 
+auto_recovery_reload_delay:
   kind: int
   get_value: '/^auto-recovery reload-delay (\d+)/'
   set_value: "auto-recovery reload-delay <delay>"
   default_value: 240
 
-delay_restore: 
+delay_restore:
   kind: int
   get_value: '/^delay restore\s+(\d+)/'
   set_value: "delay restore <delay>"
   default_value: 30
 
-delay_restore_interface_vlan: 
+delay_restore_interface_vlan:
   kind: int
   get_value: '/^delay restore interface-vlan\s+(\d+)/'
   set_value: "delay restore interface-vlan <delay>"
   default_value: 10
 
-domain: 
+domain:
   auto_default: false
   get_command: "show running-config vpc all"
   get_context: ~
@@ -47,7 +47,7 @@ domain:
   set_value: "<state> vpc domain <domain>"
   default_value: ''
 
-dual_active_exclude_interface_vlan_bridge_domain: 
+dual_active_exclude_interface_vlan_bridge_domain:
   kind: string
   N7k:
     get_value: '/^dual-active exclude interface-vlan-bridge-domain\s+(\S+)/'
@@ -58,7 +58,7 @@ dual_active_exclude_interface_vlan_bridge_domain:
   default_value: 'none'
 
 fabricpath_emulated_switch_id: 
-  _exclude: [N3k, N5k, N6k, N9k]
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   kind: int
   set_context:  ['terminal dont-ask', 'vpc domain <domain>']
   get_value: '/^fabricpath switch-id\s+(\d+)$/'
@@ -66,7 +66,7 @@ fabricpath_emulated_switch_id:
   default_value: false
 
 fabricpath_multicast_load_balance: 
-  _exclude: [N3k, N5k, N6k, N9k]
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   kind: boolean
   get_value: '/^fabricpath multicast load-balance$/'
   set_value: "<state> fabricpath multicast load-balance"
@@ -81,21 +81,21 @@ feature:
   set_value: "<state> feature vpc"
   default_value: false
 
-graceful_consistency_check: 
+graceful_consistency_check:
   auto_default: false
   kind: boolean
   get_value: '/^graceful consistency-check/'
   set_value: "<state> graceful consistency-check"
   default_value: true
 
-layer3_peer_routing: 
+layer3_peer_routing:
   kind: boolean
-  _exclude: [N3k, N5k, N9k]
+  _exclude: [N3k, N5k, N8k, N9k]
   get_value: '/^layer3 peer-router$/'
   set_value: "<state> layer3 peer-router"
   default_value: false
 
-peer_gateway: 
+peer_gateway:
   kind: boolean
   set_context:  ['terminal dont-ask', 'vpc domain <domain>']
   get_value: '/^peer-gateway/'
@@ -103,16 +103,16 @@ peer_gateway:
   default_value: false
 
 # Exclude everyone for now till the BD command is fully supported
-peer_gateway_exclude_bridge_domain: 
+peer_gateway_exclude_bridge_domain:
   kind: string
-  _exclude: [N3k, N5k, N6k, N7k, N9k]
+  _exclude: [N3k, N5k, N6k, N7k, N8k, N9k]
   set_context:  ['terminal dont-ask', 'vpc domain <domain>']
   get_value: '/^peer-gateway exclude bridge-domain\s+(\S+)/'
   set_value: "peer-gateway exclude-bridge-domain <range>"
   default_value: ''
 
-peer_gateway_exclude_vlan: 
-  _exclude: [N3k, N9k]
+peer_gateway_exclude_vlan:
+  _exclude: [N3k, N8k, N9k]
   kind: string
   set_context:  ['terminal dont-ask', 'vpc domain <domain>']
   get_value: '/^peer-gateway exclude-vlan\s(\S+)/'
@@ -124,34 +124,34 @@ peer_keepalive_dest:
   get_value:  '/^peer-keepalive destination (\S+)/'
   default_value: ''
 
-peer_keepalive_hold_timeout: 
+peer_keepalive_hold_timeout:
   kind: int
   get_value:  '/^peer-keepalive .*hold-timeout (\S+)/'
   default_value: 3
 
-peer_keepalive_interval: 
+peer_keepalive_interval:
   kind: int
   get_value:  '/^peer-keepalive .*interval (\S+)/'
   default_value: 1000
 
-peer_keepalive_precedence: 
+peer_keepalive_precedence:
   kind: int
   get_value:  '/^peer-keepalive .*precedence (\S+)/'
   default_value: 6
 
-peer_keepalive_set: 
+peer_keepalive_set:
   set_value:  "peer-keepalive destination <dest> source <src> udp-port <port_num> vrf <vrf> interval <interval> timeout <timeout> precedence <precedence> hold-timeout <hold_timeout>"
 
 peer_keepalive_src:
   get_value:  '/^peer-keepalive .*source (\S+)/'
   default_value: ''
 
-peer_keepalive_timeout: 
+peer_keepalive_timeout:
   kind: int
   get_value:  '/^peer-keepalive .* timeout (\S+)/'
   default_value: 5
 
-peer_keepalive_udp_port: 
+peer_keepalive_udp_port:
   kind: int
   get_value:  '/^peer-keepalive .*udp-port (\S+)/'
   default_value: 3200
@@ -160,30 +160,30 @@ peer_keepalive_vrf:
   get_value:  '/^peer-keepalive .*vrf (\S+)/'
   default_value: 'management'
 
-port_channel_limit: 
-  _exclude: [N3k, N5k, N6k, N9k]
+port_channel_limit:
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   auto_default: false
   kind: boolean    
   get_value: '/^port-channel limit/'
   set_value: "<state> port-channel limit"
   default_value: true
 
-role_priority: 
+role_priority:
   kind: int
   get_value: '/^role priority\s+(\d+)/'
   set_value: "role priority <priority>"
   default_value: 32667
 
-self_isolation: 
+self_isolation:
   kind: boolean
-  _exclude: [N5k, N6k, N9k]
+  _exclude: [N5k, N6k, N8k, N9k]
   get_value: '/^self-isolation/'
   set_value: "<state> self-isolation"
   default_value: false
 
-shutdown: 
+shutdown:
   kind: boolean
-  _exclude: [N3k, N9k]
+  _exclude: [N3k, N8k, N9k]
   get_value: '/^shutdown/'
   set_value: "<state> shutdown"
   default_value: false
@@ -194,16 +194,16 @@ system_mac:
   set_value: "<state> system-mac <mac_addr>"
   default_value: ''
 
-system_priority: 
+system_priority:
   kind: int
   get_value: '/^system-priority\s+(\d+)/'
   set_value: "system-priority <priority>"
   default_value: 32667
 
 # Exclude everyone for now till the track command is fully supported
-track: 
+track:
   kind: int
-  _exclude: [N3k, N5k, N6k, N7k, N9k]
+  _exclude: [N3k, N5k, N6k, N7k, N8k, N9k]
   get_value: '/^track\s+(\d+)/'
   set_value: "<state> track <val>"
   default_value: 0

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -399,7 +399,7 @@ module Cisco
         end
 
         feature_hash.each do |name, value|
-          fail "No entries under '#{name}' in '#{file}'" if value.nil?
+          debug "No entries under '#{name}' in '#{file}'" if value.nil?
           @hash[feature] ||= {}
           if value.empty?
             @hash[feature][name] = UnsupportedCmdRef.new(feature, name, file)
@@ -414,6 +414,11 @@ module Cisco
     def supports?(feature)
       value = @hash[feature]
       !(value.is_a?(UnsupportedCmdRef) || value.nil?)
+    end
+
+    def property_supported?(feature, property)
+      value = @hash[feature][property]
+      !value.is_a?(UnsupportedCmdRef)
     end
 
     # Get the command reference

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -411,14 +411,10 @@ module Cisco
       end
     end
 
-    def supports?(feature)
+    def supports?(feature, property=nil)
       value = @hash[feature]
+      value = value[property] if value && property
       !(value.is_a?(UnsupportedCmdRef) || value.nil?)
-    end
-
-    def property_supported?(feature, property)
-      value = @hash[feature][property]
-      !value.is_a?(UnsupportedCmdRef)
     end
 
     # Get the command reference

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -399,7 +399,7 @@ module Cisco
         end
 
         feature_hash.each do |name, value|
-          debug "No entries under '#{name}' in '#{file}'" if value.nil?
+          fail "No entries under '#{name}' in '#{file}'" if value.nil?
           @hash[feature] ||= {}
           if value.empty?
             @hash[feature][name] = UnsupportedCmdRef.new(feature, name, file)

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -137,6 +137,10 @@ class CiscoTestCase < TestCase
     flunk(message)
   end
 
+  def validate_property_excluded?(feature, property)
+    !node.cmd_ref.property_supported?(feature, property)
+  end
+
   def interfaces
     unless @@interfaces
       # Build the platform_info, used for interface lookup

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -138,7 +138,7 @@ class CiscoTestCase < TestCase
   end
 
   def validate_property_excluded?(feature, property)
-    !node.cmd_ref.property_supported?(feature, property)
+    !node.cmd_ref.supports?(feature, property)
   end
 
   def interfaces

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -170,7 +170,7 @@ class TestFeature < CiscoTestCase
   #####################
 
   def test_feature_set_fabric
-    if node.product_id[/N(3|9)/]
+    if node.product_id[/N(3|8|9)/]
       assert_nil(Feature.fabric_enabled?)
       assert_raises(Cisco::UnsupportedError) { Feature.fabric_enable }
       return

--- a/tests/test_portchannel_global.rb
+++ b/tests/test_portchannel_global.rb
@@ -24,15 +24,15 @@ class TestPortchannelGlobal < CiscoTestCase
 
   def setup
     super
-    config 'no port-channel load-balance' unless n6k_platform?
+    config 'no port-channel load-balance' unless /N(5|6)/ =~ node.product_id
     config 'no port-channel load-balance ethernet' unless
-    n9k_platform? || n7k_platform?
+      /N(3|7|8|9)/ =~ node.product_id
   end
 
   def teardown
-    config 'no port-channel load-balance' unless n6k_platform?
+    config 'no port-channel load-balance' unless /N(5|6)/ =~ node.product_id
     config 'no port-channel load-balance ethernet' unless
-    n9k_platform? || n7k_platform?
+      /N(3|7|8|9)/ =~ node.product_id
     super
   end
 
@@ -45,159 +45,170 @@ class TestPortchannelGlobal < CiscoTestCase
     mode[Regexp.union(patterns)] ? true : false
   end
 
-  def n7k_platform?
-    /N7/ =~ node.product_id
-  end
-
-  def n9k_platform?
-    /N(3|9)/ =~ node.product_id
-  end
-
-  def n6k_platform?
-    /N(5|6)/ =~ node.product_id
-  end
-
   def create_portchannel_global(name=DEFAULT_NAME)
     PortChannelGlobal.new(name)
   end
 
   def test_get_hash_distribution
-    skip('Platform does not support this property') if n6k_platform? ||
-                                                       n9k_platform?
-    @global = create_portchannel_global
-    @global.hash_distribution = 'fixed'
-    assert_equal('fixed', @global.hash_distribution)
-    @global.hash_distribution =
-      @global.default_hash_distribution
-    assert_equal(@global.default_hash_distribution,
-                 @global.hash_distribution)
+    global = create_portchannel_global
+    if validate_property_excluded?('portchannel_global', 'hash_distribution')
+      assert_raises(Cisco::UnsupportedError) do
+        global.hash_distribution = 'fixed'
+      end
+      assert_nil(global.hash_distribution)
+    else
+      global.hash_distribution = 'fixed'
+      assert_equal('fixed', global.hash_distribution)
+      global.hash_distribution =
+        global.default_hash_distribution
+      assert_equal(global.default_hash_distribution,
+                   global.hash_distribution)
+    end
   end
 
   def test_get_set_load_defer
-    skip('Platform does not support this property') if n6k_platform? ||
-                                                       n9k_platform?
-    @global = create_portchannel_global
-    @global.load_defer = 1000
-    assert_equal(1000, @global.load_defer)
-    @global.load_defer =
-      @global.default_load_defer
-    assert_equal(@global.default_load_defer,
-                 @global.load_defer)
+    global = create_portchannel_global
+    if validate_property_excluded?('portchannel_global', 'load_defer')
+      assert_raises(Cisco::UnsupportedError) do
+        global.load_defer = 1000
+      end
+      assert_nil(global.load_defer)
+    else
+      global.load_defer = 1000
+      assert_equal(1000, global.load_defer)
+      global.load_defer =
+        global.default_load_defer
+      assert_equal(global.default_load_defer,
+                   global.load_defer)
+    end
   end
 
   def test_get_set_resilient
-    skip('Platform does not support this property') if n6k_platform? ||
-                                                       n7k_platform?
-    @global = create_portchannel_global
-    @global.resilient = true
-    assert_equal(true, @global.resilient)
-    @global.resilient = @global.default_resilient
-    assert_equal(@global.default_resilient, @global.resilient)
+    global = create_portchannel_global
+    if validate_property_excluded?('portchannel_global', 'resilient')
+      assert_raises(Cisco::UnsupportedError) do
+        global.resilient = true
+      end
+      assert_nil(global.resilient)
+    else
+      global = create_portchannel_global
+      global.resilient = true
+      assert_equal(true, global.resilient)
+      global.resilient = global.default_resilient
+      assert_equal(global.default_resilient, global.resilient)
+    end
   end
 
   def test_get_set_port_channel_load_balance_sym_concat_rot
-    skip('Platform does not support this property') if
-      n6k_platform? || n7k_platform? || n3k_in_n3k_mode?
-    @global = create_portchannel_global
-    @global.send(:port_channel_load_balance=,
-                 'src-dst', 'ip-l4port', nil, nil, true, true, 4)
+    # rubocop:disable Style/MultilineOperationIndentation
+    skip('Test not supported on this platform') if n3k_in_n3k_mode? ||
+      validate_property_excluded?('portchannel_global', 'symmetry')
+    # rubocop:enable Style/MultilineOperationIndentation
+
+    global = create_portchannel_global
+    global.send(:port_channel_load_balance=,
+                'src-dst', 'ip-l4port', nil, nil, true, true, 4)
     assert_equal('src-dst',
-                 @global.bundle_select)
+                 global.bundle_select)
     assert_equal('ip-l4port',
-                 @global.bundle_hash)
-    assert_equal(true, @global.symmetry)
-    assert_equal(true, @global.concatenation)
-    assert_equal(4, @global.rotate)
-    @global.send(
+                 global.bundle_hash)
+    assert_equal(true, global.symmetry)
+    assert_equal(true, global.concatenation)
+    assert_equal(4, global.rotate)
+    global.send(
       :port_channel_load_balance=,
-      @global.default_bundle_select,
-      @global.default_bundle_hash,
+      global.default_bundle_select,
+      global.default_bundle_hash,
       nil,
       nil,
-      @global.default_symmetry,
-      @global.default_concatenation,
-      @global.default_rotate)
+      global.default_symmetry,
+      global.default_concatenation,
+      global.default_rotate)
     assert_equal(
-      @global.default_bundle_select,
-      @global.bundle_select)
+      global.default_bundle_select,
+      global.bundle_select)
     assert_equal(
-      @global.default_bundle_hash,
-      @global.bundle_hash)
+      global.default_bundle_hash,
+      global.bundle_hash)
     assert_equal(
-      @global.default_symmetry,
-      @global.symmetry)
+      global.default_symmetry,
+      global.symmetry)
     assert_equal(
-      @global.default_concatenation,
-      @global.concatenation)
-    assert_equal(@global.default_rotate,
-                 @global.rotate)
+      global.default_concatenation,
+      global.concatenation)
+    assert_equal(global.default_rotate,
+                 global.rotate)
   end
 
   def test_get_set_port_channel_load_balance_hash_poly
-    skip('Platform does not support this property') if n7k_platform? ||
-                                                       n9k_platform?
-    @global = create_portchannel_global
-    @global.send(:port_channel_load_balance=,
-                 'src-dst', 'ip-only', 'CRC10c', nil, nil, nil, nil)
-    assert_equal('src-dst',
-                 @global.bundle_select)
-    assert_equal('ip-only',
-                 @global.bundle_hash)
-    assert_equal('CRC10c', @global.hash_poly)
-    @global.send(:port_channel_load_balance=,
-                 'dst', 'mac', 'CRC10a', nil, nil, nil, nil)
-    assert_equal('dst',
-                 @global.bundle_select)
-    assert_equal('mac',
-                 @global.bundle_hash)
-    assert_equal('CRC10a', @global.hash_poly)
-    @global.send(
-      :port_channel_load_balance=,
-      @global.default_bundle_select,
-      @global.default_bundle_hash,
-      'CRC10b',
-      nil, nil, nil, nil)
-    assert_equal(
-      @global.default_bundle_select,
-      @global.bundle_select)
-    assert_equal(
-      @global.default_bundle_hash,
-      @global.bundle_hash)
-    assert_equal('CRC10b',
-                 @global.hash_poly)
+    global = create_portchannel_global
+    if validate_property_excluded?('portchannel_global', 'hash_poly')
+      skip('Test not supported on this platform')
+    else
+      global.send(:port_channel_load_balance=,
+                  'src-dst', 'ip-only', 'CRC10c', nil, nil, nil, nil)
+      assert_equal('src-dst',
+                   global.bundle_select)
+      assert_equal('ip-only',
+                   global.bundle_hash)
+      assert_equal('CRC10c', global.hash_poly)
+      global.send(:port_channel_load_balance=,
+                  'dst', 'mac', 'CRC10a', nil, nil, nil, nil)
+      assert_equal('dst',
+                   global.bundle_select)
+      assert_equal('mac',
+                   global.bundle_hash)
+      assert_equal('CRC10a', global.hash_poly)
+      global.send(
+        :port_channel_load_balance=,
+        global.default_bundle_select,
+        global.default_bundle_hash,
+        'CRC10b',
+        nil, nil, nil, nil)
+      assert_equal(
+        global.default_bundle_select,
+        global.bundle_select)
+      assert_equal(
+        global.default_bundle_hash,
+        global.bundle_hash)
+      assert_equal('CRC10b',
+                   global.hash_poly)
+    end
   end
 
   def test_get_set_port_channel_load_balance_asym_rot
-    skip('Platform does not support this property') if n6k_platform? ||
-                                                       n9k_platform?
-    @global = create_portchannel_global
-    @global.send(:port_channel_load_balance=,
-                 'src-dst', 'ip-vlan', nil, true, nil, nil, 4)
-    assert_equal('src-dst',
-                 @global.bundle_select)
-    assert_equal('ip-vlan',
-                 @global.bundle_hash)
-    assert_equal(true, @global.asymmetric)
-    assert_equal(4, @global.rotate)
-    @global.send(
-      :port_channel_load_balance=,
-      @global.default_bundle_select,
-      @global.default_bundle_hash,
-      nil,
-      @global.default_asymmetric,
-      nil,
-      nil,
-      @global.default_rotate)
-    assert_equal(
-      @global.default_bundle_select,
-      @global.bundle_select)
-    assert_equal(
-      @global.default_bundle_hash,
-      @global.bundle_hash)
-    assert_equal(
-      @global.default_asymmetric,
-      @global.asymmetric)
-    assert_equal(@global.default_rotate,
-                 @global.rotate)
+    global = create_portchannel_global
+    if validate_property_excluded?('portchannel_global', 'asymmetric')
+      skip('Test not supported on this platform')
+    else
+      global.send(:port_channel_load_balance=,
+                  'src-dst', 'ip-vlan', nil, true, nil, nil, 4)
+      assert_equal('src-dst',
+                   global.bundle_select)
+      assert_equal('ip-vlan',
+                   global.bundle_hash)
+      assert_equal(true, global.asymmetric)
+      assert_equal(4, global.rotate)
+      global.send(
+        :port_channel_load_balance=,
+        global.default_bundle_select,
+        global.default_bundle_hash,
+        nil,
+        global.default_asymmetric,
+        nil,
+        nil,
+        global.default_rotate)
+      assert_equal(
+        global.default_bundle_select,
+        global.bundle_select)
+      assert_equal(
+        global.default_bundle_hash,
+        global.bundle_hash)
+      assert_equal(
+        global.default_asymmetric,
+        global.asymmetric)
+      assert_equal(global.default_rotate,
+                   global.rotate)
+    end
   end
 end


### PR DESCRIPTION
- Adds N8k where appropriate to the feature yaml `_exclude` list.
- Adds a new method `validate_property_excluded?` that uses the `_exclude` entry as the single source of truth when testing for `nil` and `Cisco::UnsupportedError`.
- Re-ordering of the platforms in `_exclude` in numerical order.

**MiniTests**
- N8k

```
# Running:


Node under test:
  - name  - n9k-157
  - type  - N85-C8508
  - image - bootflash:///n8500-dk9.7.0.3.F1.0.212.bin

TestPortchannelGlobal#test_get_set_resilient = 181.41 s = .
TestPortchannelGlobal#test_get_set_load_defer = 1.50 s = .
TestPortchannelGlobal#test_get_hash_distribution = 1.48 s = .
TestPortchannelGlobal#test_get_set_port_channel_load_balance_hash_poly = 1.46 s = S
TestPortchannelGlobal#test_get_set_port_channel_load_balance_sym_concat_rot = 123.14 s = .
TestPortchannelGlobal#test_get_set_port_channel_load_balance_asym_rot = 1.49 s = S

Finished in 311.791594s, 0.0192 runs/s, 0.0513 assertions/s.

  1) Skipped:
TestPortchannelGlobal#test_get_set_port_channel_load_balance_hash_poly [tests/test_portchannel_global.rb:146]:
Test not supported on this platform


  2) Skipped:
TestPortchannelGlobal#test_get_set_port_channel_load_balance_asym_rot [tests/test_portchannel_global.rb:182]:
Test not supported on this platform

6 runs, 16 assertions, 0 failures, 0 errors, 2 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils/coverage. 1008 / 1949 LOC (51.72%) covered.
```
- N9k

```
Run options: -v -- --seed 42921

# Running:


Node under test:
  - name  - dt-n9k5-1
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I3.1.bin

TestPortchannelGlobal#test_get_set_load_defer = 0.93 s = .
TestPortchannelGlobal#test_get_set_port_channel_load_balance_hash_poly = 0.89 s = S
TestPortchannelGlobal#test_get_set_port_channel_load_balance_sym_concat_rot = 1.61 s = .
TestPortchannelGlobal#test_get_set_resilient = 1.62 s = .
TestPortchannelGlobal#test_get_set_port_channel_load_balance_asym_rot = 0.95 s = S
TestPortchannelGlobal#test_get_hash_distribution = 0.98 s = .

Finished in 8.116998s, 0.7392 runs/s, 1.9712 assertions/s.

  1) Skipped:
TestPortchannelGlobal#test_get_set_port_channel_load_balance_hash_poly [tests/test_portchannel_global.rb:146]:
Test not supported on this platform


  2) Skipped:
TestPortchannelGlobal#test_get_set_port_channel_load_balance_asym_rot [tests/test_portchannel_global.rb:182]:
Test not supported on this platform

6 runs, 16 assertions, 0 failures, 0 errors, 2 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils/coverage. 1018 / 1949 LOC (52.23%) covered.

Node under test:
  - name  - agent-lab10-nx
  - type  - N9K-NXOSV
  - image - bootflash:///nxos.7.0.3.I2.1.bin

TestPortchannelGlobal#test_get_set_port_channel_load_balance_asym_rot = 1.01 s = S
TestPortchannelGlobal#test_get_set_port_channel_load_balance_sym_concat_rot = 7.10 s = .
TestPortchannelGlobal#test_get_set_port_channel_load_balance_hash_poly = 1.14 s = S
TestPortchannelGlobal#test_get_hash_distribution = 1.15 s = .
TestPortchannelGlobal#test_get_set_load_defer = 1.14 s = .
TestPortchannelGlobal#test_get_set_resilient = 1.92 s = .

Finished in 14.604323s, 0.4108 runs/s, 1.0956 assertions/s.

  1) Skipped:
TestPortchannelGlobal#test_get_set_port_channel_load_balance_asym_rot [tests/test_portchannel_global.rb:182]:
Test not supported on this platform


  2) Skipped:
TestPortchannelGlobal#test_get_set_port_channel_load_balance_hash_poly [tests/test_portchannel_global.rb:146]:
Test not supported on this platform

6 runs, 16 assertions, 0 failures, 0 errors, 2 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils/coverage. 1018 / 1949 LOC (52.23%) covered.
```
- N7k

```
Node under test:
  - name  - n7k-j
  - type  - N7K-C7009
  - image - bootflash:///n7000-s2-dk9.7.3.0.D1.0.202.bin

TestPortchannelGlobal#test_get_hash_distribution = 3.20 s = .
TestPortchannelGlobal#test_get_set_port_channel_load_balance_hash_poly = 1.71 s = S
TestPortchannelGlobal#test_get_set_port_channel_load_balance_asym_rot = 3.07 s = .
TestPortchannelGlobal#test_get_set_resilient = 1.66 s = .
TestPortchannelGlobal#test_get_set_load_defer = 3.06 s = .
TestPortchannelGlobal#test_get_set_port_channel_load_balance_sym_concat_rot = 1.73 s = S

Finished in 16.003528s, 0.3749 runs/s, 0.8748 assertions/s.

  1) Skipped:
TestPortchannelGlobal#test_get_set_port_channel_load_balance_hash_poly [tests/test_portchannel_global.rb:146]:
Test not supported on this platform


  2) Skipped:
TestPortchannelGlobal#test_get_set_port_channel_load_balance_sym_concat_rot [tests/test_portchannel_global.rb:104]:
Test not supported on this platform

6 runs, 14 assertions, 0 failures, 0 errors, 2 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils/coverage. 1006 / 1949 LOC (51.62%) covered.
```
- N6k

```
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils> ruby tests/test_portchannel_global.rb -v -- n6k-92 admin admin
Run options: -v -- --seed 48932

# Running:


Node under test:
  - name  - n6k-92
  - type  - N6K-C6001-64P
  - image - bootflash:///n6000-uk9-kickstart.7.3.0.N1.1.bin

TestPortchannelGlobal#test_get_set_port_channel_load_balance_asym_rot = 1.31 s = S
TestPortchannelGlobal#test_get_set_load_defer = 1.60 s = .
TestPortchannelGlobal#test_get_set_port_channel_load_balance_hash_poly = 4.27 s = .
TestPortchannelGlobal#test_get_set_resilient = 1.61 s = .
TestPortchannelGlobal#test_get_set_port_channel_load_balance_sym_concat_rot = 1.60 s = S
TestPortchannelGlobal#test_get_hash_distribution = 1.60 s = .

Finished in 14.824136s, 0.4047 runs/s, 1.0119 assertions/s.

  1) Skipped:
TestPortchannelGlobal#test_get_set_port_channel_load_balance_asym_rot [tests/test_portchannel_global.rb:182]:
Test not supported on this platform


  2) Skipped:
TestPortchannelGlobal#test_get_set_port_channel_load_balance_sym_concat_rot [tests/test_portchannel_global.rb:104]:
Test not supported on this platform

6 runs, 15 assertions, 0 failures, 0 errors, 2 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils/coverage. 1006 / 1949 LOC (51.62%) covered.
```
