### PR TITLE
Exclude N8k for vpc test - Not Supported

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vpc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vpc.yaml
@@ -1,6 +1,6 @@
 # vpc
 ---
-_exclude: [ios_xr]
+_exclude: [ios_xr, N8k]
 
 _template:
   get_command:  'show running-config vpc all'


### PR DESCRIPTION
Feature vpc is not supported on n8k in fretta_camden.

```
Node under test:
  - name  - n9k-157
  - type  - N85-C8508
  - image - bootflash:///n8500-dk9.7.0.3.F1.0.212.bin

TestVpc#all_skipped = 1.18 s = S

Finished in 2.503110s, 0.3995 runs/s, 0.0000 assertions/s.

  1) Skipped:
TestVpc#all_skipped [/nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils/tests/ciscotest.rb:54]:
Skipping TestVpc; feature 'vpc' is unsupported on this node

1 runs, 0 assertions, 0 failures, 0 errors, 1 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils/coverage. 1025 / 2259 LOC (45.37%) covered.
```
