### PR TITLE
bgp_neighbor_af: soft-reconfig platform fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
@@ -185,15 +185,12 @@ send_community:
 soft_reconfiguration_in:
   auto_default: false
   default_value: 'inherit'
-  ios_xr:
+  ios_xr: &soft_recon_always
     get_value: '/^soft-reconfiguration inbound(?: always)?/'
     set_value: '<state> soft-reconfiguration inbound <always>'
-  N3k:
-    get_value: '/^soft-reconfiguration inbound(?: always)?/'
-    set_value: '<state> soft-reconfiguration inbound <always>'
-  N9k:
-    get_value: '/^soft-reconfiguration inbound(?: always)?/'
-    set_value: '<state> soft-reconfiguration inbound <always>'
+  N3k: *soft_recon_always
+  N8k: *soft_recon_always
+  N9k: *soft_recon_always
   else:
     get_value: '/^soft-reconfiguration inbound/'
     set_value: '<state> soft-reconfiguration inbound'


### PR DESCRIPTION
- Add support for 8k
- Simplify minitest: we had separate tests for XR and NX as well as explicit platform checks; I added validate_property_excluded() to re-combine the tests.
- minitest test_tri_states passes on all platforms
