### PR TITLE
test_nxapi fixes

### DIFF
--- a/tests/test_nxapi.rb
+++ b/tests/test_nxapi.rb
@@ -17,8 +17,6 @@
 require_relative 'basetest'
 require_relative '../lib/cisco_node_utils/node'
 
-include Cisco
-
 # TestNxapi - NXAPI client unit tests
 class TestNxapi < TestCase
   @@client = nil # rubocop:disable Style/ClassVars
@@ -36,7 +34,7 @@ class TestNxapi < TestCase
 
   def setup
     super
-    @product_id = Node.new.product_id if @product_id.nil?
+    @product_id = Cisco::Node.new.product_id if @product_id.nil?
     cleanup
   end
 

--- a/tests/test_nxapi.rb
+++ b/tests/test_nxapi.rb
@@ -37,6 +37,15 @@ class TestNxapi < TestCase
   def setup
     super
     @product_id = Node.new.product_id if @product_id.nil?
+    cleanup
+  end
+
+  def teardown
+    cleanup
+    super
+  end
+
+  def cleanup
     config_no_warn('no interface loopback41', 'no interface loopback42')
   end
 


### PR DESCRIPTION
- Add platform specific values
- Remove ethernet references
- Tests now pass on n30,n31,n5,n6,n7,n8,n9-I2,n9-I3
