### PR TITLE
test_vxlan_vtep platform fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
@@ -47,6 +47,7 @@ source_intf:
   default_value: ''
 
 source_intf_hold_down_time:
+  _exclude: [N7k]
   kind: int
   get_value: '/^source-interface hold-down-time (\d+)$/'
   set_value: '<state> source-interface hold-down-time <time>'

--- a/lib/cisco_node_utils/vxlan_vtep.rb
+++ b/lib/cisco_node_utils/vxlan_vtep.rb
@@ -58,12 +58,12 @@ module Cisco
       Feature.nv_overlay_enable
       Feature.vn_segment_vlan_based_enable if VxlanVtep.mt_lite_support
       # re-use the "interface command ref hooks"
-      config_set('interface', 'create', @name)
+      config_set('interface', 'create', name: @name)
     end
 
     def destroy
       # re-use the "interface command ref hooks"
-      config_set('interface', 'destroy', @name)
+      config_set('interface', 'destroy', name: @name)
     end
 
     def ==(other)
@@ -75,16 +75,14 @@ module Cisco
     ########################################################
 
     def description
-      config_get('interface', 'description', @name)
+      config_get('interface', 'description', name: @name)
     end
 
     def description=(desc)
       fail TypeError unless desc.is_a?(String)
-      if desc.empty?
-        config_set('interface', 'description', @name, 'no', '')
-      else
-        config_set('interface', 'description', @name, '', desc)
-      end
+      state = desc.empty? ? 'no' : ''
+      config_set('interface', 'description',
+                 name: @name, state: state, desc: desc)
     end
 
     def default_description

--- a/tests/test_vxlan_vtep.rb
+++ b/tests/test_vxlan_vtep.rb
@@ -206,6 +206,12 @@ class TestVxlanVtep < CiscoTestCase
     mt_lite_env_setup if VxlanVtep.mt_lite_support
 
     vtep = VxlanVtep.new('nve1')
+    if validate_property_excluded?('vxlan_vtep', 'source_intf_hold_down_time')
+      assert_raises(Cisco::UnsupportedError) do
+        vtep.source_interface_hold_down_time = 50
+      end
+      return
+    end
 
     # Set source_interface to non-default value
     val = 'loopback55'


### PR DESCRIPTION
- vxlan_vtep uses the interface class, which was converted at some point to use key-val yaml; vxlan_vtep needed to be updated as well
- Added appropriate excludes and unsupported checks
