### PR TITLE
Fix ascii name git hook to properly check result

### DIFF
--- a/bin/git/hooks/pre-commit/validate-diffs
+++ b/bin/git/hooks/pre-commit/validate-diffs
@@ -23,8 +23,8 @@ step_name 'Checking for non-ASCII filenames'
 # Note that the use of brackets around a tr range is ok here, (it's
 # even required, for portability to Solaris 10's /usr/bin/tr), since
 # the square bracket bytes happen to fall in the designated range.
-git diff --cached --name-only --diff-filter=A -z $against |
-        LC_ALL=C tr -d '[ -~]\0' | wc -c
+(git diff --cached --name-only --diff-filter=A -z $against |
+  LC_ALL=C tr -d '[ -~]\0' | exit $(wc -c))
 check_rc "Rename non-ASCII file name(s) before committing"
 
 step_name 'Checking for trailing whitespace in non-Ruby files'

--- a/bin/git/hooks/pre-commit/validate-diffs
+++ b/bin/git/hooks/pre-commit/validate-diffs
@@ -27,8 +27,8 @@ added_files=$(git diff --cached --name-only --diff-filter=A -z $against | tr '\0
 added_files_array=(`echo $added_files`)
 # Print the files that have non-ascii text
 for i in ${added_files_array[@]}; do
-  non_ascii_text=$(echo -n $i | LC_ALL=C tr -d '[ -~]\0')
-  echo -n $i | LC_ALL=C tr -d '[ -~]\0'
+  bad_chars=$(echo -n $i | LC_ALL=C tr -d '[ -~]\0')
+  if [ -n "$bad_chars" ]; then echo $i; fi
 done
 # Fail if any non-ASCII characters are discovered
 (echo -n $added_files | LC_ALL=C tr -d '[ -~]\0' | exit $(wc -c))

--- a/bin/git/hooks/pre-commit/validate-diffs
+++ b/bin/git/hooks/pre-commit/validate-diffs
@@ -27,8 +27,8 @@ added_files=$(git diff --cached --name-only --diff-filter=A -z $against | tr '\0
 added_files_array=(`echo $added_files`)
 # Print the files that have non-ascii text
 for i in ${added_files_array[@]}; do
-  non_ascii_text=$(echo $i | LC_ALL=C tr -d '[ -~]\0')
-  echo $i | sed -n "s/\($non_ascii_text\)/\1/p"
+  non_ascii_text=$(echo -n $i | LC_ALL=C tr -d '[ -~]\0')
+  echo -n $i | LC_ALL=C tr -d '[ -~]\0'
 done
 # Fail if any non-ASCII characters are discovered
 (echo -n $added_files | LC_ALL=C tr -d '[ -~]\0' | exit $(wc -c))

--- a/bin/git/hooks/pre-commit/validate-diffs
+++ b/bin/git/hooks/pre-commit/validate-diffs
@@ -23,8 +23,15 @@ step_name 'Checking for non-ASCII filenames'
 # Note that the use of brackets around a tr range is ok here, (it's
 # even required, for portability to Solaris 10's /usr/bin/tr), since
 # the square bracket bytes happen to fall in the designated range.
-(git diff --cached --name-only --diff-filter=A -z $against |
-  LC_ALL=C tr -d '[ -~]\0' | exit $(wc -c))
+added_files=$(git diff --cached --name-only --diff-filter=A -z $against | tr '\0' ' ')
+added_files_array=(`echo $added_files`)
+# Print the files that have non-ascii text
+for i in ${added_files_array[@]}; do
+  non_ascii_text=$(echo $i | LC_ALL=C tr -d '[ -~]\0')
+  echo $i | sed -n "s/\($non_ascii_text\)/\1/p"
+done
+# Fail if any non-ASCII characters are discovered
+(echo -n $added_files | LC_ALL=C tr -d '[ -~]\0' | exit $(wc -c))
 check_rc "Rename non-ASCII file name(s) before committing"
 
 step_name 'Checking for trailing whitespace in non-Ruby files'


### PR DESCRIPTION
Previously, the non-ASCII filename check would just print the result to STDOUT.  This meant that the git hook was unable to properly check if the hook succeeded and resulted in the hook always passing.  This simple fix wraps the non-ASCII check in a sub-shell so the exit value can be properly checked by the git hook.
### Pre-fix:  commit with invalid filename

``` bash
~/cisco-network-node-utils/tests$ git status
On branch feature/interface-test-fixes
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

    new file:   "test-\340\271\200\340\271\200"

~/cisco-network-node-utils/tests$ git commit -m "test"
[snip]
*** Running Git hook script: pre-commit-validate-diffs...
    Checking for non-ASCII filenames
6
    Checking for trailing whitespace in non-Ruby files
    ...[ OK ]
[snip]
 1 file changed, 1 insertion(+)
 create mode 100644 "tests/test-\340\271\200\340\271\200"
```
### Commit with proper filenames

``` bash
~/cisco-network-node-utils/tests$ git commit -m "Fix ascii name hook to properly check result"
[snip]
*** Running Git hook script: pre-commit-validate-diffs...
    Checking for non-ASCII filenames
    Checking for trailing whitespace in non-Ruby files
    ...[ OK ]
[snip]
[feature/git-hooks-ascii-fix 3990e71] Fix ascii name hook to properly check result
 1 file changed, 2 insertions(+), 2 deletions(-)
```
### Commit with unicode filename

``` bash
~/cisco-network-node-utils/tests$ git status
On branch feature/git-hooks-ascii-fix
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

    new file:   "test-\340\271\200\340\271\200"

~/cisco-network-node-utils/tests$ git commit -m "Test unicode filename"
[snip]
*** Running Git hook script: pre-commit-validate-diffs...
    Checking for non-ASCII filenames
    ...[ FAIL ] Rename non-ASCII file name(s) before committing
```
