### PR TITLE
Interface test fixes for n9k

### DIFF
--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -288,10 +288,7 @@ class Cisco::Client::NXAPI < Cisco::Client
            "Structured output not supported for #{command}"
     # Error 432: Requested object does not exist
     # Ignore 432 errors because it means that a property is not configured
-    elsif output['code'] =~ /4\d\d/ && output['code'] != '432'
-      fail Cisco::RequestFailed, \
-           "#{output['code']} Error: #{output['msg']}"
-    elsif output['code'] =~ /5\d\d/
+    elsif output['code'] =~ /[45]\d\d/ && output['code'] != '432'
       fail Cisco::RequestFailed, \
            "#{output['code']} Error: #{output['msg']}"
     else

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -286,7 +286,9 @@ class Cisco::Client::NXAPI < Cisco::Client
       # handle accordingly
       fail Cisco::RequestNotSupported, \
            "Structured output not supported for #{command}"
-    elsif output['code'] =~ /4\d\d/
+    # Error 432: Requested object does not exist
+    # Ignore 432 errors because it means that a property is not configured
+    elsif output['code'] =~ /4\d\d/ && output['code'] != '432'
       fail Cisco::RequestFailed, \
            "#{output['code']} Error: #{output['msg']}"
     elsif output['code'] =~ /5\d\d/

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -286,6 +286,12 @@ class Cisco::Client::NXAPI < Cisco::Client
       # handle accordingly
       fail Cisco::RequestNotSupported, \
            "Structured output not supported for #{command}"
+    elsif output['code'] =~ /4\d\d/
+      fail Cisco::RequestFailed, \
+           "#{output['code']} Error: #{output['msg']}"
+    elsif output['code'] =~ /5\d\d/
+      fail Cisco::RequestFailed, \
+           "#{output['code']} Error: #{output['msg']}"
     else
       debug("Result for '#{command}': #{output['msg']}")
       if output['body'] && !output['body'].empty?

--- a/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
@@ -48,6 +48,7 @@ lacp_suspend_individual:
 
 port_hash_distribution:
   _exclude: [N6k, N5k]
+  set_context:  ['terminal dont-ask', "interface %s"]
   get_value: '/^port-channel port hash.distribution (.*)$/'
   set_value: "%s port-channel port hash-distribution %s"
   default_value: false

--- a/lib/cisco_node_utils/vtp.rb
+++ b/lib/cisco_node_utils/vtp.rb
@@ -33,7 +33,7 @@ module Cisco
       config_get('vtp', 'feature')
     rescue Cisco::CliError => e
       # cmd will syntax reject when feature is not enabled
-      raise unless e.clierror =~ /Syntax error/
+      raise unless e.clierror =~ /Syntax error|Service not enabled/
       return false
     end
 

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -34,6 +34,7 @@ class TestInterface < CiscoTestCase
 
   def setup
     super
+    interface_ethernet_default(interfaces[0])
     if platform == :nexus
       @port_channel = 'port-channel'
       # rubocop:disable Style/AlignHash
@@ -476,7 +477,6 @@ class TestInterface < CiscoTestCase
     description = 'This is a test description ! '
     interface.description = description
     assert_equal(description.rstrip, interface.description)
-    interface_ethernet_default(interfaces[0])
   end
 
   def test_encapsulation_dot1q
@@ -489,7 +489,6 @@ class TestInterface < CiscoTestCase
     subif.encapsulation_dot1q = 25
     assert_equal(25, subif.encapsulation_dot1q)
     subif.destroy
-    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_mtu_change
@@ -501,7 +500,6 @@ class TestInterface < CiscoTestCase
     assert_equal(1580, interface.mtu)
     interface.mtu = interface.default_mtu
     assert_equal(interface.default_mtu, interface.mtu)
-    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_mtu_invalid
@@ -517,7 +515,6 @@ class TestInterface < CiscoTestCase
     assert_equal(1550, interface.mtu)
     interface.mtu = interface.default_mtu
     assert_equal(interface.default_mtu, interface.mtu)
-    interface_ethernet_default(interfaces[0])
   end
 
   def test_mtu_invalid_loopback
@@ -546,7 +543,6 @@ class TestInterface < CiscoTestCase
         speed_change_disallowed(e.message)
       end
     end
-    interface_ethernet_default(interfaces[0])
   end
 
   def test_duplex
@@ -569,7 +565,6 @@ class TestInterface < CiscoTestCase
         speed_change_disallowed(e.message)
       end
     end
-    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_shutdown_valid
@@ -579,7 +574,6 @@ class TestInterface < CiscoTestCase
 
     interface.shutdown = false
     refute(interface.shutdown, 'Error: shutdown state is not false')
-    interface_ethernet_default(interfaces[0])
   end
 
   def test_svi_prop_nil_when_ethernet
@@ -595,7 +589,6 @@ class TestInterface < CiscoTestCase
   #     interface.switchport_mode = :access
   #     addresses = interface.prefixes
   #     assert_empty(addresses)
-  #     interface_ethernet_default(interfaces[0])
   #   end
   #
   #   def test_interface_get_prefix_list_with_ipv4_address_assignment
@@ -609,7 +602,6 @@ class TestInterface < CiscoTestCase
   #     assert(prefixes.has_key?("192.168.1.100"))
   #     interface.switchport_mode = :access
   #     prefixes = nil
-  #     interface_ethernet_default(interfaces[0])
   #   end
   #
   #   def test_interface_get_prefix_list_with_ipv6_address_assignment
@@ -623,7 +615,6 @@ class TestInterface < CiscoTestCase
   #     assert(prefixes.has_key?("fd56:31f7:e4ad:5585::1"))
   #     interface.switchport_mode = :access
   #     prefixes = nil
-  #     interface_ethernet_default(interfaces[0])
   #   end
   #
   #   def test_interface_prefix_list_with_both_ip4_and_ipv6_address_assignments
@@ -639,7 +630,6 @@ class TestInterface < CiscoTestCase
   #     assert(prefixes.has_key?("fd56:31f7:e4ad:5585::1"))
   #     interface.switchport_mode = :access
   #     prefixes = nil
-  #     interface_ethernet_default(interfaces[0])
   #   end
 
   def negotiate_auto_helper(interface, default, cmd_ref)
@@ -721,7 +711,6 @@ class TestInterface < CiscoTestCase
     assert(ref, 'Error, reference not found')
 
     # Create interface member of this group (required for XR)
-    interface_ethernet_default(interfaces[0])
     member = InterfaceChannelGroup.new(interfaces[0])
     begin
       member.channel_group = 10
@@ -761,9 +750,6 @@ class TestInterface < CiscoTestCase
                          'negotiate_auto_ethernet')
     assert(ref, 'Error, reference not found')
 
-    # Cleanup
-    interface_ethernet_default(interfaces[0])
-
     # Some platforms does not support negotiate auto
     # if so then we abort the test.
 
@@ -785,8 +771,7 @@ class TestInterface < CiscoTestCase
     rescue Cisco::CliError => e
       skip('Skip test: Interface type does not allow config change') if
         e.message[/requested config change not allowed/]
-      flunk(e.message) unless
-        e.message[/cannot turn off auto-negotiate with auto-negotiate speeds/]
+      flunk(e.message)
     end
 
     default = ref.default_value
@@ -798,9 +783,6 @@ class TestInterface < CiscoTestCase
     # Test with no switchport
     config_no_warn("interface #{interfaces[0]}", 'no switchport')
     negotiate_auto_helper(interface, default, ref)
-
-    # Cleanup
-    interface_ethernet_default(interfaces[0])
   end
 
   def test_negotiate_auto_loopback
@@ -836,7 +818,6 @@ class TestInterface < CiscoTestCase
     assert_raises(Cisco::CliError) do
       interface.ipv4_addr_mask_set('', 14)
     end
-    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_ipv4_addr_mask_set_netmask_invalid
@@ -845,7 +826,6 @@ class TestInterface < CiscoTestCase
     assert_raises(Cisco::CliError) do
       interface.ipv4_addr_mask_set('8.1.1.2', DEFAULT_IF_IP_NETMASK_LEN)
     end
-    interface_ethernet_default(interfaces[0])
   end
 
   def test_ipv4_acl
@@ -865,7 +845,6 @@ class TestInterface < CiscoTestCase
         config("ipv4 access-list #{acl_name} 1 permit any")
       end
     end
-    interface_ethernet_default(interfaces[0])
     intf = Interface.new(interfaces[0])
 
     intf.ipv4_acl_in = 'v4acl1'
@@ -896,7 +875,6 @@ class TestInterface < CiscoTestCase
     #     ipv6 traffic-filter v6acl1 in
     #     ipv6 traffic-filter v6acl2 out
     #
-    interface_ethernet_default(interfaces[0])
     intf = Interface.new(interfaces[0])
 
     # create acls first
@@ -983,8 +961,6 @@ class TestInterface < CiscoTestCase
     assert_equal(DEFAULT_IF_IP_NETMASK_LEN,
                  interface.ipv4_netmask_length,
                  'Error: ipv4 netmask length default get value mismatch')
-
-    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_ipv4_address_getter_with_preconfig
@@ -1002,7 +978,6 @@ class TestInterface < CiscoTestCase
                  'Error: ipv4 netmask length get value mismatch')
     # unconfigure ipaddress
     interface_ipv4_config(ifname, address, length, false)
-    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_ipv4_address_getter_with_preconfig_secondary
@@ -1024,7 +999,6 @@ class TestInterface < CiscoTestCase
                  'Error: ipv4 netmask length get value mismatch')
     # unconfigure ipaddress includign secondary
     interface_ipv4_config(ifname, address, length, false, false)
-    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_ipv4_arp_timeout
@@ -1049,7 +1023,6 @@ class TestInterface < CiscoTestCase
 
   def test_interface_ipv4_forwarding
     intf = interfaces[0]
-    interface_ethernet_default(interfaces[0])
     i = Interface.new(intf)
 
     if platform == :ios_xr
@@ -1153,8 +1126,6 @@ class TestInterface < CiscoTestCase
     assert_equal(DEFAULT_IF_IP_PROXY_ARP,
                  interface.ipv4_proxy_arp,
                  'Error: ip proxy-arp default get value mismatch')
-
-    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_ipv4_redirects
@@ -1199,8 +1170,6 @@ class TestInterface < CiscoTestCase
                       msg:     'Error: default ip redirects set failed')
     assert_equal(interface.default_ipv4_redirects, interface.ipv4_redirects,
                  'Error: ip redirects default get value mismatch')
-
-    interface_ethernet_default(interfaces[0])
   end
 
   def config_from_hash(inttype_h)

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -147,8 +147,8 @@ class TestInterface < CiscoTestCase
     Interface.new(ifname)
   end
 
-  def interface_ethernet_default(ethernet_id)
-    config("default interface ethernet #{ethernet_id}")
+  def interface_ethernet_default(ethernet_intf)
+    config("default interface #{ethernet_intf}")
   end
 
   def interface_supports_property?(intf, message)
@@ -471,7 +471,7 @@ class TestInterface < CiscoTestCase
     description = 'This is a test description ! '
     interface.description = description
     assert_equal(description.rstrip, interface.description)
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_encapsulation_dot1q
@@ -484,7 +484,7 @@ class TestInterface < CiscoTestCase
     subif.encapsulation_dot1q = 25
     assert_equal(25, subif.encapsulation_dot1q)
     subif.destroy
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_mtu_change
@@ -496,7 +496,7 @@ class TestInterface < CiscoTestCase
     assert_equal(1580, interface.mtu)
     interface.mtu = interface.default_mtu
     assert_equal(interface.default_mtu, interface.mtu)
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_mtu_invalid
@@ -512,7 +512,7 @@ class TestInterface < CiscoTestCase
     assert_equal(1550, interface.mtu)
     interface.mtu = interface.default_mtu
     assert_equal(interface.default_mtu, interface.mtu)
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_mtu_invalid_loopback
@@ -541,7 +541,7 @@ class TestInterface < CiscoTestCase
         speed_change_disallowed(e.message)
       end
     end
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_duplex
@@ -564,7 +564,7 @@ class TestInterface < CiscoTestCase
         speed_change_disallowed(e.message)
       end
     end
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_shutdown_valid
@@ -574,7 +574,7 @@ class TestInterface < CiscoTestCase
 
     interface.shutdown = false
     refute(interface.shutdown, 'Error: shutdown state is not false')
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_svi_prop_nil_when_ethernet
@@ -590,7 +590,7 @@ class TestInterface < CiscoTestCase
   #     interface.switchport_mode = :access
   #     addresses = interface.prefixes
   #     assert_empty(addresses)
-  #     interface_ethernet_default(interfaces_id[0])
+  #     interface_ethernet_default(interfaces[0])
   #   end
   #
   #   def test_interface_get_prefix_list_with_ipv4_address_assignment
@@ -604,7 +604,7 @@ class TestInterface < CiscoTestCase
   #     assert(prefixes.has_key?("192.168.1.100"))
   #     interface.switchport_mode = :access
   #     prefixes = nil
-  #     interface_ethernet_default(interfaces_id[0])
+  #     interface_ethernet_default(interfaces[0])
   #   end
   #
   #   def test_interface_get_prefix_list_with_ipv6_address_assignment
@@ -618,7 +618,7 @@ class TestInterface < CiscoTestCase
   #     assert(prefixes.has_key?("fd56:31f7:e4ad:5585::1"))
   #     interface.switchport_mode = :access
   #     prefixes = nil
-  #     interface_ethernet_default(interfaces_id[0])
+  #     interface_ethernet_default(interfaces[0])
   #   end
   #
   #   def test_interface_prefix_list_with_both_ip4_and_ipv6_address_assignments
@@ -634,7 +634,7 @@ class TestInterface < CiscoTestCase
   #     assert(prefixes.has_key?("fd56:31f7:e4ad:5585::1"))
   #     interface.switchport_mode = :access
   #     prefixes = nil
-  #     interface_ethernet_default(interfaces_id[0])
+  #     interface_ethernet_default(interfaces[0])
   #   end
 
   def negotiate_auto_helper(interface, default, cmd_ref)
@@ -716,7 +716,7 @@ class TestInterface < CiscoTestCase
     assert(ref, 'Error, reference not found')
 
     # Create interface member of this group (required for XR)
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
     member = InterfaceChannelGroup.new(interfaces[0])
     begin
       member.channel_group = 10
@@ -757,7 +757,7 @@ class TestInterface < CiscoTestCase
     assert(ref, 'Error, reference not found')
 
     # Cleanup
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
 
     # Some platforms does not support negotiate auto
     # if so then we abort the test.
@@ -790,11 +790,11 @@ class TestInterface < CiscoTestCase
     negotiate_auto_helper(interface, default, ref)
 
     # Test with no switchport
-    config("interface #{interfaces[0]}", 'no switchport')
+    config_no_warn("interface #{interfaces[0]}", 'no switchport')
     negotiate_auto_helper(interface, default, ref)
 
     # Cleanup
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_negotiate_auto_loopback
@@ -830,7 +830,7 @@ class TestInterface < CiscoTestCase
     assert_raises(Cisco::CliError) do
       interface.ipv4_addr_mask_set('', 14)
     end
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_ipv4_addr_mask_set_netmask_invalid
@@ -839,7 +839,7 @@ class TestInterface < CiscoTestCase
     assert_raises(Cisco::CliError) do
       interface.ipv4_addr_mask_set('8.1.1.2', DEFAULT_IF_IP_NETMASK_LEN)
     end
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_ipv4_acl
@@ -859,7 +859,7 @@ class TestInterface < CiscoTestCase
         config("ipv4 access-list #{acl_name} 1 permit any")
       end
     end
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
     intf = Interface.new(interfaces[0])
 
     intf.ipv4_acl_in = 'v4acl1'
@@ -890,7 +890,7 @@ class TestInterface < CiscoTestCase
     #     ipv6 traffic-filter v6acl1 in
     #     ipv6 traffic-filter v6acl2 out
     #
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
     intf = Interface.new(interfaces[0])
 
     # create acls first
@@ -978,7 +978,7 @@ class TestInterface < CiscoTestCase
                  interface.ipv4_netmask_length,
                  'Error: ipv4 netmask length default get value mismatch')
 
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_ipv4_address_getter_with_preconfig
@@ -996,7 +996,7 @@ class TestInterface < CiscoTestCase
                  'Error: ipv4 netmask length get value mismatch')
     # unconfigure ipaddress
     interface_ipv4_config(ifname, address, length, false)
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_ipv4_address_getter_with_preconfig_secondary
@@ -1018,7 +1018,7 @@ class TestInterface < CiscoTestCase
                  'Error: ipv4 netmask length get value mismatch')
     # unconfigure ipaddress includign secondary
     interface_ipv4_config(ifname, address, length, false, false)
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_ipv4_arp_timeout
@@ -1043,7 +1043,7 @@ class TestInterface < CiscoTestCase
 
   def test_interface_ipv4_forwarding
     intf = interfaces[0]
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
     i = Interface.new(intf)
 
     if platform == :ios_xr
@@ -1148,7 +1148,7 @@ class TestInterface < CiscoTestCase
                  interface.ipv4_proxy_arp,
                  'Error: ip proxy-arp default get value mismatch')
 
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def test_interface_ipv4_redirects
@@ -1194,7 +1194,7 @@ class TestInterface < CiscoTestCase
     assert_equal(interface.default_ipv4_redirects, interface.ipv4_redirects,
                  'Error: ip redirects default get value mismatch')
 
-    interface_ethernet_default(interfaces_id[0])
+    interface_ethernet_default(interfaces[0])
   end
 
   def config_from_hash(inttype_h)

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1332,14 +1332,11 @@ class TestInterface < CiscoTestCase
 
   def test_interface_vrf_default
     interface = Interface.new('loopback1')
+    assert_empty(interface.vrf)
+    interface.vrf = 'foo'
+    assert_equal(interface.vrf, 'foo')
     interface.vrf = interface.default_vrf
-    assert_equal(DEFAULT_IF_VRF, interface.vrf)
-  end
-
-  def test_interface_vrf_empty
-    interface = Interface.new('loopback1')
-    interface.vrf = DEFAULT_IF_VRF
-    assert_equal(DEFAULT_IF_VRF, interface.vrf)
+    assert_equal(interface.vrf, interface.default_vrf)
   end
 
   def test_interface_vrf_invalid_type

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -89,8 +89,8 @@ class TestInterface < CiscoTestCase
   def interface_ipv4_config(ifname, address, length,
                             do_config=true, secip=false)
     if do_config
-      config("interface #{ifname}",
-             'no switchport') if platform == :nexus
+      config_no_warn("interface #{ifname}",
+                     'no switchport') if platform == :nexus
       if !secip
         config("interface #{ifname}",
                "#{ipv4} address #{address}/#{length}")

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -61,6 +61,11 @@ class TestInterface < CiscoTestCase
     end
   end
 
+  def teardown
+    interface_ethernet_default(interfaces[0])
+    super
+  end
+
   def ipv4
     if platform == :nexus
       'ip'
@@ -780,7 +785,8 @@ class TestInterface < CiscoTestCase
     rescue Cisco::CliError => e
       skip('Skip test: Interface type does not allow config change') if
         e.message[/requested config change not allowed/]
-      flunk(e.message)
+      flunk(e.message) unless
+        e.message[/cannot turn off auto-negotiate with auto-negotiate speeds/]
     end
 
     default = ref.default_value
@@ -1356,14 +1362,12 @@ class TestInterface < CiscoTestCase
   end
 
   def test_interface_vrf_default
-    config('interface loopback1', 'vrf member foo')
     interface = Interface.new('loopback1')
     interface.vrf = interface.default_vrf
     assert_equal(DEFAULT_IF_VRF, interface.vrf)
   end
 
   def test_interface_vrf_empty
-    config('interface loopback1', 'vrf member foo')
     interface = Interface.new('loopback1')
     interface.vrf = DEFAULT_IF_VRF
     assert_equal(DEFAULT_IF_VRF, interface.vrf)

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1356,7 +1356,7 @@ class TestInterface < CiscoTestCase
     rescue Minitest::Assertion
       # clean up before failing
       config(*cfg)
-      InterfaceChannelGroup.new(interfaces[1]).channel_group = false
+      interface_ethernet_default(interfaces[1])
       raise
     end
   end

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1412,12 +1412,18 @@ class TestInterface < CiscoTestCase
       assert_raises(Cisco::UnsupportedError) { i.ipv4_pim_sparse_mode = true }
       return
     end
+    begin
+      i.switchport_mode = :disabled
+    rescue Cisco::CliError => e
+      skip_message = 'Interface does not support switchport disable'
+      skip(skip_message) if e.message['requested config change not allowed']
+      raise
+    end
     # Sample cli:
     #
     #   interface Ethernet1/1
     #     ip pim sparse-mode
     #
-    i.switchport_mode = :disabled
     i.ipv4_pim_sparse_mode = false
     refute(i.ipv4_pim_sparse_mode)
 

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1417,6 +1417,7 @@ class TestInterface < CiscoTestCase
     #   interface Ethernet1/1
     #     ip pim sparse-mode
     #
+    i.switchport_mode = :disabled
     i.ipv4_pim_sparse_mode = false
     refute(i.ipv4_pim_sparse_mode)
 


### PR DESCRIPTION
## Changes
- Client now raises 4xx and 5xx error codes
  - Error 432 is ignored because it only signifies lack of configured property
- `test_interface.rb` now uses teardown method to clean `interfaces[0]`
- Refactored `interface_ethernet_default` to accept `interfaces[0]` as input instead of `interfaces_id[0]`
## Errors and Skips
### I2

``` bash
  1) Skipped:
TestInterfaceServiceVni#all_skipped [/home/robgrie/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestInterfaceServiceVni; feature 'interface_service_vni' is unsupported on this node
```
### I3
- Known platform bug in `test_negotiate_auto_portchannel`
- Likely platform bug in `test_negotiate_auto_ethernet`

``` bash

  1) Failure:
TestInterface#test_negotiate_auto_ethernet [/home/robgrie/cisco-network-node-utils/tests/test_interface.rb:774]:
[interface ethernet1/1] The command 'no negotiate auto' was rejected with error:
ERROR: cannot turn off auto-negotiate with auto-negotiate speeds

  2) Failure:
TestInterface#test_negotiate_auto_portchannel [/home/robgrie/cisco-network-node-utils/tests/test_interface.rb:685]:
Error: port-channel10 negotiate auto value not false.
Expected: false
  Actual: true

  1) Skipped:
TestInterfaceServiceVni#all_skipped [/home/robgrie/cisco-network-node-utils/tests/ciscotest.rb:56]:
Skipping TestInterfaceServiceVni; feature 'interface_service_vni' is unsupported on this node
```
