### PR TITLE
ace fix

### DIFF
--- a/lib/cisco_node_utils/ace.rb
+++ b/lib/cisco_node_utils/ace.rb
@@ -262,9 +262,9 @@ module Cisco
 
     def established
       match = ace_get
-      return nil if match.nil?
-      return nil unless match.names.include?('established')
-      match[:established] == 'established' ? true : nil
+      return false if match.nil?
+      return false unless match.names.include?('established')
+      match[:established] == 'established' ? true : false
     end
 
     def established=(established)

--- a/tests/test_ace.rb
+++ b/tests/test_ace.rb
@@ -41,13 +41,14 @@ class TestAce < CiscoTestCase
   # Helper to create an ACE and return the obj. The test_hash contains
   # only the minimum properties which can be added to or overwritten as
   # required for each test.
-  def ace_helper(afi, props)
+  def ace_helper(afi, props=nil)
     test_hash = {
       action:   'permit',
       proto:    'tcp',
       src_addr: 'any',
       dst_addr: 'any',
-    }.merge!(props)
+    }
+    test_hash.merge!(props) unless props.nil?
 
     a = Ace.new(afi, afi, 10)
     begin
@@ -152,6 +153,7 @@ class TestAce < CiscoTestCase
 
   def test_established
     %w(ipv4 ipv6).each do |afi|
+      refute(ace_helper(afi).established)
       a = ace_helper(afi, established: true)
       assert(a.established)
       a = ace_helper(afi, established: false)


### PR DESCRIPTION
Puppet expects the `established` property to be either `true` or `false`.  The NodeUtils object currently returns `nil` so this updates fixes the puppet idempotence problem by returning `false` instead.

**Tests Pass On:**\* N9k(I2 and I3), N3k, N5k, N6k, N7k, N8k 
