### PR TITLE
Fix broken reference to pim feature

### DIFF
--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -379,7 +379,7 @@ module Cisco
 
     def ipv4_pim_sparse_mode=(state)
       check_switchport_disabled
-      Feature.pim_enable unless platform == :ios_xr || Feature.pim_enabled?
+      Feature.pim_enable unless platform == :ios_xr
       config_set('interface', 'ipv4_pim_sparse_mode',
                  name: @name, state: state ? '' : 'no')
     end

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -379,7 +379,7 @@ module Cisco
 
     def ipv4_pim_sparse_mode=(state)
       check_switchport_disabled
-      Pim.feature_enable unless platform == :ios_xr || Pim.feature_enabled
+      Feature.pim_enable unless platform == :ios_xr || Feature.pim_enabled?
       config_set('interface', 'ipv4_pim_sparse_mode',
                  name: @name, state: state ? '' : 'no')
     end

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -859,7 +859,7 @@ class TestInterface < CiscoTestCase
         config("ipv4 access-list #{acl_name} 1 permit any")
       end
     end
-    interface_ethernet_default(interfaces[0])
+    interface_ethernet_default(interfaces_id[0])
     intf = Interface.new(interfaces[0])
 
     intf.ipv4_acl_in = 'v4acl1'
@@ -890,7 +890,7 @@ class TestInterface < CiscoTestCase
     #     ipv6 traffic-filter v6acl1 in
     #     ipv6 traffic-filter v6acl2 out
     #
-    interface_ethernet_default(interfaces[0])
+    interface_ethernet_default(interfaces_id[0])
     intf = Interface.new(interfaces[0])
 
     # create acls first
@@ -1024,7 +1024,7 @@ class TestInterface < CiscoTestCase
   def test_interface_ipv4_arp_timeout
     unless platform == :ios_xr
       # Setup
-      config('no interface vlan11')
+      config_no_warn('no interface vlan11')
       int = Interface.new('vlan11')
 
       # Test default
@@ -1043,7 +1043,7 @@ class TestInterface < CiscoTestCase
 
   def test_interface_ipv4_forwarding
     intf = interfaces[0]
-    interface_ethernet_default(intf)
+    interface_ethernet_default(interfaces_id[0])
     i = Interface.new(intf)
 
     if platform == :ios_xr
@@ -1076,7 +1076,7 @@ class TestInterface < CiscoTestCase
   def test_interface_fabric_forwarding_anycast_gateway
     unless platform == :ios_xr
       # Setup
-      config('no interface vlan11')
+      config_no_warn('no interface vlan11')
       int = Interface.new('vlan11')
       foo = OverlayGlobal.new
       foo.anycast_gateway_mac = '1223.3445.5668'


### PR DESCRIPTION
Minor fix for test_interface that results in near-perfect minitest run on n9k.  There are some config errors that I'd like some input on before merging the PR.
## Test Results

```
~/cisco-network-node-utils$ ruby tests/test_interface.rb -v
Ignoring libyajl2-1.2.0 because its extensions are not built.  Try: gem pristine libyajl2 --version 1.2.0
Run options: -v --seed 8983

# Running:


Node under test:
  - name  - n9k-109
  - type  - N9K-C9504
  - image -

TestInterface#test_interface_ipv4_address_getter_with_preconfig = 8.38 s = .
TestInterface#test_interface_shutdown_valid = 5.56 s = .
TestInterface#test_interface_ipv4_addr_mask_set_address_invalid = 4.63 s = .
TestInterface#test_interface_mtu_valid = 5.49 s = .
W, [2016-03-09T13:06:48.743571 #3936]  WARN -- : Config result:
configure terminal
Enter configuration commands, one per line. End with CNTL/Z.
n9k-109(config)# interface loopback1
n9k-109(config-if)# no switchport
                             ^
% Invalid command at '^' marker.
n9k-109(config-if)# end
n9k-109#
TestInterface#test_vrf_change_with_ip_addr = 4.35 s = .
TestInterface#test_interface_vrf_valid = 1.95 s = .
TestInterface#test_svi_prop_nil_when_ethernet = 0.91 s = .
TestInterface#test_interface_mtu_invalid = 1.32 s = .
TestInterface#test_interface_ipv4_all_interfaces = 13.34 s = F
TestInterface#test_negotiate_auto_ethernet = 4.28 s = S
TestInterface#test_interface_vrf_empty = 2.98 s = .
TestInterface#test_interface_create_does_not_exist = 0.89 s = .
W, [2016-03-09T13:07:17.562845 #3936]  WARN -- : Config result:
configure terminal
Enter configuration commands, one per line. End with CNTL/Z.
n9k-109(config)# no interface vlan11
                              ^
Invalid interface format at '^' marker.
n9k-109(config)# end
n9k-109#
TestInterface#test_interface_fabric_forwarding_anycast_gateway = 6.35 s = .
TestInterface#test_interface_ipv4_arp_timeout = 3.65 s = .
TestInterface#test_interfaces_not_empty = 1.22 s = .
TestInterface#test_interface_ipv4_address = 7.01 s = .
TestInterface#test_interface_vrf_exceeds_max_length = 1.33 s = .
TestInterface#test_interface_ipv4_redirects = 6.65 s = .
TestInterface#test_interface_description_nil = 0.91 s = .
TestInterface#test_interface_vrf_override = 2.29 s = .
W, [2016-03-09T13:07:46.967173 #3936]  WARN -- : Config result:
configure terminal
Enter configuration commands, one per line. End with CNTL/Z.
n9k-109(config)# default interface ethernet ethernet1/1
                                           ^
Invalid interface format at '^' marker.
n9k-109(config)# end
n9k-109#
TestInterface#test_interface_ipv4_forwarding = 3.07 s = .
TestInterface#test_interface_vrf_invalid_type = 0.93 s = .
TestInterface#test_interface_vrf_default = 2.93 s = .
TestInterface#test_negotiate_auto_portchannel = 9.76 s = .
TestInterface#test_duplex = 8.81 s = .
TestInterface#test_mtu_invalid_loopback = 0.99 s = .
W, [2016-03-09T13:08:13.463209 #3936]  WARN -- : Config result:
configure terminal
Enter configuration commands, one per line. End with CNTL/Z.
n9k-109(config)# default interface ethernet ethernet1/1
                                           ^
Invalid interface format at '^' marker.
n9k-109(config)# end
n9k-109#
TestInterface#test_ipv6_acl = 5.18 s = .
TestInterface#test_interface_create_name_invalid = 0.86 s = .
TestInterface#test_interface_create_name_nil = 0.86 s = .
TestInterface#test_interface_mtu_change = 7.90 s = .
TestInterface#test_interface_create_valid = 0.91 s = .
TestInterface#test_interface_description_zero_length = 1.66 s = .
TestInterface#test_ipv4_pim_sparse_mode = 5.98 s = .
TestInterface#test_negotiate_auto_loopback = 2.38 s = .
TestInterface#test_interface_ipv4_addr_mask_set_netmask_invalid = 4.61 s = .
TestInterface#test_interface_ipv4_proxy_arp = 6.44 s = .
TestInterface#test_encapsulation_dot1q = 6.95 s = .
TestInterface#test_speed = 6.32 s = .
TestInterface#test_interface_description_valid = 4.76 s = .
W, [2016-03-09T13:09:08.466829 #3936]  WARN -- : Config result:
configure terminal
Enter configuration commands, one per line. End with CNTL/Z.
n9k-109(config)# default interface ethernet ethernet1/1
                                           ^
Invalid interface format at '^' marker.
n9k-109(config)# end
n9k-109#
TestInterface#test_ipv4_acl = 5.17 s = .
TestInterface#test_interface_ipv4_address_getter_with_preconfig_secondary = 7.26 s = .

Finished in 177.224145s, 0.2313 runs/s, 1.1229 assertions/s.

  1) Failure:
TestInterface#test_interface_ipv4_all_interfaces [tests/test_interface.rb:295]:
Expected /^\s+ip address 9.7.1.1\/15$/ to match output of '"show run interface vlan45 all | no-more"':
show run interface vlan45 all | no-more

!Command: show running-config interface Vlan45 all
!Time: Wed Mar  9 18:07:03 2016

version 7.0(3)I2(1)

interface Vlan45
  description Mini Me
  shutdown
  mtu 1500
  bandwidth 1000000
  autostate
  delay 1
  medium broadcast
  snmp trap link-status
  carrier-delay msec 100
  load-interval counter 1 60
  load-interval counter 2 300
  no load-interval counter 3
  mac-address 18e7.28db.64bf
  no management
  ip proxy-arp

n9k-109# .


  2) Skipped:
TestInterface#test_negotiate_auto_ethernet [tests/test_interface.rb:781]:
Skip test: Interface type does not allow config change

41 runs, 199 assertions, 1 failures, 0 errors, 1 skips
```
