### PR TITLE
Feature/interface test all plats

### DIFF
--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -186,6 +186,7 @@ class Cisco::Client::NXAPI < Cisco::Client
     debug("Sending HTTP request to NX-API at #{@http.address}:\n" \
           "#{request.to_hash}\n#{request.body}")
     begin
+      @http.use_ssl = false
       response = @http.request(request)
     rescue Errno::ECONNREFUSED, Errno::ECONNRESET
       emsg = 'Connection refused or reset. Is the NX-API feature enabled?'

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -186,6 +186,8 @@ class Cisco::Client::NXAPI < Cisco::Client
     debug("Sending HTTP request to NX-API at #{@http.address}:\n" \
           "#{request.to_hash}\n#{request.body}")
     begin
+      # Explicitly use http to avoid EOFError
+      # http://stackoverflow.com/a/23080693
       @http.use_ssl = false
       response = @http.request(request)
     rescue Errno::ECONNREFUSED, Errno::ECONNRESET

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -21,7 +21,7 @@ fabric_forwarding:
   set_value: "feature fabric forwarding"
 
 fex:
-  _exclude: [N5k, N6k]
+  _exclude: [C3064, C3132, N5k, N6k, N8k]
   get_command: "show feature-set"
   get_value: '/^fex[\s\d]+(\w+)/'
   set_value: "<state> feature-set fex"

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -20,6 +20,12 @@ fabric_forwarding:
   get_value: '/^feature fabric forwarding$/'
   set_value: "feature fabric forwarding"
 
+fex:
+  _exclude: [N5k, N6k]
+  get_command: "show feature-set"
+  get_value: '/^fex[\s\d]+(\w+)/'
+  set_value: "<state> feature-set fex"
+
 itd:
   _exclude: [N3k, N5k, N6k]
   get_command: "show running | i ^feature"

--- a/lib/cisco_node_utils/cmd_ref/fex.yaml
+++ b/lib/cisco_node_utils/cmd_ref/fex.yaml
@@ -1,9 +1,0 @@
-# fex
----
-feature:
-  get_command: "show feature-set"
-  get_value: '/^fex[\s\d]+(\w+)/'
-  set_value: "%s feature-set fex"
-
-feature_install:
-  set_value: "%s install feature-set fex"

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -49,7 +49,7 @@ encapsulation_dot1q:
   set_value: "<state> encapsulation dot1q <vlan>"
 
 fabric_forwarding_anycast_gateway:
-  _exclude: [ios_xr]
+  _exclude: [ios_xr, N3k, N7k]
   kind: boolean
   get_value: '/^fabric forwarding mode anycast-gateway$/'
   set_value: "<state> fabric forwarding mode anycast-gateway"

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -40,7 +40,10 @@ duplex:
   kind: string
   get_value: '/^duplex (.*)$/'
   set_value: "duplex <duplex>"
-  default_value: "auto"
+  C3064:
+    default_value: 'full'
+  else:
+    default_value: 'auto'
 
 encapsulation_dot1q:
   kind: int
@@ -238,10 +241,19 @@ shutdown_vlan:
     default_value: true
 
 speed:
-  _exclude: [ios_xr]
+  _exclude: [ios_xr, C3132]
   get_value: '/^speed (.*)$/'
   set_value: "speed <speed>"
-  default_value: "auto"
+  C3064:
+    default_value: 10000
+  C3172:
+    default_value: 10000
+  N5k:
+    default_value: 10000
+  N6k:
+    default_value: 10000
+  else:
+    default_value: 'auto'
 
 stp_bpdufilter:
   kind: string

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -52,7 +52,7 @@ encapsulation_dot1q:
   set_value: "<state> encapsulation dot1q <vlan>"
 
 fabric_forwarding_anycast_gateway:
-  _exclude: [ios_xr, N3k, N7k]
+  _exclude: [ios_xr, N3k]
   kind: boolean
   get_value: '/^fabric forwarding mode anycast-gateway$/'
   set_value: "<state> fabric forwarding mode anycast-gateway"

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -195,31 +195,17 @@ mtu_other_interfaces:
 
 negotiate_auto_ethernet:
   kind: boolean
-  _exclude: [ios_xr]
-  N7k:
-    default_only: false
-  C3064:
-    default_only: false
-  else:
-    get_value: '/^(no )?negotiate auto$/'
-    set_value: "<state> negotiate auto"
-    default_value: true
-
-negotiate_auto_other_interfaces:
-  kind: boolean
-  _exclude: [ios_xr]
-  default_only: false
+  _exclude: [ios_xr, C3064, N7k]
+  get_value: '/^(no )?negotiate auto$/'
+  set_value: "<state> negotiate auto"
+  default_value: true
 
 negotiate_auto_portchannel:
   kind: boolean
-  _exclude: [ios_xr]
-  nexus:
-    N7k:
-      default_only: false
-    else:
-      get_value: '/^(no )?negotiate auto$/'
-      set_value: "<state> negotiate auto"
-      default_value: true
+  _exclude: [ios_xr, N7k]
+  get_value: '/^(no )?negotiate auto$/'
+  set_value: "<state> negotiate auto"
+  default_value: true
 
 shutdown:
   kind: boolean

--- a/lib/cisco_node_utils/cmd_ref/overlay_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/overlay_global.yaml
@@ -3,7 +3,7 @@
 _exclude: [ios_xr]
 
 anycast_gateway_mac:
-  _exclude: [N3k, N7k]
+  _exclude: [N3k]
   kind: string
   get_command: "show running all | inc 'fabric forwarding'"
   get_value: '/^fabric forwarding anycast-gateway-mac (\S+)$/'

--- a/lib/cisco_node_utils/cmd_ref/overlay_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/overlay_global.yaml
@@ -3,7 +3,7 @@
 _exclude: [ios_xr]
 
 anycast_gateway_mac:
-  _exclude: [N3k]
+  _exclude: [N3k, N7k]
   kind: string
   get_command: "show running all | inc 'fabric forwarding'"
   get_value: '/^fabric forwarding anycast-gateway-mac (\S+)$/'

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -434,27 +434,16 @@ module Cisco
       puts "DEBUG: #{text}" if @@debug
     end
 
-    KNOWN_PLATFORMS = %w(C3064 N3k N5k N6k N7k N8k N9k XRv9k)
+    KNOWN_PLATFORMS = %w(C3064 C3132 C3172 N3k N5k N6k N7k N8k N9k XRv9k)
 
     def self.platform_to_filter(platform)
-      case platform
-      when 'C3064'
-        /C3064/
-      when 'N3k'
-        /N3/
-      when 'N5k'
-        /N5/
-      when 'N6k'
-        /N6/
-      when 'N7k'
-        /N7/
-      when 'N8k'
-        # TBD: This platform currently reports the chassis as N9K
-        /N8/
-      when 'N9k'
-        /N9/
-      when 'XRv9k'
-        /XRV9/
+      if KNOWN_PLATFORMS.include?(platform)
+        case platform
+        when 'XRv9k'
+          /XRV9/
+        else
+          Regexp.new platform.tr('k', '')
+        end
       else
         fail IndexError, "Unknown platform key '#{platform}'"
       end

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -72,6 +72,26 @@ module Cisco
     end
 
     # ---------------------------
+    def self.fex_enable
+      # install feature-set and enable it
+      return if fex_enabled?
+      config_set('feature', 'fex', state: 'install') unless fex_installed?
+      config_set('feature', 'fex', state: '')
+    end
+
+    def self.fex_enabled?
+      config_get('feature', 'fex') =~ /^enabled/
+    end
+
+    def self.fex_installed?
+      config_get('feature', 'fex') !~ /^uninstalled/
+    end
+
+    def self.fex_supported?
+      config_get('feature', 'fex')
+    end
+
+    # ---------------------------
     def self.itd_enable
       return if itd_enabled?
       config_set('feature', 'itd')

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -15,9 +15,7 @@
 # limitations under the License.
 
 require_relative 'cisco_cmn_utils'
-require_relative 'feature'
 require_relative 'node_util'
-require_relative 'pim'
 require_relative 'vrf'
 require_relative 'overlay_global'
 

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -475,13 +475,11 @@ module Cisco
     end
 
     def speed
-      config_get('interface', 'speed', name: @name)
+      val = config_get('interface', 'speed', name: @name)
+      val == 'auto' ? val : val.to_i
     end
 
     def speed=(val)
-      if node.product_id =~ /C31\d\d/
-        fail 'Changing interface speed is not permitted on this platform'
-      end
       config_set('interface', 'speed', name: @name, speed: val)
     end
 
@@ -494,9 +492,6 @@ module Cisco
     end
 
     def duplex=(val)
-      if node.product_id =~ /C31\d\d/
-        fail 'Changing interface duplex is not permitted on this platform'
-      end
       config_set('interface', 'duplex', name: @name, duplex: val)
     end
 

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -474,6 +474,7 @@ module Cisco
 
     def speed
       val = config_get('interface', 'speed', name: @name)
+      return val if val.nil?
       val == 'auto' ? val : val.to_i
     end
 

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 require_relative 'cisco_cmn_utils'
+require_relative 'feature'
 require_relative 'node_util'
 require_relative 'pim'
 require_relative 'vrf'
@@ -179,31 +180,6 @@ module Cisco
 
     def default_fabric_forwarding_anycast_gateway
       config_get_default('interface', 'fabric_forwarding_anycast_gateway')
-    end
-
-    def fex_feature
-      fex = config_get('fex', 'feature')
-      fail 'fex_feature not found' if fex.nil?
-      fex.to_sym
-    end
-
-    def fex_feature_set(fex_set)
-      curr = fex_feature
-      return if curr == fex_set
-
-      case fex_set
-      when :enabled
-        config_set('fex', 'feature_install', '') if curr == :uninstalled
-        config_set('fex', 'feature', '')
-      when :disabled
-        config_set('fex', 'feature', 'no') if curr == :enabled
-        return
-      when :installed
-        config_set('fex', 'feature_install', '') if curr == :uninstalled
-      when :uninstalled
-        config_set('fex', 'feature', 'no') if curr == :enabled
-        config_set('fex', 'feature_install', 'no')
-      end
     end
 
     def ipv4_acl_in
@@ -862,7 +838,7 @@ module Cisco
       if :fabricpath == mode_set
         fabricpath_feature_set(:enabled) unless :enabled == fabricpath_feature
       elsif :fex_fabric == mode_set
-        fex_feature_set(:enabled) unless :enabled == fex_feature
+        Feature.fex_enable
       end
       config_set('interface', switchport_mode_lookup_string,
                  name: @name, state: '', mode: IF_SWITCHPORT_MODE[mode_set])

--- a/spec/schema.yaml
+++ b/spec/schema.yaml
@@ -12,6 +12,7 @@ mapping:
           - 'ios_xr'
           - 'nexus'
           # Product IDs
+          - 'C3064'
           - 'N3k'
           - 'N5k'
           - 'N6k'

--- a/spec/schema.yaml
+++ b/spec/schema.yaml
@@ -13,6 +13,8 @@ mapping:
           - 'nexus'
           # Product IDs
           - 'C3064'
+          - 'C3132'
+          - 'C3172'
           - 'N3k'
           - 'N5k'
           - 'N6k'
@@ -28,6 +30,8 @@ mapping:
       ios_xr: *base
       nexus: *base
       C3064: *base
+      C3132: *base
+      C3172: *base
       N3k: *base
       N5k: *base
       N6k: *base

--- a/tests/test_command_reference.rb
+++ b/tests/test_command_reference.rb
@@ -187,6 +187,8 @@ name:
   default_value: 'generic'
   nexus:
     default_value: 'NXAPI base'
+    C3064:
+      default_value: 'NXAPI C3064'
     N7k:
       default_value: ~
     N9k:
@@ -222,12 +224,20 @@ name:
     assert_equal(nil, reference.lookup('test', 'name').default_value)
   end
 
+  def test_load_n3k
+    write_variants
+    reference = load_file(platform:     :nexus,
+                          product:      'N3K',
+                          data_formats: [:nxapi_structured, :cli])
+    assert_equal('NXAPI base', reference.lookup('test', 'name').default_value)
+  end
+
   def test_load_n3k_3064
     write_variants
     reference = load_file(platform:     :nexus,
                           product:      'N3K-C3064PQ-10GE',
                           data_formats: [:nxapi_structured, :cli])
-    assert_equal('NXAPI base', reference.lookup('test', 'name').default_value)
+    assert_equal('NXAPI C3064', reference.lookup('test', 'name').default_value)
   end
 
   def test_load_ios_xr_xrv9k

--- a/tests/test_command_reference.rb
+++ b/tests/test_command_reference.rb
@@ -189,6 +189,10 @@ name:
     default_value: 'NXAPI base'
     C3064:
       default_value: 'NXAPI C3064'
+    C3132:
+      default_value: 'NXAPI C3132'
+    C3172:
+      default_value: 'NXAPI C3172'
     N7k:
       default_value: ~
     N9k:
@@ -238,6 +242,22 @@ name:
                           product:      'N3K-C3064PQ-10GE',
                           data_formats: [:nxapi_structured, :cli])
     assert_equal('NXAPI C3064', reference.lookup('test', 'name').default_value)
+  end
+
+  def test_load_n3k_3132
+    write_variants
+    reference = load_file(platform:     :nexus,
+                          product:      'N3K-C3132Q-40GE',
+                          data_formats: [:nxapi_structured, :cli])
+    assert_equal('NXAPI C3132', reference.lookup('test', 'name').default_value)
+  end
+
+  def test_load_n3k_3172
+    write_variants
+    reference = load_file(platform:     :nexus,
+                          product:      'N3K-C3172PQ-10GE',
+                          data_formats: [:nxapi_structured, :cli])
+    assert_equal('NXAPI C3172', reference.lookup('test', 'name').default_value)
   end
 
   def test_load_ios_xr_xrv9k

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -198,4 +198,24 @@ class TestFeature < CiscoTestCase
     config("no install #{fs}") unless feature_set_installed
     vdc_lc_state(vdc_current) if vdc_current
   end
+
+  def test_feature_set_fex
+    if validate_property_excluded?('feature', 'fex')
+      assert_nil(Feature.fex_enabled?)
+      assert_raises(Cisco::UnsupportedError) { Feature.fex_enable }
+      return
+    end
+    fs = 'feature-set fex'
+
+    # clean
+    config("no #{fs} ; no install #{fs}") if Feature.fex_installed?
+    refute_show_match(
+      command: "show running | i '^install #{fs}$'",
+      pattern: /^install #{fs}$/,
+      msg:     "(#{fs}) is still configured",
+    )
+
+    Feature.fex_enable
+    assert(Feature.fex_enabled?, "(#{fs}) is not enabled")
+  end
 end

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1072,9 +1072,8 @@ class TestInterface < CiscoTestCase
   end
 
   def test_interface_fabric_forwarding_anycast_gateway
-    # Skip test if incompatible linecard detected
-    msg = 'Required Multi-Tenancy Full compatible linecard for this platform'
-    skip(msg) if node.product_id[/N7/] && !mt_full_interface?
+    # Ensure N7k has compatible interface
+    mt_full_interface? if node.product_id[/N7/]
 
     if validate_property_excluded?('overlay_global', 'anycast_gateway_mac')
       assert_raises(Cisco::UnsupportedError) do

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1058,6 +1058,15 @@ class TestInterface < CiscoTestCase
       end
       return
     end
+    if validate_property_excluded?('interface',
+                                   'fabric_forwarding_anycast_gateway')
+      int = Interface.new('vlan11')
+      OverlayGlobal.new.anycast_gateway_mac = '1223.3445.5668'
+      assert_raises(Cisco::UnsupportedError) do
+        int.fabric_forwarding_anycast_gateway = true
+      end
+      return
+    end
 
     # Setup
     config_no_warn('no interface vlan11')
@@ -1085,9 +1094,10 @@ class TestInterface < CiscoTestCase
 
     # 5. Attempt to set 'fabric forwarding anycast gateway' while the
     #    overlay gateway mac is not set.
+    int.destroy
     int = Interface.new('vlan11')
-    foo = OverlayGlobal.new
-    foo.anycast_gateway_mac = foo.default_anycast_gateway_mac
+    bar = OverlayGlobal.new
+    bar.anycast_gateway_mac = bar.default_anycast_gateway_mac
     assert_raises(RuntimeError) do
       int.fabric_forwarding_anycast_gateway = true
     end

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1323,7 +1323,7 @@ class TestInterface < CiscoTestCase
       validate_interface_shutdown(inttype_h)
       validate_vrf(inttype_h)
       config(*cfg)
-      InterfaceChannelGroup.new(interfaces[1]).channel_group = false
+      interface_ethernet_default(interfaces[1])
     rescue Minitest::Assertion
       # clean up before failing
       config(*cfg)

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1072,6 +1072,10 @@ class TestInterface < CiscoTestCase
   end
 
   def test_interface_fabric_forwarding_anycast_gateway
+    # Skip test if incompatible linecard detected
+    msg = 'Required Multi-Tenancy Full compatible linecard for this platform'
+    skip(msg) if node.product_id[/N7/] && !mt_full_interface?
+
     if validate_property_excluded?('overlay_global', 'anycast_gateway_mac')
       assert_raises(Cisco::UnsupportedError) do
         OverlayGlobal.new.anycast_gateway_mac = '1223.3445.5668'

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1147,16 +1147,13 @@ class TestInterface < CiscoTestCase
 
   def config_from_hash(inttype_h)
     inttype_h.each do |k, v|
-      # puts "TEST: pre-config hash key : #{k}"
       config('feature interface-vlan') if (/^Vlan\d./).match(k.to_s)
 
-      # puts "TEST: pre-config k: v '#{k} : #{v}'"
       cfg = ["interface #{k}"]
-      if !(/^Ethernet\d.\d/).match(k.to_s).nil? ||
-         !(/^#{@port_channel}\d/).match(k.to_s).nil?
-        cfg << 'no switchport'
-      end
-      # puts "k: #{k}, k1: #{k1}, address #{v1[:address_len]}"
+
+      switchport_intfs = Regexp.union(/ethernet/i, @port_channel)
+      cfg << 'no switchport' if platform == :nexus && k =~ switchport_intfs
+
       cfg << "#{ipv4} address #{v[:address_len]}" unless v[:address_len].nil?
       if platform == :nexus
         cfg << 'ip proxy-arp' if v[:proxy_arp]

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1053,25 +1053,30 @@ class TestInterface < CiscoTestCase
   end
 
   def test_interface_fabric_forwarding_anycast_gateway
-    unless platform == :ios_xr
-      # Setup
-      config_no_warn('no interface vlan11')
-      int = Interface.new('vlan11')
-      foo = OverlayGlobal.new
-      foo.anycast_gateway_mac = '1223.3445.5668'
-
-      # 1. Testing default for newly created vlan
-      assert_equal(int.default_fabric_forwarding_anycast_gateway,
-                   int.fabric_forwarding_anycast_gateway)
-
-      # 2. Testing non-default:true
-      int.fabric_forwarding_anycast_gateway = true
-      assert(int.fabric_forwarding_anycast_gateway)
-
-      # 3. Setting back to false
-      int.fabric_forwarding_anycast_gateway = false
-      refute(int.fabric_forwarding_anycast_gateway)
+    if validate_property_excluded?('overlay_global', 'anycast_gateway_mac')
+      assert_raises(Cisco::UnsupportedError) do
+        OverlayGlobal.new.anycast_gateway_mac = '1223.3445.5668'
+      end
+      return
     end
+
+    # Setup
+    config_no_warn('no interface vlan11')
+    int = Interface.new('vlan11')
+    foo = OverlayGlobal.new
+    foo.anycast_gateway_mac = '1223.3445.5668'
+
+    # 1. Testing default for newly created vlan
+    assert_equal(int.default_fabric_forwarding_anycast_gateway,
+                 int.fabric_forwarding_anycast_gateway)
+
+    # 2. Testing non-default:true
+    int.fabric_forwarding_anycast_gateway = true
+    assert(int.fabric_forwarding_anycast_gateway)
+
+    # 3. Setting back to false
+    int.fabric_forwarding_anycast_gateway = false
+    refute(int.fabric_forwarding_anycast_gateway)
 
     # 4. Attempt to configure on a non-vlan interface
     nonvlanint = create_interface
@@ -1079,15 +1084,13 @@ class TestInterface < CiscoTestCase
       nonvlanint.fabric_forwarding_anycast_gateway = true
     end
 
-    unless platform == :ios_xr # rubocop:disable Style/GuardClause
-      # 5. Attempt to set 'fabric forwarding anycast gateway' while the
-      #    overlay gateway mac is not set.
-      int = Interface.new('vlan11')
-      foo = OverlayGlobal.new
-      foo.anycast_gateway_mac = foo.default_anycast_gateway_mac
-      assert_raises(RuntimeError) do
-        int.fabric_forwarding_anycast_gateway = true
-      end
+    # 5. Attempt to set 'fabric forwarding anycast gateway' while the
+    #    overlay gateway mac is not set.
+    int = Interface.new('vlan11')
+    foo = OverlayGlobal.new
+    foo.anycast_gateway_mac = foo.default_anycast_gateway_mac
+    assert_raises(RuntimeError) do
+      int.fabric_forwarding_anycast_gateway = true
     end
   end
 

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -564,9 +564,7 @@ class TestInterface < CiscoTestCase
 
   def test_speed
     interface = Interface.new(interfaces[0])
-    if node.product_id =~ /C3132/
-      skip('Speed is not supported on this platform')
-    elsif validate_property_excluded?('interface', 'speed')
+    if validate_property_excluded?('interface', 'speed')
       assert_nil(interface.speed)
       assert_nil(interface.default_speed)
       assert_raises(Cisco::UnsupportedError) { interface.speed = 1000 }

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -742,7 +742,6 @@ class TestInterface < CiscoTestCase
 
     # Cleanup
     config("no interface #{@port_channel} 10")
-    member.channel_group = false # rubocop:disable Lint/UselessSetterCall
   end
 
   def test_negotiate_auto_ethernet

--- a/tests/test_interface_switchport.rb
+++ b/tests/test_interface_switchport.rb
@@ -240,7 +240,7 @@ class TestSwitchport < TestInterfaceSwitchport
     end
 
     interface.switchport_mode = :fex_fabric
-    assert_equal(start, interface.switchport_mode)
+    assert_equal(interface.switchport_mode, :fex_fabric)
   end
 
   def test_interface_switchport_trunk_allowed_vlan

--- a/tests/test_interface_switchport.rb
+++ b/tests/test_interface_switchport.rb
@@ -312,46 +312,6 @@ class TestSwitchport < TestInterfaceSwitchport
     end
   end
 
-  # TODO: Run this test at your peril as it can cause timeouts for this test and
-  # others - 'no feature-set fex' states:
-  # "Feature-set Operation may take up to 30 minutes depending on the
-  #  size of configuration."
-  #
-  #   def test_interface_switchport_fex_feature
-  #     test_matrix = {
-  #       #    [ <set_state>,  <expected> ]
-  #       1 => [:uninstalled, :uninstalled], # noop
-  #       2 => [:installed,   :installed],
-  #       3 => [:uninstalled, :uninstalled],
-  #       4 => [:enabled,     :enabled],
-  #       5 => [:enabled,     :enabled],     # noop
-  #       6 => [:installed,   :enabled],     # noop
-  #       7 => [:uninstalled, :uninstalled],
-  #       8 => [:disabled,    :uninstalled], # noop
-  #       9 => [:installed,   :installed],
-  #       10 => [:installed,   :installed],  # noop
-  #       11 => [:enabled,     :enabled],
-  #       12 => [:disabled,    :disabled],
-  #       13 => [:uninstalled, :uninstalled],
-  #       14 => [:installed,   :installed],
-  #       15 => [:disabled,    :installed],  # noop
-  #       16 => [:uninstalled, :uninstalled],
-  #     }
-  #     interface = Interface.new(interfaces[0])
-  #     # start test from :uninstalled state
-  #     interface.fex_feature_set(:uninstalled)
-  #     from = interface.fex_feature
-  #     test_matrix.each do |id,test|
-  #       #puts "Test #{id}: #{test}, (from: #{from}"
-  #       set_state, expected = test
-  #       interface.fex_feature_set(set_state)
-  #       curr = interface.fex_feature
-  #       assert_equal(expected, curr,
-  #                    "Error: fex test #{id}: from #{from} to #{set_state}")
-  #       from = curr
-  #     end
-  #   end
-
   def test_system_default_switchport_on_off
     if platform == :nexus
       system_default_switchport('')

--- a/tests/test_interface_switchport.rb
+++ b/tests/test_interface_switchport.rb
@@ -30,13 +30,17 @@ class TestInterfaceSwitchport < CiscoTestCase
 
   def setup
     super
-    config('no feature vtp', 'no feature interface-vlan')
+    config_no_warn('no feature vtp', 'no feature interface-vlan')
     @interface = Interface.new(interfaces[0])
   end
 
   def teardown
-    config("default interface ethernet #{interfaces_id[0]}")
+    interface_ethernet_default(interfaces[0])
     super
+  end
+
+  def interface_ethernet_default(ethernet_intf)
+    config("default interface #{ethernet_intf}")
   end
 
   def mgmt_intf

--- a/tests/test_interface_switchport.rb
+++ b/tests/test_interface_switchport.rb
@@ -115,7 +115,13 @@ class TestSwitchport < TestInterfaceSwitchport
   end
 
   def test_switchport_vtp_disabled_unsupported_mode_fex
-    if platform == :ios_xr
+    if validate_property_excluded?('feature', 'fex')
+      assert_raises(Cisco::UnsupportedError) do
+        Feature.fex_enable
+      end
+      return
+    end
+    if validate_property_excluded?('interface', 'switchport')
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode = :fex_fabric
       end
@@ -197,7 +203,6 @@ class TestSwitchport < TestInterfaceSwitchport
       :disabled,
       :access,
       :trunk,
-      #:fex_fabric, (fex is tested by test_interface_switchport_mode_valid_fex)
       :tunnel,
     ]
 
@@ -221,30 +226,21 @@ class TestSwitchport < TestInterfaceSwitchport
   end
 
   def test_interface_switchport_mode_valid_fex
-    skip('Not supported on IOS XR') if platform == :ios_xr
-    switchport_modes = [
-      :unknown,
-      :fex_fabric,
-    ]
-
-    switchport_modes.each do |start|
-      switchport_modes.each do |finish|
-        next if start == :unknown || finish == :unknown
-        begin
-          # puts "#{start},#{finish}"
-          interface.switchport_mode = start
-          assert_equal(start, interface.switchport_mode,
-                       "Error: Switchport mode, #{start}, not as expected")
-          interface.switchport_mode = finish
-          assert_equal(finish, interface.switchport_mode,
-                       "Error: Switchport mode, #{finish}, not as expected")
-        rescue Cisco::CliError => e
-          msg = "[#{interfaces[0]}] switchport_mode is not supported " \
-                'on this interface'
-          assert_equal(msg.downcase, e.message)
-        end
+    if validate_property_excluded?('feature', 'fex')
+      assert_raises(Cisco::UnsupportedError) do
+        Feature.fex_enable
       end
+      return
     end
+    if validate_property_excluded?('interface', 'switchport')
+      assert_raises(Cisco::UnsupportedError) do
+        interface.switchport_mode = :fex_fabric
+      end
+      return
+    end
+
+    interface.switchport_mode = :fex_fabric
+    assert_equal(start, interface.switchport_mode)
   end
 
   def test_interface_switchport_trunk_allowed_vlan


### PR DESCRIPTION
## Changes
1. Specify `@http.use_ssl = false` to avoid EOFError from `net/protocol`
   - Note: still seeing EOFError error on n3k-52 (C3064) but it may be resolved by reload
2. Added C3064, C3132, and C3172 as valid product ids in YAML
3. Refactored speed tests to properly test valid values
4. Refactored product id code in `command_reference` to reduce overhead of adding platforms
5. Moved `feature-set fex` to feature provider
## Test Results

|  | N3k | N5k | N6k | N7k | N8k | N9k I2 | N9k I3 | XR |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| test_interface | 1 F <br>1 S | ✅ | ✅ | ✅ | ✅ | 1 F <br>1 S | 2 F | ✅ |
| test_interface_switchport | ✅ | ✅ <br>3 S | ✅ <br>3 S | ✅ <br>3 S | ✅ | ✅ | ✅ | ✅ <br>24 S |
| test_interface_svi | ✅ | ✅ <br>4 S | ✅ <br>4 S | ✅ | ✅ | ✅ | ✅ | ✅ <br>Skipped |
## Failures
### N3k / N9k I2
- Known issue with vlan interfaces not updating ip configuration

``` bash
  1) Failure:
TestInterface#test_interface_ipv4_all_interfaces [/home/robgrie/cisco-network-node-utils/tests/test_interface.rb:337]:
Expected /^\s+ip address 9.7.1.1\/15$/ to match output of '"show run interface vlan45 all | no-more"':
show run interface vlan45 all | no-more
```
### N8k
- All failures are due to the node reporting as a N9k switch
### N9k I3
- Known issue where `negotiate auto` error is not raised by switch
