### PR TITLE
Add hook - whitespace check for non-Ruby files

### DIFF
--- a/bin/git/hooks/pre-commit/validate-diffs
+++ b/bin/git/hooks/pre-commit/validate-diffs
@@ -17,6 +17,7 @@ else
     against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
 
+step_name 'Checking for non-ASCII filenames'
 # We exploit the fact that the printable range starts at the space character
 # and ends with tilde.
 # Note that the use of brackets around a tr range is ok here, (it's
@@ -25,3 +26,12 @@ fi
 git diff --cached --name-only --diff-filter=A -z $against |
         LC_ALL=C tr -d '[ -~]\0' | wc -c
 check_rc "Rename non-ASCII file name(s) before committing"
+
+step_name 'Checking for trailing whitespace'
+# If there are whitespace errors, print the offending file names and fail.
+# We only check YAML/MD files, as whitespace in .rb files is managed by Rubocop
+non_ruby_files=`git diff --staged --name-only | grep -v \.rb`
+if [ -n "$non_ruby_files" ]; then
+  ! git grep -n ' $' -- $non_ruby_files
+  check_rc "Fix trailing whitespace before committing"
+fi

--- a/bin/git/hooks/pre-commit/validate-diffs
+++ b/bin/git/hooks/pre-commit/validate-diffs
@@ -27,10 +27,11 @@ git diff --cached --name-only --diff-filter=A -z $against |
         LC_ALL=C tr -d '[ -~]\0' | wc -c
 check_rc "Rename non-ASCII file name(s) before committing"
 
-step_name 'Checking for trailing whitespace'
+step_name 'Checking for trailing whitespace in non-Ruby files'
 # If there are whitespace errors, print the offending file names and fail.
-# We only check YAML/MD files, as whitespace in .rb files is managed by Rubocop
-non_ruby_files=`git diff --staged --name-only | grep -v \.rb`
+# Ignore .rb files, as whitespace in these files is managed by Rubocop
+# Ignore .proto files, as they are generated code
+non_ruby_files=`git diff --staged --name-only | grep -v \.rb | grep -v \.proto`
 if [ -n "$non_ruby_files" ]; then
   ! git grep -n -I ' $' -- $non_ruby_files
   check_rc "Fix trailing whitespace before committing"

--- a/bin/git/hooks/pre-commit/validate-diffs
+++ b/bin/git/hooks/pre-commit/validate-diffs
@@ -33,6 +33,6 @@ step_name 'Checking for trailing whitespace in non-Ruby files'
 # Ignore .proto files, as they are generated code
 non_ruby_files=`git diff --staged --name-only | grep -v \.rb | grep -v \.proto`
 if [ -n "$non_ruby_files" ]; then
-  ! git grep -n -I ' $' -- $non_ruby_files
+  ! git grep -n -I '\s$' -- $non_ruby_files
   check_rc "Fix trailing whitespace before committing"
 fi

--- a/bin/git/hooks/pre-commit/validate-diffs
+++ b/bin/git/hooks/pre-commit/validate-diffs
@@ -32,6 +32,6 @@ step_name 'Checking for trailing whitespace'
 # We only check YAML/MD files, as whitespace in .rb files is managed by Rubocop
 non_ruby_files=`git diff --staged --name-only | grep -v \.rb`
 if [ -n "$non_ruby_files" ]; then
-  ! git grep -n ' $' -- $non_ruby_files
+  ! git grep -n -I ' $' -- $non_ruby_files
   check_rc "Fix trailing whitespace before committing"
 fi


### PR DESCRIPTION
Adds a trailing whitespace check in the git pre-commit-validate-diffs hook. Whitespace in ruby files is managed by rubocop, so this check explicitly excludes .rb files and only covers other staged files (yaml, md).

Example:

```
glmatthe@fe-ucs36:~/cisco-network-node-utils$ git status
On branch develop
Your branch is up-to-date with 'origin/develop'.
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

        modified:   bin/git/hooks/pre-commit/validate-diffs
        modified:   lib/cisco_node_utils/cmd_ref/acl.yaml
glmatthe@fe-ucs36:~/cisco-network-node-utils$ git commit -m 'Test whitespace change'
*** Running Git hook script: pre-commit-check_unstaged_changes...
        ...[ OK ]
*** Running Git hook script: pre-commit-rubocop...
        Running RuboCop lint checks
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2.4-compliant syntax, but you are running 2.2.3.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
        ...[ OK ]
*** Running Git hook script: pre-commit-validate-diffs...
        Checking for non-ASCII filenames
0
        Checking for trailing whitespace
lib/cisco_node_utils/cmd_ref/acl.yaml:27:                      
lib/cisco_node_utils/cmd_ref/acl.yaml:31:   
        ...[ FAIL ] Fix trailing whitespace before committing
```
