### PR TITLE
test_evpn_vni updates

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -28,6 +28,7 @@ nv_overlay:
   set_value: "feature nv overlay"
 
 nv_overlay_evpn:
+  # TBD: Exclude all n3k even though N31xx in 'switchmode n9k' supports evpn
   _exclude: [N3k]
   kind: boolean
   get_command: "show running | section nv"

--- a/lib/cisco_node_utils/evpn_vni.rb
+++ b/lib/cisco_node_utils/evpn_vni.rb
@@ -84,11 +84,13 @@ module Cisco
     def route_distinguisher=(rd)
       if rd == default_route_distinguisher
         @set_args[:state] = 'no'
-        @set_args[:rd] = ''
+        # I2 images require an rd for removal
+        rd = route_distinguisher
+        return if rd.to_s.empty?
       else
         @set_args[:state] = ''
-        @set_args[:rd] = rd
       end
+      @set_args[:rd] = rd
       config_set('evpn_vni', 'route_distinguisher', @set_args)
       set_args_keys_default
     end

--- a/tests/test_evpn_vni.rb
+++ b/tests/test_evpn_vni.rb
@@ -28,11 +28,16 @@ class TestEvpnVni < CiscoTestCase
     # ensure we are starting with a clean slate for each test.
     super
     config('no feature bgp')
-    config('no nv overlay evpn')
+
+    # Some platforms complain when nv overlay is not configured
+    config_no_warn('no nv overlay evpn')
 
     # Some platforms remove the 'evpn' command when 'no nv overlay evpn'
     # is processed, while others must remove it explicitly.
     config_no_warn('no evpn')
+
+  rescue RuntimeError => e
+    hardware_supports_feature?(e.message)
   end
 
   def test_create_and_destroy
@@ -43,6 +48,9 @@ class TestEvpnVni < CiscoTestCase
     vni.destroy
     vni_list = EvpnVni.vnis
     refute(vni_list.key?('4096'), 'Error: failed to destroy evpn vni 4096')
+
+  rescue RuntimeError => e
+    hardware_supports_feature?(e.message)
   end
 
   def test_vni_collection
@@ -62,6 +70,9 @@ class TestEvpnVni < CiscoTestCase
     assert_empty(vni.route_distinguisher,
                  'vni route_distinguisher should *NOT* be configured')
     vni.destroy
+
+  rescue RuntimeError => e
+    hardware_supports_feature?(e.message)
   end
 
   # test route_target
@@ -91,6 +102,9 @@ class TestEvpnVni < CiscoTestCase
     route_target_tester(vni, opts, should, 'Test 4')
 
     vni .destroy
+
+  rescue RuntimeError => e
+    hardware_supports_feature?(e.message)
   end
 
   def route_target_tester(vni, opts, should, test_id)

--- a/tests/test_evpn_vni.rb
+++ b/tests/test_evpn_vni.rb
@@ -80,7 +80,11 @@ class TestEvpnVni < CiscoTestCase
     vni = EvpnVni.new(4096)
 
     # test route target both auto and route target both auto evpn
-    opts = [:both, :import, :export]
+    if Utils.nexus_i2_image
+      opts = [:import, :export]
+    else
+      opts = [:both, :import, :export]
+    end
 
     # Master list of communities to test against
     master = ['1.2.3.4:55', '2:2', '55:33', 'auto']

--- a/tests/test_evpn_vni.rb
+++ b/tests/test_evpn_vni.rb
@@ -29,7 +29,10 @@ class TestEvpnVni < CiscoTestCase
     super
     config('no feature bgp')
     config('no nv overlay evpn')
-    config('no evpn')
+
+    # Some platforms remove the 'evpn' command when 'no nv overlay evpn'
+    # is processed, while others must remove it explicitly.
+    config_no_warn('no evpn')
   end
 
   def test_create_and_destroy


### PR DESCRIPTION
- I2 images require an explicit rd value when removing route-distinguisher
- route_target_both does not work on I2 images because it nvgens separate, explicit import/export clis
- Add hardware_support checks to test_evpn_vni for N3k
- minitest now passes on all NX + I2
