### PR TITLE
Add sort to redistribute getter

### DIFF
--- a/lib/cisco_node_utils/bgp_af.rb
+++ b/lib/cisco_node_utils/bgp_af.rb
@@ -450,7 +450,7 @@ module Cisco
     # Build an array of all redistribute commands currently on the device
     def redistribute
       c = config_get('bgp_af', 'redistribute', @get_args)
-      c.nil? ? nil : c.each(&:compact!)
+      c.nil? ? nil : c.each(&:compact!).sort
     end
 
     # redistribute setter.


### PR DESCRIPTION
- Some platforms nvgen the redist cfgs in sorted order, some do not, so we will normalize in the getter
- minitest
  TestBgpAF#test_redistribute = 35.80 s = .

Finished in 35.799651s, 0.0279 runs/s, 0.5587 assertions/s.

1 runs, 20 assertions, 0 failures, 0 errors, 0 skips
- beaker redist change tested on n3k,n6k,n7k,XR
