### PR TITLE
MT-lite support for VxLAN on 5k/6k

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -33,7 +33,7 @@ itd:
   set_value: "feature itd"
 
 nv_overlay:
-  _exclude: [N3k, N5k, N6k]
+  _exclude: [N3k]
   kind: boolean
   get_value: '/^feature nv overlay$/'
   set_value: "feature nv overlay"
@@ -73,6 +73,8 @@ vn_segment_vlan_based:
     default_value: false
   N8k: *vn_segment_vlan_based_mt_lite
   N9k: *vn_segment_vlan_based_mt_lite
+  N6k: *vn_segment_vlan_based_mt_lite
+  N5k: *vn_segment_vlan_based_mt_lite
 
 vni:
   kind: boolean

--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
@@ -1,6 +1,6 @@
 # vxlan_vtep
 ---
-_exclude: [N3k, N5k, N6k, N7k, ios_xr]
+_exclude: [N3k, ios_xr]
 
 _template:
   get_command: "show running-config interface all | section 'interface nve'"
@@ -30,6 +30,12 @@ mt_lite_support:
   # This is only used for determining support for Multi-Tenancy Lite
   kind: boolean
   N9k:
+    default_only: true
+  N8k:
+    default_only: true
+  N6k:
+    default_only: true
+  N5k:
     default_only: true
   else:
     # this feature is always off on these platforms and cannot be changed

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -237,7 +237,8 @@ class CiscoTestCase < TestCase
     # Example 'show mod' output to match against:
     #   '9  12  10/40 Gbps Ethernet Module  N7K-F312FQ-25 ok'
     #   '9  12  10/40 Gbps Ethernet Module  N77-F312FQ-25 ok'
-    sh_mod = @device.cmd("sh mod | i '^[0-9]+.*N7[7K]-F3'")[/^(\d+)\s.*N7[7K]-F3/]
+    sh_mod_string = @device.cmd("sh mod | i '^[0-9]+.*N7[7K]-F3'")
+    sh_mod = sh_mod_string[/^(\d+)\s.*N7[7K]-F3/]
     slot = sh_mod.nil? ? nil : Regexp.last_match[1]
     skip('Unable to find compatible interface in chassis') if slot.nil?
 

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -236,7 +236,8 @@ class CiscoTestCase < TestCase
     # we will provide an appropriate interface name if the linecard is present.
     # Example 'show mod' output to match against:
     #   '9  12  10/40 Gbps Ethernet Module  N7K-F312FQ-25 ok'
-    sh_mod = @device.cmd("sh mod | i '^[0-9]+.*N7K-F3'")[/^(\d+)\s.*N7K-F3/]
+    #   '9  12  10/40 Gbps Ethernet Module  N77-F312FQ-25 ok'
+    sh_mod = @device.cmd("sh mod | i '^[0-9]+.*N7[7K]-F3'")[/^(\d+)\s.*N7[7K]-F3/]
     slot = sh_mod.nil? ? nil : Regexp.last_match[1]
     skip('Unable to find compatible interface in chassis') if slot.nil?
 


### PR DESCRIPTION
- Added support for 5k,6k in the yaml files
- Added support for N7700
- Ran vxlan_vtep+vxlan_vtep_vni minitests on the 6k/7k to validate changes.
