### PR TITLE
tacacs_server_group source_interface fixes

### DIFF
--- a/lib/cisco_node_utils/tacacs_server_group.rb
+++ b/lib/cisco_node_utils/tacacs_server_group.rb
@@ -125,7 +125,7 @@ module Cisco
 
     def source_interface
       i = config_get('tacacs_server_group', 'source_interface', @name)
-      i.nil? ? default_source_interface : i
+      i.nil? ? default_source_interface : i.downcase
     end
 
     def source_interface=(s)

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -153,7 +153,7 @@ class CiscoTestCase < TestCase
       end
       # rubocop:enable Style/ClassVars
     end
-    abort "No suitable interfaces found on #{node} for this test" if
+    skip "No suitable interfaces found on #{node} for this test" if
       @@interfaces.empty?
     @@interfaces
   end

--- a/tests/test_tacacs_server_group.rb
+++ b/tests/test_tacacs_server_group.rb
@@ -331,12 +331,12 @@ class TestTacacsServerGroup < CiscoTestCase
     assert_equal(intf, aaa_group.source_interface,
                  'Error: TacacsServerGroup, source-interface set')
 
-    intf = 'Ethernet1/1'
+    intf = interfaces[0]
     create_source_interface(group_name, 'tacacs+', intf)
     assert_equal(intf, aaa_group.source_interface,
                  'Error: TacacsServerGroup, source-interface not correct')
 
-    intf = 'Ethernet1/32'
+    intf = interfaces[1]
     create_source_interface(group_name, 'tacacs+', intf)
     assert_equal(intf, aaa_group.source_interface,
                  'Error: TacacsServerGroup, source-interface not correct')


### PR DESCRIPTION
Addresses the following:
- Normalize getter to downcase the interface name
  - This will also need to be changed for puppet similar to what we do in interface. https://github.com/cisco/cisco-network-puppet-module/blob/develop/lib/puppet/type/cisco_interface.rb#L124
- Update `test_tacacs_server_group.rb` to use `interfaces[]`.
- Instead of aborting we now skip if no suitable interfaces are found.  This way if there are tests in the suite that don't require an interface they still get executed.

```
Node under test:
  - name  - n31x-101
  - type  - N3K-C3132Q-40GX
  - image - bootflash:///nxos.7.0.3.I3.1.bin

TestTacacsServerGroup#test_get_deadtime_tacacs = 1.62 s = .
TestTacacsServerGroup#test_collection_empty_tacacs = 3.91 s = .
TestTacacsServerGroup#test_create_invalid_name_tacacs = 0.92 s = .
TestTacacsServerGroup#test_get_default_source_interface_tacacs = 1.00 s = .
TestTacacsServerGroup#test_collection_multi_tacacs = 4.53 s = .
TestTacacsServerGroup#test_get_source_interface_tacacs = 1.94 s = .
TestTacacsServerGroup#test_get_vrf_tacacs = 1.63 s = .
TestTacacsServerGroup#test_create_valid_multiple_tacacs = 1.48 s = .
TestTacacsServerGroup#test_remove_server_tacacs = 5.01 s = .
TestTacacsServerGroup#test_servers_tacacs = 4.62 s = .
TestTacacsServerGroup#test_set_source_interface_tacacs = 1.55 s = .
TestTacacsServerGroup#test_set_vrf_tacacs = 1.26 s = .
TestTacacsServerGroup#test_remove_server_twice_tacacs = 5.15 s = .
TestTacacsServerGroup#test_groups_methods_equality = 1.87 s = .
TestTacacsServerGroup#test_get_default_vrf_tacacs = 1.13 s = .
TestTacacsServerGroup#test_create_valid_tacacs = 1.21 s = .
TestTacacsServerGroup#test_destroy_tacacs = 1.21 s = .
TestTacacsServerGroup#test_add_server_tacacs = 1.93 s = .
TestTacacsServerGroup#test_get_default_deadtime_tacacs = 1.13 s = .
TestTacacsServerGroup#test_set_deadtime_tacacs = 1.30 s = .

Finished in 45.749481s, 0.4372 runs/s, 1.7049 assertions/s.

20 runs, 78 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils/coverage. 1094 / 1931 LOC (56.65%) covered.
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils> ruby tests/test_tacacs_server_group.rb -v -- n9k-157  admin admin
Run options: -v -- --seed 64552

# Running:


Node under test:
  - name  - n9k-157
  - type  - N85-C8508
  - image - bootflash:///n8500-dk9.7.0.3.F1.0.212.bin

TestTacacsServerGroup#test_create_valid_tacacs = 1.52 s = .
TestTacacsServerGroup#test_set_source_interface_tacacs = 1.88 s = .
TestTacacsServerGroup#test_set_vrf_tacacs = 1.56 s = .
TestTacacsServerGroup#test_collection_multi_tacacs = 6.65 s = .
TestTacacsServerGroup#test_servers_tacacs = 6.82 s = .
TestTacacsServerGroup#test_groups_methods_equality = 2.22 s = .
TestTacacsServerGroup#test_get_vrf_tacacs = 2.39 s = .
TestTacacsServerGroup#test_get_deadtime_tacacs = 2.41 s = .
TestTacacsServerGroup#test_collection_empty_tacacs = 5.89 s = .
TestTacacsServerGroup#test_remove_server_twice_tacacs = 7.42 s = .
TestTacacsServerGroup#test_destroy_tacacs = 1.54 s = .
TestTacacsServerGroup#test_get_default_vrf_tacacs = 1.40 s = .
TestTacacsServerGroup#test_add_server_tacacs = 2.39 s = .
TestTacacsServerGroup#test_get_default_source_interface_tacacs = 1.42 s = .
TestTacacsServerGroup#test_get_default_deadtime_tacacs = 1.42 s = .
TestTacacsServerGroup#test_get_source_interface_tacacs = 1.95 s = S
TestTacacsServerGroup#test_set_deadtime_tacacs = 1.45 s = .
TestTacacsServerGroup#test_remove_server_tacacs = 7.28 s = .
TestTacacsServerGroup#test_create_valid_multiple_tacacs = 1.84 s = .
TestTacacsServerGroup#test_create_invalid_name_tacacs = 1.15 s = .

Finished in 61.990368s, 0.3226 runs/s, 1.2260 assertions/s.

  1) Skipped:
TestTacacsServerGroup#test_get_source_interface_tacacs [/nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils/tests/ciscotest.rb:156]:
No suitable interfaces found on n9k-157 for this test

20 runs, 76 assertions, 0 failures, 0 errors, 1 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/REPOS_NODE_UTILS/develop/cisco-network-node-utils/coverage. 1085 / 1931 LOC (56.19%) covered.

```
