### PR TITLE
Add spec checking whitespace in non-Ruby files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Changelog
   * `stp_bpdufilter`, `stp_bpduguard`, `stp_cost`, `stp_guard`, `stp_link_type`, `stp_mst_cost`
   * `stp_mst_port_priority`, `stp_port_priority`, `stp_port_type`, `stp_vlan_cost`, `stp_vlan_port_priority`
 * Extend vpc with vpc+ attributes on Nexus 5k/6k/7k:
-  * `fabricpath_emulated_switch_id` 
+  * `fabricpath_emulated_switch_id`
   * `fabricpath_multicast_load_balance` (only on Nexus 7k)
   * `port_channel_limit` (only on Nexus 7k)
 

--- a/Rakefile
+++ b/Rakefile
@@ -26,12 +26,16 @@ end
 RSpec::Core::RakeTask.new(:spec_yaml) do |t|
   t.pattern = 'spec/yaml_spec.rb'
 end
+RSpec::Core::RakeTask.new(:spec_whitespace) do |t|
+  t.pattern = 'spec/whitespace_spec.rb'
+end
 
 task spec: [:spec_no_clients,
             :spec_nxapi_only,
             :spec_grpc_only,
             :spec_all_clients,
             :spec_yaml,
+            :spec_whitespace,
            ]
 
 task :build do

--- a/docs/README-develop-best-practices.md
+++ b/docs/README-develop-best-practices.md
@@ -462,8 +462,7 @@ The more specific assertions also produce more helpful failure messages if somet
 
 ### <a name="mt3">MT3: Do not hardcode interface names.
 
-Rather then hardcode an interface name that may or may not exist, instead use 
-the `interfaces[]` array.
+Rather then hardcode an interface name that may or may not exist, instead use the `interfaces[]` array.
 
 ```ruby
 def create_interface(ifname=interfaces[0])

--- a/docs/README-develop-node-utils-APIs.md
+++ b/docs/README-develop-node-utils-APIs.md
@@ -182,7 +182,7 @@ feature:
 maximum_paths:
   # This is an integer property
   kind: int
-  context: 
+  context:
     - 'router eigrp <name>'
   get_command: 'show running eigrp all'
   get_value: 'maximum-paths (\d+)'

--- a/docs/README-maintainers.md
+++ b/docs/README-maintainers.md
@@ -75,15 +75,15 @@ When the release checklist above has been fully completed, the process for publi
     ```diff
      Changelog
      =========
- 
+
     -(unreleased)
     -------------
     +1.0.1
     +-----
     ```
-    
+
     and also update `version.rb`:
-    
+
     ```diff
     -  VERSION = '1.0.0'
     +  VERSION = '1.0.1'

--- a/lib/cisco_node_utils/cmd_ref/bridge_domain.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bridge_domain.yaml
@@ -20,13 +20,13 @@ fabric_control:
   get_value: '/^Configured fabric-control.*:\s+(\d+)/'
   set_context: ["bridge-domain <bd>"]
   set_value: "<state> fabric-control"
-  default_value: false 
+  default_value: false
 
 # For the below member_vni, name, shutdown commands we are going to use show
 # bridge-domain cli as show running-config bridge-domain cli is very difficult
 # to parse for n7k platform. Also this feature is present only in n7k
 # show bridge-domain cli looks like:
-# 
+#
 # Bridge-domain 100  (0 ports in all)
 # Name:: Bridge-Domain100
 #  Administrative State: UP               Operational State: DOWN
@@ -35,7 +35,7 @@ member_vni:
   get_command: "show running-config bridge-domain | inc 'member vni'"
   get_value: '/^  member vni (.*)/'
   set_value: "<vnistate> vni <vni> ; bridge-domain <bd> ; <membstate> member vni <membvni>"
-  default_value: '' 
+  default_value: ''
 
 member_vni_bd:
   get_command: "show running-config bridge-domain | inc 'member vni' prev 1"

--- a/lib/cisco_node_utils/cmd_ref/encapsulation.yaml
+++ b/lib/cisco_node_utils/cmd_ref/encapsulation.yaml
@@ -22,4 +22,4 @@ dot1q_map:
   get_value: '/^.* vni <profile>\s+dot1q ([\d\s,-]+) vni ([\d\s,-]+)$/'
   set_context: ['encapsulation profile vni <profile>']
   set_value: '<state> dot1q <vlans> vni <vnis>'
-  default_value: ~ 
+  default_value: ~

--- a/lib/cisco_node_utils/cmd_ref/show_version.yaml
+++ b/lib/cisco_node_utils/cmd_ref/show_version.yaml
@@ -59,7 +59,7 @@ system_image:
   nexus:
     get_value: "kick_file_name"
   ios_xr:
-    get_value: '/IOS XR.*Version (.*)$/' 
+    get_value: '/IOS XR.*Version (.*)$/'
   N7k:
     get_value: "isan_file_name"
 

--- a/lib/cisco_node_utils/cmd_ref/vpc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vpc.yaml
@@ -57,7 +57,7 @@ dual_active_exclude_interface_vlan_bridge_domain:
     set_value: "<state> dual-active exclude interface-vlan <range>"
   default_value: 'none'
 
-fabricpath_emulated_switch_id: 
+fabricpath_emulated_switch_id:
   _exclude: [N3k, N5k, N6k, N8k, N9k]
   kind: int
   set_context:  ['terminal dont-ask', 'vpc domain <domain>']
@@ -65,14 +65,14 @@ fabricpath_emulated_switch_id:
   set_value: '<state> fabricpath switch-id <swid>'
   default_value: false
 
-fabricpath_multicast_load_balance: 
+fabricpath_multicast_load_balance:
   _exclude: [N3k, N5k, N6k, N8k, N9k]
   kind: boolean
   get_value: '/^fabricpath multicast load-balance$/'
   set_value: "<state> fabricpath multicast load-balance"
   default_value: false
 
-feature: 
+feature:
   kind: boolean
   get_command: "show feature | section vpc"
   get_context: ~
@@ -163,7 +163,7 @@ peer_keepalive_vrf:
 port_channel_limit:
   _exclude: [N3k, N5k, N6k, N8k, N9k]
   auto_default: false
-  kind: boolean    
+  kind: boolean
   get_value: '/^port-channel limit/'
   set_value: "<state> port-channel limit"
   default_value: true

--- a/spec/whitespace_spec.rb
+++ b/spec/whitespace_spec.rb
@@ -1,8 +1,9 @@
 require_relative 'spec_helper.rb'
 
-# Whitespace in ruby files is managed by Rubocop
 context 'non-ruby files' do
-  failures = `git grep -n -I ' $' | grep -v .rb`
+  # Whitespace in ruby files is managed by Rubocop.
+  # Ignore ems.proto as it's a generated file.
+  failures = `git grep -n -I ' $' | grep -v .rb | grep -v ems.proto`
   it 'should have no trailing whitespace' do
     expect(failures).to be_empty, -> { failures }
   end

--- a/spec/whitespace_spec.rb
+++ b/spec/whitespace_spec.rb
@@ -3,7 +3,7 @@ require_relative 'spec_helper.rb'
 context 'non-ruby files' do
   # Whitespace in ruby files is managed by Rubocop.
   # Ignore ems.proto as it's a generated file.
-  failures = `git grep -n -I ' $' | grep -v .rb | grep -v ems.proto`
+  failures = `git grep -n -I '\s$' | grep -v .rb | grep -v ems.proto`
   it 'should have no trailing whitespace' do
     expect(failures).to be_empty, -> { failures }
   end

--- a/spec/whitespace_spec.rb
+++ b/spec/whitespace_spec.rb
@@ -1,0 +1,9 @@
+require_relative 'spec_helper.rb'
+
+# Whitespace in ruby files is managed by Rubocop
+context 'non-ruby files' do
+  failures = `git grep -n -I ' $' | grep -v .rb`
+  it 'should have no trailing whitespace' do
+    expect(failures).to be_empty, -> { failures }
+  end
+end

--- a/tests/cmd_config_invalid.yaml
+++ b/tests/cmd_config_invalid.yaml
@@ -6,7 +6,7 @@ feature-global_bad_syntax:
 
 
 feature-nested_bad_syntax:
-  command: > 
+  command: >
           interface loopback0
             descrion testloopback
 


### PR DESCRIPTION
Counterpart to #280 - add a Rake task to check for whitespace, so that we get validation in Travis-CI as well. This will show a lot of failures - #279 is fixing a number of them but there may be a number left over still.
