### PR TITLE
test_router_ospf, test_router_ospf_vrf fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -2,9 +2,11 @@
 ---
 _exclude: [ios_xr]
 
+_template:
+  get_command: "show running | i ^feature"
+
 bgp:
   kind: boolean
-  get_command: "show running | i ^feature"
   get_value: '/^feature bgp$/'
   set_value: "feature bgp"
 
@@ -16,20 +18,17 @@ fabric:
 
 fabric_forwarding:
   _exclude: [N3k]
-  get_command: "show running | i ^feature"
   get_value: '/^feature fabric forwarding$/'
   set_value: "feature fabric forwarding"
 
 itd:
   _exclude: [N3k, N5k, N6k]
-  get_command: "show running | i ^feature"
   get_value: '/^feature itd$/'
   set_value: "feature itd"
 
 nv_overlay:
   _exclude: [N3k, N5k, N6k]
   kind: boolean
-  get_command: "show running | i ^feature"
   get_value: '/^feature nv overlay$/'
   set_value: "feature nv overlay"
 
@@ -41,9 +40,13 @@ nv_overlay_evpn:
   get_value: '/^nv overlay evpn$/'
   set_value: "nv overlay evpn"
 
+ospf:
+  kind: boolean
+  get_value: '/^feature ospf$/'
+  set_value: "feature ospf"
+
 pim:
   kind: boolean
-  get_command: "show running | i ^feature"
   get_value: '/^feature pim$/' # TBD pim6
   set_value: 'feature pim'
 
@@ -52,7 +55,6 @@ vn_segment_vlan_based:
   N3k: &vn_segment_vlan_based_mt_lite
     # Note: Some N3k are not hardware-capable
     kind: boolean
-    get_command: "show running | i ^feature"
     get_value: '/^feature vn-segment-vlan-based$/'
     set_value: 'feature vn-segment-vlan-based'
     default_value: false
@@ -63,13 +65,11 @@ vni:
   kind: boolean
   N7k:
     # MT-Full only
-    get_command: "show running | i ^feature"
     get_value: '/^feature vni$/'
     set_value: 'feature vni'
   N3k: &feature_mt_lite
     # MT-lite only
     # Note: Some N3k are not hardware-capable
-    get_command: "show running | i ^feature"
     get_value: '/^feature vn-segment-vlan-based$/'
     set_value: 'feature vn-segment-vlan-based'
   N8k: *feature_mt_lite

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -77,7 +77,6 @@ vni:
 
 vtp:
   kind: boolean
-  get_command: "show running | i ^feature"
   get_value: '/^feature vtp$/'
   set_value: "<state> feature vtp"
   default_value: false

--- a/lib/cisco_node_utils/cmd_ref/ospf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf.yaml
@@ -19,12 +19,6 @@ default_metric:
   set_value: "<state> default-metric <metric>"
   default_value: 0
 
-feature:
-  get_command: "show running ospf"
-  context: ~
-  get_value: '/^feature ospf$/'
-  set_value: "%s feature ospf"
-
 log_adjacency:
   auto_default: false
   get_value: '/^(log-adjacency-changes)\s*(detail)?$/'
@@ -36,7 +30,7 @@ router:
   get_command: "show running ospf"
   context: ~
   get_value: '/^router ospf (\S+)$/'
-  set_value: "%s router ospf %s"
+  set_value: "<state> router ospf <name>"
 
 router_id:
   get_value: '/^router-id (\S+)?$/'

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -119,6 +119,16 @@ module Cisco
     end
 
     # ---------------------------
+    def self.ospf_enable
+      return if ospf_enabled?
+      config_set('feature', 'ospf')
+    end
+
+    def self.ospf_enabled?
+      config_get('feature', 'ospf')
+    end
+
+    # ---------------------------
     def self.pim_enable
       return if pim_enabled?
       config_set('feature', 'pim')

--- a/lib/cisco_node_utils/router_ospf.rb
+++ b/lib/cisco_node_utils/router_ospf.rb
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 require_relative 'node_util'
-require_relative 'feature'
 
 module Cisco
   # RouterOspf - node utility class for process-level OSPF config management

--- a/lib/cisco_node_utils/router_ospf.rb
+++ b/lib/cisco_node_utils/router_ospf.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 require_relative 'node_util'
+require_relative 'feature'
 
 module Cisco
   # RouterOspf - node utility class for process-level OSPF config management
@@ -44,49 +45,15 @@ module Cisco
       return {}
     end
 
-    def self.enabled
-      feat = config_get('ospf', 'feature')
-      return (!feat.nil? && !feat.empty?)
-    rescue Cisco::CliError => e
-      # cmd will syntax reject when feature is not enabled
-      raise unless e.clierror =~ /Syntax error/
-      return false
-    end
-
-    def self.enable(state='')
-      config_set('ospf', 'feature', state)
-    end
-
-    def ospf_router(name, state='')
-      config_set('ospf', 'router', state, name)
-    end
-
-    def enable_create_router_ospf(name)
-      RouterOspf.enable
-      ospf_router(name)
-    end
-
     # Create one router ospf instance
     def create
-      if RouterOspf.enabled
-        ospf_router(name)
-      else
-        enable_create_router_ospf(name)
-      end
+      Feature.ospf_enable
+      config_set('ospf', 'router', state: '', name: @name)
     end
 
     # Destroy one router ospf instance
     def destroy
-      ospf_ids = config_get('ospf', 'router')
-      return if ospf_ids.nil?
-      if ospf_ids.size == 1
-        RouterOspf.enable('no')
-      else
-        ospf_router(name, 'no')
-      end
-    rescue Cisco::CliError => e
-      # cmd will syntax reject when feature is not enabled
-      raise unless e.clierror =~ /Syntax error/
+      config_set('ospf', 'router', state: 'no', name: @name)
     end
   end
 end

--- a/lib/cisco_node_utils/router_ospf_vrf.rb
+++ b/lib/cisco_node_utils/router_ospf_vrf.rb
@@ -155,13 +155,13 @@ module Cisco
       config_get('ospf', 'router_id', @get_args)
     end
 
-    def router_id=(router_id)
-      if router_id == default_router_id
+    def router_id=(rid)
+      if rid == default_router_id
         @set_args[:state] = 'no'
-        @set_args[:router_id] = ''
+        @set_args[:router_id] = router_id
       else
         @set_args[:state] = ''
-        @set_args[:router_id] = router_id
+        @set_args[:router_id] = rid
       end
 
       config_set('ospf', 'router_id', @set_args)

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -129,6 +129,10 @@ class TestFeature < CiscoTestCase
     vdc_lc_state(vdc_current) if vdc_current
   end
 
+  def test_ospf
+    feature('ospf')
+  end
+
   def test_pim
     feature('pim')
   end
@@ -159,6 +163,10 @@ class TestFeature < CiscoTestCase
 
     # vni can't be removed if nv overlay is present
     config('no feature nv overlay')
+
+    # Hang observed on n3|9k when show run occurs immediately after removing
+    # nv overlay. This minor delay avoids the hang.
+    sleep 1
     feature('vni')
     vdc_lc_state(vdc_current) if vdc_current
   rescue RuntimeError => e

--- a/tests/test_router_ospf.rb
+++ b/tests/test_router_ospf.rb
@@ -21,115 +21,36 @@ class TestRouterOspf < CiscoTestCase
 
   def setup
     super
-    @default_show_command = "show run | include '^router ospf .*'"
+    config_no_warn('no feature ospf')
   end
 
-  def routerospf_routers_destroy(routers)
-    routers.each_value(&:destroy)
-  end
+  def test_create_destroy
+    assert_empty(RouterOspf.routers, 'RouterOspf.routers should be empty')
 
-  def test_routerospf_collection_empty
-    config('no feature ospf')
-    routers = RouterOspf.routers
-    assert_equal(true, routers.empty?,
-                 'RouterOspf collection is not empty')
-  end
+    # Create two ospf instances
+    o1_name = 'ospf1'
+    o1 = RouterOspf.new(o1_name)
+    assert(RouterOspf.routers[o1_name],
+           "router ospf #{o1_name} not present")
+    assert_equal(o1_name, o1.name)
 
-  def test_routerospf_collection_not_empty
-    config('feature ospf', 'router ospf TestOSPF', 'router ospf 100')
-    routers = RouterOspf.routers
-    assert_equal(false, routers.empty?,
-                 'RouterOspf collection is empty')
-    # validate the collection
-    routers.each_key do |name|
-      assert_show_match(pattern: /router ospf #{name}/)
-    end
-    routerospf_routers_destroy(routers)
-  end
+    o2_name = 'ospf2'
+    o2 = RouterOspf.new(o2_name)
+    assert(RouterOspf.routers[o2_name],
+           "router ospf #{o2_name} not present")
 
-  def test_routerospf_create_name_zero_length
-    assert_raises(ArgumentError) do
-      RouterOspf.new('')
-    end
-  end
+    # Destroy each in turn
+    o1.destroy
+    assert_nil(RouterOspf.routers[o1_name],
+               "router ospf #{o1_name} still present")
+    assert(RouterOspf.routers[o2_name],
+           "router ospf #{o2_name} not present")
 
-  def test_routerospf_create_valid
-    name = 'ospfTest'
-    ospf = RouterOspf.new(name)
-    assert_show_match(pattern: /router ospf #{name}/,
-                      msg:     "'router ospf ospfTest' not configured")
-    ospf.destroy
-  end
+    o2.destroy
+    assert_nil(RouterOspf.routers[o2_name],
+               "router ospf #{o2_name} still present")
 
-  def test_routerospf_create_valid_no_feature
-    name = 'ospfTest'
-    ospf = RouterOspf.new(name)
-    assert_show_match(pattern: /router ospf #{name}/,
-                      msg:     "'router ospf ospfTest' not configured")
-    ospf.destroy
-
-    refute_show_match(command: 'show run all | inc feature | no-more',
-                      pattern: /feature ospf/,
-                      msg:     "Error: 'feature ospf' still configured")
-  end
-
-  def test_routerospf_create_valid_multiple
-    name = 'ospfTest_1'
-    ospf_1 = RouterOspf.new(name)
-    assert_show_match(pattern: /router ospf #{name}/)
-
-    name = 'ospfTest_2'
-    ospf_2 = RouterOspf.new(name)
-    assert_show_match(pattern: /router ospf #{name}/)
-
-    ospf_1.destroy
-    ospf_2.destroy
-  end
-
-  def test_routerospf_get_name
-    name = 'ospfTest'
-    ospf = RouterOspf.new(name)
-    line = assert_show_match(pattern: /router ospf #{name}/)
-    name = line.to_s.split(' ').last
-    # puts "name from cli: #{name}"
-    # puts "name from get: #{routerospf.name}"
-    assert_equal(name, ospf.name,
-                 'Error: router name not correct')
-    ospf.destroy
-  end
-
-  def test_routerospf_destroy
-    name = 'ospfTest'
-    ospf = RouterOspf.new(name)
-    ospf.destroy
-    refute_show_match(pattern: /router ospf #{name}/,
-                      msg:     "'router ospf ospfTest' not destroyed")
-  end
-
-  def test_routerospf_create_valid_multiple_delete_one
-    name = 'ospfTest_1'
-    ospf_1 = RouterOspf.new(name)
-    assert_show_match(pattern: /router ospf #{name}/,
-                      msg:     "Error: #{name}, not configured")
-
-    name = 'ospfTest_2'
-    ospf_2 = RouterOspf.new(name)
-    assert_show_match(pattern: /router ospf #{name}/,
-                      msg:     "Error: #{name}, not configured")
-
-    ospf_1.destroy
-
-    # Remove one router then check that we only have one router left
-    routers = RouterOspf.routers
-    assert_equal(false, routers.empty?,
-                 'Error: RouterOspf collection is empty')
-    assert_equal(1, routers.size,
-                 'Error: RouterOspf collection is not one')
-    assert_equal(true, routers.key?(name),
-                 "Error: #{name}, not found in the collection")
-    # validate the collection
-    assert_show_match(pattern: /router ospf #{name}/,
-                      msg:     "Error: #{name}, instance not found")
-    ospf_2.destroy
+    # Negative
+    assert_raises(ArgumentError) { RouterOspf.new('') }
   end
 end

--- a/tests/test_router_ospf_vrf.rb
+++ b/tests/test_router_ospf_vrf.rb
@@ -19,17 +19,21 @@ require_relative '../lib/cisco_node_utils/router_ospf_vrf'
 # TestRouterOspfVrf - Minitest for RouterOspfVrf node utility class
 class TestRouterOspfVrf < CiscoTestCase
   @skip_unless_supported = 'ospf'
+  @@pre_clean_needed = true # rubocop:disable Style/ClassVars
 
   def setup
-    # Disable feature ospf before each test to ensure we
-    # are starting with a clean slate for each test.
     super
-    config('no feature ospf')
+    cleanup if @@pre_clean_needed
+    @@pre_clean_needed = false # rubocop:disable Style/ClassVars
   end
 
   def teardown
-    config('no feature ospf')
+    cleanup
     super
+  end
+
+  def cleanup
+    RouterOspf.routers.each { |_name, obj| obj.destroy }
   end
 
   def assert_match_vrf_line(routername, vrfname, cmd=nil)
@@ -109,7 +113,7 @@ class TestRouterOspfVrf < CiscoTestCase
     config(*cfg)
   end
 
-  def test_routerospfvrf_collection_size
+  def test_collection_size
     create_routerospfvrf('green')
     vrfs = RouterOspfVrf.vrfs
     assert_equal(1, vrfs.size, 'Error: Collection is not one')
@@ -146,7 +150,7 @@ class TestRouterOspfVrf < CiscoTestCase
   )
   # rubocop:enable Style/AlignHash
 
-  def test_routerospfvrf_collection_not_empty_valid
+  def test_collection_not_empty_valid
     # pre-populate values
     config_from_hash(MULTIPLE_OSPFS)
 
@@ -178,11 +182,11 @@ class TestRouterOspfVrf < CiscoTestCase
     end
   end
 
-  def test_routerospfvrf_create_vrf_nil
+  def test_create_vrf_nil
     assert_raises(TypeError) { RouterOspfVrf.new(nil, 'testvrf') }
   end
 
-  def test_routerospfvrf_create_name_zero_length
+  def test_create_name_zero_length
     routerospf = RouterOspf.new('testOspf')
     assert_raises(ArgumentError) do
       RouterOspfVrf.new('testOspf', '')
@@ -190,9 +194,9 @@ class TestRouterOspfVrf < CiscoTestCase
     routerospf.destroy
   end
 
-  def test_routerospfvrf_create_valid
+  def test_create_valid
     ospfname = 'ospfTest'
-    # routerospf = RouterOspf.new(ospfname)
+
     vrfname = 'default'
     vrf = RouterOspfVrf.new(ospfname, vrfname)
     assert_match_vrf_line(ospfname, vrfname)
@@ -201,7 +205,7 @@ class TestRouterOspfVrf < CiscoTestCase
     vrf.parent.destroy
   end
 
-  def test_routerospfvrf_get_parent_name
+  def test_get_parent_name
     routerospf = create_routerospf
     vrf = create_routerospfvrf(routerospf.name)
     assert_equal(routerospf.name, vrf.parent.name,
@@ -209,7 +213,7 @@ class TestRouterOspfVrf < CiscoTestCase
     routerospf.destroy
   end
 
-  def test_routerospfvrf_get_name
+  def test_get_name
     vrfname = 'default'
     vrf = create_routerospfvrf('green')
     assert_match_vrf_line('green', vrfname)
@@ -218,7 +222,7 @@ class TestRouterOspfVrf < CiscoTestCase
     vrf.parent.destroy
   end
 
-  def test_routerospfvrf_destroy
+  def test_destroy
     vrfname = 'default'
     vrf = create_routerospfvrf
     assert_raises(RuntimeError) do
@@ -228,10 +232,10 @@ class TestRouterOspfVrf < CiscoTestCase
     vrf.parent.destroy
   end
 
-  def test_routerospfvrf_auto_cost
+  def test_auto_cost
     vrf = create_routerospfvrf
     auto_cost_value = [400_000, RouterOspfVrf::OSPF_AUTO_COST[:mbps]]
-    # set auto-cost
+
     vrf.auto_cost_set(auto_cost_value[0], :mbps)
     pattern = /\s+auto-cost reference-bandwidth #{auto_cost_value[0]}/
     assert_match_vrf_line(vrf.parent.name, vrf.name, pattern)
@@ -240,12 +244,12 @@ class TestRouterOspfVrf < CiscoTestCase
     vrf.parent.destroy
   end
 
-  def test_routerospfvrf_auto_cost_multiple_vrf
+  def test_auto_cost_multiple_vrf
     routerospf = create_routerospf
     vrf = create_routerospfvrf(routerospf.name)
     vrf1 = create_routerospfvrf(routerospf.name, 'testvrf')
     auto_cost_value = [600_000, RouterOspfVrf::OSPF_AUTO_COST[:mbps]]
-    # set auto-cost
+
     vrf.auto_cost_set(auto_cost_value[0], :mbps)
     pattern = /\s+auto-cost reference-bandwidth #{auto_cost_value[0]}/
     assert_match_vrf_line(routerospf.name, vrf.name, pattern)
@@ -254,7 +258,7 @@ class TestRouterOspfVrf < CiscoTestCase
 
     # vrf 1
     auto_cost_value = [500_000, RouterOspfVrf::OSPF_AUTO_COST[:mbps]]
-    # set cost
+
     vrf1.auto_cost_set(auto_cost_value[0], :mbps)
     pattern = /\s+auto-cost reference-bandwidth #{auto_cost_value[0]}/
     assert_match_vrf_line(routerospf.name, vrf1.name, pattern)
@@ -263,7 +267,7 @@ class TestRouterOspfVrf < CiscoTestCase
     routerospf.destroy
   end
 
-  def test_routerospfvrf_get_default_auto_cost
+  def test_get_default_auto_cost
     vrf = create_routerospfvrf
     # NXOS specific
     auto_cost_value = [40, RouterOspfVrf::OSPF_AUTO_COST[:gbps]]
@@ -274,7 +278,7 @@ class TestRouterOspfVrf < CiscoTestCase
     vrf.parent.destroy
   end
 
-  def test_routerospfvrf_default_metric
+  def test_default_metric
     vrf = create_routerospfvrf
     metric = 30_000
     vrf.default_metric = metric
@@ -282,18 +286,18 @@ class TestRouterOspfVrf < CiscoTestCase
     assert_match_vrf_line(vrf.parent.name, vrf.name, pattern)
     assert_equal(metric, vrf.default_metric,
                  "Error: #{vrf.name} vrf, default-metric get value mismatch")
-    # set default metric
+
     vrf.default_metric = vrf.default_default_metric
     refute_match_vrf_line(vrf.parent.name, vrf.name, pattern)
     vrf.parent.destroy
   end
 
-  def test_routerospfvrf_default_metric_multiple_vrf
+  def test_default_metric_multiple_vrf
     routerospf = create_routerospf
     vrf = create_routerospfvrf(routerospf.name)
     vrf1 = create_routerospfvrf(routerospf.name, 'testvrf')
     metric = 35_000
-    # set metric
+
     vrf.default_metric = metric
     pattern = /\s+default-metric #{metric}/
     assert_match_vrf_line(routerospf.name, vrf.name, pattern)
@@ -311,7 +315,7 @@ class TestRouterOspfVrf < CiscoTestCase
     routerospf.destroy
   end
 
-  def test_routerospfvrf_log_adjacency_changes
+  def test_log_adjacency_changes
     vrf = create_routerospfvrf
 
     assert_equal(:none, vrf.log_adjacency,
@@ -330,18 +334,17 @@ class TestRouterOspfVrf < CiscoTestCase
                  "Error: #{vrf.name} vrf, " \
                  'log-adjacency detail get value mismatch')
 
-    # set default log adjacency
     vrf.log_adjacency = vrf.default_log_adjacency
     pattern = /\s+log-adjacency-changes(.*)/
     refute_match_vrf_line(vrf.parent.name, vrf.name, pattern)
     vrf.parent.destroy
   end
 
-  def test_routerospfvrf_log_adjacency_multiple_vrf
+  def test_log_adjacency_multiple_vrf
     routerospf = create_routerospf
     vrf = create_routerospfvrf(routerospf.name)
     vrf1 = create_routerospfvrf(routerospf.name, 'testvrf')
-    # set log_adjacency
+
     vrf.log_adjacency = :log
     pattern = /\s+log-adjacency-changes/
     assert_match_vrf_line(routerospf.name, vrf.name, pattern)
@@ -349,7 +352,6 @@ class TestRouterOspfVrf < CiscoTestCase
                  "Error: #{vrf.name} vrf, log-adjacency get value mismatch")
 
     # vrf 1
-    # set log_adjacency
     vrf1.log_adjacency = :detail
     pattern = /\s+log-adjacency-changes/
     assert_match_vrf_line(routerospf.name, vrf1.name, pattern)
@@ -359,20 +361,19 @@ class TestRouterOspfVrf < CiscoTestCase
     routerospf.destroy
   end
 
-  def test_routerospfvrf_log_adjacency_multiple_vrf_2
+  def test_log_adjacency_multiple_vrf_2
     routerospf = create_routerospf
     vrf_default = create_routerospfvrf(routerospf.name)
     vrf1 = create_routerospfvrf(routerospf.name, 'testvrf')
     # DO NOT set log_adjacency for default vrf
     # DO set log_adjacency for non-default vrf
-    # set log_adjacency
+
     vrf1.log_adjacency = :detail
     pattern = /\s+log-adjacency-changes/
     assert_match_vrf_line(routerospf.name, vrf1.name, pattern)
     assert_equal(:detail, vrf1.log_adjacency,
                  "Error: #{vrf1.name} vrf, log-adjacency get value mismatch")
 
-    # Make sure default vrf is set to :none
     assert_equal(:none, vrf_default.log_adjacency,
                  "Error: #{vrf_default.name} vrf_default, " \
                  'log-adjacency get value mismatch')
@@ -380,7 +381,7 @@ class TestRouterOspfVrf < CiscoTestCase
     routerospf.destroy
   end
 
-  def test_routerospfvrf_router_id
+  def test_router_id
     vrf = create_routerospfvrf
     id = '8.1.1.3'
     vrf.router_id = id
@@ -388,18 +389,18 @@ class TestRouterOspfVrf < CiscoTestCase
     assert_match_vrf_line(vrf.parent.name, vrf.name, pattern)
     assert_equal(id, vrf.router_id,
                  "Error: #{vrf.name} vrf, router-id get value mismatch")
-    # set default router id
+
     vrf.router_id = vrf.default_router_id
     refute_match_vrf_line(vrf.parent.name, vrf.name, pattern)
     vrf.parent.destroy
   end
 
-  def test_routerospfvrf_router_id_multiple_vrf
+  def test_router_id_multiple_vrf
     routerospf = create_routerospf
     vrf = create_routerospfvrf(routerospf.name)
     vrf1 = create_routerospfvrf(routerospf.name, 'testvrf')
     id = '8.1.1.3'
-    # set id
+
     vrf.router_id = id
     pattern = /\s+router-id #{id}/
     assert_match_vrf_line(routerospf.name, vrf.name, pattern)
@@ -408,7 +409,7 @@ class TestRouterOspfVrf < CiscoTestCase
 
     # vrf 1
     id = '10.1.1.3'
-    # set id
+
     vrf1.router_id = id
     pattern = /\s+router-id #{id}/
     assert_match_vrf_line(routerospf.name, vrf1.name, pattern)
@@ -418,11 +419,11 @@ class TestRouterOspfVrf < CiscoTestCase
     routerospf.destroy
   end
 
-  def test_routerospfvrf_timer_throttle_lsa
+  def test_timer_throttle_lsa
     vrf = create_routerospfvrf
     lsa = [] << 100 << 500 << 1000
     vrf.timer_throttle_lsa_set(lsa[0], lsa[1], lsa[2])
-    # vrf.send(:timer_throttle_lsa=, lsa[0], lsa[1], lsa[2])
+
     pattern = /\s+timers throttle lsa #{lsa[0]} #{lsa[1]} #{lsa[2]}/
     assert_match_vrf_line(vrf.parent.name, vrf.name, pattern)
     assert_equal(lsa, vrf.timer_throttle_lsa,
@@ -431,14 +432,13 @@ class TestRouterOspfVrf < CiscoTestCase
     vrf.parent.destroy
   end
 
-  def test_routerospfvrf_timer_throttle_lsa_multiple_vrf
+  def test_timer_throttle_lsa_multiple_vrf
     routerospf = create_routerospf
     vrf = create_routerospfvrf(routerospf.name)
     vrf1 = create_routerospfvrf(routerospf.name, 'testvrf')
     lsa = [] << 100 << 500 << 1000
-    # set lsa
+
     vrf.timer_throttle_lsa_set(lsa[0], lsa[1], lsa[2])
-    # vrf.send(:timer_throttle_lsa=, lsa[0], lsa[1], lsa[2])
     pattern = /\s+timers throttle lsa #{lsa[0]} #{lsa[1]} #{lsa[2]}/
     assert_match_vrf_line(routerospf.name, vrf.name, pattern)
     assert_equal(lsa, vrf.timer_throttle_lsa,
@@ -446,9 +446,8 @@ class TestRouterOspfVrf < CiscoTestCase
                  'get values mismatch')
 
     lsa = [] << 300 << 700 << 2000
-    # set lsa
+
     vrf1.timer_throttle_lsa_set(lsa[0], lsa[1], lsa[2])
-    # vrf1.send(:timer_throttle_lsa=, lsa[0], lsa[1], lsa[2])
     pattern = /\s+timers throttle lsa #{lsa[0]} #{lsa[1]} #{lsa[2]}/
     assert_match_vrf_line(routerospf.name, vrf1.name, pattern)
     assert_equal(lsa, vrf1.timer_throttle_lsa,
@@ -458,7 +457,7 @@ class TestRouterOspfVrf < CiscoTestCase
     routerospf.destroy
   end
 
-  def test_routerospfvrf_get_default_timer_throttle_lsa
+  def test_get_default_timer_throttle_lsa
     vrf = create_routerospfvrf
     lsa = [0, 5000, 5000]
     assert_equal(lsa[0], vrf.timer_throttle_lsa_start,
@@ -476,10 +475,10 @@ class TestRouterOspfVrf < CiscoTestCase
     vrf.parent.destroy
   end
 
-  def test_routerospfvrf_timer_throttle_spf
+  def test_timer_throttle_spf
     vrf = create_routerospfvrf
     spf = [250, 500, 1000]
-    # vrf.send(:timer_throttle_spf=, spf[0], spf[1], spf[2])
+
     vrf.timer_throttle_spf_set(spf[0], spf[1], spf[2])
     pattern = /\s+timers throttle spf #{spf[0]} #{spf[1]} #{spf[2]}/
     assert_match_vrf_line(vrf.parent.name, vrf.name, pattern)
@@ -489,14 +488,13 @@ class TestRouterOspfVrf < CiscoTestCase
     vrf.parent.destroy
   end
 
-  def test_routerospfvrf_timer_throttle_spf_multiple_vrf
+  def test_timer_throttle_spf_multiple_vrf
     routerospf = create_routerospf
     vrf = create_routerospfvrf(routerospf.name)
     vrf1 = create_routerospfvrf(routerospf.name, 'testvrf')
     spf = [] << 250 << 500 << 1000
-    # set spf
+
     vrf.timer_throttle_spf_set(spf[0], spf[1], spf[2])
-    # vrf.send(:timer_throttle_spf=, spf[0], spf[1], spf[2])
     pattern = /\s+timers throttle spf #{spf[0]} #{spf[1]} #{spf[2]}/
     assert_match_vrf_line(routerospf.name, vrf.name, pattern)
     assert_equal(spf, vrf.timer_throttle_spf,
@@ -504,9 +502,8 @@ class TestRouterOspfVrf < CiscoTestCase
                  'get values mismatch')
 
     spf = [] << 300 << 700 << 2000
-    # set spf
+
     vrf1.timer_throttle_spf_set(spf[0], spf[1], spf[2])
-    # vrf1.send(:timer_throttle_spf=, spf[0], spf[1], spf[2])
     pattern = /\s+timers throttle spf #{spf[0]} #{spf[1]} #{spf[2]}/
     assert_match_vrf_line(routerospf.name, vrf1.name, pattern)
     assert_equal(spf, vrf1.timer_throttle_spf,
@@ -516,7 +513,7 @@ class TestRouterOspfVrf < CiscoTestCase
     routerospf.destroy
   end
 
-  def test_routerospfvrf_get_default_timer_throttle_spf
+  def test_get_default_timer_throttle_spf
     vrf = create_routerospfvrf
     spf = [200, 1000, 5000]
     assert_equal(spf[0], vrf.default_timer_throttle_spf_start,
@@ -537,7 +534,7 @@ class TestRouterOspfVrf < CiscoTestCase
     vrf.parent.destroy
   end
 
-  def test_routerospfvrf_create_valid_destroy_default
+  def test_create_valid_destroy_default
     ospfname = 'ospfTest'
     routerospf = RouterOspf.new(ospfname)
     vrfname = 'default'
@@ -578,7 +575,7 @@ class TestRouterOspfVrf < CiscoTestCase
   )
   # rubocop:enable Style/AlignHash
 
-  def test_routerospfvrf_collection_router_multi_vrfs
+  def test_collection_router_multi_vrfs
     config_from_hash(MULTIPLE_OSPFS_MULTIPLE_VRFS)
     routers = RouterOspf.routers
     # validate the collection
@@ -611,7 +608,7 @@ class TestRouterOspfVrf < CiscoTestCase
     end
   end
 
-  def test_routerospfvrf_timer_throttle_lsa_start_hold_max
+  def test_timer_throttle_lsa_start_hold_max
     vrf = create_routerospfvrf
     vrf.timer_throttle_lsa_set(250, 900, 5001)
     assert_equal(250, vrf.timer_throttle_lsa_start,
@@ -623,7 +620,7 @@ class TestRouterOspfVrf < CiscoTestCase
     vrf.parent.destroy
   end
 
-  def test_routerospfvrf_timer_throttle_spf_start_hold_max
+  def test_timer_throttle_spf_start_hold_max
     vrf = create_routerospfvrf
     vrf.timer_throttle_spf_set(250, 900, 5001)
     assert_equal(250, vrf.timer_throttle_spf_start,
@@ -635,7 +632,7 @@ class TestRouterOspfVrf < CiscoTestCase
     vrf.parent.destroy
   end
 
-  def test_routerospfvrf_noninstantiated
+  def test_noninstantiated
     routerospf = create_routerospf
     vrf = RouterOspfVrf.new('absent', 'absent', false)
     vrf.auto_cost


### PR DESCRIPTION
- I ran into some issues with feature disablement on one platform so I took the opportunity to just remove it altogether since that was the long-term plan anyway; also moved feature enable into the Feature provider.
- test_router_ospf.rb was one of the original minitests. It had a lot of repetitive tests so I gutted it.
- Minitests now pass on all NX platforms
