### PR TITLE
test_vxlan_vtep_vni platform fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
@@ -6,16 +6,17 @@ _template:
   get_command: "show running-config interface all | section 'interface nve'"
   get_context:
     - '/^interface <name>$/i'
-    - '/^member vni <vni> ?(associate-vrf)?$/'
+    - '(?)/^member vni <vni> ?(associate-vrf)?$/'
   set_context:
     - 'interface <name>'
-    - 'member vni <vni> <assoc_vrf>'
+    - '(?)member vni <vni> <assoc_vrf>'
 
 all_vnis:
   multiple:
   get_value: '/^member vni (\d+|\d+-\d+) ?(associate-vrf)?$/'
 
 ingress_replication:
+  _exclude: [N7k]
   kind: string
   get_value: '/^ingress-replication protocol (\S+)$/'
   set_value: '<state> ingress-replication protocol <protocol>'
@@ -27,6 +28,7 @@ multicast_group:
   default_value: ''
 
 peer_list:
+  _exclude: [N7k]
   multiple:
   get_context:
     - '/^interface <name>$/i'

--- a/lib/cisco_node_utils/vxlan_vtep_vni.rb
+++ b/lib/cisco_node_utils/vxlan_vtep_vni.rb
@@ -104,12 +104,16 @@ module Cisco
     #                      PROPERTIES                      #
     ########################################################
 
+    def ingress_replication_supported?
+      node.cmd_ref.supports?('vxlan_vtep_vni', 'ingress_replication')
+    end
+
     def ingress_replication
       config_get('vxlan_vtep_vni', 'ingress_replication', @get_args)
     end
 
     def remove_add_ingress_replication(protocol)
-      if ingress_replication.empty?
+      if ingress_replication.to_s.empty?
         set_args_keys(state: '', protocol: protocol)
         config_set('vxlan_vtep_vni', 'ingress_replication', @set_args)
       else
@@ -171,7 +175,7 @@ module Cisco
         ip_end = '' if ip_end.nil?
         # Since multicast group and ingress replication are exclusive
         # properties, remove ingress replication first
-        unless ingress_replication.empty?
+        if ingress_replication_supported? && !ingress_replication.empty?
           set_args_keys(state: 'no', protocol: ingress_replication)
           config_set('vxlan_vtep_vni', 'ingress_replication', @set_args)
         end

--- a/lib/cisco_node_utils/vxlan_vtep_vni.rb
+++ b/lib/cisco_node_utils/vxlan_vtep_vni.rb
@@ -113,6 +113,8 @@ module Cisco
     end
 
     def remove_add_ingress_replication(protocol)
+      # Note: ingress-replication is not supported on all platforms.
+      # Use to_s.empty check to also handle nil check.
       if ingress_replication.to_s.empty?
         set_args_keys(state: '', protocol: protocol)
         config_set('vxlan_vtep_vni', 'ingress_replication', @set_args)

--- a/tests/test_vxlan_vtep_vni.rb
+++ b/tests/test_vxlan_vtep_vni.rb
@@ -94,6 +94,10 @@ class TestVxlanVtepVni < CiscoTestCase
 
   def test_ingress_replication
     vni = VxlanVtepVni.new('nve1', '5000')
+    if validate_property_excluded?('vxlan_vtep_vni', 'ingress_replication')
+      assert_raises(Cisco::UnsupportedError) { vni.ingress_replication = 'bgp' }
+      return
+    end
 
     # Test non-default values
     vni.ingress_replication = 'static'
@@ -129,11 +133,13 @@ class TestVxlanVtepVni < CiscoTestCase
 
     # Test the case where an existing ingress_replication is removed before
     # configuring multicast_group
-    vni1.ingress_replication = 'static'
-    assert_equal('static', vni1.ingress_replication)
+    unless validate_property_excluded?('vxlan_vtep_vni', 'ingress_replication')
+      vni1.ingress_replication = 'static'
+      assert_equal('static', vni1.ingress_replication)
 
-    vni1.multicast_group = '224.1.1.1'
-    assert_equal('224.1.1.1', vni1.multicast_group)
+      vni1.multicast_group = '224.1.1.1'
+      assert_equal('224.1.1.1', vni1.multicast_group)
+    end
 
     # Test multicast group range
     vni2.multicast_group = '224.1.1.1 224.1.1.200'
@@ -148,6 +154,10 @@ class TestVxlanVtepVni < CiscoTestCase
 
   def test_peer_list
     vni = VxlanVtepVni.new('nve1', '6000')
+    if validate_property_excluded?('vxlan_vtep_vni', 'ingress_replication')
+      assert_raises(Cisco::UnsupportedError) { vni.peer_list = ['1.1.1.1'] }
+      return
+    end
 
     peer_list = ['1.1.1.1', '2.2.2.2', '3.3.3.3', '4.4.4.4']
 


### PR DESCRIPTION
- <vni> needs to be optional or else all_vnis fails
- no ingress_replication support on N7k, which means no peer-list either
- Some of the setters need to remove ingress-replication when setting other commands; however, they assumed ingress-replication was supported everywhere, so I added add'l checks for that.
- minitest now passes on all NX + I2 (yes, checked N8k as well). XR is n/a.
