### PR TITLE
test_bgp_af.rb platform fixes

### DIFF
--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -59,7 +59,10 @@ module Cisco
     end
 
     def create
-      Feature.bgp_enable if platform == :nexus
+      if platform == :nexus
+        Feature.bgp_enable
+        Feature.nv_overlay_evpn_enable if @safi[/evpn/]
+      end
       set_args_keys(state: '')
       config_set('bgp', 'address_family', @set_args)
     end

--- a/lib/cisco_node_utils/cmd_ref/bgp_af.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp_af.yaml
@@ -11,7 +11,7 @@ _template:
     get_command: 'show running-config router bgp'
 
 additional_paths_install:
-  _exclude: [ios_xr]
+  _exclude: [ios_xr, N3k, N8k, N9k]
   kind: boolean
   get_value: '/^additional-paths install backup$/'
   set_value: '<state> additional-paths install backup'


### PR DESCRIPTION
- Now passes on n30,n31,n5,n6,n7,n9-I2,n9-I3. Still needs validation on n8k,ios_xr.
- Added conditional feature enable for evpn safi's
- Added validate_property_unsupported check to the big property_matrix test, so I also removed the old :unsupported checks
- Added config_no_warn() for the XR pre-req calls
