### PR TITLE
Change RuntimeError to CliError

### DIFF
--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -18,6 +18,8 @@ require_relative 'basetest'
 require_relative 'platform_info'
 require_relative '../lib/cisco_node_utils/interface'
 require_relative '../lib/cisco_node_utils/node'
+require_relative '../lib/cisco_node_utils/vlan'
+require_relative '../lib/cisco_node_utils/bridge_domain'
 
 include Cisco
 
@@ -220,5 +222,23 @@ class CiscoTestCase < TestCase
     skip('Unable to find compatible interface in chassis') if slot.nil?
 
     "ethernet#{slot}/1"
+  end
+
+  def remove_all_vlans
+    # This testcase will remove all the vlans existing in the system
+    # specifically in cleanup for minitests
+    Vlan.vlans.each do |vlan, obj|
+      # skip reserved vlan
+      next if vlan == '1'
+      obj.destroy
+    end
+  end
+
+  def remove_all_bridge_domains
+    # This testcase will remove all the vlans existing in the system
+    # specifically in cleanup for minitests
+    BridgeDomain.bds.each do |_bd, obj|
+      obj.destroy
+    end
   end
 end

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -186,6 +186,25 @@ class CiscoTestCase < TestCase
     end
   end
 
+  # This testcase will remove all the bds existing in the system
+  # specifically in cleanup for minitests
+  def remove_all_bridge_domains
+    BridgeDomain.bds.each do |_bd, obj|
+      obj.destroy
+    end
+  end
+
+  # This testcase will remove all the vlans existing in the system
+  # specifically in cleanup for minitests
+  def remove_all_vlans
+    Vlan.vlans.each do |vlan, obj|
+      # skip reserved vlan
+      next if vlan == '1'
+      next if node.product_id[/N5K|N6K|N7K/] && (1002..1005).include?(vlan.to_i)
+      obj.destroy
+    end
+  end
+
   # Remove all user vrfs.
   def remove_all_vrfs
     require_relative '../lib/cisco_node_utils/vrf'
@@ -222,23 +241,5 @@ class CiscoTestCase < TestCase
     skip('Unable to find compatible interface in chassis') if slot.nil?
 
     "ethernet#{slot}/1"
-  end
-
-  def remove_all_vlans
-    # This testcase will remove all the vlans existing in the system
-    # specifically in cleanup for minitests
-    Vlan.vlans.each do |vlan, obj|
-      # skip reserved vlan
-      next if vlan == '1'
-      obj.destroy
-    end
-  end
-
-  def remove_all_bridge_domains
-    # This testcase will remove all the vlans existing in the system
-    # specifically in cleanup for minitests
-    BridgeDomain.bds.each do |_bd, obj|
-      obj.destroy
-    end
   end
 end

--- a/tests/test_bridge_domain.rb
+++ b/tests/test_bridge_domain.rb
@@ -206,6 +206,7 @@ class TestBridgeDomain < CiscoTestCase
                  'Error: Bridge-Domain is mapped to different vnis')
     bd.destroy
   end
+
   def test_another_bd_as_fabric_control
     bd = BridgeDomain.new(100)
     assert_equal(bd.default_fabric_control, bd.fabric_control,
@@ -221,6 +222,7 @@ class TestBridgeDomain < CiscoTestCase
     bd.destroy
     another_bd.destroy
   end
+
   def test_invalid_bd_create
     assert_raises(CliError,
                   'BD misconfig did not raise CliError') do

--- a/tests/test_bridge_domain.rb
+++ b/tests/test_bridge_domain.rb
@@ -14,6 +14,7 @@
 
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/bridge_domain'
+require_relative '../lib/cisco_node_utils/vlan'
 
 include Cisco
 

--- a/tests/test_bridge_domain.rb
+++ b/tests/test_bridge_domain.rb
@@ -14,7 +14,6 @@
 
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/bridge_domain'
-require_relative '../lib/cisco_node_utils/vlan'
 
 include Cisco
 
@@ -24,14 +23,8 @@ class TestBridgeDomain < CiscoTestCase
   @@cleaned = false # rubocop:disable Style/ClassVars
 
   def cleanup
-    Vlan.vlans.each do |vlan, obj|
-      # skip reserved vlans
-      next if vlan == '1'
-      obj.destroy
-    end
-    BridgeDomain.bds.each do |_bd, obj|
-      obj.destroy
-    end
+    remove_all_vlans
+    remove_all_bridge_domains
   end
 
   def setup


### PR DESCRIPTION
Issue seen on Chris's setup are all valid ones or should throw an error as they are negative testcases. The issue here was it was throwing CliError instead of RuntimeError, which was changed due to the fix from @glennmatthews to automatically wrap these errors into CliError #266 
