### PR TITLE
test_overlay platform fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/overlay_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/overlay_global.yaml
@@ -3,6 +3,7 @@
 _exclude: [ios_xr]
 
 anycast_gateway_mac:
+  _exclude: [N3k]
   kind: string
   get_command: "show running all | inc 'fabric forwarding'"
   get_value: '/^fabric forwarding anycast-gateway-mac (\S+)$/'
@@ -10,6 +11,7 @@ anycast_gateway_mac:
   default_value: ""
 
 dup_host_ip_addr_detection:
+  _exclude: [N3k]
   get_command: "show running all | inc 'fabric forwarding'"
   get_value: '/^fabric forwarding dup-host-ip-addr-detection (\d+) (\d+)$/'
   set_value: "<state> fabric forwarding dup-host-ip-addr-detection <host_moves> <timeout>"

--- a/lib/cisco_node_utils/overlay_global.rb
+++ b/lib/cisco_node_utils/overlay_global.rb
@@ -51,6 +51,7 @@ module Cisco
     end
 
     def dup_host_ip_addr_detection_set(host_moves, timeout)
+      Feature.fabric_forwarding_enable
       Feature.nv_overlay_evpn_enable
       if host_moves == default_dup_host_ip_addr_detection_host_moves &&
          timeout == default_dup_host_ip_addr_detection_timeout

--- a/tests/test_overlay_global.rb
+++ b/tests/test_overlay_global.rb
@@ -25,13 +25,20 @@ class TestOverlayGlobal < CiscoTestCase
 
   def setup
     super
-    config('no feature fabric forwarding')
-    config('no nv overlay evpn')
-    config('l2rib dup-host-mac-detection default')
+    config_no_warn('no feature fabric forwarding')
+    config_no_warn('no nv overlay evpn')
+    config_no_warn('l2rib dup-host-mac-detection default')
   end
 
   def test_dup_host_ip_addr_detection
     o = OverlayGlobal.new
+    if validate_property_excluded?('overlay_global',
+                                   'dup_host_ip_addr_detection')
+      assert_raises(Cisco::UnsupportedError) do
+        o.dup_host_ip_addr_detection_set(200, 20)
+      end
+      return
+    end
 
     # Before enabling 'nv overlay evpn', these properties do not exist
     assert_nil(o.dup_host_ip_addr_detection_host_moves)
@@ -80,6 +87,11 @@ class TestOverlayGlobal < CiscoTestCase
 
   def test_anycast_gateway_mac
     o = OverlayGlobal.new
+    if validate_property_excluded?('overlay_global', 'anycast_gateway_mac')
+      assert_raises(Cisco::UnsupportedError) { o.anycast_gateway_mac = '1.1.1' }
+      return
+    end
+
     # Before enabling 'nv overlay evpn', this property does not exist
     assert_nil(o.anycast_gateway_mac)
 


### PR DESCRIPTION
- N3k excludes
- Feature.fabric_forwarding needed on some plats
- fix config warnings
- minitests 100% on all NX + I2. XR is n/a
