### PR TITLE
Feature/vxlan bridge domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Changelog
   * bridge_domain_vni (@rkorlepa)
 * Encapsulation Profile
   * vni_encapsulation_profile (@rkorlepa)
+* Interface Bridge Domain
+  * interface bdi (@rkorlepa)
 
 #### NetDev Resources
 *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,13 @@ Changelog
   * bridge_domain_vni (@rkorlepa)
 * Encapsulation Profile
   * vni_encapsulation_profile (@rkorlepa)
-* Interface Bridge Domain
-  * interface bdi (@rkorlepa)
 
 #### NetDev Resources
 *
 
 ### Added
 
+* Added support for bdi interfaces to interface provider.
 * Added a new node util to handle bridge domain range cli for member vni
 * Added Bridge Domain, VNI and encapsulation profile node utils for MT-FULL on Nexus 7k.
 * Added client support for gRPC on IOS XR.

--- a/lib/cisco_node_utils/encapsulation.rb
+++ b/lib/cisco_node_utils/encapsulation.rb
@@ -81,7 +81,7 @@ module Cisco
     # ----------
 
     def range_summarize(string)
-      Utils.array_to_string(Encapsulation.string_to_array(string.to_s), false)
+      Utils.array_to_str(Encapsulation.string_to_array(string.to_s), false)
     end
 
     def dot1q_map

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -73,6 +73,7 @@ module Cisco
 
     def create
       feature_vlan_set(true) if @name[/vlan/i]
+      feature_vlan_set(true) if @name[/bdi/i]
       config_set('interface', 'create', name: @name)
     rescue Cisco::CliError
       # Some XR platforms do not support channel-group configuration

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -96,8 +96,7 @@ module Cisco
     end
 
     def create
-      feature_vlan_set(true) if @name[/vlan/i]
-      feature_vlan_set(true) if @name[/bdi/i]
+      feature_vlan_set(true) if @name[/(vlan|bdi)/i]
       config_set('interface', 'create', name: @name)
     rescue Cisco::CliError
       # Some XR platforms do not support channel-group configuration

--- a/tests/test_interface_bdi.rb
+++ b/tests/test_interface_bdi.rb
@@ -1,0 +1,80 @@
+# Copyright (c) 2014-2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/interface'
+require_relative '../lib/cisco_node_utils/bridge_domain'
+
+include Cisco
+
+# TestSvi - Minitest for Interface configuration of SVI interfaces.
+class TestSvi < CiscoTestCase
+  @@pre_clean_needed = true # rubocop:disable Style/ClassVars
+  attr_reader :bdi
+
+  def self.runnable_methods
+    # We don't have a separate YAML file to key off, so we check platform
+    return super if node.product_id[/N7/]
+    remove_method :setup
+    remove_method :teardown
+    [:unsupported]
+  end
+
+  def unsupported
+    skip("Skipping #{self.class}; Bdi interfaces are not supported on the \
+platform")
+  end
+
+  def setup
+    super
+    remove_all_bdis if @@pre_clean_needed
+    @@pre_clean_needed = false # rubocop:disable Style/ClassVars
+    BridgeDomain.new('100')
+    @bdi = Interface.new('Bdi100')
+  end
+
+  def remove_all_bdis
+    Interface.interfaces.each do |int, obj|
+      next unless int[/bdi/i]
+      obj.destroy
+    end
+    remove_all_bridge_domains
+  end
+
+  def teardown
+    remove_all_bdis
+    super
+  end
+
+  def test_create_all_properties
+    # Check all the default values
+    assert_equal(@bdi.default_vrf, @bdi.vrf)
+    assert_equal(@bdi.default_ipv4_address, @bdi.ipv4_address)
+    assert_equal(@bdi.default_ipv4_netmask_length, @bdi.ipv4_netmask_length)
+    address = '8.7.1.1'
+    length = 15
+
+    @bdi.ipv4_addr_mask_set(address, length)
+    assert_equal(address, @bdi.ipv4_address,
+                 'Error: ipv4 address get value mismatch')
+    assert_equal(length, @bdi.ipv4_netmask_length,
+                 'Error: ipv4 netmask length get value mismatch')
+
+    vrf = 'pepsi'
+    @bdi.vrf = vrf
+    assert_equal(vrf, @bdi.vrf)
+    @bdi.vrf = ''
+    assert_equal(@bdi.default_vrf, @bdi.vrf)
+  end
+end

--- a/tests/test_interface_bdi.rb
+++ b/tests/test_interface_bdi.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2016 Cisco and/or its affiliates.
+# Copyright (c) 2016 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ require_relative '../lib/cisco_node_utils/bridge_domain'
 
 include Cisco
 
-# TestSvi - Minitest for Interface configuration of SVI interfaces.
-class TestSvi < CiscoTestCase
+# TestBdi - Minitest for Interface configuration of BDI interfaces.
+class TestBdi < CiscoTestCase
   @@pre_clean_needed = true # rubocop:disable Style/ClassVars
   attr_reader :bdi
 

--- a/tests/test_interface_bdi.rb
+++ b/tests/test_interface_bdi.rb
@@ -57,7 +57,7 @@ platform")
     super
   end
 
-  def test_create_all_properties
+  def test_create_and_check_all_properties
     # Check all the default values
     assert_equal(@bdi.default_vrf, @bdi.vrf)
     assert_equal(@bdi.default_ipv4_address, @bdi.ipv4_address)


### PR DESCRIPTION
For feature interface bdi check and correction in function definition in encapsulation.rb file

Below is the cli to test:

interface bdi 100
  ip address 8.7.1.1/15
  no shut

Also ran this test case on n7k;
1 runs, 7 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /ws/rkorlepa-sjc/puppetlabs/cisco-network-node-utils/tests/coverage. 0.0 / 0.0 LOC (100.0%) covered.

And all other platforms (n3k, n5k, n6k, n8k, n9k, iosxr) it returns;
1) Skipped:
TestBdi#unsupported [test_interface_bdi.rb:35]:
Skipping TestBdi; Bdi interfaces are not supported on the platform
