### PR TITLE
Interface test fixes for n9k

### DIFF
--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -286,7 +286,9 @@ class Cisco::Client::NXAPI < Cisco::Client
       # handle accordingly
       fail Cisco::RequestNotSupported, \
            "Structured output not supported for #{command}"
-    elsif output['code'] =~ /4\d\d/
+    # Error 432: Requested object does not exist
+    # Ignore 432 errors because it means that a property is not configured
+    elsif output['code'] =~ /4\d\d/ && output['code'] != '432'
       fail Cisco::RequestFailed, \
            "#{output['code']} Error: #{output['msg']}"
     elsif output['code'] =~ /5\d\d/

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -286,6 +286,12 @@ class Cisco::Client::NXAPI < Cisco::Client
       # handle accordingly
       fail Cisco::RequestNotSupported, \
            "Structured output not supported for #{command}"
+    elsif output['code'] =~ /4\d\d/
+      fail Cisco::RequestFailed, \
+           "#{output['code']} Error: #{output['msg']}"
+    elsif output['code'] =~ /5\d\d/
+      fail Cisco::RequestFailed, \
+           "#{output['code']} Error: #{output['msg']}"
     else
       debug("Result for '#{command}': #{output['msg']}")
       if output['body'] && !output['body'].empty?

--- a/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
@@ -48,6 +48,7 @@ lacp_suspend_individual:
 
 port_hash_distribution:
   _exclude: [N6k, N5k]
+  set_context:  ['terminal dont-ask', "interface %s"]
   get_value: '/^port-channel port hash.distribution (.*)$/'
   set_value: "%s port-channel port hash-distribution %s"
   default_value: false

--- a/lib/cisco_node_utils/vtp.rb
+++ b/lib/cisco_node_utils/vtp.rb
@@ -33,7 +33,7 @@ module Cisco
       config_get('vtp', 'feature')
     rescue Cisco::CliError => e
       # cmd will syntax reject when feature is not enabled
-      raise unless e.clierror =~ /Syntax error/
+      raise unless e.clierror =~ /Syntax error|Service not enabled/
       return false
     end
 

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -147,8 +147,8 @@ class TestInterface < CiscoTestCase
     Interface.new(ifname)
   end
 
-  def interface_ethernet_default(ethernet_id)
-    config("default interface ethernet #{ethernet_id}")
+  def interface_ethernet_default(ethernet_intf)
+    config("default interface #{ethernet_intf}")
   end
 
   def interface_supports_property?(intf, message)
@@ -471,7 +471,7 @@ class TestInterface < CiscoTestCase
     description = 'This is a test description ! '
     interface.description = description
     assert_equal(description.rstrip, interface.description)
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_encapsulation_dot1q
@@ -484,7 +484,7 @@ class TestInterface < CiscoTestCase
     subif.encapsulation_dot1q = 25
     assert_equal(25, subif.encapsulation_dot1q)
     subif.destroy
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_mtu_change
@@ -496,7 +496,7 @@ class TestInterface < CiscoTestCase
     assert_equal(1580, interface.mtu)
     interface.mtu = interface.default_mtu
     assert_equal(interface.default_mtu, interface.mtu)
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_mtu_invalid
@@ -512,7 +512,7 @@ class TestInterface < CiscoTestCase
     assert_equal(1550, interface.mtu)
     interface.mtu = interface.default_mtu
     assert_equal(interface.default_mtu, interface.mtu)
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_mtu_invalid_loopback
@@ -541,7 +541,7 @@ class TestInterface < CiscoTestCase
         speed_change_disallowed(e.message)
       end
     end
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_duplex
@@ -564,7 +564,7 @@ class TestInterface < CiscoTestCase
         speed_change_disallowed(e.message)
       end
     end
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_shutdown_valid
@@ -574,7 +574,7 @@ class TestInterface < CiscoTestCase
 
     interface.shutdown = false
     refute(interface.shutdown, 'Error: shutdown state is not false')
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_svi_prop_nil_when_ethernet
@@ -590,7 +590,7 @@ class TestInterface < CiscoTestCase
   #     interface.switchport_mode = :access
   #     addresses = interface.prefixes
   #     assert_empty(addresses)
-  #     interface_ethernet_default(interfaces_id[0])
+  #     interface_ethernet_default(interfaces[0])
   #   end
   #
   #   def test_interface_get_prefix_list_with_ipv4_address_assignment
@@ -604,7 +604,7 @@ class TestInterface < CiscoTestCase
   #     assert(prefixes.has_key?("192.168.1.100"))
   #     interface.switchport_mode = :access
   #     prefixes = nil
-  #     interface_ethernet_default(interfaces_id[0])
+  #     interface_ethernet_default(interfaces[0])
   #   end
   #
   #   def test_interface_get_prefix_list_with_ipv6_address_assignment
@@ -618,7 +618,7 @@ class TestInterface < CiscoTestCase
   #     assert(prefixes.has_key?("fd56:31f7:e4ad:5585::1"))
   #     interface.switchport_mode = :access
   #     prefixes = nil
-  #     interface_ethernet_default(interfaces_id[0])
+  #     interface_ethernet_default(interfaces[0])
   #   end
   #
   #   def test_interface_prefix_list_with_both_ip4_and_ipv6_address_assignments
@@ -634,7 +634,7 @@ class TestInterface < CiscoTestCase
   #     assert(prefixes.has_key?("fd56:31f7:e4ad:5585::1"))
   #     interface.switchport_mode = :access
   #     prefixes = nil
-  #     interface_ethernet_default(interfaces_id[0])
+  #     interface_ethernet_default(interfaces[0])
   #   end
 
   def negotiate_auto_helper(interface, default, cmd_ref)
@@ -716,7 +716,7 @@ class TestInterface < CiscoTestCase
     assert(ref, 'Error, reference not found')
 
     # Create interface member of this group (required for XR)
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
     member = InterfaceChannelGroup.new(interfaces[0])
     begin
       member.channel_group = 10
@@ -757,7 +757,7 @@ class TestInterface < CiscoTestCase
     assert(ref, 'Error, reference not found')
 
     # Cleanup
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
 
     # Some platforms does not support negotiate auto
     # if so then we abort the test.
@@ -790,11 +790,11 @@ class TestInterface < CiscoTestCase
     negotiate_auto_helper(interface, default, ref)
 
     # Test with no switchport
-    config("interface #{interfaces[0]}", 'no switchport')
+    config_no_warn("interface #{interfaces[0]}", 'no switchport')
     negotiate_auto_helper(interface, default, ref)
 
     # Cleanup
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_negotiate_auto_loopback
@@ -830,7 +830,7 @@ class TestInterface < CiscoTestCase
     assert_raises(Cisco::CliError) do
       interface.ipv4_addr_mask_set('', 14)
     end
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_ipv4_addr_mask_set_netmask_invalid
@@ -839,7 +839,7 @@ class TestInterface < CiscoTestCase
     assert_raises(Cisco::CliError) do
       interface.ipv4_addr_mask_set('8.1.1.2', DEFAULT_IF_IP_NETMASK_LEN)
     end
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_ipv4_acl
@@ -859,7 +859,7 @@ class TestInterface < CiscoTestCase
         config("ipv4 access-list #{acl_name} 1 permit any")
       end
     end
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
     intf = Interface.new(interfaces[0])
 
     intf.ipv4_acl_in = 'v4acl1'
@@ -890,7 +890,7 @@ class TestInterface < CiscoTestCase
     #     ipv6 traffic-filter v6acl1 in
     #     ipv6 traffic-filter v6acl2 out
     #
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
     intf = Interface.new(interfaces[0])
 
     # create acls first
@@ -978,7 +978,7 @@ class TestInterface < CiscoTestCase
                  interface.ipv4_netmask_length,
                  'Error: ipv4 netmask length default get value mismatch')
 
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_ipv4_address_getter_with_preconfig
@@ -996,7 +996,7 @@ class TestInterface < CiscoTestCase
                  'Error: ipv4 netmask length get value mismatch')
     # unconfigure ipaddress
     interface_ipv4_config(ifname, address, length, false)
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_ipv4_address_getter_with_preconfig_secondary
@@ -1018,7 +1018,7 @@ class TestInterface < CiscoTestCase
                  'Error: ipv4 netmask length get value mismatch')
     # unconfigure ipaddress includign secondary
     interface_ipv4_config(ifname, address, length, false, false)
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_ipv4_arp_timeout
@@ -1043,7 +1043,7 @@ class TestInterface < CiscoTestCase
 
   def test_interface_ipv4_forwarding
     intf = interfaces[0]
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
     i = Interface.new(intf)
 
     if platform == :ios_xr
@@ -1148,7 +1148,7 @@ class TestInterface < CiscoTestCase
                  interface.ipv4_proxy_arp,
                  'Error: ip proxy-arp default get value mismatch')
 
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_ipv4_redirects
@@ -1194,7 +1194,7 @@ class TestInterface < CiscoTestCase
     assert_equal(interface.default_ipv4_redirects, interface.ipv4_redirects,
                  'Error: ip redirects default get value mismatch')
 
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def config_from_hash(inttype_h)

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -89,8 +89,8 @@ class TestInterface < CiscoTestCase
   def interface_ipv4_config(ifname, address, length,
                             do_config=true, secip=false)
     if do_config
-      config("interface #{ifname}",
-             'no switchport') if platform == :nexus
+      config_no_warn("interface #{ifname}",
+                     'no switchport') if platform == :nexus
       if !secip
         config("interface #{ifname}",
                "#{ipv4} address #{address}/#{length}")

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -61,6 +61,11 @@ class TestInterface < CiscoTestCase
     end
   end
 
+  def teardown
+    interface_ethernet_default(interfaces[0])
+    super
+  end
+
   def ipv4
     if platform == :nexus
       'ip'
@@ -780,7 +785,8 @@ class TestInterface < CiscoTestCase
     rescue Cisco::CliError => e
       skip('Skip test: Interface type does not allow config change') if
         e.message[/requested config change not allowed/]
-      flunk(e.message)
+      flunk(e.message) unless
+        e.message[/cannot turn off auto-negotiate with auto-negotiate speeds/]
     end
 
     default = ref.default_value
@@ -1356,14 +1362,12 @@ class TestInterface < CiscoTestCase
   end
 
   def test_interface_vrf_default
-    config('interface loopback1', 'vrf member foo')
     interface = Interface.new('loopback1')
     interface.vrf = interface.default_vrf
     assert_equal(DEFAULT_IF_VRF, interface.vrf)
   end
 
   def test_interface_vrf_empty
-    config('interface loopback1', 'vrf member foo')
     interface = Interface.new('loopback1')
     interface.vrf = DEFAULT_IF_VRF
     assert_equal(DEFAULT_IF_VRF, interface.vrf)

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1356,7 +1356,7 @@ class TestInterface < CiscoTestCase
     rescue Minitest::Assertion
       # clean up before failing
       config(*cfg)
-      InterfaceChannelGroup.new(interfaces[1]).channel_group = false
+      interface_ethernet_default(interfaces[1])
       raise
     end
   end

--- a/tests/test_interface_ospf.rb
+++ b/tests/test_interface_ospf.rb
@@ -406,13 +406,13 @@ class TestInterfaceOspf < CiscoTestCase
         interfaces[0].downcase => {
           area: '0.0.0.0', cost: 10, hello: 30, dead: 120, pass: true },
         interfaces[1].downcase => {
-          area: '1.1.1.38', dead: 40, pass: false },
+          area: '1.1.1.38', cost: 10, dead: 40, pass: false },
         'vlan101'              => {
           area: '2.2.2.101', cost: 5, hello: 20, dead: 80, pass: true },
       },
       'TestOspfInt' => {
         interfaces[2].downcase => {
-          area: '0.0.0.19' },
+          area: '0.0.0.19', cost: 10 },
         'vlan290'              => {
           area: '2.2.2.29', cost: 200, hello: 30, dead: 120, pass: true },
         'port-channel100'      => {

--- a/tests/test_interface_ospf.rb
+++ b/tests/test_interface_ospf.rb
@@ -445,9 +445,9 @@ class TestInterfaceOspf < CiscoTestCase
     config('no feature ospf',
            'feature ospf',
            'feature interface-vlan',
-           'default interface interfaces[0]',
-           'default interface interfaces[1]',
-           'default interface interfaces[2]',
+           "default interface #{interfaces[0]}",
+           "default interface #{interfaces[1]}",
+           "default interface #{interfaces[2]}",
           )
 
     # pre-configure


### PR DESCRIPTION
## Changes
- Client now raises 4xx and 5xx error codes
  - Error 432 is ignored because it only signifies lack of configured property
- `test_interface.rb` now uses teardown method to clean `interfaces[0]`
- Refactored `interface_ethernet_default` to accept `interfaces[0]` as input instead of `interfaces_id[0]`

``` bash
  1) Error:
TestInterfacePortChannel#test_get_set_port_hash_distribution:
Cisco::RequestNotSupported: [interface_port_channel port-channel134] Server Error: Backend processing error
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:292:in `handle_output'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:200:in `block in req'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:199:in `zip'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:199:in `req'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:116:in `set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node.rb:197:in `set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node.rb:137:in `config_set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node_util.rb:72:in `config_set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/interface_portchannel.rb:127:in `port_hash_distribution='
    tests/test_interface_portchannel.rb:47:in `test_get_set_port_hash_distribution'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```
## Fixes
### I3 Failures

``` bash
TestInterface#test_negotiate_auto_portchannel = 10.50 s = F
W, [2016-03-15T11:34:59.888041 #2893]  WARN -- : Config result:
configure terminal
Enter configuration commands, one per line. End with CNTL/Z.
n9k-109(config)# interface ethernet1/1
n9k-109(config-if)# no switchport
                             ^
% Invalid command at '^' marker.
n9k-109(config-if)# end
n9k-109#
W, [2016-03-15T11:34:59.931232 #2893]  WARN -- : Config result:
configure terminal
Enter configuration commands, one per line. End with CNTL/Z.
n9k-109(config)# interface ethernet1/1
n9k-109(config-if)# ip address 8.7.1.1/15
                         ^
% Invalid command at '^' marker.
n9k-109(config-if)# end
n9k-109#
TestInterface#test_interface_ipv4_address_getter_with_preconfig = 1.84 s = F
TestInterface#test_interface_shutdown_valid = 1.03 s = E
TestInterface#test_interface_description_valid = 1.01 s = E
TestInterface#test_interface_mtu_change = 1.84 s = E
TestInterface#test_interface_mtu_valid = 1.78 s = E
TestInterface#test_interface_ipv4_redirects = 1.75 s = F
W, [2016-03-15T11:39:52.409823 #2893]  WARN -- : Config result:
configure terminal
Enter configuration commands, one per line. End with CNTL/Z.
n9k-109(config)# interface loopback1
n9k-109(config-if)# no switchport
                             ^
% Invalid command at '^' marker.
n9k-109(config-if)# end
n9k-109#
TestInterface#test_vrf_change_with_ip_addr = 6.22 s = .
TestInterface#test_negotiate_auto_ethernet = 4.45 s = F

Finished in 402.840125s, 0.1018 runs/s, 0.8341 assertions/s.

  1) Failure:
TestInterface#test_negotiate_auto_portchannel [tests/test_interface.rb:690]:
Error: port-channel10 negotiate auto value not false.
Expected: false
  Actual: true


  2) Failure:
TestInterface#test_interface_ipv4_address_getter_with_preconfig [tests/test_interface.rb:993]:
Error: ipv4 address get value mismatch.
Expected: "8.7.1.1"
  Actual: nil


  3) Error:
TestInterface#test_interface_shutdown_valid:
Cisco::CliError: [interface ethernet1/1] The command ' shutdown' was rejected with error:
ERROR: cannot turn off auto-negotiate with auto-negotiate speeds

    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:273:in `handle_output'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:200:in `block in req'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:199:in `zip'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:199:in `req'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:116:in `set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node.rb:197:in `set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node.rb:137:in `config_set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node_util.rb:72:in `config_set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/interface.rb:562:in `shutdown='
    tests/test_interface.rb:572:in `test_interface_shutdown_valid'


  4) Error:
TestInterface#test_interface_description_valid:
Cisco::CliError: [interface ethernet1/1] The command ' description This is a test description ! ' was rejected with error:
ERROR: cannot turn off auto-negotiate with auto-negotiate speeds

    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:273:in `handle_output'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:200:in `block in req'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:199:in `zip'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:199:in `req'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:116:in `set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node.rb:197:in `set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node.rb:137:in `config_set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node_util.rb:72:in `config_set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/interface.rb:124:in `description='
    tests/test_interface.rb:472:in `test_interface_description_valid'


  5) Error:
TestInterface#test_interface_mtu_change:
Cisco::CliError: [interface ethernet1/1] The command ' mtu 1520' was rejected with error:
ERROR: cannot turn off auto-negotiate with auto-negotiate speeds

    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:273:in `handle_output'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:200:in `block in req'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:199:in `zip'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:199:in `req'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:116:in `set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node.rb:197:in `set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node.rb:137:in `config_set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node_util.rb:72:in `config_set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/interface.rb:493:in `mtu='
    tests/test_interface.rb:493:in `test_interface_mtu_change'


  6) Error:
TestInterface#test_interface_mtu_valid:
Cisco::CliError: [interface ethernet1/1] The command ' mtu 1550' was rejected with error:
ERROR: cannot turn off auto-negotiate with auto-negotiate speeds

    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:273:in `handle_output'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:200:in `block in req'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:199:in `zip'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:199:in `req'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/client/nxapi/client.rb:116:in `set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node.rb:197:in `set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node.rb:137:in `config_set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/node_util.rb:72:in `config_set'
    /home/robgrie/cisco-network-node-utils/lib/cisco_node_utils/interface.rb:493:in `mtu='
    tests/test_interface.rb:511:in `test_interface_mtu_valid'


  7) Failure:
TestInterface#test_interface_ipv4_redirects [tests/test_interface.rb:1162]:
Error: ip redirects default get value mismatch.
Expected: true
  Actual: false


  8) Failure:
TestInterface#test_negotiate_auto_ethernet [tests/test_interface.rb:783]:
[interface ethernet1/1] The command 'no negotiate auto' was rejected with error:
ERROR: cannot turn off auto-negotiate with auto-negotiate speeds


41 runs, 336 assertions, 4 failures, 4 errors, 0 skips
```
### I2 Config Failure

``` bash
W, [2016-03-15T11:36:49.832394 #2899]  WARN -- : Config result:
configure terminal
Enter configuration commands, one per line. End with CNTL/Z.
agent-lab10-nx(config)# interface loopback1
agent-lab10-nx(config-if)# no switchport
                                    ^
% Invalid command at '^' marker.
agent-lab10-nx(config-if)# end
agent-lab10-nx#
TestInterface#test_vrf_change_with_ip_addr = 4.55 s = .
```
### Portchannel Failure

``` bash
TestInterfacePortChannel#test_get_set_port_hash_distribution = 58.60 s = F

Finished in 83.080088s, 0.0722 runs/s, 0.1324 assertions/s.

  1) Failure:
TestInterfacePortChannel#test_get_set_port_hash_distribution [tests/test_interface_portchannel.rb:48]:
Expected: "adaptive"
  Actual: false
```
