### PR TITLE
test_vrf/test_vrf_af updates

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vrf_af.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vrf_af.yaml
@@ -39,14 +39,14 @@ route_policy_import:
     set_value: '<state> import route-policy <policy_name>'
 
 route_target_both_auto:
-  _exclude: [ios_xr]
+  _exclude: [N3k, ios_xr]
   kind: boolean
   get_value: '/^route-target both auto$/'
   set_value: '<state> route-target both auto'
   default_value: false
 
 route_target_both_auto_evpn:
-  _exclude: [ios_xr]
+  _exclude: [N3k, ios_xr]
   kind: boolean
   get_value: '/^route-target both auto evpn$/'
   set_value: '<state> route-target both auto evpn'
@@ -67,7 +67,7 @@ route_target_export:
     set_value: '<state> export route-target <community>'
 
 route_target_export_evpn:
-  _exclude: [ios_xr]
+  _exclude: [N3k, ios_xr]
   multiple: true
   get_value: '/^route-target export (\S+) evpn$/'
   set_value: '<state> route-target export <community> evpn'
@@ -99,7 +99,7 @@ route_target_import:
     set_value: '<state> import route-target <community>'
 
 route_target_import_evpn:
-  _exclude: [ios_xr]
+  _exclude: [N3k, ios_xr]
   multiple: true
   get_value: '/^route-target import (\S+) evpn$/'
   set_value: '<state> route-target import <community> evpn'

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -86,6 +86,10 @@ module Cisco
       return false
     end
 
+    def self.nv_overlay_supported?
+      node.cmd_ref.supports?('feature', 'nv_overlay')
+    end
+
     # ---------------------------
     def self.nv_overlay_evpn_enable
       return if nv_overlay_evpn_enabled?
@@ -94,6 +98,10 @@ module Cisco
 
     def self.nv_overlay_evpn_enabled?
       config_get('feature', 'nv_overlay_evpn')
+    end
+
+    def self.nv_overlay_evpn_supported?
+      node.cmd_ref.supports?('feature', 'nv_overlay_evpn')
     end
 
     # ---------------------------

--- a/lib/cisco_node_utils/vrf.rb
+++ b/lib/cisco_node_utils/vrf.rb
@@ -141,12 +141,14 @@ module Cisco
       # feature bgp and nv overlay required for rd cli in NXOS
       if platform == :nexus
         Feature.bgp_enable
-        Feature.nv_overlay_enable      # TBD: Only req'd for n7k?
-        Feature.nv_overlay_evpn_enable # TBD: Only req'd for n7k?
+        Feature.nv_overlay_enable if Feature.nv_overlay_supported?
+        Feature.nv_overlay_evpn_enable if Feature.nv_overlay_evpn_supported?
       end
       if rd == default_route_distinguisher
         state = 'no'
-        rd = ''
+        # I2 images require an rd for removal
+        rd = route_distinguisher
+        return if rd.to_s.empty?
       else
         state = ''
       end

--- a/lib/cisco_node_utils/vrf_af.rb
+++ b/lib/cisco_node_utils/vrf_af.rb
@@ -96,6 +96,7 @@ module Cisco
     end
 
     def route_policy_export=(name)
+      Feature.bgp_enable if platform == :nexus
       # Nexus requires passing in <policy_name> in "no export map" command.
       if name
         set_args_keys(state: '', policy_name: name)
@@ -116,6 +117,7 @@ module Cisco
     end
 
     def route_policy_import=(name)
+      Feature.bgp_enable if platform == :nexus
       # Nexus requires passing in <policy_name> in "no import map" command.
       if name
         set_args_keys(state: '', policy_name: name)

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -74,7 +74,7 @@ class TestVrf < CiscoTestCase
   end
 
   # This helper is needed on some platforms to allow enough time for the
-  # 'no shutdown' process to complete before 'shutdown' can be successful.
+  # 'shutdown' process to complete before 'no shutdown' can be successful.
   def shutdown_with_sleep(obj, val)
     obj.shutdown = val
   rescue CliError => e

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -29,8 +29,8 @@ class TestVrf < CiscoTestCase
   end
 
   def teardown
-    super
     remove_all_vrfs
+    super
   end
 
   def test_collection_default
@@ -84,11 +84,15 @@ class TestVrf < CiscoTestCase
     end
     v.shutdown = true
     assert(v.shutdown)
+
+    sleep 20 if node.product_id[/N(5|6)/]
     v.shutdown = false
     refute(v.shutdown)
 
     v.shutdown = true
     assert(v.shutdown)
+
+    sleep 20 if node.product_id[/N(5|6)/]
     v.shutdown = v.default_shutdown
     refute(v.shutdown)
     v.destroy
@@ -165,6 +169,9 @@ class TestVrf < CiscoTestCase
 
   def test_vni
     vrf = Vrf.new('test_vni')
+    assert_equal(vrf.default_vni, vrf.vni,
+                 'vrf vni should be set to default value')
+
     vrf.vni = 4096
     assert_equal(4096, vrf.vni,
                  "vrf vni should be set to '4096'")

--- a/tests/test_vrf_af.rb
+++ b/tests/test_vrf_af.rb
@@ -132,7 +132,7 @@ class TestVrfAf < CiscoTestCase
     refute(v.default_route_target_both_auto_evpn,
            'default value for route target both auto evpn should be false')
 
-    if platform == :ios_xr || node.product_id[/N3/]
+    if validate_property_excluded?('vrf_af', 'route_target_both_auto')
       assert_raises(Cisco::UnsupportedError) { v.route_target_both_auto = true }
     else
       v.route_target_both_auto = true
@@ -144,7 +144,7 @@ class TestVrfAf < CiscoTestCase
              'v route-target both auto should be disabled')
     end
 
-    if platform == :ios_xr || node.product_id[/N3/]
+    if validate_property_excluded?('vrf_af', 'route_target_both_auto_evpn')
       assert_raises(Cisco::UnsupportedError) do
         v.route_target_both_auto_evpn = true
       end
@@ -188,12 +188,12 @@ class TestVrfAf < CiscoTestCase
       # non-evpn
       v.send("route_target_#{opt}=", should)
       # evpn
-      if platform == :nexus && !node.product_id[/N3/]
-        v.send("route_target_#{opt}_evpn=", should)
-      else
+      if validate_property_excluded?('vrf_af', "route_target_#{opt}_evpn")
         assert_raises(Cisco::UnsupportedError, "route_target_#{opt}_evpn=") do
           v.send("route_target_#{opt}_evpn=", should)
         end
+      else
+        v.send("route_target_#{opt}_evpn=", should)
       end
       # stitching
       if platform == :nexus
@@ -214,11 +214,11 @@ class TestVrfAf < CiscoTestCase
                    "#{test_id} : #{af} : route_target_#{opt}")
       # evpn
       result = v.send("route_target_#{opt}_evpn")
-      if platform == :nexus && !node.product_id[/N3/]
+      if validate_property_excluded?('vrf_af', "route_target_#{opt}_evpn")
+        assert_nil(result)
+      else
         assert_equal(should, result,
                      "#{test_id} : #{af} : route_target_#{opt}_evpn")
-      else
-        assert_nil(result)
       end
       # stitching
       result = v.send("route_target_#{opt}_stitching")

--- a/tests/test_vrf_af.rb
+++ b/tests/test_vrf_af.rb
@@ -23,16 +23,30 @@ class TestVrfAf < CiscoTestCase
 
   def setup
     super
-    remove_all_vrfs if @@pre_clean_needed
+    return unless @@pre_clean_needed
+    nexus_feature_disable
+    remove_all_vrfs
     @@pre_clean_needed = false # rubocop:disable Style/ClassVars
   end
 
   def teardown
-    super
+    nexus_feature_disable
     remove_all_vrfs
+    super
   end
 
-  def test_vrf_af_create_destroy
+  def nexus_feature_disable
+    config('no feature bgp')
+
+    # Some platforms complain when nv overlay is not configured
+    config_no_warn('no nv overlay evpn')
+
+    # Some platforms remove the 'evpn' command when 'no nv overlay evpn'
+    # is processed, while others must remove it explicitly.
+    config_no_warn('no evpn')
+  end
+
+  def test_create_destroy
     v1 = VrfAF.new('cyan', %w(ipv4 unicast))
     v2 = VrfAF.new('cyan', %w(ipv6 unicast))
     v3 = VrfAF.new('red', %w(ipv4 unicast))
@@ -118,7 +132,7 @@ class TestVrfAf < CiscoTestCase
     refute(v.default_route_target_both_auto_evpn,
            'default value for route target both auto evpn should be false')
 
-    if platform == :ios_xr
+    if platform == :ios_xr || node.product_id[/N3/]
       assert_raises(Cisco::UnsupportedError) { v.route_target_both_auto = true }
     else
       v.route_target_both_auto = true
@@ -130,7 +144,7 @@ class TestVrfAf < CiscoTestCase
              'v route-target both auto should be disabled')
     end
 
-    if platform == :ios_xr
+    if platform == :ios_xr || node.product_id[/N3/]
       assert_raises(Cisco::UnsupportedError) do
         v.route_target_both_auto_evpn = true
       end
@@ -174,7 +188,7 @@ class TestVrfAf < CiscoTestCase
       # non-evpn
       v.send("route_target_#{opt}=", should)
       # evpn
-      if platform == :nexus
+      if platform == :nexus && !node.product_id[/N3/]
         v.send("route_target_#{opt}_evpn=", should)
       else
         assert_raises(Cisco::UnsupportedError, "route_target_#{opt}_evpn=") do
@@ -200,7 +214,7 @@ class TestVrfAf < CiscoTestCase
                    "#{test_id} : #{af} : route_target_#{opt}")
       # evpn
       result = v.send("route_target_#{opt}_evpn")
-      if platform == :nexus
+      if platform == :nexus && !node.product_id[/N3/]
         assert_equal(should, result,
                      "#{test_id} : #{af} : route_target_#{opt}_evpn")
       else


### PR DESCRIPTION
- route_target_both_auto\* and route_target*evpn props require nv overlay evpn support, which we have excluded for n3k
- I2 images require an rd when removing the cli
- Fixed route_target_feature_enable() so that it only attempts to enable the feature command if it's actually supported.
- N5k/N6k vrf shutdown is timing sensitive
- Added feature disablement to test_vrf_af since some platforms can give a false positive if the testbed already has them enabled
- test_vrf & test_vrf_af now pass on all NX + I2
