### PR TITLE
test_portchannel_global fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
@@ -61,7 +61,7 @@ port_channel_load_balance:
   set_value: "port-channel load-balance %s %s %s %s %s %s"
 
 resilient:
-  _exclude: [N5k, N6k, N8k, N7k]
+  _exclude: [N5k, N6k, N7k, N8k]
   kind: boolean
   get_value: '/^port-channel load-balance resilient$/'
   set_value: "%s port-channel load-balance resilient"

--- a/lib/cisco_node_utils/portchannel_global.rb
+++ b/lib/cisco_node_utils/portchannel_global.rb
@@ -203,15 +203,20 @@ module Cisco
       end
     end
 
-    # on n6k, the bundle hash and bundle select are
-    # merged into one and so we need to break them apart,
-    # also they are called source and destination instead of
-    # src and dst as in other devices, so we convert them
+    # N5k/N6k: The bundle hash and bundle select are merged into one output;
+    # also note that the field names are source & destination instead of
+    # src & dst as in other devices.
     def _parse_ethernet_params(hash, params)
       hash_poly = params[2]
-      # hash_poly is not shown on the running config
-      # if it is default under some circumstatnces
+
+      # Depending on the chipset, hash_poly may have have a different
+      # default value within the same platform family (this is done to
+      # avoid polarization) but there is currently no command available
+      # to dynamically determine the default state. As a result the
+      # getter simply hard-codes a default value which means it may
+      # encounter occasional idempotence issues.
       hash_poly = hash_poly.nil? ? 'CRC10b' : hash_poly
+
       select_hash = params[1]
       lparams = select_hash.split('-')
       if lparams[0].downcase == 'destination'


### PR DESCRIPTION
- n5 had a problem with hash_poly when it got set to default
- My n30 h/w did not support `resilient`. The cli displays a warning but does not raise an error so we have to explicitly check for that in the minitest
- minitest now passes on n30,n31,n5,n6,n7,n9-I2,n9_i3
