### PR TITLE
Proper discovery of spec files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,34 +9,26 @@ task default: %w(rubocop spec build)
 
 RuboCop::RakeTask.new
 
+RSpec::Core::RakeTask.new(:spec_common) do |t|
+  t.pattern = 'spec/*_spec.rb'
+  t.rspec_opts = '--format documentation'
+  t.verbose = false
+end
+spec_tasks = [:spec_common]
+
 # Because each of the below specs requires a clean Ruby environment,
 # they need to be run individually instead of as a single RSpec task.
-RSpec::Core::RakeTask.new(:spec_no_clients) do |t|
-  t.pattern = 'spec/no_clients_spec.rb'
-end
-RSpec::Core::RakeTask.new(:spec_nxapi_only) do |t|
-  t.pattern = 'spec/nxapi_only_spec.rb'
-end
-RSpec::Core::RakeTask.new(:spec_grpc_only) do |t|
-  t.pattern = 'spec/grpc_only_spec.rb'
-end
-RSpec::Core::RakeTask.new(:spec_all_clients) do |t|
-  t.pattern = 'spec/all_clients_spec.rb'
-end
-RSpec::Core::RakeTask.new(:spec_yaml) do |t|
-  t.pattern = 'spec/yaml_spec.rb'
-end
-RSpec::Core::RakeTask.new(:spec_whitespace) do |t|
-  t.pattern = 'spec/whitespace_spec.rb'
+Dir.glob('spec/isolate/*_spec.rb').each do |f|
+  task = File.basename(f, '.rb').to_sym
+  RSpec::Core::RakeTask.new(task) do |t|
+    t.pattern = f
+    t.rspec_opts = '--format documentation'
+    t.verbose = false
+  end
+  spec_tasks << task
 end
 
-task spec: [:spec_no_clients,
-            :spec_nxapi_only,
-            :spec_grpc_only,
-            :spec_all_clients,
-            :spec_yaml,
-            :spec_whitespace,
-           ]
+task spec: spec_tasks
 
 task :build do
   system 'gem build cisco_node_utils.gemspec'

--- a/bin/git/hooks/pre-commit/validate-yaml
+++ b/bin/git/hooks/pre-commit/validate-yaml
@@ -6,7 +6,7 @@
 # Run the Kwalify YAML schema validation
 
 step_name "Validating YAML files"
-rake spec_yaml
+rspec "$REPO_DIR"/spec/yaml_spec.rb
 check_rc "Please fix YAML schema validation failures before committing"
 
 # Ensure that command_reference can parse all the YAML as well

--- a/spec/isolate/all_clients_spec.rb
+++ b/spec/isolate/all_clients_spec.rb
@@ -1,4 +1,4 @@
-require_relative 'spec_helper.rb'
+require_relative '../spec_helper.rb'
 
 context 'when both clients are installed' do
   it 'should have both clients' do

--- a/spec/isolate/grpc_only_spec.rb
+++ b/spec/isolate/grpc_only_spec.rb
@@ -1,4 +1,4 @@
-require_relative 'spec_helper.rb'
+require_relative '../spec_helper.rb'
 
 context 'when only gRPC client is installed' do
   let(:main_self) { TOPLEVEL_BINDING.eval('self') }

--- a/spec/isolate/no_clients_spec.rb
+++ b/spec/isolate/no_clients_spec.rb
@@ -1,4 +1,4 @@
-require_relative 'spec_helper.rb'
+require_relative '../spec_helper.rb'
 require 'rspec/core'
 
 context 'when no client implementations are installed' do

--- a/spec/isolate/nxapi_only_spec.rb
+++ b/spec/isolate/nxapi_only_spec.rb
@@ -1,4 +1,4 @@
-require_relative 'spec_helper.rb'
+require_relative '../spec_helper.rb'
 
 context 'when only NXAPI client is installed' do
   let(:main_self) { TOPLEVEL_BINDING.eval('self') }


### PR DESCRIPTION
Instead of hard-coding individual RSpec spec files in the Rakefile, do the following:
- Task `:spec_common` covers all files in the main `spec/` directory in one task
- Files that need a clean environment for each test (the client loader specs) have been moved to a `spec/isolate/` subdirectory, and the Rakefile automatically creates a separate task for each file found in this directory.

With this change, we should no longer need to update the Rakefile every time we add a new spec file.

```
glmatthe@fe-ucs36:~/cisco-network-node-utils$ rake spec

non-ruby files
  should have no trailing whitespace

schema.yaml
  should have no schema metavalidation errors

snmp_notification_receiver.yaml
  should have no schema validation errors

encapsulation.yaml
  should have no schema validation errors

aaa_authentication_login.yaml
  should have no schema validation errors

syslog_settings.yaml
  should have no schema validation errors

yum.yaml
  should have no schema validation errors

fabricpath.yaml
  should have no schema validation errors

interface_channel_group.yaml
  should have no schema validation errors

tacacs_server_host.yaml
  should have no schema validation errors

show_system.yaml
  should have no schema validation errors

vdc.yaml
  should have no schema validation errors

virtual_service.yaml
  should have no schema validation errors

ospf.yaml
  should have no schema validation errors

interface.yaml
  should have no schema validation errors

vrf_af.yaml
  should have no schema validation errors

vtp.yaml
  should have no schema validation errors

pim.yaml
  should have no schema validation errors

system.yaml
  should have no schema validation errors

ntp_server.yaml
  should have no schema validation errors

bgp_neighbor.yaml
  should have no schema validation errors

syslog_server.yaml
  should have no schema validation errors

bridge_domain.yaml
  should have no schema validation errors

vxlan_vtep.yaml
  should have no schema validation errors

aaa_auth_login_service.yaml
  should have no schema validation errors

tacacs_server.yaml
  should have no schema validation errors

interface_ospf.yaml
  should have no schema validation errors

bgp.yaml
  should have no schema validation errors

radius_server_group.yaml
  should have no schema validation errors

fex.yaml
  should have no schema validation errors

evpn_vni.yaml
  should have no schema validation errors

acl.yaml
  should have no schema validation errors

bgp_af.yaml
  should have no schema validation errors

snmp_community.yaml
  should have no schema validation errors

radius_server.yaml
  should have no schema validation errors

vrf.yaml
  should have no schema validation errors

vpc.yaml
  should have no schema validation errors

aaa_authorization_service.yaml
  should have no schema validation errors

fabricpath_topology.yaml
  should have no schema validation errors

images.yaml
  should have no schema validation errors

show_version.yaml
  should have no schema validation errors

tacacs_server_group.yaml
  should have no schema validation errors

vxlan_vtep_vni.yaml
  should have no schema validation errors

dnsclient.yaml
  should have no schema validation errors

interface_service_vni.yaml
  should have no schema validation errors

interface_portchannel.yaml
  should have no schema validation errors

overlay_global.yaml
  should have no schema validation errors

stp_global.yaml
  should have no schema validation errors

bgp_neighbor_af.yaml
  should have no schema validation errors

radius_global.yaml
  should have no schema validation errors

vlan.yaml
  should have no schema validation errors

snmp_group.yaml
  should have no schema validation errors

snmp_user.yaml
  should have no schema validation errors

memory.yaml
  should have no schema validation errors

snmpnotification.yaml
  should have no schema validation errors

portchannel_global.yaml
  should have no schema validation errors

feature.yaml
  should have no schema validation errors

inventory.yaml
  should have no schema validation errors

snmp_server.yaml
  should have no schema validation errors

ntp_config.yaml
  should have no schema validation errors

Finished in 0.14072 seconds (files took 0.17132 seconds to load)
60 examples, 0 failures


when no client implementations are installed
  should not have any clients
  should fail Client.create

Finished in 0.19344 seconds (files took 0.11072 seconds to load)
2 examples, 0 failures


when only NXAPI client is installed
  should have NXAPI client

Finished in 0.07852 seconds (files took 0.10975 seconds to load)
1 example, 0 failures


when both clients are installed
  should have both clients

Finished in 0.14519 seconds (files took 0.10799 seconds to load)
1 example, 0 failures


when only gRPC client is installed
  should have gRPC client

Finished in 0.16991 seconds (files took 0.10424 seconds to load)
1 example, 0 failures
```
