### PR TITLE
vlan mode prop: sym vs str changes

### DIFF
--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -83,16 +83,11 @@ module Cisco
     def mode
       result = config_get('vlan', 'mode', @vlan_id)
       return default_mode if result.nil?
-      case result
-      when /fabricpath/i
-        return :fabricpath
-      when /ce/i
-        return :CE
-      end
+      result.downcase! if result[/FABRICPATH/]
+      result
     end
 
     def mode=(str)
-      str = str.to_s
       if str.empty?
         config_set('vlan', 'mode', @vlan_id, 'no', '')
       else
@@ -105,7 +100,7 @@ module Cisco
     end
 
     def default_mode
-      config_get_default('vlan', 'mode').to_sym
+      config_get_default('vlan', 'mode')
     end
 
     def vlan_name

--- a/tests/test_vlan_mt_full.rb
+++ b/tests/test_vlan_mt_full.rb
@@ -78,6 +78,6 @@ class TestVlanMtFull < CiscoTestCase
     assert_equal(default, v.mode,
                  'Mode should have been default value: #{default}')
 
-    assert_raises(RuntimeError) { v.mode = 'junk' }
+    assert_raises(CliError) { v.mode = 'junk' }
   end
 end


### PR DESCRIPTION
- mode was normalizing to symbols instead of strings and was inconsistent in the tests; I modified it to use strings as that is the convention used in most of our providers. Note that this may break puppet temporarily; if so we will fix it during the beaker test phase.
- mode state values are currently either 'CE' or 'FABRICPATH'; however, release v1.2.0 states that the expected values should be 'CE' or 'fabricpath', so the getter now normalizes FABRICPATH to downcase.
- test_vlan.rb and test_vlan_mt_full.rb now pass on n30,n31,n5,n6,n7,n9-I2,n9-I3
