### PR TITLE
private_vlan fixes and refactoring

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vlan.yaml
@@ -46,14 +46,13 @@ name:
 
 private_vlan_association:
   _exclude: [N8k]
-  kind: string
   multiple: true
   get_command: "show vlan private-vlan"
   get_value: '/^<id>\s+(\d+)/'
   set_context: ['vlan <vlan>']
   # Need end to push the config Without the config wont take effect
   set_value: "<state> private-vlan association <vlans> ; end"
-  default_value: ""
+  default_value: []
 
 private_vlan_type:
   _exclude: [N8k]

--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -71,8 +71,9 @@ module Cisco
       return unless
         result[2].is_a?(Hash) && errors.match(result[2]['body'].to_s)
       # Split errors into a list, but keep the delimiter as part of the message.
-      lst = (result[2]['body'].split(errors) - ['']).each_slice(2).map(&:join)
-      lst.each do |msg|
+      error_list =
+        (result[2]['body'].split(errors) - ['']).each_slice(2).map(&:join)
+      error_list.each do |msg|
         next if ignore_message && msg.to_s.include?(ignore_message)
         fail result[2]['body']
       end
@@ -255,7 +256,7 @@ module Cisco
 
     # --------------------------
     # vlan_list_delta is a helper function for the private_vlan_association
-    # propertie. It walks the delta hash and adds/removes each target private
+    # property. It walks the delta hash and adds/removes each target private
     # vlan.
     def vlan_list_delta(is_list, should_list)
       should_list.each { |item| item.gsub!('-', '..') }

--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require_relative 'cisco_cmn_utils'
 require_relative 'node_util'
 require_relative 'interface'
 require_relative 'fabricpath_global'
@@ -65,29 +66,15 @@ module Cisco
       # returned by NXAPI. This vlan cli behavior is unlikely to change.
       # Check for messages that can be safely ignored.
 
-      wrn_msg = false
+      errors = /(ERROR:|VLAN:|Warning:)/
 
-      unless ignore_message.nil?
-        # Check if ignore_message is present
-        wrn_msg = true
-      end
-
-      if result[2].is_a?(Hash) &&
-         /(ERROR:|VLAN:|Warning:)/.match(result[2]['body'].to_s)
-        messages = (result[2]['body'].split(/(ERROR:|VLAN:|Warning:)/) - [''])
-                   .each_slice(2).map(&:join)
-        messages.each do |msg|
-          next if msg.empty? || (wrn_msg && msg.to_s.include?(ignore_message))
-          fail
-        end
-      end
-      return unless result[2].is_a?(String) &&
-                    /(ERROR:|VLAN:|Warning:)/.match(result[2])
-      messages = (result[2].split(/(ERROR:|VLAN:|Warning:)/) - [''])
-                 .each_slice(2).map(&:join)
-      messages.each do |msg|
-        next if msg.empty? || (wrn_msg && msg.to_s.include?(ignore_message))
-        fail
+      return unless
+        result[2].is_a?(Hash) && errors.match(result[2]['body'].to_s)
+      # Split errors into a list, but keep the delimiter as part of the message.
+      lst = (result[2]['body'].split(errors) - ['']).each_slice(2).map(&:join)
+      lst.each do |msg|
+        next if ignore_message && msg.to_s.include?(ignore_message)
+        fail result[2]['body']
       end
     end
 
@@ -99,34 +86,6 @@ module Cisco
     def set_args_keys(hash={}) # rubocop:disable Style/AccessorMethodName
       set_args_keys_default
       @set_args = @set_args.merge!(hash) unless hash.empty?
-    end
-
-    def compute_vlan_list_association(cfg_vlan_list, to_be_cfg_vlan_list)
-      # This method takes in input the user config private vlan association
-      # list and the configured private vlan association list.
-      # Converts both list into array and compute the difference. The difference
-      # will be the vlan that need to be removed from the final configuration.
-
-      vlan_config = to_be_cfg_vlan_list.gsub('-', '..').split(',')
-
-      present_vlan = cfg_vlan_list.split(',')
-      vlan_cfg_array = []
-
-      vlan_config.each do |elem|
-        if elem.include?('..')
-          elema = elem.split('..').map { |d| Integer(d) }
-          tr = elema[0]..elema[1]
-          tr.to_a.each do |item|
-            vlan_cfg_array.push(item.to_s)
-          end
-        else
-          vlan_cfg_array.push(elem)
-        end
-      end
-
-      rem_list = (present_vlan - vlan_cfg_array).map(&:to_s) * ','
-      config_list = vlan_cfg_array.map(&:to_s) * ','
-      set_args_keys(vlan_to_remove: rem_list, vlan_to_config: config_list)
     end
 
     def fabricpath_feature
@@ -261,16 +220,15 @@ module Cisco
       config_get('vlan', 'private_vlan_type', id: @vlan_id)
     end
 
-    def private_vlan_type=(pv_type)
+    def private_vlan_type=(type)
       Feature.private_vlan_enable
-      fail TypeError unless pv_type && pv_type.is_a?(String)
+      fail TypeError unless type && type.is_a?(String)
 
-      if pv_type == default_private_vlan_type
-        pv_type = private_vlan_type
-        set_args_keys(state: 'no', type: pv_type)
+      if type == default_private_vlan_type
+        set_args_keys(state: 'no', type: private_vlan_type)
         ignore_msg = 'Warning: Private-VLAN CLI removed'
       else
-        set_args_keys(state: '', type: pv_type)
+        set_args_keys(state: '', type: type)
         ignore_msg = 'Warning: Private-VLAN CLI entered'
       end
       result = config_set('vlan', 'private_vlan_type', @set_args)
@@ -282,50 +240,48 @@ module Cisco
     end
 
     def private_vlan_association
-      result = config_get('vlan', 'private_vlan_association',
-                          id: @vlan_id)
-      result.gsub(/["\[\]" "]/, '')
+      result = config_get('vlan', 'private_vlan_association', id: @vlan_id)
+      result.sort
     end
 
     def private_vlan_association=(vlan_list)
-      fail TypeError unless vlan_list &&
-                            vlan_list.is_a?(String)
       Feature.private_vlan_enable
-
-      if vlan_list == default_private_vlan_association
-        set_args_keys(state: 'no', vlans: vlan_list)
-        result = config_set('vlan', 'private_vlan_association',
-                            @set_args)
-        cli_error_check(result)
-      else
-        vlan_cfg = private_vlan_association
-        if vlan_cfg.empty?
-          set_args_keys(state: '', vlans: vlan_list)
-          result = config_set('vlan', 'private_vlan_association',
-                              @set_args)
-          cli_error_check(result)
-        else
-          compute_vlan_list_association(vlan_cfg, vlan_list)
-          vlan_to_remove = @set_args[:vlan_to_remove]
-          vlan_to_config = @set_args[:vlan_to_config]
-
-          unless vlan_to_remove.empty?
-            set_args_keys(state: 'no', vlans: vlan_to_remove)
-            result = config_set('vlan', 'private_vlan_association',
-                                @set_args)
-            cli_error_check(result)
-
-            set_args_keys(state: '', vlans: vlan_to_config)
-            result = config_set('vlan', 'private_vlan_association',
-                                @set_args)
-            cli_error_check(result)
-          end
-        end
-      end
+      vlan_list_delta(private_vlan_association, vlan_list)
     end
 
     def default_private_vlan_association
       config_get_default('vlan', 'private_vlan_type')
+    end
+
+    # --------------------------
+    # vlan_list_delta is a helper function for the private_vlan_association
+    # propertie. It walks the delta hash and adds/removes each target private
+    # vlan.
+    def vlan_list_delta(is_list, should_list)
+      should_list.each { |item| item.gsub!('-', '..') }
+
+      should_list_new = []
+      should_list.each do |elem|
+        if elem.include?('..')
+          elema = elem.split('..').map { |d| Integer(d) }
+          tr = elema[0]..elema[1]
+          tr.to_a.each do |item|
+            should_list_new.push(item.to_s)
+          end
+        else
+          should_list_new.push(elem)
+        end
+      end
+
+      delta_hash = Utils.delta_add_remove(should_list_new, is_list)
+      [:add, :remove].each do |action|
+        delta_hash[action].each do |vlans|
+          state = (action == :add) ? '' : 'no'
+          set_args_keys(state: state, vlans: vlans)
+          result = config_set('vlan', 'private_vlan_association', @set_args)
+          cli_error_check(result)
+        end
+      end
     end
   end # class
 end # module

--- a/tests/test_vlan_private.rb
+++ b/tests/test_vlan_private.rb
@@ -656,22 +656,14 @@ class TestVlan < CiscoTestCase
 
       assert_equal(result, v1.private_vlan_association)
 
-      if node.product_id[/N(10)K/]
-        puts 'assert_rasies_check'
-        assert_raises(RuntimeError, 'vlan did not raise RuntimeError') do
-          v1.private_vlan_association = ['101', '103-105', '108']
-        end
-      else
-        v1.private_vlan_association = ['101', '103-105', '108']
+      v1.private_vlan_association = ['101', '103-105', '108']
 
-        result = %w(101 103 104 105 108)
-        assert_equal(result, v1.private_vlan_association)
+      result = %w(101 103 104 105 108)
+      assert_equal(result, v1.private_vlan_association)
 
-        v1.private_vlan_association = ['101', '103-105', '108']
-        result = %w(101 103 104 105 108)
-        assert_equal(result, v1.private_vlan_association)
-      end
-
+      v1.private_vlan_association = ['101', '103-105', '108']
+      result = %w(101 103 104 105 108)
+      assert_equal(result, v1.private_vlan_association)
     end
   end
 end

--- a/tests/test_vlan_private.rb
+++ b/tests/test_vlan_private.rb
@@ -31,8 +31,8 @@ class TestVlan < CiscoTestCase
       next if node.product_id[/N5K|N6K|N7K/] && (1002..1005).include?(vlan.to_i)
       obj.destroy
     end
-    config('no feature vtp')
-    config('no feature private-vlan')
+    config_no_warn('no feature vtp')
+    config_no_warn('no feature private-vlan')
   end
 
   def setup
@@ -65,7 +65,7 @@ class TestVlan < CiscoTestCase
       assert_nil(v1.private_vlan_type)
       return
     else
-      result = ''
+      result = []
       assert_equal(result, v1.private_vlan_association)
     end
   end
@@ -310,7 +310,7 @@ class TestVlan < CiscoTestCase
 
   def test_private_vlan_isolate_association
     vlan_list = %w(100 101)
-    result = '101'
+    result = ['101']
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     pv_type = 'primary'
@@ -327,7 +327,7 @@ class TestVlan < CiscoTestCase
       v2.private_vlan_type = pv_type
       assert_equal(pv_type, v2.private_vlan_type)
 
-      v1.private_vlan_association = vlan_list[1]
+      v1.private_vlan_association = ['101']
 
       assert_equal(result, v1.private_vlan_association)
     end
@@ -335,7 +335,7 @@ class TestVlan < CiscoTestCase
 
   def test_private_vlan_community_association
     vlan_list = %w(100 101)
-    result = '101'
+    result = ['101']
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     pv_type = 'primary'
@@ -352,7 +352,7 @@ class TestVlan < CiscoTestCase
       v2.private_vlan_type = pv_type
       assert_equal(pv_type, v2.private_vlan_type)
 
-      v1.private_vlan_association = vlan_list[1]
+      v1.private_vlan_association = ['101']
 
       assert_equal(result, v1.private_vlan_association)
     end
@@ -360,7 +360,7 @@ class TestVlan < CiscoTestCase
 
   def test_private_vlan_association_failure
     vlan_list = %w(100 101 200)
-    result = '101,200'
+    result = %w(101 200)
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     v3 = Vlan.new(vlan_list[2])
@@ -381,7 +381,7 @@ class TestVlan < CiscoTestCase
       v3.private_vlan_type = pv_type
       assert_equal(pv_type, v3.private_vlan_type)
 
-      v1.private_vlan_association = '101,200'
+      v1.private_vlan_association = %w(101 200)
 
       assert_equal(result, v1.private_vlan_association)
 
@@ -397,7 +397,7 @@ class TestVlan < CiscoTestCase
 
   def test_private_vlan_association_operational_and_not_operational
     vlan_list = %w(100 101 200)
-    result = '101,200'
+    result = %w(101 200)
 
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
@@ -417,7 +417,7 @@ class TestVlan < CiscoTestCase
       v2.private_vlan_type = pv_type
       assert_equal(pv_type, v2.private_vlan_type)
 
-      v1.private_vlan_association = '101,200'
+      v1.private_vlan_association = %w(101 200)
 
       assert_equal(result, v1.private_vlan_association)
     end
@@ -425,7 +425,7 @@ class TestVlan < CiscoTestCase
 
   def test_private_vlan_association_vlan_not_configured
     vlan_list = %w(100 101 200)
-    result = '101,200'
+    result = %w(101 200)
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     pv_type = 'primary'
@@ -442,14 +442,14 @@ class TestVlan < CiscoTestCase
       v2.private_vlan_type = pv_type
       assert_equal(pv_type, v2.private_vlan_type)
 
-      v1.private_vlan_association = '101,200'
+      v1.private_vlan_association = %w(101 200)
       assert_equal(result, v1.private_vlan_association)
     end
   end
 
   def test_private_vlan_association_add_vlan
     vlan_list = %w(100 101)
-    result = '101'
+    result = ['101']
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     pv_type = 'primary'
@@ -466,14 +466,14 @@ class TestVlan < CiscoTestCase
       v2.private_vlan_type = pv_type
       assert_equal(pv_type, v2.private_vlan_type)
 
-      v1.private_vlan_association = '101'
+      v1.private_vlan_association = ['101']
       assert_equal(result, v1.private_vlan_association)
     end
   end
 
   def test_private_vlan_association_remove_vlan
     vlan_list = %w(100 101 200)
-    result = '101,200'
+    result = %w(101 200)
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     v3 = Vlan.new(vlan_list[2])
@@ -495,7 +495,7 @@ class TestVlan < CiscoTestCase
       v3.private_vlan_type = pv_type
       assert_equal(pv_type, v3.private_vlan_type)
 
-      v1.private_vlan_association = '101,200'
+      v1.private_vlan_association = %w(101 200)
       assert_equal(result, v1.private_vlan_association)
 
       # v1.private_vlan_association_remove_vlans = '101'
@@ -507,7 +507,7 @@ class TestVlan < CiscoTestCase
 
   def test_no_private_vlan_association
     vlan_list = %w(100 101 200)
-    result = '101,200'
+    result = %w(101 200)
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     v3 = Vlan.new(vlan_list[2])
@@ -531,11 +531,11 @@ class TestVlan < CiscoTestCase
       v3.private_vlan_type = pv_type
       assert_equal(pv_type, v3.private_vlan_type)
 
-      v1.private_vlan_association = '101,200'
+      v1.private_vlan_association = %w(101 200)
       assert_equal(result, v1.private_vlan_association)
 
-      v1.private_vlan_association = '200'
-      result = '200'
+      v1.private_vlan_association = ['200']
+      result = ['200']
       assert_equal(result, v1.private_vlan_association)
 
     end
@@ -543,7 +543,7 @@ class TestVlan < CiscoTestCase
 
   def test_no_private_vlan_association_all
     vlan_list = %w(100 101 200)
-    result = '101,200'
+    result = %w(101 200)
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     v3 = Vlan.new(vlan_list[2])
@@ -567,10 +567,10 @@ class TestVlan < CiscoTestCase
       v3.private_vlan_type = pv_type
       assert_equal(pv_type, v3.private_vlan_type)
 
-      v1.private_vlan_association = '101,200'
+      v1.private_vlan_association = %w(101 200)
       assert_equal(result, v1.private_vlan_association)
-      v1.private_vlan_association = ''
-      result = ''
+      v1.private_vlan_association = []
+      result = []
       assert_equal(result, v1.private_vlan_association)
 
     end
@@ -578,7 +578,7 @@ class TestVlan < CiscoTestCase
 
   def test_private_vlan_isolate_community_association
     vlan_list = %w(100 101 200)
-    result = '101,200'
+    result = %w(101 200)
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     v3 = Vlan.new(vlan_list[2])
@@ -599,7 +599,7 @@ class TestVlan < CiscoTestCase
       v3.private_vlan_type = pv_type
       assert_equal(pv_type, v3.private_vlan_type)
 
-      v1.private_vlan_association = '101,200'
+      v1.private_vlan_association = %w(101 200)
 
       assert_equal(result, v1.private_vlan_association)
     end
@@ -607,7 +607,7 @@ class TestVlan < CiscoTestCase
 
   def test_private_vlan_multi_isolate_community_association
     vlan_list = %w(100 101 102 104 105 200 201 202)
-    result = '101,104,105,200,202'
+    result = %w(101 104 105 200 202)
     v1 = Vlan.new(vlan_list[0])
 
     pv_type = 'primary'
@@ -652,22 +652,23 @@ class TestVlan < CiscoTestCase
       v7.private_vlan_type = pv_type
       assert_equal(pv_type, v7.private_vlan_type)
 
-      v1.private_vlan_association = '101,104-105,200,202'
+      v1.private_vlan_association = ['101', '104-105', '200', '202']
 
       assert_equal(result, v1.private_vlan_association)
 
-      if node.product_id[/N9K/]
+      if node.product_id[/N(10)K/]
+        puts 'assert_rasies_check'
         assert_raises(RuntimeError, 'vlan did not raise RuntimeError') do
-          v1.private_vlan_association = '101,103-105,108'
+          v1.private_vlan_association = ['101', '103-105', '108']
         end
       else
-        v1.private_vlan_association = '101,103-105,108'
+        v1.private_vlan_association = ['101', '103-105', '108']
 
-        result = '101,103,104,105,108'
+        result = %w(101 103 104 105 108)
         assert_equal(result, v1.private_vlan_association)
 
-        v1.private_vlan_association = '101,103-105,108'
-        result = '101,103,104,105,108'
+        v1.private_vlan_association = ['101', '103-105', '108']
+        result = %w(101 103 104 105 108)
         assert_equal(result, v1.private_vlan_association)
       end
 


### PR DESCRIPTION
**Summary of changes**
- Originally, I asked @davidefdl to treat the private_vlans as a list for both the `private_vlan_association` property setter, getter but I decided it would be best to treat these as arrays for the following reasons.
  - We can sort the list easily.
  - Take advantage of autogen code when using this api in puppet.
- Refactored `private_vlan_association` setter to simplify the code.
- Refactored `cli_error_check`
- Use `config_no_warn` to supress `feature private-vlan` syntax error on n8k

Tests pass on n3k, n5k, n6k, n7k, n8k, n9k
