### PR TITLE
vtp fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -74,3 +74,10 @@ vni:
     set_value: 'feature vn-segment-vlan-based'
   N8k: *feature_mt_lite
   N9k: *feature_mt_lite
+
+vtp:
+  kind: boolean
+  get_command: "show running vtp"
+  get_value: '/^feature vtp$/'
+  set_value: "<state> feature vtp"
+  default_value: false

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -77,7 +77,7 @@ vni:
 
 vtp:
   kind: boolean
-  get_command: "show running vtp"
+  get_command: "show running | i ^feature"
   get_value: '/^feature vtp$/'
   set_value: "<state> feature vtp"
   default_value: false

--- a/lib/cisco_node_utils/cmd_ref/vtp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vtp.yaml
@@ -2,33 +2,30 @@
 ---
 _exclude: [ios_xr]
 
+# VTP behaves differently across the various Nexus platforms and as a
+# result it's not currently possible to use a single 'show running'
+# command to query the device state.
 domain:
   get_command: "show vtp status"
-  get_value: "domain_name"
-  set_value: "vtp domain %s"
-
-feature:
-  kind: boolean
-  get_command: "show running vtp"
-  get_value: '/^feature vtp$/'
-  set_value: "%s feature vtp"
-  default_value: false
+  get_value: '/^VTP\s+Domain\s+Name\s+:\s+(\S+)$/'
+  set_value: "vtp domain <domain>"
+  default_value: ""
 
 filename:
-  get_command: "show running vtp"
-  get_value: '/vtp file (\S+)/'
-  set_value: "%s vtp file %s"
+  get_command: "show running-config vtp all"
+  get_value: '/vtp\s+file\s+(\S+)/'
+  set_value: "<state> vtp file <uri>"
   default_value: "bootflash:/vlan.dat"
 
 password:
   get_command: "show vtp password"
-  get_value: "passwd"
-  set_value: "%s vtp password %s"
+  get_value: '/VTP\s+Password:\s+(\S+)/i'
+  set_value: "<state> vtp password <password>"
   default_value: ""
 
 version:
   kind: int
   get_command: "show vtp status"
-  get_value: '/VTP\s+version\s+running\s+:\s+(\d+)/'
-  set_value: "vtp version %s"
+  get_value: '/^VTP\s+version\s+running\s+:\s+(\d+)$/'
+  set_value: "vtp version <version>"
   default_value: 1

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -157,6 +157,8 @@ module Cisco
       cli_error_check(result)
     end
 
+    # Special Case: The only way to remove a vtp instance
+    # is by disabling the feature.
     def self.vtp_disable
       return unless vtp_enabled?
       config_set('feature', 'vtp', state: 'no')

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -151,6 +151,26 @@ module Cisco
     end
 
     # ---------------------------
+    def self.vtp_enable
+      return if vtp_enabled?
+      result = config_set('feature', 'vtp', state: '')
+      cli_error_check(result)
+    end
+
+    def self.vtp_disable
+      return unless vtp_enabled?
+      config_set('feature', 'vtp', state: 'no')
+    end
+
+    def self.vtp_enabled?
+      config_get('feature', 'vtp')
+    rescue Cisco::CliError => e
+      # cmd will syntax reject when feature is not enabled.
+      raise unless e.clierror =~ /Syntax error/
+      return false
+    end
+
+    # ---------------------------
     def self.cli_error_check(result)
       # The NXOS feature cli may not raise an exception in some conditions and
       # instead just displays a STDOUT error message; thus NXAPI does not detect

--- a/lib/cisco_node_utils/vtp.rb
+++ b/lib/cisco_node_utils/vtp.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 require_relative 'node_util'
+require_relative 'logger'
 
 module Cisco
   # Vtp - node utility class for VTP configuration management
@@ -26,29 +27,22 @@ module Cisco
 
     # Constructor for Vtp
     def initialize(instantiate=true)
-      enable if instantiate && !Vtp.enabled
-    end
-
-    def self.enabled
-      config_get('vtp', 'feature')
-    rescue Cisco::CliError => e
-      # cmd will syntax reject when feature is not enabled
-      raise unless e.clierror =~ /Syntax error|Service not enabled/
-      return false
-    end
-
-    def enable
-      config_set('vtp', 'feature', '')
-    end
-
-    # Disable vtp feature
-    def destroy
-      config_set('vtp', 'feature', 'no')
+      Feature.vtp_enable if instantiate
     end
 
     # Get vtp domain name
     def self.domain
-      enabled ? config_get('vtp', 'domain') : ''
+      if Feature.vtp_enabled?
+        config_get('vtp', 'domain')
+      else
+        config_get_default('vtp', 'domain')
+      end
+    end
+
+    # The only way to remove a vtp domain is to turn the vtp
+    # feature off.
+    def destroy
+      Feature.vtp_disable
     end
 
     def domain
@@ -59,19 +53,13 @@ module Cisco
     def domain=(d)
       fail ArgumentError unless d && d.is_a?(String) &&
                                 d.length.between?(1, MAX_VTP_DOMAIN_NAME_SIZE)
-      enable unless Vtp.enabled
-      begin
-        config_set('vtp', 'domain', d)
-      rescue Cisco::CliError => e
-        # cmd will syntax reject when setting name to same name
-        raise unless e.clierror =~ /ERROR: Domain name already set to /
-      end
+      config_set('vtp', 'domain', domain: d)
     end
 
     # Get vtp password
     def password
       # Unfortunately nxapi returns "\\" when the password is not set
-      password = config_get('vtp', 'password') if Vtp.enabled
+      password = config_get('vtp', 'password') if Feature.vtp_enabled?
       return '' if password.nil? || password == '\\'
       password
     end
@@ -81,18 +69,11 @@ module Cisco
       fail TypeError if password.nil?
       fail TypeError unless password.is_a? String
       fail ArgumentError if password.length > MAX_VTP_PASSWORD_SIZE
-      enable unless Vtp.enabled
-      begin
-        if password == default_password
-          config_set('vtp', 'password', 'no', '')
-        else
-          config_set('vtp', 'password', '', password)
-        end
-      rescue Cisco::CliError => e
-        raise unless e.clierror =~ /password cannot be set for NULL domain/
-        unless password == default_password
-          raise 'Setting VTP password requires first setting VTP domain'
-        end
+      Feature.vtp_enable
+      if password == default_password
+        config_set('vtp', 'password', state: 'no', password: '')
+      else
+        config_set('vtp', 'password', state: '', password: password)
       end
     end
 
@@ -103,17 +84,18 @@ module Cisco
 
     # Get vtp filename
     def filename
-      config_get('vtp', 'filename')
+      filename = config_get('vtp', 'filename') if Feature.vtp_enabled?
+      filename.nil? ? default_filename : filename
     end
 
     # Set vtp filename
     def filename=(uri)
       fail TypeError if uri.nil?
-      enable unless Vtp.enabled
+      Feature.vtp_enable
       if uri.empty?
-        config_set('vtp', 'filename', 'no', '')
+        config_set('vtp', 'filename', state: 'no', uri: '')
       else
-        config_set('vtp', 'filename', '', uri)
+        config_set('vtp', 'filename', state: '', uri: uri)
       end
     end
 
@@ -124,13 +106,13 @@ module Cisco
 
     # Get vtp version
     def version
-      Vtp.enabled ? config_get('vtp', 'version') : default_version
+      Feature.vtp_enabled? ? config_get('vtp', 'version') : default_version
     end
 
     # Set vtp version
-    def version=(version)
-      enable unless Vtp.enabled
-      config_set('vtp', 'version', "#{version}")
+    def version=(v)
+      Feature.vtp_enable
+      config_set('vtp', 'version', version: v)
     end
 
     # Get default vtp version

--- a/lib/cisco_node_utils/vtp.rb
+++ b/lib/cisco_node_utils/vtp.rb
@@ -51,8 +51,8 @@ module Cisco
 
     # Set vtp domain name
     def domain=(d)
-      fail ArgumentError unless d && d.is_a?(String) &&
-                                d.length.between?(1, MAX_VTP_DOMAIN_NAME_SIZE)
+      d = d.to_s
+      fail ArgumentError unless d.length.between?(1, MAX_VTP_DOMAIN_NAME_SIZE)
       config_set('vtp', 'domain', domain: d)
     end
 
@@ -70,11 +70,8 @@ module Cisco
       fail TypeError unless password.is_a? String
       fail ArgumentError if password.length > MAX_VTP_PASSWORD_SIZE
       Feature.vtp_enable
-      if password == default_password
-        config_set('vtp', 'password', state: 'no', password: '')
-      else
-        config_set('vtp', 'password', state: '', password: password)
-      end
+      state = (password == default_password) ? 'no' : ''
+      config_set('vtp', 'password', state: state, password: password)
     end
 
     # Get default vtp password
@@ -92,11 +89,9 @@ module Cisco
     def filename=(uri)
       fail TypeError if uri.nil?
       Feature.vtp_enable
-      if uri.empty?
-        config_set('vtp', 'filename', state: 'no', uri: '')
-      else
-        config_set('vtp', 'filename', state: '', uri: uri)
-      end
+      uri = uri.to_s
+      state = uri.empty? ? 'no' : ''
+      config_set('vtp', 'filename', state: state, uri: uri)
     end
 
     # Get default vtp filename

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -41,7 +41,7 @@ class TestFeature < CiscoTestCase
   # feature test helper
   def feature(feat)
     # Get the feature name string from the yaml
-    ref = cmd_ref.lookup('feature', feat).to_s[/set_value: feature (.*)/]
+    ref = cmd_ref.lookup('feature', feat).to_s[/set_value:.*feature (.*)/]
 
     if ref
       feat_str = Regexp.last_match[1]
@@ -51,7 +51,7 @@ class TestFeature < CiscoTestCase
 
     # Get current state of feature, then disable it
     pre_clean_enabled = Feature.send("#{feat}_enabled?")
-    config("no #{feat_str}") if pre_clean_enabled
+    config("no feature #{feat_str}") if pre_clean_enabled
     refute_show_match(
       command: "show running | i #{feat_str}",
       pattern: /^#{feat_str}$/,
@@ -68,7 +68,7 @@ class TestFeature < CiscoTestCase
            "Feature #{feat} (#{feat_str}) is not enabled")
 
     # Return testbed to pre-clean state
-    config("no #{feat_str}") unless pre_clean_enabled
+    config("no feature #{feat_str}") unless pre_clean_enabled
   end
 
   ###################
@@ -163,6 +163,10 @@ class TestFeature < CiscoTestCase
     vdc_lc_state(vdc_current) if vdc_current
   rescue RuntimeError => e
     hardware_supports_feature?(e.message)
+  end
+
+  def test_vtp
+    feature('vtp')
   end
 
   #####################

--- a/tests/test_vtp.rb
+++ b/tests/test_vtp.rb
@@ -21,18 +21,12 @@ class TestVtp < CiscoTestCase
 
   def setup
     super
-    no_feature_vtp
+    config('no feature vtp')
   end
 
   def teardown
-    no_feature_vtp
-    super
-  end
-
-  def no_feature_vtp
-    # VTP will raise an error if the domain is configured twice so we need to
-    # turn the feature off for a clean test.
     config('no feature vtp')
+    super
   end
 
   def vtp_domain(domain)
@@ -41,19 +35,19 @@ class TestVtp < CiscoTestCase
     vtp
   end
 
-  def test_vtp_disabled
+  def test_disabled
     vtp = Vtp.new(false)
     assert_empty(vtp.domain)
     assert_equal(vtp.default_password, vtp.password)
     assert_equal(vtp.default_filename, vtp.filename)
     assert_equal(vtp.default_version, vtp.version)
-    refute(Vtp.enabled, 'VTP feature was unexpectedly enabled?')
+    refute(Feature.vtp_enabled?, 'VTP feature was unexpectedly enabled?')
   end
 
-  def test_vtp_enabled_but_no_domain
+  def test_enabled_but_no_domain
     vtp = Vtp.new(false)
     config('feature vtp')
-    assert(Vtp.enabled)
+    assert(Feature.vtp_enabled?)
     assert_empty(vtp.domain)
     assert_equal(vtp.default_password, vtp.password)
     assert_equal(vtp.default_filename, vtp.filename)
@@ -69,7 +63,7 @@ class TestVtp < CiscoTestCase
     end
   end
 
-  def test_vtp_domain_enable_disable
+  def test_domain_enable_disable
     assert_empty(Vtp.domain)
     vtp = vtp_domain('enable')
     assert_equal('enable', Vtp.domain)
@@ -77,57 +71,42 @@ class TestVtp < CiscoTestCase
     assert_empty(Vtp.domain)
   end
 
-  def test_vtp_create_valid
-    vtp_domain('accounting')
-    s = @device.cmd("show run vtp | incl '^vtp domain'")
-    assert_match(/^vtp domain accounting/, s,
-                 'Error: failed to create vtp domain')
+  def test_create_valid
+    vtp = vtp_domain('accounting')
+    assert_equal('accounting', vtp.domain)
   end
 
-  def test_vtp_domain_name_change
+  def test_domain_name_change
     vtp = vtp_domain('accounting')
     vtp_domain('uplink')
     assert_equal('uplink', vtp.domain,
                  'Error: vtp domain name incorrect')
   end
 
-  def test_vtp_create_preconfig_no_change
-    config('feature vtp', 'vtp domain accounting')
-
-    vtp = vtp_domain('accounting')
-    assert_equal('accounting', vtp.domain,
-                 'Error: vtp domain wrong')
+  def test_create_double
+    vtp_domain('accounting')
+    assert_raises(Cisco::CliError) { vtp_domain('accounting') }
   end
 
-  def test_vtp_create_double
-    vtp = vtp_domain('accounting')
-    vtp_new = vtp_domain('accounting')
-
-    assert_equal('accounting', vtp.domain,
-                 'Error: vtp domain wrong')
-    assert_equal('accounting', vtp_new.domain,
-                 'Error: vtp_new domain wrong')
-  end
-
-  def test_vtp_create_domain_invalid
+  def test_create_domain_invalid
     assert_raises(ArgumentError) do
       vtp_domain(node)
     end
   end
 
-  def test_vtp_create_domain_nil
+  def test_create_domain_nil
     assert_raises(ArgumentError) do
       vtp_domain(nil)
     end
   end
 
-  def test_vtp_create_domain_empty
+  def test_create_domain_empty
     assert_raises(ArgumentError) do
       vtp_domain('')
     end
   end
 
-  def test_vtp_assignment
+  def test_assignment
     vtp = vtp_domain('accounting')
     vtp.password = 'copy_test'
     assert_equal('copy_test', vtp.password,
@@ -137,20 +116,20 @@ class TestVtp < CiscoTestCase
                  'Error: vtp password not set')
   end
 
-  def test_vtp_domain_get
+  def test_domain_get
     vtp = vtp_domain('accounting')
     assert_equal('accounting', vtp.domain,
                  'Error: vtp domain incorrect')
   end
 
-  def test_vtp_password_nil
+  def test_password_nil
     vtp = vtp_domain('accounting')
     assert_raises(TypeError) do
       vtp.password = nil
     end
   end
 
-  def test_vtp_password_default
+  def test_password_default
     vtp = vtp_domain('accounting')
     vtp.password = 'test_me'
     assert_equal('test_me', vtp.password,
@@ -161,14 +140,14 @@ class TestVtp < CiscoTestCase
                  'Error: vtp password not correct')
   end
 
-  def test_vtp_password_zero_length
+  def test_password_zero_length
     vtp = vtp_domain('accounting')
     vtp.password = ''
     assert_equal('', vtp.password,
                  'Error: vtp password not empty')
   end
 
-  def test_vtp_password_get
+  def test_password_get
     vtp = vtp_domain('accounting')
 
     config('vtp password cisco123')
@@ -176,13 +155,13 @@ class TestVtp < CiscoTestCase
                  'Error: vtp password not correct')
   end
 
-  def test_vtp_password_get_not_set
+  def test_password_get_not_set
     vtp = vtp_domain('accounting')
     assert_equal('', vtp.password,
                  'Error: vtp password not empty')
   end
 
-  def test_vtp_password_clear
+  def test_password_clear
     vtp = vtp_domain('accounting')
     vtp.password = 'cisco123'
     assert_equal('cisco123', vtp.password,
@@ -193,7 +172,7 @@ class TestVtp < CiscoTestCase
                  'Error: vtp default password not set')
   end
 
-  def test_vtp_password_valid
+  def test_password_valid
     vtp = vtp_domain('accounting')
     alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789'
     password = ''
@@ -205,33 +184,33 @@ class TestVtp < CiscoTestCase
     end
   end
 
-  def test_vtp_password_too_long
+  def test_password_too_long
     vtp = vtp_domain('accounting')
     password = 'a' * (Vtp::MAX_VTP_PASSWORD_SIZE + 1)
     assert_raises(ArgumentError) { vtp.password = password }
   end
 
-  def test_vtp_password_special_characters
+  def test_password_special_characters
     vtp = vtp_domain('password')
     vtp.password = 'hello!//\\#%$x'
     assert_equal('hello!//\\#%$x', vtp.password)
   end
 
-  def test_vtp_filename_nil
+  def test_filename_nil
     vtp = vtp_domain('accounting')
     assert_raises(TypeError) do
       vtp.filename = nil
     end
   end
 
-  def test_vtp_filename_valid
+  def test_filename_valid
     vtp = vtp_domain('accounting')
     vtp.filename = 'bootflash:/test.dat'
     assert_equal('bootflash:/test.dat', vtp.filename,
                  'Error: vtp file content wrong')
   end
 
-  def test_vtp_filename_zero_length
+  def test_filename_zero_length
     vtp = vtp_domain('accounting')
     vtp.filename = vtp.default_filename
     assert_equal(node.config_get_default('vtp', 'filename'), vtp.filename,
@@ -244,29 +223,29 @@ class TestVtp < CiscoTestCase
                  'Error: vtp file content wrong')
   end
 
-  def test_vtp_filename_auto_enable
+  def test_filename_auto_enable
     vtp = Vtp.new(false)
-    refute(Vtp.enabled, 'VTP should not be enabled')
+    refute(Feature.vtp_enabled?, 'VTP should not be enabled')
     vtp.filename = 'bootflash:/foo.bar'
-    assert(Vtp.enabled)
+    assert(Feature.vtp_enabled?)
     assert_equal('bootflash:/foo.bar', vtp.filename)
   end
 
-  def test_vtp_version_valid
+  def test_version_valid
     vtp = vtp_domain('accounting')
     vtp.version = vtp.default_version
     assert_equal(node.config_get_default('vtp', 'version'), vtp.version,
                  'Error: vtp version not default')
   end
 
-  def test_vtp_version3_valid
+  def test_version3_valid
     vtp = vtp_domain('accounting')
 
     ref = cmd_ref.lookup('vtp', 'version')
     assert(ref, 'Error, reference not found for vtp version3')
 
     case node.product_id
-    when /N7K/
+    when /N(5|6|7)K/
       vtp.version = 3
       assert_equal(vtp.version, 3)
     else
@@ -287,14 +266,14 @@ class TestVtp < CiscoTestCase
     end
   end
 
-  def test_vtp_version_invalid
+  def test_version_invalid
     vtp = vtp_domain('accounting')
     assert_raises(Cisco::CliError) do
       vtp.version = 34
     end
   end
 
-  def test_vtp_version_default
+  def test_version_default
     vtp = vtp_domain('accounting')
     vtp.version = 2
     assert_equal(2, vtp.version,
@@ -304,19 +283,19 @@ class TestVtp < CiscoTestCase
                  'Error: vtp version not default')
   end
 
-  def test_vtp_version_auto_enable
+  def test_version_auto_enable
     vtp = Vtp.new(false)
-    refute(Vtp.enabled, 'VTP should not be enabled')
+    refute(Feature.vtp_enabled?, 'VTP should not be enabled')
     vtp.version = 1
-    assert(Vtp.enabled)
+    assert(Feature.vtp_enabled?)
     assert_equal(1, vtp.version)
   end
 
-  def test_vtp_feature_enable_disable
-    Vtp.new.enable
-    assert(Vtp.enabled, 'Error: vtp is not enabled')
+  def test_feature_enable_disable
+    Feature.vtp_enable
+    assert(Feature.vtp_enabled?, 'Error: vtp is not enabled')
 
     Vtp.new.destroy
-    refute(Vtp.enabled, 'Error: vtp is not disabled')
+    refute(Feature.vtp_enabled?, 'Error: vtp is not disabled')
   end
 end


### PR DESCRIPTION
- Refactored to use non-structured output since structured output is not supported on `n5|6k`
- Fixed a few bugs in test_feature.rb
- Tests pass on n8k, n9k (I2 and I3)
- Failures on n5k, n6k and n7k due platform defects (see below).

```
  1) Failure:
TestVtp#test_password_special_characters [tests/test_vtp.rb:196]:
Expected: "hello!//\\#%$x"
  Actual: "hello!//\\\\\\\\#%$x"


  2) Failure:
TestVtp#test_create_double [tests/test_vtp.rb:88]:
Cisco::CliError expected but nothing was raised.
```
- Failure 1 caused by incorrect nxapi handling of backslashes.
- Failure 2 should generate a CLI error on n5|6|7k but does not.
