### PR TITLE
wait_for_initialize for slow-start bgp

### DIFF
--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -102,14 +102,15 @@ module Cisco
     def wait_for_process_initialized
       return unless node.product_id[/N(5|6)/]
 
-      # Hack for slow-start platforms which may have setter failures if the
-      # bgp instance is still initializing when they process. To see this
-      # problem in a sandbox do 'router bgp 1 ; router bgp 1 ; shutdown'.
+      # Hack for slow-start platforms which will have setter failures if the
+      # bgp instance is still initializing. To see this problem in a sandbox
+      # do 'router bgp 1 ; router bgp 1 ; shutdown'.
       4.times do
-        break if process_initialized?
+        return if process_initialized?
         sleep 1
         node.cache_flush
       end
+      fail 'BGP process is not initialized yet'
     end
 
     # Helper method to delete @set_args hash keys

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -87,11 +87,29 @@ module Cisco
     def create
       Feature.bgp_enable if platform == :nexus
       router_bgp
+      wait_for_process_initialized
     end
 
     # Destroy router bgp instance
     def destroy
       router_bgp('no')
+    end
+
+    def process_initialized?
+      config_get('bgp', 'process_initialized')
+    end
+
+    def wait_for_process_initialized
+      return unless node.product_id[/N(5|6)/]
+
+      # Hack for slow-start platforms which may have setter failures if the
+      # bgp instance is still initializing when they process. To see this
+      # problem in a sandbox do 'router bgp 1 ; router bgp 1 ; shutdown'.
+      4.times do
+        break if process_initialized?
+        sleep 1
+        node.cache_flush
+      end
     end
 
     # Helper method to delete @set_args hash keys

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -271,8 +271,15 @@ nsr:
   get_value: '/^nsr$/'
   set_value: '<state> nsr'
 
+process_initialized:
+  _exclude: [ios_xr, N3k, N7k, N8k, N9k]
+  # bgp process initialization state
+  kind: boolean
+  context: ~
+  get_command: "show ip bgp"
+  get_value: '/^BGP routing table information/'
+
 reconnect_interval:
-  # Note: Does not exist in IOS XR
   _exclude: [ios_xr, N5k, N6k, N7k]
   kind: int
   get_value: 'reconnect-interval (\d+)'

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -172,6 +172,22 @@ class TestRouterBgp < CiscoTestCase
     bgp.destroy
   end
 
+  def test_process_initialized
+    return if validate_property_excluded?('bgp', 'process_initialized')
+
+    # Cleanup may be slow on some platforms; make sure it's really dead
+    bgp = RouterBgp.new('55', 'default', false)
+    if bgp.process_initialized?
+      sleep 4
+      node.cache_flush
+    end
+    refute(bgp.process_initialized?, 'bgp should not be initialized')
+
+    bgp = RouterBgp.new('55', 'default')
+    bgp.wait_for_process_initialized unless bgp.process_initialized?
+    assert(bgp.process_initialized?, 'bgp should be initialized')
+  end
+
   def test_valid_asn
     [1, 4_294_967_295, '55', '1.0', '1.65535',
      '65535.0', '65535.65535'].each do |test|


### PR DESCRIPTION
- 5/6k take a second or two to fully initialize; if our setters are called too quickly they'll fail with e.code 400 e.clierror {}
- Easy to repro in the sandbox (or cli) by doing:  'router bgp 1 ; router bgp 1 ; event cli size small' to simulate NU doing bgp create followed immediately by event_history_cli=
- Fixed by checking for the bgp process init state via 'show ip bgp'
- This is more noticeable with our 6k but the 5k has similar slow start problems so I kept 5k in the include list
