### PR TITLE
Fixed issue in radius_server

### DIFF
--- a/lib/cisco_node_utils/radius_server.rb
+++ b/lib/cisco_node_utils/radius_server.rb
@@ -381,6 +381,9 @@ module Cisco
           unless format.is_a?(Integer)
       end
 
+      # Return as we don't need to do anything
+      return if value.nil? && key.nil?
+
       if value.nil? && !key.nil?
         config_set('radius_server',
                    'key',

--- a/tests/test_radius_server.rb
+++ b/tests/test_radius_server.rb
@@ -93,6 +93,9 @@ class TestRadiusServer < CiscoTestCase
       server.auth_port = 77
       assert_equal(77, Cisco::RadiusServer.radiusservers[id].auth_port)
 
+      server.key_set(nil, nil)
+      assert_equal(nil, Cisco::RadiusServer.radiusservers[id].key)
+
       server.key_set('44444444', nil)
       assert_equal('44444444', Cisco::RadiusServer.radiusservers[id].key)
     else


### PR DESCRIPTION
If someone where to set key => unset on a new (i.e. not already existing) resource, then an error would occur. This PR fixes that.
