### PR TITLE
Corrected minitests

### DIFF
--- a/lib/cisco_node_utils/bridge_domain.rb
+++ b/lib/cisco_node_utils/bridge_domain.rb
@@ -93,7 +93,7 @@ module Cisco
           bd_list.map { |elem| BridgeDomain.bd_ids_to_array(elem) }
           .flatten.uniq.sort
       final_bd_list.each do |id|
-        hash[id] = BridgeDomain.new(id, false)
+        hash[id.to_s] = BridgeDomain.new(id, false)
       end
       hash
     end

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -205,7 +205,7 @@ class CiscoTestCase < TestCase
     end
   end
 
-  def compatible_interface?
+  def mt_full_interface?
     # MT-full tests require a specific linecard; either because they need a
     # compatible interface or simply to enable the features. Either way
     # we will provide an appropriate interface name if the linecard is present.

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -204,4 +204,17 @@ class CiscoTestCase < TestCase
       ["default interface #{intf_name}"]
     end
   end
+
+  def compatible_interface?
+    # MT-full tests require a specific linecard; either because they need a
+    # compatible interface or simply to enable the features. Either way
+    # we will provide an appropriate interface name if the linecard is present.
+    # Example 'show mod' output to match against:
+    #   '9  12  10/40 Gbps Ethernet Module  N7K-F312FQ-25 ok'
+    sh_mod = @device.cmd("sh mod | i '^[0-9]+.*N7K-F3'")[/^(\d+)\s.*N7K-F3/]
+    slot = sh_mod.nil? ? nil : Regexp.last_match[1]
+    skip('Unable to find compatible interface in chassis') if slot.nil?
+
+    "ethernet#{slot}/1"
+  end
 end

--- a/tests/test_bridge_domain.rb
+++ b/tests/test_bridge_domain.rb
@@ -43,11 +43,11 @@ class TestBridgeDomain < CiscoTestCase
   def test_single_bd_create_destroy
     bd = BridgeDomain.new('100', true)
     bds = BridgeDomain.bds
-    assert(bds.key?(100), 'Error: failed to create bridge-domain 100')
+    assert(bds.key?(100.to_s), 'Error: failed to create bridge-domain 100')
 
     bd.destroy
     bds = BridgeDomain.bds
-    refute(bds.key?(100), 'Error: failed to destroy bridge-domain 100')
+    refute(bds.key?(100.to_s), 'Error: failed to destroy bridge-domain 100')
   end
 
   def test_bd_create_if_vlan_exists
@@ -65,7 +65,7 @@ class TestBridgeDomain < CiscoTestCase
     bd = BridgeDomain.new('100-120')
     bds = BridgeDomain.bds
     BridgeDomain.bd_ids_to_array(create).each do |id|
-      assert(bds.key?(id.to_i), 'Error: failed to create bridge-domain ' << id)
+      assert(bds.key?(id.to_s), 'Error: failed to create bridge-domain ' << id)
     end
     bd.destroy
   end
@@ -77,13 +77,13 @@ class TestBridgeDomain < CiscoTestCase
     bd = BridgeDomain.new(create, true)
     bds = BridgeDomain.bds
     bdlist.each do |id|
-      assert(bds.key?(id.to_i), 'Error: failed to create bridge-domain ' << id)
+      assert(bds.key?(id.to_s), 'Error: failed to create bridge-domain ' << id)
     end
 
     bd.destroy
     bds = BridgeDomain.bds
     bdlist.each do |id|
-      refute(bds.key?(id.to_i), 'Error: failed to destroy bridge-domain ' << id)
+      refute(bds.key?(id.to_s), 'Error: failed to destroy bridge-domain ' << id)
     end
   end
 
@@ -92,7 +92,7 @@ class TestBridgeDomain < CiscoTestCase
     bd = BridgeDomain.new(create)
     bds = BridgeDomain.bds
     BridgeDomain.bd_ids_to_array(create).each do |id|
-      assert(bds.key?(id.to_i), 'Error: failed to create bridge-domain ' << id)
+      assert(bds.key?(id.to_s), 'Error: failed to create bridge-domain ' << id)
     end
     bd.destroy
   end
@@ -131,6 +131,7 @@ class TestBridgeDomain < CiscoTestCase
   end
 
   def test_bd_member_vni
+    compatible_interface?
     bd = BridgeDomain.new(100)
     curr_vni = bd.member_vni.values.join(',')
     assert_equal(bd.default_member_vni, curr_vni,
@@ -151,6 +152,7 @@ class TestBridgeDomain < CiscoTestCase
   end
 
   def test_mapped_bd_member_vni
+    compatible_interface?
     bd = BridgeDomain.new(100)
     curr_vni = bd.member_vni.values.join(',')
     assert_equal(bd.default_member_vni, curr_vni,
@@ -170,6 +172,7 @@ class TestBridgeDomain < CiscoTestCase
   end
 
   def test_multiple_bd_vni_mapping
+    compatible_interface?
     bd = BridgeDomain.new('100,110,120')
     curr_vni = bd.member_vni.values.join(',')
     assert_equal(bd.default_member_vni, curr_vni,
@@ -190,6 +193,7 @@ class TestBridgeDomain < CiscoTestCase
   end
 
   def test_member_vni_empty_assign
+    compatible_interface?
     bd = BridgeDomain.new(100)
     bd.member_vni = ''
     curr_vni = bd.member_vni.values.join(',')

--- a/tests/test_bridge_domain.rb
+++ b/tests/test_bridge_domain.rb
@@ -43,11 +43,11 @@ class TestBridgeDomain < CiscoTestCase
   def test_single_bd_create_destroy
     bd = BridgeDomain.new('100', true)
     bds = BridgeDomain.bds
-    assert(bds.key?(100.to_s), 'Error: failed to create bridge-domain 100')
+    assert(bds.key?('100'), 'Error: failed to create bridge-domain 100')
 
     bd.destroy
     bds = BridgeDomain.bds
-    refute(bds.key?(100.to_s), 'Error: failed to destroy bridge-domain 100')
+    refute(bds.key?('100'), 'Error: failed to destroy bridge-domain 100')
   end
 
   def test_bd_create_if_vlan_exists

--- a/tests/test_bridge_domain.rb
+++ b/tests/test_bridge_domain.rb
@@ -131,7 +131,7 @@ class TestBridgeDomain < CiscoTestCase
   end
 
   def test_bd_member_vni
-    compatible_interface?
+    mt_full_interface?
     bd = BridgeDomain.new(100)
     curr_vni = bd.member_vni.values.join(',')
     assert_equal(bd.default_member_vni, curr_vni,
@@ -152,7 +152,7 @@ class TestBridgeDomain < CiscoTestCase
   end
 
   def test_mapped_bd_member_vni
-    compatible_interface?
+    mt_full_interface?
     bd = BridgeDomain.new(100)
     curr_vni = bd.member_vni.values.join(',')
     assert_equal(bd.default_member_vni, curr_vni,
@@ -172,7 +172,7 @@ class TestBridgeDomain < CiscoTestCase
   end
 
   def test_multiple_bd_vni_mapping
-    compatible_interface?
+    mt_full_interface?
     bd = BridgeDomain.new('100,110,120')
     curr_vni = bd.member_vni.values.join(',')
     assert_equal(bd.default_member_vni, curr_vni,
@@ -193,7 +193,7 @@ class TestBridgeDomain < CiscoTestCase
   end
 
   def test_member_vni_empty_assign
-    compatible_interface?
+    mt_full_interface?
     bd = BridgeDomain.new(100)
     bd.member_vni = ''
     curr_vni = bd.member_vni.values.join(',')

--- a/tests/test_encapsulation.rb
+++ b/tests/test_encapsulation.rb
@@ -14,6 +14,7 @@
 
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/encapsulation'
+require_relative '../lib/cisco_node_utils/vdc'
 
 # TestEncapsulation - Minitest for Encapsulation node utility class
 class TestEncapsulation < CiscoTestCase
@@ -24,6 +25,8 @@ class TestEncapsulation < CiscoTestCase
     Encapsulation.encaps.each do |_encap, obj|
       obj.destroy
     end
+  rescue
+    skip('Unsupported in non F3 vdcs')
   end
 
   def setup
@@ -42,11 +45,13 @@ class TestEncapsulation < CiscoTestCase
   # TESTS
 
   def test_encapsulation_create_destroy
+    compatible_interface?
     encap = Encapsulation.new('cisco')
     encap.destroy
   end
 
   def test_encapsulation_dot1_mapping
+    compatible_interface?
     encap = Encapsulation.new('cisco')
     assert_equal(encap.default_dot1q_map, encap.dot1q_map,
                  'Error: dot1q is not matching')
@@ -61,6 +66,7 @@ class TestEncapsulation < CiscoTestCase
   end
 
   def test_invalid_range_dot1q_mapping
+    compatible_interface?
     encap = Encapsulation.new('cisco')
     assert_equal(encap.default_dot1q_map, encap.dot1q_map,
                  'Error: dot1q is not matching')

--- a/tests/test_encapsulation.rb
+++ b/tests/test_encapsulation.rb
@@ -14,7 +14,6 @@
 
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/encapsulation'
-require_relative '../lib/cisco_node_utils/vdc'
 
 # TestEncapsulation - Minitest for Encapsulation node utility class
 class TestEncapsulation < CiscoTestCase

--- a/tests/test_encapsulation.rb
+++ b/tests/test_encapsulation.rb
@@ -45,13 +45,13 @@ class TestEncapsulation < CiscoTestCase
   # TESTS
 
   def test_encapsulation_create_destroy
-    compatible_interface?
+    mt_full_interface?
     encap = Encapsulation.new('cisco')
     encap.destroy
   end
 
   def test_encapsulation_dot1_mapping
-    compatible_interface?
+    mt_full_interface?
     encap = Encapsulation.new('cisco')
     assert_equal(encap.default_dot1q_map, encap.dot1q_map,
                  'Error: dot1q is not matching')
@@ -66,7 +66,7 @@ class TestEncapsulation < CiscoTestCase
   end
 
   def test_invalid_range_dot1q_mapping
-    compatible_interface?
+    mt_full_interface?
     encap = Encapsulation.new('cisco')
     assert_equal(encap.default_dot1q_map, encap.dot1q_map,
                  'Error: dot1q is not matching')

--- a/tests/test_interface_service_vni.rb
+++ b/tests/test_interface_service_vni.rb
@@ -47,7 +47,7 @@ class TestInterfaceServiceVni < CiscoTestCase
 
   def mt_full_env_setup
     skip('Platform does not support MT-full') unless Vni.mt_full_support
-    intf = compatible_interface?
+    intf = mt_full_interface?
     v = Vdc.new('default')
     v.limit_resource_module_type = 'f3' unless
       v.limit_resource_module_type == 'f3'

--- a/tests/test_interface_service_vni.rb
+++ b/tests/test_interface_service_vni.rb
@@ -45,19 +45,6 @@ class TestInterfaceServiceVni < CiscoTestCase
     v.limit_resource_module_type = '' if v.limit_resource_module_type == 'f3'
   end
 
-  def compatible_interface?
-    # MT-full tests require a specific linecard; either because they need a
-    # compatible interface or simply to enable the features. Either way
-    # we will provide an appropriate interface name if the linecard is present.
-    # Example 'show mod' output to match against:
-    #   '9  12  10/40 Gbps Ethernet Module  N7K-F312FQ-25 ok'
-    sh_mod = @device.cmd("sh mod | i '^[0-9]+.*N7K-F3'")[/^(\d+)\s.*N7K-F3/]
-    slot = sh_mod.nil? ? nil : Regexp.last_match[1]
-    skip('Unable to find compatible interface in chassis') if slot.nil?
-
-    "ethernet#{slot}/1"
-  end
-
   def mt_full_env_setup
     skip('Platform does not support MT-full') unless Vni.mt_full_support
     intf = compatible_interface?

--- a/tests/test_vdc.rb
+++ b/tests/test_vdc.rb
@@ -47,7 +47,7 @@ class TestVdc < CiscoTestCase
   end
 
   def test_limit_resource_module_type
-    compatible_interface?
+    mt_full_interface?
     v = Vdc.new('default')
     # Set limit-resource module-type to default (this is variable for each
     # device, so the default is for this device only)

--- a/tests/test_vdc.rb
+++ b/tests/test_vdc.rb
@@ -46,19 +46,6 @@ class TestVdc < CiscoTestCase
     end
   end
 
-  def compatible_interface?
-    # MT-full tests require a specific linecard; either because they need a
-    # compatible interface or simply to enable the features. Either way
-    # we will provide an appropriate interface name if the linecard is present.
-    # Example 'show mod' output to match against:
-    #   '9  12  10/40 Gbps Ethernet Module  N7K-F312FQ-25 ok'
-    sh_mod = @device.cmd("sh mod | i '^[0-9]+.*N7K-F3'")[/^(\d+)\s.*N7K-F3/]
-    slot = sh_mod.nil? ? nil : Regexp.last_match[1]
-    skip('Unable to find compatible interface in chassis') if slot.nil?
-
-    "ethernet#{slot}/1"
-  end
-
   def test_limit_resource_module_type
     compatible_interface?
     v = Vdc.new('default')

--- a/tests/test_vlan_mt_full.rb
+++ b/tests/test_vlan_mt_full.rb
@@ -53,7 +53,7 @@ class TestVlanMtFull < CiscoTestCase
 
   def mt_full_env_setup
     skip('Platform does not support MT-full') unless VxlanVtep.mt_full_support
-    compatible_interface?
+    mt_full_interface?
     v = Vdc.new('default')
     v.limit_resource_module_type = 'f3' unless
       v.limit_resource_module_type == 'f3'

--- a/tests/test_vlan_mt_full.rb
+++ b/tests/test_vlan_mt_full.rb
@@ -51,19 +51,6 @@ class TestVlanMtFull < CiscoTestCase
     config("default interface ethernet #{ethernet_id}")
   end
 
-  def compatible_interface?
-    # MT-full tests require a specific linecard; either because they need a
-    # compatible interface or simply to enable the features. Either way
-    # we will provide an appropriate interface name if the linecard is present.
-    # Example 'show mod' output to match against:
-    #   '9  12  10/40 Gbps Ethernet Module  N7K-F312FQ-25 ok'
-    sh_mod = @device.cmd("sh mod | i '^[0-9]+.*N7K-F3'")[/^(\d+)\s.*N7K-F3/]
-    slot = sh_mod.nil? ? nil : Regexp.last_match[1]
-    skip('Unable to find a compatible interface in chassis') if slot.nil?
-
-    "ethernet#{slot}/1"
-  end
-
   def mt_full_env_setup
     skip('Platform does not support MT-full') unless VxlanVtep.mt_full_support
     compatible_interface?

--- a/tests/test_vxlan_vtep.rb
+++ b/tests/test_vxlan_vtep.rb
@@ -38,7 +38,7 @@ class TestVxlanVtep < CiscoTestCase
 
   def mt_full_env_setup
     skip('Platform does not support MT-full') unless VxlanVtep.mt_full_support
-    compatible_interface?
+    mt_full_interface?
     v = Vdc.new('default')
     v.limit_resource_module_type = 'f3' unless
       v.limit_resource_module_type == 'f3'

--- a/tests/test_vxlan_vtep.rb
+++ b/tests/test_vxlan_vtep.rb
@@ -36,19 +36,6 @@ class TestVxlanVtep < CiscoTestCase
     v.limit_resource_module_type = '' if v.limit_resource_module_type == 'f3'
   end
 
-  def compatible_interface?
-    # MT-full tests require a specific linecard; either because they need a
-    # compatible interface or simply to enable the features. Either way
-    # we will provide an appropriate interface name if the linecard is present.
-    # Example 'show mod' output to match against:
-    #   '9  12  10/40 Gbps Ethernet Module  N7K-F312FQ-25 ok'
-    sh_mod = @device.cmd("sh mod | i '^[0-9]+.*N7K-F3'")[/^(\d+)\s.*N7K-F3/]
-    slot = sh_mod.nil? ? nil : Regexp.last_match[1]
-    skip('Unable to find a compatible interface in chassis') if slot.nil?
-
-    "ethernet#{slot}/1"
-  end
-
   def mt_full_env_setup
     skip('Platform does not support MT-full') unless VxlanVtep.mt_full_support
     compatible_interface?


### PR DESCRIPTION
Fixed the minitest case scenarios for failing if F3 card was not present in the switch.
Moved compatible_interface? to ciscotest.rb and included it where ever necessary.

This also contains a small fix related to getting all the instances of bridge-domain, it was causing issues in puppet layer so storing all the hash keys in string format rather than in integer.
