### PR TITLE
Negotiate auto loopback int fix

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -203,6 +203,11 @@ negotiate_auto_ethernet:
   set_value: "<state> negotiate auto"
   default_value: true
 
+negotiate_auto_other_interfaces:
+  kind: boolean
+  _exclude: [ios_xr]
+  default_only: false
+
 negotiate_auto_portchannel:
   kind: boolean
   _exclude: [ios_xr, N7k]

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -827,6 +827,29 @@ class TestInterface < CiscoTestCase
     negotiate_auto_helper(interface, default)
   end
 
+  def test_negotiate_auto_loopback
+    ref = cmd_ref.lookup('interface',
+                         'negotiate_auto_other_interfaces')
+    assert(ref, 'Error, reference not found')
+
+    int = 'loopback2'
+    config("interface #{int}")
+    interface = Interface.new(int)
+
+    assert_equal(interface.negotiate_auto, ref.default_value,
+                 "Error: #{int} negotiate auto value mismatch")
+
+    assert_raises(Cisco::UnsupportedError) do
+      interface.negotiate_auto = true
+    end
+    assert_raises(Cisco::UnsupportedError) do
+      interface.negotiate_auto = false
+    end
+
+    # Cleanup
+    config("no interface #{int}")
+  end
+
   def test_interfaces_not_empty
     refute_empty(Interface.interfaces, 'Error: interfaces collection empty')
   end


### PR DESCRIPTION
Fixes regression caused by https://github.com/cisco/cisco-network-node-utils/pull/316.  The `negotiate_auto_other_interfaces` yaml key and test case that validates it was removed.  This causes the `puppet resource` command to fail.

```
root@dt-n9k5-1#puppet resource cisco_interface --trace
Error: Could not run: No CmdRef defined for interface, negotiate_auto_other_interfaces
```

Tested on n5k, n7k, n9k(I3) and XR.  Same as baseline. 
