### PR TITLE
minitest fixes for test_vpc

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vpc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vpc.yaml
@@ -90,7 +90,7 @@ graceful_consistency_check:
 
 layer3_peer_routing:
   kind: boolean
-  _exclude: [N3k, N5k, N8k, N9k]
+  _exclude: [N3k, N8k, N9k]
   get_value: '/^layer3 peer-router$/'
   set_value: "<state> layer3 peer-router"
   default_value: false
@@ -176,7 +176,7 @@ role_priority:
 
 self_isolation:
   kind: boolean
-  _exclude: [N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
   get_value: '/^self-isolation/'
   set_value: "<state> self-isolation"
   default_value: false

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -413,7 +413,7 @@ module Cisco
 
     def supports?(feature, property=nil)
       value = @hash[feature]
-      value = value[property] if value && property
+      value = value[property] if value.is_a?(Hash) && property
       !(value.is_a?(UnsupportedCmdRef) || value.nil?)
     end
 

--- a/lib/cisco_node_utils/fabricpath_global.rb
+++ b/lib/cisco_node_utils/fabricpath_global.rb
@@ -46,13 +46,18 @@ module Cisco
 
     def self.fabricpath_feature
       fabricpath = config_get('fabricpath', 'feature')
-      fail 'fabricpath_feature not found' if fabricpath.nil?
       return :disabled if fabricpath.nil?
       fabricpath.to_sym
     rescue Cisco::CliError => e
       # cmd will syntax reject when feature is not enabled
       raise unless e.clierror =~ /Syntax error/
       return :disabled
+    end
+
+    def self.fabricpath_enable
+      # TBD: Move to Feature provider
+      FabricpathGlobal.fabricpath_feature_set(:enabled) unless
+        FabricpathGlobal.fabricpath_feature == :enabled
     end
 
     def self.fabricpath_feature_set(fabricpath_set)
@@ -90,8 +95,7 @@ module Cisco
     end
 
     def create
-      FabricpathGlobal.fabricpath_feature_set(:enabled) unless
-      :enabled == FabricpathGlobal.fabricpath_feature
+      FabricpathGlobal.fabricpath_enable
     end
 
     def destroy

--- a/lib/cisco_node_utils/vpc.rb
+++ b/lib/cisco_node_utils/vpc.rb
@@ -164,16 +164,15 @@ module Cisco
       config_get_default('vpc', 'fabricpath_emulated_switch_id')
     end
 
+    # Note: fabricpath_multicast_load_balance also requires
+    # fabricpath_emulated_switch_id before it will be functional but it
+    # will config & nvgen independently.
     def fabricpath_multicast_load_balance
       config_get('vpc', 'fabricpath_multicast_load_balance')
     end
 
     def fabricpath_multicast_load_balance=(state)
       FabricpathGlobal.fabricpath_enable
-
-      fail 'This property also requires fabricpath_emulated_switch_id' if
-        state && !fabricpath_emulated_switch_id
-
       set_args_keys(state: state ? '' : 'no')
       config_set('vpc', 'fabricpath_multicast_load_balance', @set_args)
     end

--- a/lib/cisco_node_utils/vpc.rb
+++ b/lib/cisco_node_utils/vpc.rb
@@ -154,9 +154,7 @@ module Cisco
     end
 
     def fabricpath_emulated_switch_id=(switch_id)
-      # automatically enable fabricpath if it is not already enabled
-      FabricpathGlobal.fabricpath_feature_set(:enabled) if
-        switch_id && :enabled != FabricpathGlobal.fabricpath_feature
+      FabricpathGlobal.fabricpath_enable
       set_args_keys(state: switch_id ? '' : 'no',
                     swid:  switch_id ? switch_id : '')
       config_set('vpc', 'fabricpath_emulated_switch_id', @set_args)
@@ -170,11 +168,13 @@ module Cisco
       config_get('vpc', 'fabricpath_multicast_load_balance')
     end
 
-    def fabricpath_multicast_load_balance=(val)
-      set_args_keys(state: val ? '' : 'no')
-      # This requires fabricpath_emulated_switch_id to be set first
-      fail 'fabricpath_switch_id configuration is required in the vPC domain' if
-        !fabricpath_emulated_switch_id && val
+    def fabricpath_multicast_load_balance=(state)
+      FabricpathGlobal.fabricpath_enable
+
+      fail 'This property also requires fabricpath_emulated_switch_id' if
+        state && !fabricpath_emulated_switch_id
+
+      set_args_keys(state: state ? '' : 'no')
       config_set('vpc', 'fabricpath_multicast_load_balance', @set_args)
     end
 

--- a/tests/test_vpc.rb
+++ b/tests/test_vpc.rb
@@ -428,20 +428,19 @@ class TestVpc < CiscoTestCase
 
     refute(vpc.fabricpath_multicast_load_balance,
            'fabricpath multicast loadbalance should not be enabled by default')
-    e = assert_raises(RuntimeError) do
-      vpc.fabricpath_multicast_load_balance = true
-    end
 
-    assert_match(/property also requires fabricpath_emulated_switch_id/,
-                 e.message)
-
-    vpc.fabricpath_emulated_switch_id = 1000
     vpc.fabricpath_multicast_load_balance = true
     assert(vpc.fabricpath_multicast_load_balance,
-           'fabricpath multicast loadbalance not getting enabled')
+           'fabricpath multicast load-balance is not enabled')
+
     vpc.fabricpath_multicast_load_balance = false
     refute(vpc.fabricpath_multicast_load_balance,
-           'fabricpath multicast loadbalance not getting disabled')
+           'fabricpath multicast load-balance is not disabled')
+
+    default = vpc.default_fabricpath_multicast_load_balance
+    vpc.fabricpath_multicast_load_balance = default
+    assert_equal(default, vpc.fabricpath_multicast_load_balance,
+                 'fabricpath multicast load-balance is not default')
   end
 
   def test_port_channel_limit


### PR DESCRIPTION
- Tests now pass on n30,n31,n5,n6,n7,n9-I2,n9-I3
- Cleanup for feature-set fabricpath
- Includes infra fix for command_reference.rb: `supports?`
  - top-level excludes result in an empty `@hash`, so `value[property]` fails with:
    `undefined method`[]' for #Cisco::UnsupportedCmdRef:`
  - Fix tested against current `validate_property_excluded?` callers
