### PR TITLE
Remove vni object references

### DIFF
--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -14,7 +14,6 @@
 
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/vrf'
-require_relative '../lib/cisco_node_utils/vni'
 
 include Cisco
 
@@ -108,7 +107,6 @@ class TestVrf < CiscoTestCase
   end
 
   def test_vni
-    skip('Platform does not support MT-lite') unless Vni.mt_lite_support
     vrf = Vrf.new('test_vni')
     vrf.vni = 4096
     assert_equal(4096, vrf.vni,


### PR DESCRIPTION
The vni.rb object was removed in https://github.com/cisco/cisco-network-node-utils/pull/254 but this reference was missed.

```
Node under test:
  - name  - n9k-157
  - type  - N85-C8508
  - image - bootflash:///n8500-dk9.7.0.3.F1.0.212.bin

TestVrf#test_description = 4.72 s = .
TestVrf#test_create_and_destroy = 2.19 s = .
TestVrf#test_vni = 1.91 s = S
TestVrf#test_shutdown = 3.69 s = .
TestVrf#test_name_type_invalid = 1.21 s = .
TestVrf#test_collection_default = 1.19 s = .
TestVrf#test_name_too_long = 1.64 s = .
TestVrf#test_route_distinguisher = 5.32 s = .
TestVrf#test_name_zero_length = 1.65 s = .

Finished in 23.539854s, 0.3823 runs/s, 0.8071 assertions/s.

  1) Skipped:
TestVrf#test_vni [/nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils/tests/ciscotest.rb:135]:
Skip test: Feature is unsupported on this device

9 runs, 19 assertions, 0 failures, 0 errors, 1 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils/coverage. 994 / 1753 LOC (56.7%) covered.


Node under test:
  - name  - dt-n9k5-1
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I3.1.bin

TestVrf#test_collection_default = 2.33 s = .
TestVrf#test_name_too_long = 0.98 s = .
TestVrf#test_vni = 2.07 s = .
TestVrf#test_route_distinguisher = 3.91 s = .
TestVrf#test_name_type_invalid = 0.67 s = .
TestVrf#test_create_and_destroy = 1.36 s = .
TestVrf#test_description = 1.67 s = .
TestVrf#test_shutdown = 2.35 s = .
TestVrf#test_name_zero_length = 1.02 s = .

Finished in 16.365948s, 0.5499 runs/s, 1.2832 assertions/s.

9 runs, 21 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils/coverage. 990 / 1753 LOC (56.47%) covered.

hih
```
