### PR TITLE
Modification of tacacs_server for tacacs_global

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/tacacs_server.yaml
+++ b/lib/cisco_node_utils/cmd_ref/tacacs_server.yaml
@@ -1,8 +1,8 @@
 # tacacs_server
 ---
-_exclude: [ios_xr]
 
 deadtime:
+  _exclude: [ios_xr]
   kind: int
   get_command: "show run tacacs all"
   get_value: '/^tacacs-server deadtime\s+(\d+)/'
@@ -10,6 +10,7 @@ deadtime:
   default_value: 0
 
 directed_request:
+  _exclude: [ios_xr]
   kind: boolean
   # oddly, directed request must be retrieved from aaa output
   get_command: "show running aaa all"
@@ -18,26 +19,34 @@ directed_request:
   default_value: false
 
 encryption:
-  set_value: "%s tacacs-server key %d %s"
+  set_value: "<state> tacacs-server key <option> <key>"
 
 encryption_password:
-  get_command: "show run tacacs all"
   get_value: '/^tacacs-server key (\d+)\s+(\S+)/'
   default_value: ""
+  nexus:
+    get_command: "show run tacacs all"
+  ios_xr:
+    get_command: "show running-config tacacs-server"
 
 encryption_type:
   auto_default: false
-  get_command: "show run tacacs all"
   get_value: '/^tacacs-server key (\d+)\s+(\S+)/'
   default_value: 0
+  nexus:
+    get_command: "show run tacacs all"
+  ios_xr:
+    get_command: "show running-config tacacs-server"
 
 feature:
+  _exclude: [ios_xr]
   kind: boolean
   get_command: "show run tacacs all"
   get_value: '/^feature tacacs/'
   set_value: "%s feature tacacs+"
 
 source_interface:
+  _exclude: [ios_xr]
   get_command: "show run tacacs all"
   get_value: '/(no)?\s*ip tacacs source-interface\s+(\S+)?/'
   set_value: "%s ip tacacs source-interface %s"
@@ -45,7 +54,10 @@ source_interface:
 
 timeout:
   kind: int
-  get_command: "show run tacacs all"
   get_value: '/tacacs-server timeout\s+(\d+)/'
-  set_value: "%s tacacs-server timeout %d"
+  set_value: "<state> tacacs-server timeout <timeout>"
   default_value: 5
+  nexus:
+    get_command: "show run tacacs all"
+  ios_xr:
+    get_command: "show running-config tacacs-server"

--- a/lib/cisco_node_utils/tacacs_server.rb
+++ b/lib/cisco_node_utils/tacacs_server.rb
@@ -39,12 +39,12 @@ module Cisco
 
     # Enable tacacs_server feature
     def enable
-      config_set('tacacs_server', 'feature', '')
+      config_set('tacacs_server', 'feature', '') unless platform == :ios_xr
     end
 
     # Disable tacacs_server feature
     def destroy
-      config_set('tacacs_server', 'feature', 'no')
+      config_set('tacacs_server', 'feature', 'no') unless platform == :ios_xr
     end
 
     # --------------------
@@ -55,7 +55,7 @@ module Cisco
     def timeout=(timeout)
       # 'no tacacs timeout' will fail.
       # Just set it to the requested timeout value.
-      config_set('tacacs_server', 'timeout', '', timeout)
+      config_set('tacacs_server', 'timeout', state: '', timeout: timeout)
     end
 
     # Get timeout
@@ -162,12 +162,13 @@ module Cisco
         # need to unset it. Otherwise the box is not configured with key, we
         # don't need to do anything
         if encryption_type != TACACS_SERVER_ENC_UNKNOWN
-          config_set('tacacs_server', 'encryption', 'no',
-                     encryption_type,
-                     encryption_password)
+          config_set('tacacs_server', 'encryption', state:  'no',
+                                                    option: encryption_type,
+                                                    key:    encryption_password)
         end
       else
-        config_set('tacacs_server', 'encryption', '', enctype, password)
+        config_set('tacacs_server', 'encryption', state: '', option: enctype,
+                    key: password)
       end
     end
   end


### PR DESCRIPTION
**Minitest Results:**

Run options: -v -- --seed 61992
# Running:

Node under test:
- name  - g67805gyd9rqnbz
- type  - R-IOSXRV9000-CH
- image - 6.0.0.20I

TestTacacsServer#test_get_encryption_type = 21.40 s = .
TestTacacsServer#test_get_deadtime = 10.50 s = .
TestTacacsServer#test_get_default_source_interface = 10.65 s = .
TestTacacsServer#test_get_default_directed_request = 10.58 s = .
TestTacacsServer#test_set_directed_request = 12.05 s = .
TestTacacsServer#test_key_unconfigure = 23.97 s = .
TestTacacsServer#test_get_timeout = 20.27 s = .
TestTacacsServer#test_get_default_deadtime = 12.85 s = .
TestTacacsServer#test_get_default_timeout = 9.60 s = .
TestTacacsServer#test_set_source_interface = 10.01 s = .
TestTacacsServer#test_get_source_interface = 9.42 s = .
TestTacacsServer#test_create_valid = 10.84 s = .
TestTacacsServer#test_get_encryption_password = 26.12 s = .
TestTacacsServer#test_set_timeout = 18.79 s = .
TestTacacsServer#test_get_default_encryption = 12.87 s = .
TestTacacsServer#test_key_set = 17.19 s = .
TestTacacsServer#test_set_deadtime = 10.55 s = .
TestTacacsServer#test_get_default_encryption_password = 10.75 s = .
TestTacacsServer#test_destroy = 10.25 s = .
TestTacacsServer#test_get_directed_request = 9.72 s = .

Finished in 285.236133s, 0.0701 runs/s, 0.0841 assertions/s.

20 runs, 24 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /Users/helencampbell/workspace/cisco_devenv/cisco-network-node-utils/coverage. 1368 / 2806 LOC (48.75%) covered.
