### PR TITLE
Fix ace log idempotence issue

### DIFF
--- a/lib/cisco_node_utils/ace.rb
+++ b/lib/cisco_node_utils/ace.rb
@@ -337,9 +337,9 @@ module Cisco
 
     def log
       match = ace_get
-      return nil if match.nil?
-      return nil unless match.names.include?('log')
-      match[:log] == 'log' ? true : nil
+      return false if match.nil?
+      return false unless match.names.include?('log')
+      match[:log] == 'log' ? true : false
     end
 
     def log=(log)

--- a/tests/test_ace.rb
+++ b/tests/test_ace.rb
@@ -171,6 +171,7 @@ class TestAce < CiscoTestCase
 
   def test_log
     %w(ipv4 ipv6).each do |afi|
+      refute(ace_helper(afi).log)
       a = ace_helper(afi, log: true)
       assert(a.log)
       a = ace_helper(afi, log: false)


### PR DESCRIPTION
Another case where a property was returning `nil` instead of false.

Tests pass on: n3k, n5k, n6k, n8k, n9k(I2 and I3)
