### PR TITLE
Add n8k support

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
@@ -26,14 +26,14 @@ lacp_max_bundle:
   kind: int
   get_value: '/^lacp max.bundle (\d+)$/'
   set_value: "lacp max-bundle %s"
-  N3k:
+  N3k: &lacp_max_bundle_32
     default_value: 32
-  N8k:
-    default_value: 32
-  N9k:
-    default_value: 32
-  else:
+  N5k: &lacp_max_bundle_16
     default_value: 16
+  N6k: *lacp_max_bundle_16
+  N7k: *lacp_max_bundle_16
+  N8k: *lacp_max_bundle_32
+  N9k: *lacp_max_bundle_32
 
 lacp_min_links:
   kind: int

--- a/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
@@ -28,6 +28,8 @@ lacp_max_bundle:
   set_value: "lacp max-bundle %s"
   N3k:
     default_value: 32
+  N8k:
+    default_value: 32
   N9k:
     default_value: 32
   else:

--- a/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
@@ -23,7 +23,7 @@ bundle_select:
   default_value: 'src-dst'
 
 concatenation:
-  _exclude: [N5k, N6k, N7k]
+  _exclude: [N5k, N6k, N7k, N8k]
   default_value: false
 
 hash_distribution:
@@ -45,7 +45,8 @@ load_balance_type:
   N6k: *load_balance_type_ethernet
   N7k: &load_balance_type_asymmetric
     default_only: "asymmetric"
-  N8k: *load_balance_type_symmetry
+  N8k: &load_balance_type_no_hash
+    default_only: "no_hash"
   N9k: *load_balance_type_symmetry
 
 load_defer:
@@ -73,5 +74,5 @@ rotate:
   default_value: 0
 
 symmetry:
-  _exclude: [N5k, N6k, N7k]
+  _exclude: [N5k, N6k, N7k, N8k]
   default_value: false

--- a/lib/cisco_node_utils/portchannel_global.rb
+++ b/lib/cisco_node_utils/portchannel_global.rb
@@ -107,6 +107,8 @@ module Cisco
           _parse_ethernet_params(hash, params)
         when :asymmetric # n7k
           _parse_asymmetric_params(hash, params, line)
+        when :no_hash # n8k
+          _parse_no_hash_params(hash, params)
         when :symmetry # n9k
           _parse_symmetry_params(hash, params, line)
         end
@@ -192,6 +194,12 @@ module Cisco
         # port-channel load-balance dst ip-l4port rotate 4 asymmetric
         config_set('portchannel_global', 'port_channel_load_balance',
                    bselect, bhash, 'rotate', rot.to_s, asym, '')
+      when :no_hash # n8k
+        # port-channel load-balance dst ip-l4port rotate 4
+        rot_str = rot.zero? ? '' : 'rotate'
+        rot_val = rot.zero? ? '' : rot.to_s
+        config_set('portchannel_global', 'port_channel_load_balance',
+                   bselect, bhash, rot_str, rot_val, '', '')
       when :symmetry # n9k
         sym = sy ? 'symmetric' : ''
         concat = conc ? 'concatenation' : ''
@@ -250,6 +258,17 @@ module Cisco
       hash[:bundle_select] = bselect
       hash[:bundle_hash] = bhash
       hash[:asymmetric] = asym
+      hash[:rotate] = rotate
+      hash
+    end
+
+    def _parse_no_hash_params(hash, params)
+      bselect = params[0]
+      bhash = params[1]
+      ri = params.index('rotate')
+      rotate = params[ri + 1].to_i
+      hash[:bundle_select] = bselect
+      hash[:bundle_hash] = bhash
       hash[:rotate] = rotate
       hash
     end

--- a/tests/test_portchannel_global.rb
+++ b/tests/test_portchannel_global.rb
@@ -218,7 +218,7 @@ class TestPortchannelGlobal < CiscoTestCase
 
   def test_load_balance_no_hash_rot
     global = create_portchannel_global
-    unless validate_property_excluded?('portchannel_global', 'hash_poly')
+    if validate_property_excluded?('portchannel_global', 'rotate')
       skip('Test not supported on this platform')
       return
     end

--- a/tests/test_portchannel_global.rb
+++ b/tests/test_portchannel_global.rb
@@ -215,4 +215,26 @@ class TestPortchannelGlobal < CiscoTestCase
     assert_equal(global.default_asymmetric, global.asymmetric)
     assert_equal(global.default_rotate, global.rotate)
   end
+
+  def test_load_balance_no_hash_rot
+    global = create_portchannel_global
+    unless validate_property_excluded?('portchannel_global', 'hash_poly')
+      skip('Test not supported on this platform')
+      return
+    end
+    global.send(:port_channel_load_balance=,
+                'src-dst', 'ip-vlan', nil, nil, nil, nil, 4)
+    assert_equal('src-dst', global.bundle_select)
+    assert_equal('ip-vlan', global.bundle_hash)
+    assert_equal(4, global.rotate)
+
+    global.send(:port_channel_load_balance=,
+                global.default_bundle_select,
+                global.default_bundle_hash,
+                nil, nil,
+                nil, nil, global.default_rotate)
+    assert_equal(global.default_bundle_select, global.bundle_select)
+    assert_equal(global.default_bundle_hash, global.bundle_hash)
+    assert_equal(global.default_rotate, global.rotate)
+  end
 end


### PR DESCRIPTION
For n8k, the CLIs for port-channel global are different. This is for adding support to n8k. Also the default value for lacp_max_bundle is 32 for n8k.

All tests passed for all switches except n3k where this provider does not work unless it is put in n9k mode.

Test results on n8k:
[saichint@sjc-ads-7106 /ws/saichint-sjc/puppet_agent/cisco-network-node-utils/tests] $ ruby test_portchannel_global.rb -e n8k -v  
Run options: -e n8k -v --seed 41452                                                                                 
# Running:

Node under test:
- name  - n9k-157
- type  - N85-C8508
- image - bootflash:///n8500-dk9.7.0.3.F1.0.267.bin

TestPortchannelGlobal#test_load_balance_hash_poly = 2.85 s = S
TestPortchannelGlobal#test_load_balance_no_hash_rot = 5.17 s = .
TestPortchannelGlobal#test_hash_distribution = 2.64 s = .  
TestPortchannelGlobal#test_load_defer = 2.68 s = .  
TestPortchannelGlobal#test_load_balance_sym_concat_rot = 2.75 s = S
TestPortchannelGlobal#test_load_balance_asym_rot = 2.69 s = S  
TestPortchannelGlobal#test_resilient = 2.70 s = .                  

Finished in 23.916315s, 0.2927 runs/s, 0.5017 assertions/s.

  1) Skipped:
TestPortchannelGlobal#test_load_balance_hash_poly [test_portchannel_global.rb:169]:
Test not supported on this platform                                                

  2) Skipped:
TestPortchannelGlobal#test_load_balance_sym_concat_rot [test_portchannel_global.rb:113]:
Test not supported on this platform                                                     

  3) Skipped:
TestPortchannelGlobal#test_load_balance_asym_rot [test_portchannel_global.rb:197]:
Test not supported on this platform                                               

7 runs, 12 assertions, 0 failures, 0 errors, 3 skips
Coverage report generated for MiniTest to /ws/saichint-sjc/puppet_agent/cisco-network-node-utils/tests/coverage. 0.0 / 0.0 LOC (100.0%) covered.                                          
