### PR TITLE
Configuration file support for client and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ Changelog
 * Improved minitest logging CLI.
   - `ruby test_foo.rb -l debug` instead of `ruby test_foo.rb -- <host> <user> <pass> debug`
   - `rake test TESTOPTS='--log-level=debug'`
+* Client connectivity is now specified in `/etc/cisco_node_utils.yaml` or `~/cisco_node_utils.yaml` instead of environment variables or command-line arguments to minitest.
+  - `ruby test_foo.rb -e <node name defined in YAML>`
+  - `rake test TESTOPTS='--environment=default'`
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,21 +15,7 @@ Cisco Network Elements support a rich set of features to make networks robust, e
   * Make changes in your branch.
 * Testing
   * Create a minitest script for any new APIs or new functionality
-  * Run all the tests to ensure there was no collateral damage to existing code. There are two ways you can specify the router or switch (virtual or physical) to test against when running the full test suite:
-    1. Create a YAML config file as `/etc/cisco_node_utils.yaml` or `~/cisco_node_utils.yaml` to specify the host, username, and password. There is an example file in `docs/cisco_node_utils.yaml.example`. You can specify a single test node as `default` in this YAML, or you can describe multiple test hosts and specify the desired host with the `--environment` option:
-
-        ```bash
-        rake test TEST_OPTS='--environment=nxapi_remote'
-        ```
-
-    2. Enter the connection information at runtime:
-
-        ```
-        rake test
-        Enter address or hostname of node under test: 192.168.100.1
-        Enter username for node under test:           user
-        Enter password for node under test:           password
-        ```
+  * Run all the tests to ensure there was no collateral damage to existing code. See [README-test-execution](docs/README-test-execution.md) for details.
 
 * Committing
   * Check for unnecessary whitespace with `git diff --check` before committing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,12 +15,11 @@ Cisco Network Elements support a rich set of features to make networks robust, e
   * Make changes in your branch.
 * Testing
   * Create a minitest script for any new APIs or new functionality
-  * Run all the tests to ensure there was no collateral damage to existing code. There are two ways you can specify the Nexus switch (virtual or physical) to test against when running the full test suite:
-    1. Use the NODE environment variable to specify the address, username, and password:
+  * Run all the tests to ensure there was no collateral damage to existing code. There are two ways you can specify the router or switch (virtual or physical) to test against when running the full test suite:
+    1. Create a YAML config file as `/etc/cisco_node_utils.yaml` or `~/cisco_node_utils.yaml` to specify the host, username, and password. There is an example file in `docs/cisco_node_utils.yaml.example`. You can specify a single test node as `default` in this YAML, or you can describe multiple test hosts and specify the desired host with the `--environment` option:
 
         ```bash
-        export NODE="192.168.100.1 user password"
-        rake test
+        rake test TEST_OPTS='--environment=nxapi_remote'
         ```
 
     2. Enter the connection information at runtime:

--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ Please see [Learning Resources](#resources) for additional references.
 #### Table of Contents
 
 1. [Overview](#overview)
-2. [Installation](#installation)
-3. [Documentation](#documentation)
-4. [Examples](#examples)
-5. [Changelog](#changelog)
-6. [Learning Resources](#resources)
-7. [License Information](#license_info)
+1. [Installation](#installation)
+1. [Configuration](#configuration)
+1. [Documentation](#documentation)
+1. [Examples](#examples)
+1. [Changelog](#changelog)
+1. [Learning Resources](#resources)
+1. [License Information](#license_info)
 
 
 ## <a name="overview">Overview</a>
@@ -40,16 +41,17 @@ open source management tools.
 
 This CiscoNodeUtils gem release supports the following:
 
-Platform         | OS    | OS Version           |
------------------|-------|----------------------|
-Cisco Nexus 30xx | NX-OS | 7.0(3)I2(1) and later
-Cisco Nexus 31xx | NX-OS | 7.0(3)I2(1) and later
-Cisco Nexus 93xx | NX-OS | 7.0(3)I2(1) and later
-Cisco Nexus 95xx | NX-OS | 7.0(3)I2(1) and later
-Cisco N9kv       | NX-OS | 7.0(3)I2(1) and later
-Cisco Nexus 56xx | NX-OS | 7.3(0)N1(1) and later
-Cisco Nexus 60xx | NX-OS | 7.3(0)N1(1) and later
-Cisco Nexus 7xxx | NX-OS | 7.3(0)D1(1) and later
+Platform         | OS     | OS Version           |
+-----------------|--------|----------------------|
+Cisco Nexus 30xx | NX-OS  | 7.0(3)I2(1) and later
+Cisco Nexus 31xx | NX-OS  | 7.0(3)I2(1) and later
+Cisco Nexus 93xx | NX-OS  | 7.0(3)I2(1) and later
+Cisco Nexus 95xx | NX-OS  | 7.0(3)I2(1) and later
+Cisco N9kv       | NX-OS  | 7.0(3)I2(1) and later
+Cisco Nexus 56xx | NX-OS  | 7.3(0)N1(1) and later
+Cisco Nexus 60xx | NX-OS  | 7.3(0)N1(1) and later
+Cisco Nexus 7xxx | NX-OS  | 7.3(0)D1(1) and later
+TODO             | IOS XR | TODO
 
 
 Please note: For Cisco Nexus 3k and 9k platforms, a virtual Nexus N9000/N3000 may be helpful for development and testing. Users with a valid [cisco.com](http://cisco.com) user ID can obtain a copy of a virtual Nexus N9000/N3000 by sending their [cisco.com](http://cisco.com) user ID in an email to <get-n9kv@cisco.com>. If you do not have a [cisco.com](http://cisco.com) user ID please register for one at [https://tools.cisco.com/IDREG/guestRegistration](https://tools.cisco.com/IDREG/guestRegistration)
@@ -64,6 +66,27 @@ To install the CiscoNodeUtils, use the following command:
 
 Alternatively, if you've checked the source out directly, you can call
 `rake install` from the root project directory.
+
+## Configuration
+
+Depending on the installation environment (Linux, NX-OS, or IOS XR), this gem may require configuration in order to be used. Two configuration file locations are supported:
+
+* `/etc/cisco_node_utils.yaml` (system and/or root user configuration)
+* `~/cisco_node_utils.yaml` (per-user configuration)
+
+If both files exist and are readable, configuration in the user-specific file will take precedence over the system configuration.
+
+This file specifies the host, port, username, and/or password to be used to connect to one or more nodes.
+
+* When installing this gem on NX-OS nodes, this file is generally not needed, as the default client behavior is sufficient.
+* When installing this gem on IOS XR nodes, this file needs to specify an IOS XR administrator `username` and `password` for the local (`default`) node. Additionally, if the gRPC server is configured to listen on a port other than its default of 57400, the `port` number must be specified in this file. *For security purposes, it is highly recommended that access to this file be restricted to only the owning user (`chmod 0600`).*
+* When developing for or testing this gem, this file can specify one or more NX-OS and/or IOS XR nodes to run tests against. In this case:
+  - A node labeled as `default` will be the default node to test against.
+  - Nodes with other names can be selected at test execution time.
+  - NX-OS nodes must be defined with a `host` (hostname or IP address), `username`, and `password`.
+  - IOS XR nodes must be defined with a `host`, `username`, and `password`, plus a `port` if the gRPC server is listening on a non-default port.
+
+An example configuration file (illustrating each of the above scenarios) is provided with this gem at [`docs/cisco_node_utils.yaml.example`](docs/cisco_node_utils.yaml.example).
 
 ## <a name="documentation">Documentation</a>
 

--- a/docs/README-develop-node-utils-APIs.md
+++ b/docs/README-develop-node-utils-APIs.md
@@ -96,12 +96,7 @@ or (if you don't have admin/root privileges and have used `--user-install` to in
 ~/.gem/ruby/$RUBY_VERSION/bin/bundle install --path ~/.gem
 ```
 
-Create the file `/etc/cisco_node_utils.yaml` or `~/cisco_node_utils.yaml` to specify how the gem will connect to your Nexus VM or other node under test. Refer to `docs/cisco_node_utils.yaml.example` for examples:
-
-```bash
-cp docs/cisco_node_utils.yaml.example ~/cisco_node_utils.yaml
-vim ~/cisco_node_utils.yaml
-```
+Optionally create the file `~/cisco_node_utils.yaml` to specify how the test scripts will connect to your Nexus VM or other node under test. Refer to the project [README](../README.md#configuration) for details.
 
 If you intend to contribute your code back to the project then you should install the git hooks that are checked in with the project source code.  These hooks check your commits for conformance with various style guidelines.  To install them in your local repository (or to update them to match the files currently in the repository, in case they are out of sync), simply run the `update-hooks` script:
 
@@ -498,7 +493,7 @@ class TestRouterEigrp < CiscoTestCase
 end
 ```
 
-Now run the test (using the `--environment` option to specify your node under test):
+Now run the test (see [README-test-execution](README-test-execution.md) for detailed instructions):
 
 ```bash
 % ruby test_router_eigrp.rb -v --environment my_nexus_vm

--- a/docs/README-develop-node-utils-APIs.md
+++ b/docs/README-develop-node-utils-APIs.md
@@ -96,6 +96,13 @@ or (if you don't have admin/root privileges and have used `--user-install` to in
 ~/.gem/ruby/$RUBY_VERSION/bin/bundle install --path ~/.gem
 ```
 
+Create the file `/etc/cisco_node_utils.yaml` or `~/cisco_node_utils.yaml` to specify how the gem will connect to your Nexus VM or other node under test. Refer to `docs/cisco_node_utils.yaml.example` for examples:
+
+```bash
+cp docs/cisco_node_utils.yaml.example ~/cisco_node_utils.yaml
+vim ~/cisco_node_utils.yaml
+```
+
 If you intend to contribute your code back to the project then you should install the git hooks that are checked in with the project source code.  These hooks check your commits for conformance with various style guidelines.  To install them in your local repository (or to update them to match the files currently in the repository, in case they are out of sync), simply run the `update-hooks` script:
 
 ```bash
@@ -491,10 +498,10 @@ class TestRouterEigrp < CiscoTestCase
 end
 ```
 
-Now run the test:
+Now run the test (using the `--environment` option to specify your node under test):
 
 ```bash
-% ruby test_router_eigrp.rb -v -- 192.168.0.1 admin admin
+% ruby test_router_eigrp.rb -v --environment my_nexus_vm
 Run options: -v -- --seed 56593
 
 # Running:

--- a/docs/README-maintainers.md
+++ b/docs/README-maintainers.md
@@ -47,6 +47,7 @@ When we are considering publishing a new release, all of the following steps mus
     - N31xx
     - N56xx
     - N6xxx
+    - N7xxx
     - N9xxx
 
 3. Triage any minitest failures.

--- a/docs/README-maintainers.md
+++ b/docs/README-maintainers.md
@@ -8,7 +8,7 @@ Guidelines for the core maintainers of the cisco-network-node-utils project - ab
 * Does `rubocop` pass? (TODO - this will be part of our CI integration to run automatically)
 * Is `CHANGELOG.md` updated appropriately?
 * Are new minitests added? Do they provide sufficient coverage and consistent results?
-* Do minitests pass on both N9K and N3K?
+* Do minitests pass on all supported platforms
 
 ## Setting up git-flow
 
@@ -45,6 +45,8 @@ When we are considering publishing a new release, all of the following steps mus
   * Platforms (all with latest released software or release candidate)
     - N30xx
     - N31xx
+    - N56xx
+    - N6xxx
     - N9xxx
 
 3. Triage any minitest failures.

--- a/docs/README-test-execution.md
+++ b/docs/README-test-execution.md
@@ -1,0 +1,57 @@
+# Executing the tests provided for this gem
+
+## RSpec tests
+
+The test files located in the `spec/` directory use [RSpec](http://rspec.info/) as their test framework. These tests are generally standalone and do not generally require any actual Cisco hardware or virtual machines to test against.
+
+### Running a single RSpec test
+
+You can execute a single spec file by name:
+
+```bash
+rspec spec/environment_spec.rb
+```
+
+### Running all RSpec tests
+
+
+```bash
+rake spec
+```
+
+## Minitest tests
+
+The test files located in the `tests/` directory use [minitest](https://github.com/seattlerb/minitest/) as their test framework. These tests generally require one or more Cisco routers, switches, or virtual machines to test against.
+
+It is recommended that you create a `cisco_node_utils.yaml` file (as described in [README.md](../README.md#configuration) to specify the node(s) under test, but if you do not create such a file, the test will prompt you to enter the required information at runtime:
+
+```bash
+$ rake test
+Enter address or hostname of node under test: 192.168.100.1
+Enter username for node under test:           user
+Enter password for node under test:           password
+```
+
+### Running a single minitest test
+
+You can execute a single test file by name. If you do not specify the `-e` / `--environment` option, the node labeled as `default` in `cisco_node_utils.yaml` will be used (or, if no such entry exists, you will be prompted to enter the required information as shown above):
+
+```bash
+# Run test against the 'default' node:
+$ ruby tests/test_node.rb
+# Run test against node 'n7k':
+$ ruby tests/test_node.rb --environment n7k
+# Run test against node 'n9k':
+$ ruby tests/test_node.rb -e n9k
+```
+
+### Running all minitest tests
+
+As above, if you do not specify the `--environment` option, the `default` node will be used or you will be prompted if necessary.
+
+```bash
+# Run all tests against the 'default' node:
+$ rake test
+# Run all tests against 'n7k':
+$ rake test TEST_OPTS='--environment=n7k'
+```

--- a/docs/cisco_node_utils.yaml.example
+++ b/docs/cisco_node_utils.yaml.example
@@ -1,4 +1,6 @@
-# The entry labeled 'default' will be used unless another entry is specified
+# The entry labeled 'default' will be used by default.
+# The user can select a different entry by name if desired.
+#
 # default:
 #   host: foo
 

--- a/docs/cisco_node_utils.yaml.example
+++ b/docs/cisco_node_utils.yaml.example
@@ -1,0 +1,28 @@
+# The entry labeled 'default' will be used unless another entry is specified
+# default:
+#   host: foo
+
+# Example config for running NXAPI remotely:
+nxapi_remote:
+  host: 192.168.1.100
+  username: devops
+  password: devops
+
+# Example config for running NXAPI on a node:
+nxapi_local:
+  # (none needed)
+
+# Example config for running gRPC remotely:
+grpc_remote:
+  host: 192.168.1.100
+  # gRPC port defaults to 57400 if unset
+  # port: 57400
+  username: admin
+  password: admin
+
+# Example config for running gRPC on a node:
+grpc_local:
+  port: 57999
+  username: admin
+  password: admin
+

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -37,18 +37,18 @@ class Cisco::Client::NXAPI < Cisco::Client
 
   # Constructor for Client. By default this connects to the local
   # unix domain socket. If you need to connect to a remote device,
-  # you must provide the address/username/password parameters.
-  def initialize(address=nil, username=nil, password=nil)
-    super(address:      address,
-          username:     username,
-          password:     password,
-          data_formats: [:nxapi_structured, :cli],
-          platform:     :nexus)
+  # you must provide the host/username/password parameters.
+  def initialize(**kwargs)
+    # rubocop:disable Style/HashSyntax
+    super(data_formats: [:nxapi_structured, :cli],
+          platform:     :nexus,
+          **kwargs)
+    # rubocop:enable Style/HashSyntax
     # Default: connect to unix domain socket on localhost, if available
-    if address.nil?
+    if @host.nil?
       unless File.socket?(NXAPI_UDS)
         fail Cisco::ConnectionRefused, \
-             "No address specified but no UDS found at #{NXAPI_UDS} either"
+             "No host specified but no UDS found at #{NXAPI_UDS} either"
       end
       # net_http_unix provides NetX::HTTPUnix, a small subclass of Net::HTTP
       # which supports connection to local unix domain sockets. We need this
@@ -59,7 +59,7 @@ class Cisco::Client::NXAPI < Cisco::Client
     else
       # Remote connection. This is primarily expected
       # when running e.g. from a Unix server as part of Minitest.
-      @http = Net::HTTP.new(address)
+      @http = Net::HTTP.new(@host)
     end
     # The default read time out is 60 seconds, which may be too short for
     # scaled configuration to apply. Change it to 300 seconds, which is
@@ -71,21 +71,16 @@ class Cisco::Client::NXAPI < Cisco::Client
     get(command: 'show hostname')
   end
 
-  def validate_args(address, username, password)
+  def self.validate_args(**kwargs)
     super
-    if address.nil?
+    if kwargs[:host].nil?
       # Connection to UDS - no username or password either
-      fail ArgumentError unless username.nil? && password.nil?
+      fail ArgumentError unless kwargs[:username].nil? && kwargs[:password].nil?
     else
-      fail ArgumentError, 'no port number permitted' if address =~ /:/
       # Connection to remote system - username and password are required
-      fail TypeError, 'username is required' if username.nil?
-      fail TypeError, 'password is required' if password.nil?
+      fail TypeError, 'username is required' if kwargs[:username].nil?
+      fail TypeError, 'password is required' if kwargs[:password].nil?
     end
-  end
-
-  def reload
-    # no-op for now
   end
 
   # Clear the cache of CLI output results.

--- a/lib/cisco_node_utils/client/utils.rb
+++ b/lib/cisco_node_utils/client/utils.rb
@@ -152,7 +152,8 @@ class Cisco::Client
     data
   end
 
-  # Helper method for require - suppress Ruby warnings for the given block
+  # Helper method for calls into third-party code - suppresses Ruby warnings
+  # for the given block since we have no control over that code.
   def self.silence_warnings(&block)
     warn_level = $VERBOSE
     $VERBOSE = nil

--- a/lib/cisco_node_utils/environment.rb
+++ b/lib/cisco_node_utils/environment.rb
@@ -23,6 +23,8 @@ module Cisco
     @environments = {}
     @default_environment_name = 'default'
 
+    # Autogenerate Cisco::Environment.default_environment_name and
+    # Cisco::Environment.default_environment_name= class methods.
     class << self
       attr_accessor :default_environment_name
     end

--- a/lib/cisco_node_utils/environment.rb
+++ b/lib/cisco_node_utils/environment.rb
@@ -1,0 +1,93 @@
+# March 2016, Glenn F. Matthews
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'yaml'
+require_relative 'logger'
+
+module Cisco
+  # Class representing the configuration environment
+  class Environment
+    @environments = {}
+    @default_environment_name = 'default'
+
+    class << self
+      attr_accessor :default_environment_name
+    end
+
+    # We have three tiers of configuration:
+    # 1) default (defined in this file)
+    # 2) System-wide gem configuration in /etc/cisco_node_utils.yaml
+    # 3) User configuration in ~/cisco_node_utils.yaml
+
+    DEFAULT_ENVIRONMENT = {
+      host:     nil, # localhost by default
+      port:     nil, # only applicable to gRPC
+      username: nil,
+      password: nil,
+    }
+
+    def self.environments
+      if @environments.empty?
+        @environments = merge_config('/etc/cisco_node_utils.yaml',
+                                     @environments)
+        @environments = merge_config('~/cisco_node_utils.yaml',
+                                     @environments)
+        @environments.each do |name, config|
+          Cisco::Logger.debug("Environment '#{name}': #{config}")
+        end
+      end
+      @environments
+    end
+
+    def self.merge_config(path, current_config)
+      begin
+        path = File.expand_path(path)
+      rescue ArgumentError => e
+        # Can happen if path includes '~' but $HOME is not defined
+        Cisco::Logger.debug "Failed to load #{path}: #{e}"
+        return current_config
+      end
+      if File.file?(path)
+        if File.readable?(path)
+          data = YAML.load_file(path)
+          data.each do |name, config|
+            # in case config is nil:
+            config ||= {}
+            # in case current_config has no entry for this name:
+            current_config[name] ||= DEFAULT_ENVIRONMENT.clone
+            # merge it on in!
+            current_config[name].merge!(strings_to_symbols(config))
+          end
+        else
+          Cisco::Logger.debug "No permissions to read #{path}"
+        end
+      else
+        Cisco::Logger.debug "No file found at #{path}"
+      end
+      current_config
+    end
+
+    def self.strings_to_symbols(hash)
+      Hash[hash.map { |k, v| [k.to_sym, v] }]
+    end
+
+    def self.environment(name=nil)
+      name ||= @default_environment_name
+      Cisco::Logger.debug("Getting environment '#{name}'")
+      environments.fetch(name, DEFAULT_ENVIRONMENT)
+    end
+  end
+end

--- a/lib/cisco_node_utils/logger.rb
+++ b/lib/cisco_node_utils/logger.rb
@@ -19,6 +19,10 @@
 
 require 'logger'
 
+# Ensure module Cisco is defined
+module Cisco
+end
+
 # Module for logging in CiscoNodeUtils. Will automatically
 # tie into Puppet or Chef logging modules if available.
 module Cisco::Logger

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -151,16 +151,12 @@ module Cisco
 
     attr_reader :cmd_ref, :client
 
-    def self.instance(*args)
-      if @instance && !args.empty? && args != @args
-        fail "Can't change existing instance (#{@args} -> #{args})"
-      end
-      @args ||= args
-      @instance ||= new(*args)
+    def self.instance
+      @instance ||= new
     end
 
-    def initialize(*args)
-      @client = Cisco::Client.create(*args)
+    def initialize
+      @client = Cisco::Client.create
       @cmd_ref = nil
       @cmd_ref = CommandReference.new(product:      product_id,
                                       platform:     @client.platform,

--- a/lib/minitest/environment_plugin.rb
+++ b/lib/minitest/environment_plugin.rb
@@ -1,0 +1,31 @@
+# March 2016, Glenn F. Matthews
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative '../cisco_node_utils/environment'
+
+# Add environment option to minitest
+module Minitest
+  def self.plugin_environment_options(opts, options)
+    opts.on('-e', '--environment NAME', 'Select environment by name') do |name|
+      options[:environment] = name
+    end
+  end
+
+  def self.plugin_environment_init(options)
+    name = options[:environment]
+    Cisco::Environment.default_environment_name = name unless name.nil?
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,7 @@
+require_relative 'spec_helper.rb'
+require 'shared_examples_for_clients'
+require 'cisco_node_utils/client'
+
+describe Cisco::Client do
+  it_behaves_like 'all clients'
+end

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -1,0 +1,151 @@
+require_relative 'spec_helper.rb'
+require 'cisco_node_utils/environment'
+require 'cisco_node_utils/client'
+
+context 'Cisco::Environment examples' do
+  before(:example) do
+    allow(YAML).to receive(:load_file).and_wrap_original do |orig|
+      orig.call(File.expand_path('docs/cisco_node_utils.yaml.example'))
+    end
+  end
+
+  context '#merge_config' do
+    it 'handles File.expand_path errors' do
+      expect(File).to receive(:expand_path).and_raise(ArgumentError)
+      expect(Cisco::Environment.merge_config('~/foo/bar.yaml', {})).to eq({})
+    end
+
+    it 'handles nonexistent files' do
+      expect(File).to receive(:file?).and_return(false)
+      expect(Cisco::Environment.merge_config('/foo/bar.yaml', {})).to eq({})
+    end
+
+    it 'handles unreadable files' do
+      expect(File).to receive(:file?).and_return(true)
+      expect(File).to receive(:readable?).and_return(false)
+      expect(Cisco::Environment.merge_config('/foo/bar.yaml', {})).to eq({})
+    end
+
+    it 'merges valid content' do
+      base = { 'hello' => {
+        host:     '2.2.2.2',
+        port:     57_799,
+        username: nil,
+        password: nil,
+      } }
+      expect(File).to receive(:file?).and_return(true)
+      expect(File).to receive(:readable?).and_return(true)
+      expect(YAML).to receive(:load_file).and_return(
+        'hello' => { host: '1.1.1.1' }, 'goodbye' => { password: 'foo' })
+      expect(Cisco::Environment.merge_config('/foo/bar.yaml', base)).to eq(
+        'hello'   => {
+          host:     '1.1.1.1',
+          port:     57_799,
+          username: nil,
+          password: nil,
+        },
+        'goodbye' => {
+          host:     nil,
+          port:     nil,
+          username: nil,
+          password: 'foo',
+        },
+      )
+    end
+  end
+
+  context 'default' do
+    expected = {
+      host:     nil,
+      port:     nil,
+      username: nil,
+      password: nil,
+    }
+    it 'is loaded by default' do
+      expect(Cisco::Environment.environment).to eq(expected)
+    end
+    it 'can be loaded explicitly by name' do
+      expect(Cisco::Environment.environment('default')).to eq(expected)
+    end
+  end
+
+  context 'the "nxapi_local" example' do
+    expected = {
+      host:     nil,
+      port:     nil,
+      username: nil,
+      password: nil,
+    }
+    it 'can be loaded explicitly by name' do
+      expect(Cisco::Environment.environment('nxapi_local')).to eq(expected)
+    end
+    it 'can be specified as the default then loaded implicitly' do
+      Cisco::Environment.default_environment_name = 'nxapi_local'
+      expect(Cisco::Environment.environment).to eq(expected)
+    end
+    it 'is valid configuration for the NXAPI client' do
+      hash = Cisco::Environment.environment('nxapi_local')
+      Cisco::Client::NXAPI.validate_args(hash)
+    end
+  end
+
+  context 'the "nxapi_remote" example' do
+    expected = {
+      host:     '192.168.1.100',
+      port:     nil,
+      username: 'devops',
+      password: 'devops',
+    }
+    it 'can be loaded explicitly by name' do
+      expect(Cisco::Environment.environment('nxapi_remote')).to eq(expected)
+    end
+    it 'can be specified as the default then loaded implicitly' do
+      Cisco::Environment.default_environment_name = 'nxapi_remote'
+      expect(Cisco::Environment.environment).to eq(expected)
+    end
+    it 'is valid configuration for the NXAPI client' do
+      hash = Cisco::Environment.environment('nxapi_remote')
+      Cisco::Client::NXAPI.validate_args(hash)
+    end
+  end
+
+  context 'the "grpc_local" example' do
+    expected = {
+      host:     nil,
+      port:     57_999,
+      username: 'admin',
+      password: 'admin',
+    }
+    it 'can be loaded explicitly by name' do
+      expect(Cisco::Environment.environment('grpc_local')).to eq(expected)
+    end
+    it 'can be specified as default then loaded implicitly' do
+      Cisco::Environment.default_environment_name = 'grpc_local'
+      expect(Cisco::Environment.environment).to eq(expected)
+    end
+    it 'is valid configuration for the gRPC client' do
+      hash = Cisco::Environment.environment('grpc_local')
+      Cisco::Client::GRPC.validate_args(hash)
+    end
+  end
+
+  context 'the "grpc_remote" example' do
+    expected = {
+      host:     '192.168.1.100',
+      port:     nil,
+      username: 'admin',
+      password: 'admin',
+    }
+    it 'can be loaded explicitly by name' do
+      expect(Cisco::Environment.environment('grpc_remote')).to eq(expected)
+    end
+    it 'can be specified as default then loaded implicitly' do
+      Cisco::Environment.default_environment_name = 'grpc_remote'
+      expect(Cisco::Environment.environment).to eq(expected)
+    end
+    it 'is valid configuration for the gRPC client' do
+      hash = Cisco::Environment.environment('grpc_remote')
+      Cisco::Client::GRPC.validate_args(hash)
+    end
+  end
+end

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -2,24 +2,45 @@ require_relative 'spec_helper.rb'
 require 'cisco_node_utils/environment'
 require 'cisco_node_utils/client'
 
+class << Cisco::Environment
+  attr_writer :environments
+end
+
 describe Cisco::Environment do
-  context '#merge_config' do
+  after(:each) do
+    # Revert to default environment data
+    Cisco::Environment.environments = {}
+  end
+
+  describe '.data_from_file' do
     it 'handles File.expand_path errors' do
       expect(File).to receive(:expand_path).and_raise(ArgumentError)
-      expect(Cisco::Environment.merge_config('~/foo/bar.yaml', {})).to eq({})
+      expect(Cisco::Environment.data_from_file('~/foo/bar.yaml')).to be_empty
     end
 
     it 'handles nonexistent files' do
       expect(File).to receive(:file?).and_return(false)
-      expect(Cisco::Environment.merge_config('/foo/bar.yaml', {})).to eq({})
+      expect(Cisco::Environment.data_from_file('/foo/bar.yaml')).to be_empty
     end
 
     it 'handles unreadable files' do
       expect(File).to receive(:file?).and_return(true)
       expect(File).to receive(:readable?).and_return(false)
-      expect(Cisco::Environment.merge_config('/foo/bar.yaml', {})).to eq({})
+      expect(Cisco::Environment.data_from_file('/foo/bar.yaml')).to be_empty
     end
 
+    it 'handles YAML errors' do
+      expect(File).to receive(:file?).and_return(true)
+      expect(File).to receive(:readable?).and_return(true)
+      error = Psych::SyntaxError.new('/foo/bar.yaml', 1, 1, 0, 'foo', 'bar')
+      expect(YAML).to receive(:load_file).and_raise(error)
+      # Catch the error log message Environment will generate:
+      expect(Cisco::Logger).to receive(:error).once
+      expect(Cisco::Environment.data_from_file('/foo/bar.yaml')).to eq({})
+    end
+  end
+
+  describe '.merge_config' do
     it 'merges valid content' do
       base = { 'hello' => {
         host:     '2.2.2.2',
@@ -27,9 +48,7 @@ describe Cisco::Environment do
         username: nil,
         password: nil,
       } }
-      expect(File).to receive(:file?).and_return(true)
-      expect(File).to receive(:readable?).and_return(true)
-      expect(YAML).to receive(:load_file).and_return(
+      expect(Cisco::Environment).to receive(:data_from_file).and_return(
         'hello' => { host: '1.1.1.1' }, 'goodbye' => { password: 'foo' })
       expect(Cisco::Environment.merge_config('/foo/bar.yaml', base)).to eq(
         'hello'   => {
@@ -48,110 +67,196 @@ describe Cisco::Environment do
     end
   end
 
-  context 'default values' do
-    before(:example) do
-      allow(File).to receive(:file?).and_return(false)
+  describe '.environments' do
+    before(:each) do
+      allow(Cisco::Environment).to receive(:data_from_file).and_return({})
     end
-    expected = {
-      host:     nil,
-      port:     nil,
-      username: nil,
-      password: nil,
+
+    it 'is empty by default' do
+      expect(Cisco::Environment.environments).to be_empty
+    end
+
+    global_config = {
+      'default' => {
+        host: '127.0.0.1',
+        port: 57_400,
+      },
+      'global'  => {
+        username: 'global',
+        password: 'global',
+      },
     }
-    it 'is loaded by default' do
-      expect(Cisco::Environment.environment).to eq(expected)
+
+    user_config = {
+      'default' => {
+        port:     57_799,
+        username: 'user',
+      },
+      'user'    => {
+        username: 'user',
+        password: 'user',
+      },
+    }
+
+    it 'loads data from global config if present' do
+      expect(Cisco::Environment).to receive(:data_from_file).with(
+        '/etc/cisco_node_utils.yaml').and_return(global_config)
+      env = Cisco::Environment.environments
+      env.each do |key, hash|
+        # The env hash should be fully populated with keys
+        # Any keys unspecified in the data should be nil
+        %I(host port username password).each do |hash_key|
+          expect(hash.fetch(hash_key)).to \
+            eq(global_config[key].fetch(hash_key, nil))
+        end
+      end
     end
-    it 'can be loaded explicitly by name' do
-      expect(Cisco::Environment.environment('default')).to eq(expected)
+
+    it 'loads data from user config if present' do
+      expect(Cisco::Environment).to receive(:data_from_file).with(
+        '~/cisco_node_utils.yaml').and_return(user_config)
+      env = Cisco::Environment.environments
+      env.each do |key, hash|
+        # The env hash should be fully populated with keys
+        # Any keys unspecified in the data should be nil
+        %I(host port username password).each do |hash_key|
+          expect(hash.fetch(hash_key)).to \
+            eq(user_config[key].fetch(hash_key, nil))
+        end
+      end
+    end
+
+    it 'uses both files if present but user data takes precedence' do
+      expect(Cisco::Environment).to receive(:data_from_file).with(
+        '/etc/cisco_node_utils.yaml').and_return(global_config)
+      expect(Cisco::Environment).to receive(:data_from_file).with(
+        '~/cisco_node_utils.yaml').and_return(user_config)
+      expect(Cisco::Environment.environments).to eq(
+        'default' => {
+          host:     '127.0.0.1', # global config
+          port:     57_799, # user overrides global
+          username: 'user', # user config
+          password: nil, # auto-populated with nil
+        },
+        'global'  => { # global config
+          host:     nil,
+          port:     nil,
+          username: 'global',
+          password: 'global',
+        },
+        'user'    => { # user config
+          host:     nil,
+          port:     nil,
+          username: 'user',
+          password: 'user',
+        },
+      )
     end
   end
 
-  context 'examples in docs/cisco_node_utils.yaml.example' do
-    before(:example) do
-      allow(File).to receive(:file?).and_return(true)
-      allow(File).to receive(:readable?).and_return(true)
-      allow(YAML).to receive(:load_file).and_wrap_original do |orig|
-        orig.call(File.expand_path('docs/cisco_node_utils.yaml.example'))
+  context '.environment' do
+    context 'with no config files available' do
+      before(:each) do
+        allow(Cisco::Environment).to receive(:data_from_file).and_return({})
+      end
+
+      it 'returns DEFAULT_ENVIRONMENT when called with no args' do
+        expect(Cisco::Environment.environment).to \
+          eq(Cisco::Environment::DEFAULT_ENVIRONMENT)
+      end
+      it 'returns DEFAULT_ENVIRONMENT when requested by name as "default"' do
+        expect(Cisco::Environment.environment('default')).to \
+          eq(Cisco::Environment::DEFAULT_ENVIRONMENT)
       end
     end
 
-    context 'the "nxapi_local" example' do
-      expected = {
-        host:     nil,
-        port:     nil,
-        username: nil,
-        password: nil,
-      }
-      it 'can be loaded explicitly by name' do
-        expect(Cisco::Environment.environment('nxapi_local')).to eq(expected)
+    context 'with examples in docs/cisco_node_utils.yaml.example' do
+      before(:each) do
+        allow(File).to receive(:file?).and_return(true)
+        allow(File).to receive(:readable?).and_return(true)
+        allow(YAML).to receive(:load_file).and_wrap_original do |orig|
+          orig.call(File.expand_path('docs/cisco_node_utils.yaml.example'))
+        end
       end
-      it 'can be specified as the default then loaded implicitly' do
-        Cisco::Environment.default_environment_name = 'nxapi_local'
-        expect(Cisco::Environment.environment).to eq(expected)
-      end
-      it 'is valid configuration for the NXAPI client' do
-        hash = Cisco::Environment.environment('nxapi_local')
-        Cisco::Client::NXAPI.validate_args(hash)
-      end
-    end
 
-    context 'the "nxapi_remote" example' do
-      expected = {
-        host:     '192.168.1.100',
-        port:     nil,
-        username: 'devops',
-        password: 'devops',
-      }
-      it 'can be loaded explicitly by name' do
-        expect(Cisco::Environment.environment('nxapi_remote')).to eq(expected)
+      context 'the "nxapi_local" example' do
+        expected = {
+          host:     nil,
+          port:     nil,
+          username: nil,
+          password: nil,
+        }
+        it 'can be loaded explicitly by name' do
+          expect(Cisco::Environment.environment('nxapi_local')).to eq(expected)
+        end
+        it 'can be specified as the default then loaded implicitly' do
+          Cisco::Environment.default_environment_name = 'nxapi_local'
+          expect(Cisco::Environment.environment).to eq(expected)
+        end
+        it 'is valid configuration for the NXAPI client' do
+          hash = Cisco::Environment.environment('nxapi_local')
+          Cisco::Client::NXAPI.validate_args(hash)
+        end
       end
-      it 'can be specified as the default then loaded implicitly' do
-        Cisco::Environment.default_environment_name = 'nxapi_remote'
-        expect(Cisco::Environment.environment).to eq(expected)
-      end
-      it 'is valid configuration for the NXAPI client' do
-        hash = Cisco::Environment.environment('nxapi_remote')
-        Cisco::Client::NXAPI.validate_args(hash)
-      end
-    end
 
-    context 'the "grpc_local" example' do
-      expected = {
-        host:     nil,
-        port:     57_999,
-        username: 'admin',
-        password: 'admin',
-      }
-      it 'can be loaded explicitly by name' do
-        expect(Cisco::Environment.environment('grpc_local')).to eq(expected)
+      context 'the "nxapi_remote" example' do
+        expected = {
+          host:     '192.168.1.100',
+          port:     nil,
+          username: 'devops',
+          password: 'devops',
+        }
+        it 'can be loaded explicitly by name' do
+          expect(Cisco::Environment.environment('nxapi_remote')).to eq(expected)
+        end
+        it 'can be specified as the default then loaded implicitly' do
+          Cisco::Environment.default_environment_name = 'nxapi_remote'
+          expect(Cisco::Environment.environment).to eq(expected)
+        end
+        it 'is valid configuration for the NXAPI client' do
+          hash = Cisco::Environment.environment('nxapi_remote')
+          Cisco::Client::NXAPI.validate_args(hash)
+        end
       end
-      it 'can be specified as default then loaded implicitly' do
-        Cisco::Environment.default_environment_name = 'grpc_local'
-        expect(Cisco::Environment.environment).to eq(expected)
-      end
-      it 'is valid configuration for the gRPC client' do
-        hash = Cisco::Environment.environment('grpc_local')
-        Cisco::Client::GRPC.validate_args(hash)
-      end
-    end
 
-    context 'the "grpc_remote" example' do
-      expected = {
-        host:     '192.168.1.100',
-        port:     nil,
-        username: 'admin',
-        password: 'admin',
-      }
-      it 'can be loaded explicitly by name' do
-        expect(Cisco::Environment.environment('grpc_remote')).to eq(expected)
+      context 'the "grpc_local" example' do
+        expected = {
+          host:     nil,
+          port:     57_999,
+          username: 'admin',
+          password: 'admin',
+        }
+        it 'can be loaded explicitly by name' do
+          expect(Cisco::Environment.environment('grpc_local')).to eq(expected)
+        end
+        it 'can be specified as default then loaded implicitly' do
+          Cisco::Environment.default_environment_name = 'grpc_local'
+          expect(Cisco::Environment.environment).to eq(expected)
+        end
+        it 'is valid configuration for the gRPC client' do
+          hash = Cisco::Environment.environment('grpc_local')
+          Cisco::Client::GRPC.validate_args(hash)
+        end
       end
-      it 'can be specified as default then loaded implicitly' do
-        Cisco::Environment.default_environment_name = 'grpc_remote'
-        expect(Cisco::Environment.environment).to eq(expected)
-      end
-      it 'is valid configuration for the gRPC client' do
-        hash = Cisco::Environment.environment('grpc_remote')
-        Cisco::Client::GRPC.validate_args(hash)
+
+      context 'the "grpc_remote" example' do
+        expected = {
+          host:     '192.168.1.100',
+          port:     nil,
+          username: 'admin',
+          password: 'admin',
+        }
+        it 'can be loaded explicitly by name' do
+          expect(Cisco::Environment.environment('grpc_remote')).to eq(expected)
+        end
+        it 'can be specified as default then loaded implicitly' do
+          Cisco::Environment.default_environment_name = 'grpc_remote'
+          expect(Cisco::Environment.environment).to eq(expected)
+        end
+        it 'is valid configuration for the gRPC client' do
+          hash = Cisco::Environment.environment('grpc_remote')
+          Cisco::Client::GRPC.validate_args(hash)
+        end
       end
     end
   end

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -2,13 +2,7 @@ require_relative 'spec_helper.rb'
 require 'cisco_node_utils/environment'
 require 'cisco_node_utils/client'
 
-context 'Cisco::Environment examples' do
-  before(:example) do
-    allow(YAML).to receive(:load_file).and_wrap_original do |orig|
-      orig.call(File.expand_path('docs/cisco_node_utils.yaml.example'))
-    end
-  end
-
+describe Cisco::Environment do
   context '#merge_config' do
     it 'handles File.expand_path errors' do
       expect(File).to receive(:expand_path).and_raise(ArgumentError)
@@ -54,7 +48,10 @@ context 'Cisco::Environment examples' do
     end
   end
 
-  context 'default' do
+  context 'default values' do
+    before(:example) do
+      allow(File).to receive(:file?).and_return(false)
+    end
     expected = {
       host:     nil,
       port:     nil,
@@ -69,83 +66,93 @@ context 'Cisco::Environment examples' do
     end
   end
 
-  context 'the "nxapi_local" example' do
-    expected = {
-      host:     nil,
-      port:     nil,
-      username: nil,
-      password: nil,
-    }
-    it 'can be loaded explicitly by name' do
-      expect(Cisco::Environment.environment('nxapi_local')).to eq(expected)
+  context 'examples in docs/cisco_node_utils.yaml.example' do
+    before(:example) do
+      allow(File).to receive(:file?).and_return(true)
+      allow(File).to receive(:readable?).and_return(true)
+      allow(YAML).to receive(:load_file).and_wrap_original do |orig|
+        orig.call(File.expand_path('docs/cisco_node_utils.yaml.example'))
+      end
     end
-    it 'can be specified as the default then loaded implicitly' do
-      Cisco::Environment.default_environment_name = 'nxapi_local'
-      expect(Cisco::Environment.environment).to eq(expected)
-    end
-    it 'is valid configuration for the NXAPI client' do
-      hash = Cisco::Environment.environment('nxapi_local')
-      Cisco::Client::NXAPI.validate_args(hash)
-    end
-  end
 
-  context 'the "nxapi_remote" example' do
-    expected = {
-      host:     '192.168.1.100',
-      port:     nil,
-      username: 'devops',
-      password: 'devops',
-    }
-    it 'can be loaded explicitly by name' do
-      expect(Cisco::Environment.environment('nxapi_remote')).to eq(expected)
+    context 'the "nxapi_local" example' do
+      expected = {
+        host:     nil,
+        port:     nil,
+        username: nil,
+        password: nil,
+      }
+      it 'can be loaded explicitly by name' do
+        expect(Cisco::Environment.environment('nxapi_local')).to eq(expected)
+      end
+      it 'can be specified as the default then loaded implicitly' do
+        Cisco::Environment.default_environment_name = 'nxapi_local'
+        expect(Cisco::Environment.environment).to eq(expected)
+      end
+      it 'is valid configuration for the NXAPI client' do
+        hash = Cisco::Environment.environment('nxapi_local')
+        Cisco::Client::NXAPI.validate_args(hash)
+      end
     end
-    it 'can be specified as the default then loaded implicitly' do
-      Cisco::Environment.default_environment_name = 'nxapi_remote'
-      expect(Cisco::Environment.environment).to eq(expected)
-    end
-    it 'is valid configuration for the NXAPI client' do
-      hash = Cisco::Environment.environment('nxapi_remote')
-      Cisco::Client::NXAPI.validate_args(hash)
-    end
-  end
 
-  context 'the "grpc_local" example' do
-    expected = {
-      host:     nil,
-      port:     57_999,
-      username: 'admin',
-      password: 'admin',
-    }
-    it 'can be loaded explicitly by name' do
-      expect(Cisco::Environment.environment('grpc_local')).to eq(expected)
+    context 'the "nxapi_remote" example' do
+      expected = {
+        host:     '192.168.1.100',
+        port:     nil,
+        username: 'devops',
+        password: 'devops',
+      }
+      it 'can be loaded explicitly by name' do
+        expect(Cisco::Environment.environment('nxapi_remote')).to eq(expected)
+      end
+      it 'can be specified as the default then loaded implicitly' do
+        Cisco::Environment.default_environment_name = 'nxapi_remote'
+        expect(Cisco::Environment.environment).to eq(expected)
+      end
+      it 'is valid configuration for the NXAPI client' do
+        hash = Cisco::Environment.environment('nxapi_remote')
+        Cisco::Client::NXAPI.validate_args(hash)
+      end
     end
-    it 'can be specified as default then loaded implicitly' do
-      Cisco::Environment.default_environment_name = 'grpc_local'
-      expect(Cisco::Environment.environment).to eq(expected)
-    end
-    it 'is valid configuration for the gRPC client' do
-      hash = Cisco::Environment.environment('grpc_local')
-      Cisco::Client::GRPC.validate_args(hash)
-    end
-  end
 
-  context 'the "grpc_remote" example' do
-    expected = {
-      host:     '192.168.1.100',
-      port:     nil,
-      username: 'admin',
-      password: 'admin',
-    }
-    it 'can be loaded explicitly by name' do
-      expect(Cisco::Environment.environment('grpc_remote')).to eq(expected)
+    context 'the "grpc_local" example' do
+      expected = {
+        host:     nil,
+        port:     57_999,
+        username: 'admin',
+        password: 'admin',
+      }
+      it 'can be loaded explicitly by name' do
+        expect(Cisco::Environment.environment('grpc_local')).to eq(expected)
+      end
+      it 'can be specified as default then loaded implicitly' do
+        Cisco::Environment.default_environment_name = 'grpc_local'
+        expect(Cisco::Environment.environment).to eq(expected)
+      end
+      it 'is valid configuration for the gRPC client' do
+        hash = Cisco::Environment.environment('grpc_local')
+        Cisco::Client::GRPC.validate_args(hash)
+      end
     end
-    it 'can be specified as default then loaded implicitly' do
-      Cisco::Environment.default_environment_name = 'grpc_remote'
-      expect(Cisco::Environment.environment).to eq(expected)
-    end
-    it 'is valid configuration for the gRPC client' do
-      hash = Cisco::Environment.environment('grpc_remote')
-      Cisco::Client::GRPC.validate_args(hash)
+
+    context 'the "grpc_remote" example' do
+      expected = {
+        host:     '192.168.1.100',
+        port:     nil,
+        username: 'admin',
+        password: 'admin',
+      }
+      it 'can be loaded explicitly by name' do
+        expect(Cisco::Environment.environment('grpc_remote')).to eq(expected)
+      end
+      it 'can be specified as default then loaded implicitly' do
+        Cisco::Environment.default_environment_name = 'grpc_remote'
+        expect(Cisco::Environment.environment).to eq(expected)
+      end
+      it 'is valid configuration for the gRPC client' do
+        hash = Cisco::Environment.environment('grpc_remote')
+        Cisco::Client::GRPC.validate_args(hash)
+      end
     end
   end
 end

--- a/spec/grpc_client_spec.rb
+++ b/spec/grpc_client_spec.rb
@@ -1,0 +1,23 @@
+require_relative 'spec_helper.rb'
+require 'shared_examples_for_clients'
+require 'cisco_node_utils/client/grpc'
+
+describe Cisco::Client::GRPC do
+  it_behaves_like 'all clients'
+
+  describe '.validate_args' do
+    it 'rejects nil username' do
+      kwargs = { host: '1.1.1.1', username: nil, password: 'bye' }
+      expect { described_class.validate_args(**kwargs) }.to \
+        raise_error(TypeError,
+                    'gRPC client creation failure: username must be specified')
+    end
+
+    it 'rejects nil password' do
+      kwargs = { host: '1.1.1.1', username: 'hi', password: nil }
+      expect { described_class.validate_args(**kwargs) }.to \
+        raise_error(TypeError,
+                    'gRPC client creation failure: password must be specified')
+    end
+  end
+end

--- a/spec/isolate/no_clients_spec.rb
+++ b/spec/isolate/no_clients_spec.rb
@@ -19,7 +19,7 @@ context 'when no client implementations are installed' do
 
   it 'should fail Client.create' do
     require 'cisco_node_utils'
-    expect { Cisco::Client.create('1.1.1.1', 'u', 'p') }.to \
+    expect { Cisco::Client.create }.to \
       raise_error(RuntimeError, 'No client implementations available!')
   end
   # TODO

--- a/spec/nxapi_client_spec.rb
+++ b/spec/nxapi_client_spec.rb
@@ -1,0 +1,42 @@
+require_relative 'spec_helper.rb'
+require 'shared_examples_for_clients'
+require 'cisco_node_utils/client/nxapi'
+
+describe Cisco::Client::NXAPI do
+  it_behaves_like 'all clients'
+
+  describe '.validate_args' do
+    it 'accepts nil host, username, and password together' do
+      described_class.validate_args
+    end
+
+    it 'rejects the combination of nil host with non-nil username' do
+      kwargs = { host: nil, username: 'hi', password: nil }
+      expect { described_class.validate_args(**kwargs) }.to \
+        raise_error(ArgumentError)
+    end
+
+    it 'rejects the combination of nil host with non-nil password' do
+      kwargs = { host: nil, username: nil, password: 'bye' }
+      expect { described_class.validate_args(**kwargs) }.to \
+        raise_error(ArgumentError)
+    end
+
+    it 'accepts a host with username and password' do
+      kwargs = { host: '1.1.1.1', username: 'hi', password: 'bye' }
+      described_class.validate_args(**kwargs)
+    end
+
+    it 'rejects a host with nil username' do
+      kwargs = { host: '1.1.1.1', username: nil, password: 'bye' }
+      expect { described_class.validate_args(**kwargs) }.to \
+        raise_error(TypeError, 'username is required')
+    end
+
+    it 'rejects a host with nil password' do
+      kwargs = { host: '1.1.1.1', username: 'hi', password: nil }
+      expect { described_class.validate_args(**kwargs) }.to \
+        raise_error(TypeError, 'password is required')
+    end
+  end
+end

--- a/spec/shared_examples_for_clients.rb
+++ b/spec/shared_examples_for_clients.rb
@@ -1,0 +1,14 @@
+shared_examples_for 'all clients' do
+  describe '.validate_args' do
+    %i(host username password).each do |sym|
+      it "rejects non-String #{sym}" do
+        expect { described_class.validate_args(sym => 12) }.to \
+          raise_error(TypeError)
+      end
+      it "rejects empty #{sym}" do
+        expect { described_class.validate_args(sym => '') }.to \
+          raise_error(ArgumentError)
+      end
+    end
+  end
+end

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -86,6 +86,18 @@ class TestCase < Minitest::Test
   end
 
   def setup
+    # Hack - populate environment from user-entered values from basetest.rb
+    if Cisco::Environment.environments.empty?
+      class << Cisco::Environment
+        attr_writer :environments
+      end
+      Cisco::Environment.environments['default'] = {
+        host:     address.split(':')[0],
+        port:     address.split(':')[1],
+        username: username,
+        password: password,
+      }
+    end
     @device = Net::Telnet.new('Host'    => address.split(':')[0],
                               'Timeout' => 240,
                               # NX-OS has a space after '#', IOS XR does not

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -31,6 +31,7 @@ gem 'minitest', '~> 5.0'
 require 'minitest/autorun'
 require 'net/telnet'
 require_relative '../lib/cisco_node_utils/client'
+require_relative '../lib/cisco_node_utils/environment'
 require_relative '../lib/cisco_node_utils/command_reference'
 require_relative '../lib/cisco_node_utils/logger'
 
@@ -41,22 +42,12 @@ require_relative '../lib/cisco_node_utils/logger'
 # TestCase - common base class for all minitest cases in this module.
 #   Most node utility tests should inherit from CiscoTestCase instead.
 class TestCase < Minitest::Test
-  # These variables can be set in one of three ways:
-  # 1) ARGV:
-  #   $ ruby basetest.rb -- address[:port] username password
-  # 2) NODE environment variable
-  #   $ export NODE="address[:port] username password"
-  #   $ rake test
-  # 3) At run time:
-  #   $ rake test
-  #   Enter address or hostname of node under test:
   @@address = nil
   @@username = nil
   @@password = nil
 
   def self.address
-    @@address ||= ARGV[0]
-    @@address ||= ENV['NODE'].split(' ')[0] if ENV['NODE']
+    @@address ||= Cisco::Environment.environment[:host]
     unless @@address
       print 'Enter address or hostname of node under test: '
       @@address = gets.chomp
@@ -69,8 +60,7 @@ class TestCase < Minitest::Test
   end
 
   def self.username
-    @@username ||= ARGV[1]
-    @@username ||= ENV['NODE'].split(' ')[1] if ENV['NODE']
+    @@username ||= Cisco::Environment.environment[:username]
     unless @@username
       print 'Enter username for node under test:           '
       @@username = gets.chomp
@@ -83,8 +73,7 @@ class TestCase < Minitest::Test
   end
 
   def self.password
-    @@password ||= ARGV[2]
-    @@password ||= ENV['NODE'].split(' ')[2] if ENV['NODE']
+    @@password ||= Cisco::Environment.environment[:password]
     unless @@password
       print 'Enter password for node under test:           '
       @@password = gets.chomp

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -58,7 +58,7 @@ class CiscoTestCase < TestCase
   def self.node
     unless @@node
       # rubocop:disable Style/ClassVars
-      @@node = Node.instance(address, username, password)
+      @@node = Node.instance
       # rubocop:enable Style/ClassVars
       @@node.cache_enable = true
       @@node.cache_auto = true

--- a/tests/test_grpc.rb
+++ b/tests/test_grpc.rb
@@ -25,7 +25,7 @@ class TestGRPC < TestCase
   def self.runnable_methods
     # If we're pointed to an NXAPI node (as evidenced by lack of a port num)
     # then these tests don't apply
-    return [:all_skipped] unless address[/:/]
+    return [:all_skipped] unless Cisco::Environment.environment[:port]
     super
   end
 
@@ -35,7 +35,7 @@ class TestGRPC < TestCase
 
   def client
     unless @@client
-      client = Cisco::Client::GRPC.new(address, username, password)
+      client = Cisco::Client::GRPC.new(Cisco::Environment.environment)
       client.cache_enable = true
       client.cache_auto = true
       @@client = client # rubocop:disable Style/ClassVars
@@ -186,7 +186,7 @@ int gi0/0/0/0 bark bark
   # TODO: add structured output test cases (when supported on XR)
 
   def test_smart_create
-    autoclient = Cisco::Client.create(address, username, password)
+    autoclient = Cisco::Client.create
     assert_equal(Cisco::Client::GRPC, autoclient.class)
     assert(autoclient.supports?(:cli))
     refute(autoclient.supports?(:nxapi_structured))

--- a/tests/test_node.rb
+++ b/tests/test_node.rb
@@ -22,10 +22,7 @@ include Cisco
 # TestNode - Minitest for core functionality of Node class
 class TestNode < TestCase
   def setup
-    # Load parameters for login
-    address
-    username
-    password
+    super
     # Clear out the environment so we have control over which parameters
     # we provide to Node to connect with.
     Node.instance_variable_set(:@instance, nil)

--- a/tests/test_node.rb
+++ b/tests/test_node.rb
@@ -28,104 +28,26 @@ class TestNode < TestCase
     password
     # Clear out the environment so we have control over which parameters
     # we provide to Node to connect with.
-    @env_node = ENV['NODE']
-    ENV['NODE'] = nil
     Node.instance_variable_set(:@instance, nil)
   end
 
-  def teardown
-    # Restore the environment
-    ENV['NODE'] = @env_node
-  end
-
-  def test_connect_zero_arguments
-    # No UDS present on the test host, so default logic fails to connect
+  def test_connect_no_environment
+    environment = Node::Environment.default_environment_name
+    Node::Environment.default_environment_name = '!@#$&@#$' # nonexistent
+    # No UDS present on the test host, so default environment fails to connect
     assert_raises(Cisco::ConnectionRefused) do
       Node.new
     end
     assert_raises(RuntimeError) do
       Node.instance
     end
+  ensure
+    Node::Environment.default_environment_name = environment
   end
 
-  def test_connect_one_argument
-    assert_raises(TypeError, ArgumentError) do
-      Node.new(address)
-    end
-    assert_raises(TypeError, ArgumentError) do
-      Node.instance(address)
-    end
-  end
-
-  def test_connect_two_arguments
-    assert_raises(TypeError, ArgumentError) do
-      Node.new(username, password)
-    end
-    assert_raises(TypeError, ArgumentError) do
-      Node.instance(username, password)
-    end
-  end
-
-  def test_connect_nil_username
-    assert_raises(TypeError, ArgumentError) do
-      Node.new(address, nil, password)
-    end
-    assert_raises(TypeError, ArgumentError) do
-      Node.instance(address, nil, password)
-    end
-  end
-
-  def test_connect_invalid_username
-    assert_raises(TypeError, ArgumentError) do
-      Node.new(address, self, password)
-    end
-    assert_raises(TypeError, ArgumentError) do
-      Node.instance(address, self, password)
-    end
-  end
-
-  def test_connect_username_zero_length
-    assert_raises(ArgumentError) do
-      Node.new(address, '', password)
-    end
-    assert_raises(ArgumentError) do
-      Node.instance(address, '', password)
-    end
-  end
-
-  def test_connect_nil_password
-    assert_raises(TypeError, ArgumentError) do
-      Node.new(address, username, nil)
-    end
-    assert_raises(TypeError, ArgumentError) do
-      Node.instance(address, username, nil)
-    end
-  end
-
-  def test_connect_invalid_password
-    assert_raises(TypeError, ArgumentError) do
-      Node.new(address, username, self)
-    end
-    assert_raises(TypeError, ArgumentError) do
-      Node.instance(address, username, self)
-    end
-  end
-
-  def test_connect_password_zero_length
-    assert_raises(ArgumentError) do
-      Node.new(address, username, '')
-    end
-    assert_raises(ArgumentError) do
-      Node.instance(address, username, '')
-    end
-  end
-
-  def test_connect
-    node = Node.instance(address, username, password)
+  def test_singleton
+    node = Node.instance
     node2 = Node.instance
     assert_equal(node, node2)
-    assert_raises(RuntimeError) do
-      Node.instance(address, 'hello', 'goodbye')
-    end
   end
 end

--- a/tests/test_nxapi.rb
+++ b/tests/test_nxapi.rb
@@ -23,7 +23,7 @@ class TestNxapi < TestCase
   def self.runnable_methods
     # If we're pointed to a gRPC node (as evidenced by presence of a port num)
     # then these tests don't apply
-    return [:all_skipped] if address[/:/]
+    return [:all_skipped] if Cisco::Environment.environment[:port]
     super
   end
 
@@ -33,7 +33,7 @@ class TestNxapi < TestCase
 
   def client
     unless @@client
-      client = Cisco::Client::NXAPI.new(address, username, password)
+      client = Cisco::Client::NXAPI.new(Cisco::Environment.environment)
       client.cache_enable = true
       client.cache_auto = true
       @@client = client # rubocop:disable Style/ClassVars
@@ -178,7 +178,7 @@ class TestNxapi < TestCase
   end
 
   def test_smart_create
-    autoclient = Cisco::Client.create(address, username, password)
+    autoclient = Cisco::Client.create
     assert_equal(Cisco::Client::NXAPI, autoclient.class)
     assert(autoclient.supports?(:cli))
     assert(autoclient.supports?(:nxapi_structured))


### PR DESCRIPTION
Add support for global (/etc/cisco_node_utils.yaml) and per-user (~/cisco_node_utils.yaml) configuration files - see `docs/cisco_node_utils.yaml.example` below. This replaces the `$NODE` environment variable previously used in minitest and the gRPC client, and also removes the `ARGV` hack that minitest used as a secondary option. 

Tests are now run as:
`rake test` / `ruby tests/test_foo.rb` -- use the node information defined as `default` in the YAML file(s)
`rake test TESTOPTS='--environment=n7k'` / `ruby tests/test_foo.rb --environment n7k` -- use the node defined as `n7k` in the YAML file(s).

That's right - you can define multiple nodes in your config file and switch between them by name when running tests. :smile: This should make regression testing and CI integration more straightforward.

From a deployment perspective, the expectation is that gRPC (IOS XR) nodes will have as an additional provisioning step the creation of `/etc/cisco_node_utils.yaml`, provisioning this file with the XR username/password to use for management, and marking this file as `chmod 0600` so that only root can read it.

The YAML loading is managed by new class `Cisco::Environment`. I've added an RSpec test for this class, and moved much of the negative testing of client input validation from test_node.rb into spec tests for the various client classes. 
