### PR TITLE
test_fabric_global fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
+++ b/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
@@ -1,6 +1,5 @@
 # fabricpath
 ---
-# Fabricpath feature is not available on N3K and N9K
 _exclude: [N3k, N8k, N9k, ios_xr]
 
 aggregate_multicast_routes:
@@ -34,9 +33,8 @@ feature_install:
 
 graceful_merge:
   auto_default: false
-  kind: boolean
   get_command: "show run fabricpath all"
-  get_value: '/^fabricpath graceful\-merge disable\s*$/'
+  get_value: '/^fabricpath graceful-merge disable\s*$/'
   set_value: "<state> fabricpath graceful-merge disable"
   default_value: enable
 
@@ -69,17 +67,23 @@ loadbalance_algorithm:
   get_command: "show run fabricpath all"
   get_value: '/^fabricpath load\-balance (\S+)\s*$/'
   set_value: "<state> fabricpath load-balance <algo>"
-  N5k:
+  N5k: &loadbal_alg_n5_n6
     default_value: "source-destination"
+  N6k: *loadbal_alg_n5_n6
   else:
     default_value: "symmetric"
+
+loadbalance_algorithm_symmetric_support:
+  _exclude: [N5k, N6k]
+  kind: boolean
+  default_only: true
 
 loadbalance_multicast_has_vlan:
   _exclude: [N5k, N6k]
   kind: boolean
   auto_default: false
-  get_command: "show fabricpath load-balance | begin Ftag"
-  get_value: '/^Use VLAN: TRUE\s*$/'
+  get_command: 'show run fabricpath all'
+  get_value: '/^fabricpath load-balance multicast .*include-vlan/'
   default_value: true
 
 loadbalance_multicast_reset:
@@ -91,17 +95,17 @@ loadbalance_multicast_rotate:
   kind: int
   get_command: "show fabricpath load-balance | begin Ftag"
   get_value: '/^Rotate amount: (\d+)/'
-  default_value: 1
+  # default_value: n/a. The default rotate amount is randomized to avoid polarization.
 
 loadbalance_multicast_set:
   _exclude: [N5k, N6k]
-  set_value: 'fabricpath load-balance multicast <rotate_amt> <inc_vlan>'
+  set_value: 'fabricpath load-balance multicast <rotate> <has_vlan>'
 
 loadbalance_unicast_has_vlan:
   kind: boolean
   auto_default: false
-  get_command: "show fabricpath load-balance | begin ECMP next 4"
-  get_value: '/^Use VLAN: TRUE\s*$/'
+  get_command: 'show run fabricpath all'
+  get_value: '/^fabricpath load-balance unicast .*include-vlan/'
   set_value: "<state> fabricpath load-balance unicast include-vlan"
   default_value: true
 
@@ -109,7 +113,7 @@ loadbalance_unicast_layer:
   kind: string
   get_command: "show fabricpath load-balance | begin ECMP next 4"
   get_value: '/^L3\/L4 Preference: (\S+)/'
-  set_value: "<state> fabricpath load-balance unicast <pref>"
+  set_value: "<state> fabricpath load-balance unicast <layer>"
   default_value: "mixed"
 
 loadbalance_unicast_reset:
@@ -120,23 +124,20 @@ loadbalance_unicast_rotate:
   kind: int
   get_command: "show fabricpath load-balance | begin ECMP next 4"
   get_value: '/^Rotate amount: (\d+)/'
-  default_value: 1
+  # default_value: n/a. The default rotate amount is randomized to avoid polarization.
 
 loadbalance_unicast_set:
-  set_value: 'fabricpath load-balance unicast <pref> <rotate_amt> <inc_vlan>'
+  set_value: 'fabricpath load-balance unicast <layer> <rotate> <has_vlan>'
 
 loadbalance_unicast_support:
   kind: string
-  N5k:
+  N5k: &loadbal_uni_n5_n6
     default_only: "split"
-  N6k:
-    default_only: "split"
+  N6k: *loadbal_uni_n5_n6
   else:
     default_only: "combined"
 
 mode:
-  _exclude:
-    - N5k
   kind: string
   get_command: "show run fabricpath all"
   get_value: '/^fabricpath mode (\S+)/'

--- a/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
+++ b/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
@@ -67,9 +67,9 @@ loadbalance_algorithm:
   get_command: "show run fabricpath all"
   get_value: '/^fabricpath load\-balance (\S+)\s*$/'
   set_value: "<state> fabricpath load-balance <algo>"
-  N5k: &loadbal_alg_n5_n6
+  N5k: &loadbal_alg_src_dst
     default_value: "source-destination"
-  N6k: *loadbal_alg_n5_n6
+  N6k: *loadbal_alg_src_dst
   else:
     default_value: "symmetric"
 
@@ -131,9 +131,9 @@ loadbalance_unicast_set:
 
 loadbalance_unicast_support:
   kind: string
-  N5k: &loadbal_uni_n5_n6
+  N5k: &loadbal_uni_split
     default_only: "split"
-  N6k: *loadbal_uni_n5_n6
+  N6k: *loadbal_uni_split
   else:
     default_only: "combined"
 

--- a/lib/cisco_node_utils/fabricpath_global.rb
+++ b/lib/cisco_node_utils/fabricpath_global.rb
@@ -103,23 +103,15 @@ module Cisco
       FabricpathGlobal.fabricpath_feature_set(:disabled)
     end
 
-    def my_munge(property, set_val)
-      val = config_get_default('fabricpath', property)
+    def loadbalance_munge(property, set_val)
       case property
       when /loadbalance_algorithm/
-        if (val == 'source-destination') &&
-           (set_val == 'symmetric' || set_val == 'xor')
-          val
-        else
-          set_val
-        end
+        val = config_get_default('fabricpath', property)
+        return val if (val == 'source-destination') && set_val[/symmetric|xor/]
+        set_val
       when /loadbalance_.*_rotate/
-        if val == false || set_val == ''
-          ''
-        else
-          int_val = set_val.to_i
-          "rotate-amount 0x#{int_val.to_s(16)}"
-        end
+        return '' if set_val == ''
+        "rotate-amount 0x#{set_val.to_i.to_s(16)}"
       else
         set_val
       end
@@ -227,13 +219,18 @@ module Cisco
       config_get_default('fabricpath', 'linkup_delay_enable')
     end
 
+    def loadbalance_algorithm_symmetric_support
+      config_get_default('fabricpath',
+                         'loadbalance_algorithm_symmetric_support')
+    end
+
     def loadbalance_algorithm
       algo = config_get('fabricpath', 'loadbalance_algorithm')
       algo.downcase
     end
 
     def loadbalance_algorithm=(val)
-      val = my_munge('loadbalance_algorithm', val)
+      val = loadbalance_munge('loadbalance_algorithm', val)
       state = val ? '' : 'no'
       algo = val ? val : ''
       config_set('fabricpath', 'loadbalance_algorithm', state: state,
@@ -257,16 +254,14 @@ module Cisco
       if rotate == '' && (has_vlan == '' || has_vlan == false)
         config_set('fabricpath', 'loadbalance_multicast_reset')
       else
-        rotate = my_munge('loadbalance_multicast_rotate', rotate)
+        rotate = loadbalance_munge('loadbalance_multicast_rotate', rotate)
         has_vlan = (has_vlan == true) ? 'include-vlan' : ''
         config_set('fabricpath', 'loadbalance_multicast_set',
-                   rotate_amt: rotate, inc_vlan: has_vlan)
+                   rotate: rotate, has_vlan: has_vlan)
       end
     end
 
-    def default_loadbalance_multicast_rotate
-      config_get_default('fabricpath', 'loadbalance_multicast_rotate')
-    end
+    # default_loadbalance_multicast_rotate: n/a
 
     def default_loadbalance_multicast_has_vlan
       config_get_default('fabricpath', 'loadbalance_multicast_has_vlan')
@@ -296,9 +291,9 @@ module Cisco
 
     def split_loadbalance_unicast_layer=(val)
       state = val ? '' : 'no'
-      pref = val ? val : ''
-      config_set('fabricpath', 'loadbalance_unicast_layer', state: state,
-                                                            pref:  pref)
+      layer = val ? val : ''
+      config_set('fabricpath', 'loadbalance_unicast_layer',
+                 state: state, layer: layer)
     end
 
     def split_loadbalance_unicast_has_vlan=(val)
@@ -316,10 +311,10 @@ module Cisco
         if layer == '' && rotate == '' && (has_vlan == '' || has_vlan == false)
           config_set('fabricpath', 'loadbalance_unicast_reset')
         else
-          rotate = my_munge('loadbalance_unicast_rotate', rotate)
+          rotate = loadbalance_munge('loadbalance_unicast_rotate', rotate)
           has_vlan = (has_vlan == true) ? 'include-vlan' : ''
           config_set('fabricpath', 'loadbalance_unicast_set',
-                     pref: layer, rotate_amt: rotate, inc_vlan: has_vlan)
+                     layer: layer, rotate: rotate, has_vlan: has_vlan)
         end
       else
         self.split_loadbalance_unicast_layer = layer
@@ -331,9 +326,7 @@ module Cisco
       config_get_default('fabricpath', 'loadbalance_unicast_layer')
     end
 
-    def default_loadbalance_unicast_rotate
-      config_get_default('fabricpath', 'loadbalance_unicast_rotate')
-    end
+    # default_loadbalance_unicast_rotate: n/a
 
     def default_loadbalance_unicast_has_vlan
       config_get_default('fabricpath', 'loadbalance_unicast_has_vlan')

--- a/tests/test_fabricpath_global.rb
+++ b/tests/test_fabricpath_global.rb
@@ -122,9 +122,7 @@ class TestFabricpathGlobal < CiscoTestCase
 
   def test_loadbalance_algorithm
     fg = FabricpathGlobal.new('default')
-    default =
-      cmd_ref.lookup('fabricpath', 'loadbalance_algorithm').default_value
-    assert_equal(default, fg.loadbalance_algorithm)
+    assert_equal(fg.default_loadbalance_algorithm, fg.loadbalance_algorithm)
 
     fg.loadbalance_algorithm = 'source'
     assert_equal('source', fg.loadbalance_algorithm)

--- a/tests/test_fabricpath_global.rb
+++ b/tests/test_fabricpath_global.rb
@@ -26,8 +26,6 @@ class TestFabricpathGlobal < CiscoTestCase
   def setup
     # setup runs at the beginning of each test
     super
-    skip("Test not supported on #{node.product_id}") if
-      cmd_ref.lookup('fabricpath', 'feature').default_value.nil?
     no_feature_fabricpath
   end
 
@@ -42,213 +40,203 @@ class TestFabricpathGlobal < CiscoTestCase
     config('no feature-set fabricpath')
   end
 
-  def n5k6k_platforms?
-    /N[56]K/ =~ node.product_id
-  end
-
   # TESTS
 
-  def test_global_collection_empty
-    globals = FabricpathGlobal.globals
-    assert_equal(true, globals.empty?,
-                 'Globals should be empty for this test')
-  end
+  def test_create_destroy
+    assert_empty(FabricpathGlobal.globals)
 
-  def test_global_create
-    @global = FabricpathGlobal.new('default')
-    assert_equal(true, @global.name == 'default',
-                 "Global name not set correctly #{@global.name}")
-    assert_equal(:enabled, FabricpathGlobal.fabricpath_feature,
-                 'Fabricpath feature should have been enabled')
-    refute(FabricpathGlobal.globals.empty?,
-           'Globals should not be empty after create')
-  end
+    # create
+    fg = FabricpathGlobal.new('default')
+    assert_equal('default', fg.name)
+    assert_equal(:enabled, FabricpathGlobal.fabricpath_feature)
+    refute_empty(FabricpathGlobal.globals)
 
-  def test_global_destroy
-    # create and test again
-    test_global_create
-    @global.destroy
-    # now it should be wiped out
-    test_global_collection_empty
+    # destroy
+    fg.destroy
+    assert_empty(FabricpathGlobal.globals)
   end
 
   def test_aggregate_multicast_routes
-    return if n5k6k_platforms?
-    @global = FabricpathGlobal.new('default')
-    @global.aggregate_multicast_routes = true
-    assert(@global.aggregate_multicast_routes,
-           'Aggregate multicast routes not set')
-    @global.aggregate_multicast_routes = false
-    refute(@global.aggregate_multicast_routes,
-           'Aggregate multicast routes not reset')
+    fg = FabricpathGlobal.new('default')
+    if validate_property_excluded?('fabricpath', 'aggregate_multicast_routes')
+      assert_raises(Cisco::UnsupportedError) do
+        fg.aggregate_multicast_routes = true
+      end
+      return
+    end
+
+    fg = FabricpathGlobal.new('default')
+    fg.aggregate_multicast_routes = true
+    assert(fg.aggregate_multicast_routes,
+           'aggregate_multicast_routes: Expected: true')
+
+    fg.aggregate_multicast_routes = false
+    refute(fg.aggregate_multicast_routes,
+           'aggregate_multicast_routes: Expected: false')
   end
 
   def test_allocate_delay
-    @global = FabricpathGlobal.new('default')
-    # test default value
-    assert_equal(@global.default_allocate_delay,
-                 @global.allocate_delay,
-                 'Default allocate_delay not set correctly')
-    @global.allocate_delay = 20
-    assert_equal(20, @global.allocate_delay,
-                 'allocate_delay not set to 20')
+    fg = FabricpathGlobal.new('default')
+    assert_equal(fg.default_allocate_delay, fg.allocate_delay)
+
+    fg.allocate_delay = 20
+    assert_equal(20, fg.allocate_delay)
   end
 
   def test_graceful_merge
-    @global = FabricpathGlobal.new('default')
-    # test default value
-    assert_equal(:enable, @global.graceful_merge,
-                 'Default graceful_merge not set correctly')
-    @global.graceful_merge = :disable
-    assert_equal(:disable, @global.graceful_merge,
-                 'graceful merge not set to disable')
+    fg = FabricpathGlobal.new('default')
+    assert_equal(fg.default_graceful_merge, fg.graceful_merge)
+
+    fg.graceful_merge = :disable
+    assert_equal(:disable, fg.graceful_merge)
   end
 
   def test_linkup_delay_all
-    @global = FabricpathGlobal.new('default')
-    # test default value
-    assert_equal(@global.default_linkup_delay,
-                 @global.linkup_delay,
-                 'Default linkup_delay not set correctly')
-    @global.linkup_delay = 25
-    assert_equal(25, @global.linkup_delay,
-                 'linkup_delay not set to 25')
+    fg = FabricpathGlobal.new('default')
+    assert_equal(fg.default_linkup_delay, fg.linkup_delay)
 
-    return if n5k6k_platforms?
+    fg.linkup_delay = 25
+    assert_equal(25, fg.linkup_delay)
 
-    refute(@global.linkup_delay_always,
-           'linkup_delay_always should not be set by default')
-    @global.linkup_delay_always = true
-    assert(@global.linkup_delay_always,
-           'linkup_delay_always is not getting set')
+    if validate_property_excluded?('fabricpath', 'linkup_delay_always')
+      assert_raises(Cisco::UnsupportedError) { fg.linkup_delay_always = true }
+    else
+      assert_equal(fg.default_linkup_delay_always, fg.linkup_delay_always)
+      fg.linkup_delay_always = true
+      assert(fg.linkup_delay_always, 'linkup_delay_always: Expected: true')
+      fg.linkup_delay_always = false
+      refute(fg.linkup_delay_always, 'linkup_delay_always: Expected: false')
+    end
 
-    @global.linkup_delay_enable = true
-    @global.linkup_delay_enable = false
-    refute(@global.linkup_delay_enable,
-           'linkup_delay is not getting disabled')
+    if validate_property_excluded?('fabricpath', 'linkup_delay_enable')
+      assert_raises(Cisco::UnsupportedError) { fg.linkup_delay_enable = true }
+      return
+    end
+
+    assert_equal(fg.default_linkup_delay_enable, fg.linkup_delay_enable)
+    fg.linkup_delay_enable = true
+    assert(fg.linkup_delay_enable, 'linkup_delay_enable: Expected: true')
+    fg.linkup_delay_enable = false
+    refute(fg.linkup_delay_enable, 'linkup_delay_enable: Expected: false')
   end
 
   def test_loadbalance_algorithm
-    @global = FabricpathGlobal.new('default')
-    # test default value
-    check_val = n5k6k_platforms? ? 'source-destination' : 'symmetric'
-    assert_equal(check_val, @global.loadbalance_algorithm,
-                 "default algo should be #{check_val} but is
-                  #{@global.loadbalance_algorithm}")
-    @global.loadbalance_algorithm = 'source'
-    assert_equal('source', @global.loadbalance_algorithm,
-                 'algo not getting set to source-destination')
+    fg = FabricpathGlobal.new('default')
+    default =
+      cmd_ref.lookup('fabricpath', 'loadbalance_algorithm').default_value
+    assert_equal(default, fg.loadbalance_algorithm)
+
+    fg.loadbalance_algorithm = 'source'
+    assert_equal('source', fg.loadbalance_algorithm)
+    if validate_property_excluded?('fabricpath',
+                                   'loadbalance_algorithm_symmetric_support')
+      assert_nil(fg.loadbalance_algorithm_symmetric_support)
+      return
+    end
+    fg.loadbalance_algorithm = 'symmetric'
+    assert_equal('symmetric', fg.loadbalance_algorithm)
   end
 
   def test_loadbalance_multicast
-    return if n5k6k_platforms?
-    @global = FabricpathGlobal.new('default')
-    # test default values first
-    assert_equal(@global.default_loadbalance_multicast_rotate,
-                 @global.loadbalance_multicast_rotate,
-                 "default mcast rotate should be 6
-                  but is #{@global.loadbalance_multicast_rotate}")
-    assert(@global.loadbalance_multicast_has_vlan,
-           "default mcast include-vlan should be true
-           but is #{@global.loadbalance_multicast_has_vlan}")
-    @global.send(:loadbalance_multicast=, 3, false)
-    assert_equal(3, @global.loadbalance_multicast_rotate,
-                 "mcast rotate should now be 3
-                  but is #{@global.loadbalance_multicast_rotate}")
-    refute(@global.loadbalance_multicast_has_vlan,
-           "mcast include-vlan should now be false
-           but is #{@global.loadbalance_multicast_has_vlan}")
+    # loadbalance_multicast= is a custom setter that takes 2 args:
+    #   rotate, has_vlan
+    fg = FabricpathGlobal.new('default')
+    if validate_property_excluded?('fabricpath',
+                                   'loadbalance_multicast_set')
+      assert_raises(Cisco::UnsupportedError) do
+        (fg.send(:loadbalance_multicast=, 0, 0))
+      end
+      return
+    end
+
+    # default_loadbalance_multicast_rotate: n/a
+    assert(fg.loadbalance_multicast_has_vlan,
+           'loadbalance_multicast_has_vlan: Expected: true')
+
+    fg.send(:loadbalance_multicast=, 3, false)
+    assert_equal(3, fg.loadbalance_multicast_rotate)
+    refute(fg.loadbalance_multicast_has_vlan,
+           'loadbalance_multicast_has_vlan: Expected: false')
   end
 
   def test_loadbalance_unicast
-    @global = FabricpathGlobal.new('default')
-    # test default values first
-    assert_equal(@global.default_loadbalance_unicast_layer,
-                 @global.loadbalance_unicast_layer,
-                 "default unicast layer should be mixed
-                  but is #{@global.loadbalance_unicast_layer}")
-    assert_equal(@global.default_loadbalance_unicast_rotate,
-                 @global.loadbalance_unicast_rotate,
-                 "default unicast rotate not set correctly
-                  but is set to #{@global.loadbalance_unicast_rotate}") unless
-                 n5k6k_platforms?
-    assert(@global.loadbalance_unicast_has_vlan,
-           "default unicast include-vlan should be true
-           but is #{@global.loadbalance_unicast_has_vlan}")
-    @global.send(:loadbalance_unicast=, 'layer4', 3, false)
-    assert_equal('layer4', @global.loadbalance_unicast_layer,
-                 "unicast layer should be layer4
-                  but is #{@global.loadbalance_unicast_layer}")
-    assert_equal(3, @global.loadbalance_unicast_rotate,
-                 "unicast rotate should now be 3
-                  but is #{@global.loadbalance_unicast_rotate}") unless
-                 n5k6k_platforms?
-    refute(@global.loadbalance_unicast_has_vlan,
-           "unicast include-vlan should now be false
-           but is #{@global.loadbalance_unicast_has_vlan}")
+    # loadbalance_unicast= is a custom setter that takes up to 3 args:
+    #   layer, rotate, has_vlan (rotate is not supported on some plats)
+
+    fg = FabricpathGlobal.new('default')
+    assert_equal(fg.default_loadbalance_unicast_layer,
+                 fg.loadbalance_unicast_layer)
+
+    # default_loadbalance_unicast_rotate: n/a
+    assert_equal(fg.default_loadbalance_unicast_has_vlan,
+                 fg.loadbalance_unicast_has_vlan)
+
+    fg.send(:loadbalance_unicast=, 'layer4', 3, false)
+    assert_equal('layer4', fg.loadbalance_unicast_layer)
+    unless validate_property_excluded?('fabricpath',
+                                       'loadbalance_unicast_rotate')
+      assert_equal(3, fg.loadbalance_unicast_rotate)
+    end
+    refute(fg.loadbalance_unicast_has_vlan,
+           'loadbalance_unicast_has_vlan: Expected: false')
   end
 
   def test_mode
-    @global = FabricpathGlobal.new('default')
-    @global.mode = 'transit'
-    assert_equal('transit', @global.mode,
-                 'mode not getting set to transit')
-    @global.mode = 'normal'
-    assert_equal('normal', @global.mode,
-                 'mode not getting set to transit')
+    fg = FabricpathGlobal.new('default')
+    assert_equal(fg.default_mode, fg.mode)
+
+    fg.mode = 'transit'
+    assert_equal('transit', fg.mode)
+    fg.mode = 'normal'
+    assert_equal('normal', fg.mode)
   end
 
   def test_switch_id
-    @global = FabricpathGlobal.new('default')
-    # auto_id = @global.switch_id
-    @global.switch_id = 100
-    assert_equal(100, @global.switch_id,
-                 'switchid not getting set to 100')
+    fg = FabricpathGlobal.new('default')
+    # auto_id = fg.switch_id
+    # switch_id does not have a default
+    fg.switch_id = 100
+    assert_equal(100, fg.switch_id)
   end
 
   def test_transition_delay
-    @global = FabricpathGlobal.new('default')
-    # test default value
-    assert_equal(@global.default_transition_delay,
-                 @global.transition_delay,
-                 'Default allocate_delay not set correctly')
-    @global.transition_delay = 20
-    assert_equal(20, @global.transition_delay,
-                 'transition_delay not set to 20')
+    fg = FabricpathGlobal.new('default')
+    assert_equal(fg.default_transition_delay, fg.transition_delay)
+
+    fg.transition_delay = 20
+    assert_equal(20, fg.transition_delay)
   end
 
   def test_ttl_multicast
-    return if n5k6k_platforms?
-    @global = FabricpathGlobal.new('default')
-    # test default value
-    assert_equal(@global.default_ttl_multicast,
-                 @global.ttl_multicast,
-                 'Default multicast ttl not set correctly')
-    @global.ttl_multicast = 16
-    assert_equal(16, @global.ttl_multicast,
-                 'multicast ttl not getting set to 16')
+    fg = FabricpathGlobal.new('default')
+    if validate_property_excluded?('fabricpath', 'ttl_multicast')
+      assert_raises(Cisco::UnsupportedError) { fg.ttl_multicast = 40 }
+      return
+    end
+
+    assert_equal(fg.default_ttl_multicast, fg.ttl_multicast)
+    fg.ttl_multicast = 16
+    assert_equal(16, fg.ttl_multicast)
   end
 
   def test_ttl_unicast
-    return if n5k6k_platforms?
-    @global = FabricpathGlobal.new('default')
-    # test default value
-    assert_equal(@global.default_ttl_unicast,
-                 @global.ttl_unicast,
-                 'Default unicast ttl not set correctly')
-    @global.ttl_unicast = 40
-    assert_equal(40, @global.ttl_unicast,
-                 'unicast ttl not getting set to 40')
+    fg = FabricpathGlobal.new('default')
+    if validate_property_excluded?('fabricpath', 'ttl_unicast')
+      assert_raises(Cisco::UnsupportedError) { fg.ttl_unicast = 40 }
+      return
+    end
+    assert_equal(fg.default_ttl_unicast, fg.ttl_unicast)
+    fg.ttl_unicast = 40
+    assert_equal(40, fg.ttl_unicast)
   end
 
   def test_interface_switchport_mode
-    interface = Interface.new(interfaces[0])
-    interface.switchport_mode = :fabricpath
-    assert_equal(:fabricpath, interface.switchport_mode,
-                 'switchport mode must be set to fabricpath')
-    # clean up
-    interface.switchport_mode = :trunk
-    assert_equal(:trunk, interface.switchport_mode,
-                 'switchport mode must be set to trunk')
+    i = Interface.new(interfaces[0])
+    i.switchport_mode = :fabricpath
+    assert_equal(:fabricpath, i.switchport_mode)
+
+    i.switchport_mode = :trunk
+    assert_equal(:trunk, i.switchport_mode)
+    config("default interface #{interfaces[0]}")
   end
 end

--- a/tests/test_vlan_mt_full.rb
+++ b/tests/test_vlan_mt_full.rb
@@ -39,7 +39,9 @@ class TestVlanMtFull < CiscoTestCase
 
   def setup
     super
-    cleanup unless @@cleaned
+    return if @@cleaned
+    cleanup
+    remove_all_bridge_domains # BDs may conflict with our test vlans
     @@cleaned = true # rubocop:disable Style/ClassVars
   end
 


### PR DESCRIPTION
- Now passes on n5,n6,n7. Not supported on all others.
- `rotate` defaults removed since they are randomized values
- `algorithm` type `symmetric` is only supported on n7k
- minitest general cleanup: removed class vars, added platform checks, cleaned up error messaging
- test_vlan_mt_full.rb can fail if the test vlans are currently configured as bridge-domain vlans. Added a bd cleanup to the initial setup call.
