### PR TITLE
stp_global fixes (includes interface properties)

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/stp_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/stp_global.yaml
@@ -85,7 +85,7 @@ domain:
   default_value: false
 
 fcoe:
-  _exclude: [N5k, N6k, N7k]
+  _exclude: [N3k, N5k, N6k, N7k]
   kind: boolean
   auto_default: false
   get_command: "show running-config spanning-tree all"

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -249,7 +249,7 @@ module Cisco
     end
 
     def ipv4_addr_mask_set(addr, mask, secondary=false)
-      check_switchport_disabled
+      check_switchport(:disabled)
       sec = secondary ? 'secondary' : ''
       if addr.nil? || addr == default_ipv4_address
         state = 'no'
@@ -378,7 +378,7 @@ module Cisco
     end
 
     def ipv4_pim_sparse_mode=(state)
-      check_switchport_disabled
+      check_switchport(:disabled)
       Feature.pim_enable unless platform == :ios_xr
       config_set('interface', 'ipv4_pim_sparse_mode',
                  name: @name, state: state ? '' : 'no')
@@ -393,7 +393,7 @@ module Cisco
     end
 
     def ipv4_proxy_arp=(proxy_arp)
-      check_switchport_disabled
+      check_switchport(:disabled)
       no_cmd = (proxy_arp ? '' : 'no')
       config_set('interface', 'ipv4_proxy_arp', name: @name, state: no_cmd)
     end
@@ -416,7 +416,7 @@ module Cisco
     end
 
     def ipv4_redirects=(redirects)
-      check_switchport_disabled
+      check_switchport(:disabled)
       no_cmd = (redirects ? '' : 'no')
       config_set('interface', ipv4_redirects_lookup_string,
                  name: @name, state: no_cmd)
@@ -489,7 +489,7 @@ module Cisco
     end
 
     def mtu=(val)
-      check_switchport_disabled
+      check_switchport(:disabled)
       config_set('interface', mtu_lookup_string,
                  name: @name, state: '', mtu: val)
     end
@@ -600,6 +600,7 @@ module Cisco
     end
 
     def stp_bpdufilter=(val)
+      check_switchport([:access, :trunk])
       if val
         state = ''
       else
@@ -639,6 +640,7 @@ module Cisco
     end
 
     def stp_cost=(val)
+      check_switchport([:access, :trunk])
       config_set('interface', 'stp_cost', name: @name, cost: val)
     end
 
@@ -651,6 +653,7 @@ module Cisco
     end
 
     def stp_guard=(val)
+      check_switchport([:access, :trunk])
       if val
         state = ''
       else
@@ -670,6 +673,7 @@ module Cisco
     end
 
     def stp_link_type=(val)
+      check_switchport([:access, :trunk])
       config_set('interface', 'stp_link_type', name: @name, type: val)
     end
 
@@ -682,6 +686,7 @@ module Cisco
     end
 
     def stp_port_priority=(val)
+      check_switchport([:access, :trunk])
       config_set('interface', 'stp_port_priority', name: @name, pp: val)
     end
 
@@ -700,6 +705,7 @@ module Cisco
     end
 
     def stp_mst_cost=(list)
+      check_switchport([:access, :trunk])
       config_set('interface', 'stp_mst_cost',
                  name: @name, state: 'no', range: @smr,
                  val: '') if list.empty?
@@ -721,6 +727,7 @@ module Cisco
     end
 
     def stp_mst_port_priority=(list)
+      check_switchport([:access, :trunk])
       config_set('interface', 'stp_mst_port_priority',
                  name: @name, state: 'no', range: @smr,
                  val: '') if list.empty?
@@ -761,6 +768,7 @@ module Cisco
     end
 
     def stp_vlan_cost=(list)
+      check_switchport([:access, :trunk])
       config_set('interface', 'stp_vlan_cost',
                  name: @name, state: 'no',
                  range: @svr, val: '') if list.empty?
@@ -782,6 +790,7 @@ module Cisco
     end
 
     def stp_vlan_port_priority=(list)
+      check_switchport([:access, :trunk])
       config_set('interface', 'stp_vlan_port_priority',
                  name: @name, state: 'no',
                  range: @svr, val: '') if list.empty?
@@ -1049,7 +1058,7 @@ module Cisco
     end
 
     def svi_autostate=(val)
-      check_switchport_disabled
+      check_switchport(:disabled)
       svi_cmd_allowed?('autostate')
       config_set('interface', 'svi_autostate',
                  name: @name, state: val ? '' : 'no')
@@ -1075,7 +1084,7 @@ module Cisco
     end
 
     def svi_management=(val)
-      check_switchport_disabled
+      check_switchport(:disabled)
       svi_cmd_allowed?('management')
       config_set('interface', 'svi_management',
                  name: @name, state: val ? '' : 'no')
@@ -1094,10 +1103,14 @@ module Cisco
       config_get('vtp', 'feature')
     end
 
-    def check_switchport_disabled
-      return if switchport_mode == :disabled || switchport_mode.nil?
+    def check_switchport(status)
+      if status.kind_of?(Symbol)
+        return if switchport_mode == status
+      elsif status.kind_of?(Array)
+        return if status.include?(switchport_mode)
+      end
       fail("#{caller[0][/`.*'/][1..-2]} cannot be set unless " \
-           'switchport mode is disabled')
+           "switchport mode is #{status}")
     end
 
     def vpc_id

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -1108,9 +1108,9 @@ module Cisco
       when :disabled
         return true if switchport_mode == status || switchport_mode.nil?
       when :access, :trunk
-        return true if switchport_mode == status
+        return switchport_mode == status
       when Array
-        return true if status.include?(switchport_mode)
+        return status.include?(switchport_mode)
       else
         return false
       end

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -1103,12 +1103,21 @@ module Cisco
       config_get('vtp', 'feature')
     end
 
-    def check_switchport(status)
-      if status.kind_of?(Symbol)
-        return if switchport_mode == status
-      elsif status.kind_of?(Array)
-        return if status.include?(switchport_mode)
+    def switchport_status?(status)
+      case status
+      when :disabled
+        return true if switchport_mode == status || switchport_mode.nil?
+      when :access, :trunk
+        return true if switchport_mode == status
+      when Array
+        return true if status.include?(switchport_mode)
+      else
+        return false
       end
+    end
+
+    def check_switchport(status)
+      return if switchport_status?(status)
       fail("#{caller[0][/`.*'/][1..-2]} cannot be set unless " \
            "switchport mode is #{status}")
     end

--- a/tests/test_stp_global.rb
+++ b/tests/test_stp_global.rb
@@ -36,7 +36,6 @@ class TestStpGlobal < CiscoTestCase
   def teardown
     config 'no spanning-tree mode'
     config 'system bridge-domain none' if /N7/ =~ node.product_id
-    @intf.switchport_enable
     super
   end
 

--- a/tests/test_stp_global.rb
+++ b/tests/test_stp_global.rb
@@ -24,36 +24,26 @@ class TestStpGlobal < CiscoTestCase
   def setup
     super
     config 'no spanning-tree mode'
-    config 'system bridge-domain none' if n7k_platform?
+    config 'system bridge-domain none' if /N7/ =~ node.product_id
     @intf = Interface.new(interfaces[0])
 
     # Only pre-clean interface on initial setup
-    config("default interface #{@intf}") unless @@clean
+    config("default interface #{interfaces[0]}") unless @@clean
     @@clean = true # rubocop:disable Style/ClassVars
+    @intf.switchport_enable
   end
 
   def teardown
     config 'no spanning-tree mode'
-    config 'system bridge-domain none' if n7k_platform?
+    config 'system bridge-domain none' if /N7/ =~ node.product_id
+    @intf.switchport_enable
     super
-  end
-
-  def n7k_platform?
-    /N7/ =~ node.product_id
-  end
-
-  def n9k_platform?
-    /N(3|9)/ =~ node.product_id
-  end
-
-  def n6k_platform?
-    /N(5|6)/ =~ node.product_id
   end
 
   def test_bd_forward_time_change
     global = StpGlobal.new('default')
     bdft = [%w(2-4,6,8-12 4), %w(14 30)]
-    if node.product_id =~ /N(3|5|6|9)/
+    if validate_property_excluded?('stp_global', 'bd_forward_time')
       assert_nil(global.bd_forward_time)
       assert_raises(Cisco::UnsupportedError) do
         global.bd_forward_time = bdft
@@ -74,7 +64,7 @@ class TestStpGlobal < CiscoTestCase
   def test_bd_hello_time_change
     global = StpGlobal.new('default')
     bdft = [%w(2-4,6,8-12 1), %w(14 10)]
-    if node.product_id =~ /N(3|5|6|9)/
+    if validate_property_excluded?('stp_global', 'bd_hello_time')
       assert_nil(global.bd_hello_time)
       assert_raises(Cisco::UnsupportedError) do
         global.bd_hello_time = bdft
@@ -95,7 +85,7 @@ class TestStpGlobal < CiscoTestCase
   def test_bd_max_age_change
     global = StpGlobal.new('default')
     bdft = [%w(2-4,6,8-12 10), %w(14 40)]
-    if node.product_id =~ /N(3|5|6|9)/
+    if validate_property_excluded?('stp_global', 'bd_max_age')
       assert_nil(global.bd_max_age)
       assert_raises(Cisco::UnsupportedError) do
         global.bd_max_age = bdft
@@ -116,7 +106,7 @@ class TestStpGlobal < CiscoTestCase
   def test_bd_priorities_change
     global = StpGlobal.new('default')
     bdft = [%w(2-4,6,8-12 4096), %w(14 8192)]
-    if node.product_id =~ /N(3|5|6|9)/
+    if validate_property_excluded?('stp_global', 'bd_priority')
       assert_nil(global.bd_priority)
       assert_nil(global.bd_root_priority)
       assert_nil(global.bd_designated_priority)
@@ -190,7 +180,7 @@ class TestStpGlobal < CiscoTestCase
 
   def test_get_set_domain
     global = StpGlobal.new('default')
-    if node.product_id =~ /N(3|9)/
+    if validate_property_excluded?('stp_global', 'domain')
       assert_nil(global.domain)
       assert_raises(Cisco::UnsupportedError) do
         global.domain = 200
@@ -207,7 +197,7 @@ class TestStpGlobal < CiscoTestCase
 
   def test_get_set_fcoe
     global = StpGlobal.new('default')
-    if node.product_id =~ /N(5|6|7)/
+    if validate_property_excluded?('stp_global', 'fcoe')
       assert_nil(global.fcoe)
       assert_raises(Cisco::UnsupportedError) do
         global.fcoe = false
@@ -431,135 +421,144 @@ class TestStpGlobal < CiscoTestCase
   end
 
   def test_interface_stp_bpdufilter_change
-    interface = Interface.new(interfaces[0])
-    interface.stp_bpdufilter = 'enable'
-    assert_equal('enable', interface.stp_bpdufilter)
-    interface.stp_bpdufilter = 'disable'
-    assert_equal('disable', interface.stp_bpdufilter)
-    interface.stp_bpdufilter = interface.default_stp_bpdufilter
-    assert_equal(interface.default_stp_bpdufilter,
-                 interface.stp_bpdufilter)
+    @intf.stp_bpdufilter = 'enable'
+    assert_equal('enable', @intf.stp_bpdufilter)
+    @intf.stp_bpdufilter = 'disable'
+    assert_equal('disable', @intf.stp_bpdufilter)
+    @intf.stp_bpdufilter = @intf.default_stp_bpdufilter
+    assert_equal(@intf.default_stp_bpdufilter,
+                 @intf.stp_bpdufilter)
   end
 
   def test_interface_stp_bpduguard_change
-    interface = Interface.new(interfaces[0])
-    interface.stp_bpduguard = 'enable'
-    assert_equal('enable', interface.stp_bpduguard)
-    interface.stp_bpduguard = 'disable'
-    assert_equal('disable', interface.stp_bpduguard)
-    interface.stp_bpduguard = interface.default_stp_bpduguard
-    assert_equal(interface.default_stp_bpduguard,
-                 interface.stp_bpduguard)
+    @intf.stp_bpduguard = 'enable'
+    assert_equal('enable', @intf.stp_bpduguard)
+    @intf.stp_bpduguard = 'disable'
+    assert_equal('disable', @intf.stp_bpduguard)
+    @intf.stp_bpduguard = @intf.default_stp_bpduguard
+    assert_equal(@intf.default_stp_bpduguard,
+                 @intf.stp_bpduguard)
   end
 
   def test_interface_stp_cost_change
-    interface = Interface.new(interfaces[0])
-    interface.stp_cost = 2000
-    assert_equal(2000, interface.stp_cost)
-    interface.stp_cost = interface.default_stp_cost
-    assert_equal(interface.default_stp_cost,
-                 interface.stp_cost)
+    @intf.stp_cost = 2000
+    assert_equal(2000, @intf.stp_cost)
+    @intf.stp_cost = @intf.default_stp_cost
+    assert_equal(@intf.default_stp_cost,
+                 @intf.stp_cost)
   end
 
   def test_interface_stp_guard_change
-    interface = Interface.new(interfaces[0])
-    interface.stp_guard = 'loop'
-    assert_equal('loop', interface.stp_guard)
-    interface.stp_guard = 'none'
-    assert_equal('none', interface.stp_guard)
-    interface.stp_guard = 'root'
-    assert_equal('root', interface.stp_guard)
-    interface.stp_guard = interface.default_stp_guard
-    assert_equal(interface.default_stp_guard,
-                 interface.stp_guard)
+    @intf.stp_guard = 'loop'
+    assert_equal('loop', @intf.stp_guard)
+    @intf.stp_guard = 'none'
+    assert_equal('none', @intf.stp_guard)
+    @intf.stp_guard = 'root'
+    assert_equal('root', @intf.stp_guard)
+    @intf.stp_guard = @intf.default_stp_guard
+    assert_equal(@intf.default_stp_guard,
+                 @intf.stp_guard)
   end
 
   def test_interface_stp_link_type_change
-    interface = Interface.new(interfaces[0])
-    interface.stp_link_type = 'shared'
-    assert_equal('shared', interface.stp_link_type)
-    interface.stp_link_type = 'point-to-point'
-    assert_equal('point-to-point', interface.stp_link_type)
-    interface.stp_link_type = interface.default_stp_link_type
-    assert_equal(interface.default_stp_link_type,
-                 interface.stp_link_type)
+    @intf.stp_link_type = 'shared'
+    assert_equal('shared', @intf.stp_link_type)
+    @intf.stp_link_type = 'point-to-point'
+    assert_equal('point-to-point', @intf.stp_link_type)
+    @intf.stp_link_type = @intf.default_stp_link_type
+    assert_equal(@intf.default_stp_link_type,
+                 @intf.stp_link_type)
   end
 
   def test_interface_stp_port_priority_change
-    interface = Interface.new(interfaces[0])
-    interface.stp_port_priority = 32
-    assert_equal(32, interface.stp_port_priority)
-    interface.stp_port_priority = interface.default_stp_port_priority
-    assert_equal(interface.default_stp_port_priority,
-                 interface.stp_port_priority)
+    @intf.stp_port_priority = 32
+    assert_equal(32, @intf.stp_port_priority)
+    @intf.stp_port_priority = @intf.default_stp_port_priority
+    assert_equal(@intf.default_stp_port_priority,
+                 @intf.stp_port_priority)
   end
 
   def test_interface_stp_port_type_change
-    interface = Interface.new(interfaces[0])
-    interface.switchport_mode = :disabled
-    interface.switchport_mode = :trunk
-    interface.stp_port_type = 'edge'
-    assert_equal('edge', interface.stp_port_type)
-    interface.stp_port_type = 'edge trunk'
-    assert_equal('edge trunk', interface.stp_port_type)
-    interface.stp_port_type = 'network'
-    assert_equal('network', interface.stp_port_type)
-    interface.stp_port_type = 'normal'
-    assert_equal('normal', interface.stp_port_type)
-    interface.stp_port_type = interface.default_stp_port_type
-    assert_equal(interface.default_stp_port_type,
-                 interface.stp_port_type)
+    @intf.switchport_mode = :disabled
+    @intf.switchport_mode = :trunk
+    @intf.stp_port_type = 'edge'
+    assert_equal('edge', @intf.stp_port_type)
+    @intf.stp_port_type = 'edge trunk'
+    assert_equal('edge trunk', @intf.stp_port_type)
+    @intf.stp_port_type = 'network'
+    assert_equal('network', @intf.stp_port_type)
+    @intf.stp_port_type = 'normal'
+    assert_equal('normal', @intf.stp_port_type)
+    @intf.stp_port_type = @intf.default_stp_port_type
+    assert_equal(@intf.default_stp_port_type,
+                 @intf.stp_port_type)
   end
 
   def test_interface_stp_mst_cost_change
-    interface = Interface.new(interfaces[0])
-    interface.stp_mst_cost = interface.default_stp_mst_cost
-    assert_equal(interface.default_stp_mst_cost,
-                 interface.stp_mst_cost)
+    @intf.stp_mst_cost = @intf.default_stp_mst_cost
+    assert_equal(@intf.default_stp_mst_cost,
+                 @intf.stp_mst_cost)
     mc = [%w(0,2-4,6,8-12 4500), %w(1 20000)]
-    interface.stp_mst_cost = mc
-    assert_equal(mc, interface.stp_mst_cost)
-    interface.stp_mst_cost = interface.default_stp_mst_cost
-    assert_equal(interface.default_stp_mst_cost,
-                 interface.stp_mst_cost)
+    @intf.stp_mst_cost = mc
+    assert_equal(mc, @intf.stp_mst_cost)
+    @intf.stp_mst_cost = @intf.default_stp_mst_cost
+    assert_equal(@intf.default_stp_mst_cost,
+                 @intf.stp_mst_cost)
   end
 
   def test_interface_stp_mst_port_priority_change
-    interface = Interface.new(interfaces[0])
-    interface.stp_mst_port_priority = interface.default_stp_mst_port_priority
-    assert_equal(interface.default_stp_mst_port_priority,
-                 interface.stp_mst_port_priority)
+    @intf.stp_mst_port_priority = @intf.default_stp_mst_port_priority
+    assert_equal(@intf.default_stp_mst_port_priority,
+                 @intf.stp_mst_port_priority)
     mpp = [%w(0,2-4,6,8-12 224), %w(1 32)]
-    interface.stp_mst_port_priority = mpp
-    assert_equal(mpp, interface.stp_mst_port_priority)
-    interface.stp_mst_port_priority = interface.default_stp_mst_port_priority
-    assert_equal(interface.default_stp_mst_port_priority,
-                 interface.stp_mst_port_priority)
+    @intf.stp_mst_port_priority = mpp
+    assert_equal(mpp, @intf.stp_mst_port_priority)
+    @intf.stp_mst_port_priority = @intf.default_stp_mst_port_priority
+    assert_equal(@intf.default_stp_mst_port_priority,
+                 @intf.stp_mst_port_priority)
   end
 
   def test_interface_stp_vlan_cost_change
-    interface = Interface.new(interfaces[0])
-    interface.stp_vlan_cost = interface.default_stp_vlan_cost
-    assert_equal(interface.default_stp_vlan_cost,
-                 interface.stp_vlan_cost)
+    @intf.stp_vlan_cost = @intf.default_stp_vlan_cost
+    assert_equal(@intf.default_stp_vlan_cost,
+                 @intf.stp_vlan_cost)
     vc = [%w(2-4,6,8-12 4500), %w(14 20000)]
-    interface.stp_vlan_cost = vc
-    assert_equal(vc, interface.stp_vlan_cost)
-    interface.stp_vlan_cost = interface.default_stp_vlan_cost
-    assert_equal(interface.default_stp_vlan_cost,
-                 interface.stp_vlan_cost)
+    @intf.stp_vlan_cost = vc
+    assert_equal(vc, @intf.stp_vlan_cost)
+    @intf.stp_vlan_cost = @intf.default_stp_vlan_cost
+    assert_equal(@intf.default_stp_vlan_cost,
+                 @intf.stp_vlan_cost)
   end
 
   def test_interface_stp_vlan_port_priority_change
-    interface = Interface.new(interfaces[0])
-    interface.stp_vlan_port_priority = interface.default_stp_vlan_port_priority
-    assert_equal(interface.default_stp_vlan_port_priority,
-                 interface.stp_vlan_port_priority)
+    @intf.stp_vlan_port_priority = @intf.default_stp_vlan_port_priority
+    assert_equal(@intf.default_stp_vlan_port_priority,
+                 @intf.stp_vlan_port_priority)
     vpp = [%w(2-4,6,8-12 224), %w(14 32)]
-    interface.stp_vlan_port_priority = vpp
-    assert_equal(vpp, interface.stp_vlan_port_priority)
-    interface.stp_vlan_port_priority = interface.default_stp_vlan_port_priority
-    assert_equal(interface.default_stp_vlan_port_priority,
-                 interface.stp_vlan_port_priority)
+    @intf.stp_vlan_port_priority = vpp
+    assert_equal(vpp, @intf.stp_vlan_port_priority)
+    @intf.stp_vlan_port_priority = @intf.default_stp_vlan_port_priority
+    assert_equal(@intf.default_stp_vlan_port_priority,
+                 @intf.stp_vlan_port_priority)
+  end
+
+  def test_interface_stp_props_switchport_disabled
+    @intf.switchport_enable(false)
+    proplist = {
+      'bpdufilter'         => 'enable',
+      'cost'               => 2000,
+      'guard'              => 'loop',
+      'link_type'          => 'shared',
+      'mst_cost'           => [%w(0,2-4,6,8-12 4500), %w(1 20000)],
+      'mst_port_priority'  => [%w(0,2-4,6,8-12 224), %w(1 32)],
+      'port_priority'      => 32,
+      'vlan_cost'          => [%w(2-4,6,8-12 4500), %w(14 20000)],
+      'vlan_port_priority' => [%w(2-4,6,8-12 224), %w(14 32)],
+    }
+    proplist.each do |k, v|
+      assert_raises(RuntimeError, 'foo') do
+        @intf.send("stp_#{k}=", v)
+      end
+    end
   end
 end


### PR DESCRIPTION
- Add fretta_camden n8k support.
- Refactor interface.rb `check_switchport_disabled` method to check for any switchport state.
- Added checks for switchport mode `trunk` and `access` in stp interface properties.
- stp_global test cleanup/refactoring.

**stp_global tests**

| Platform | Image | Result |
| --- | --- | --- |
| n3k | I2 | :white_check_mark: |
| n5k | N1 | :white_check_mark: |
| n6k | N1 | :white_check_mark: |
| n7k | D1 | :white_check_mark: |
| n8k | fretta_camden | :white_check_mark: |
| n9k | I2 | :white_check_mark: |
| n9k | I4 (dublin plus) | :white_check_mark: |
| xr | n/a | n/a |

**interface (interface, svi, switchport) tests**

| Platform | Image | Result |
| --- | --- | --- |
| n9k | I2 | :white_check_mark: same as baseline |
| n9k | I4 (dublin plus) | :white_check_mark: same as baseline |
| xr | 6.0.0.21I | :white_check_mark: same as baseline |
