### PR TITLE
Add cleanup step for private vlan tests

### DIFF
--- a/tests/test_vlan.rb
+++ b/tests/test_vlan.rb
@@ -320,6 +320,13 @@ class TestVlan < CiscoTestCase
 
   def test_mode_with_pvlan
     v = Vlan.new(1000)
+    if validate_property_excluded?('vlan', 'private_vlan_type')
+      assert_nil(v.private_vlan_type)
+      assert_raises(Cisco::UnsupportedError) do
+        v.private_vlan_type = 'primary'
+      end
+      return
+    end
     result = 'CE'
     v.private_vlan_type = 'primary'
     assert_equal(result, v.mode)

--- a/tests/test_vlan.rb
+++ b/tests/test_vlan.rb
@@ -31,6 +31,7 @@ class TestVlan < CiscoTestCase
       obj.destroy
     end
     interface_ethernet_default(interfaces[0])
+    config_no_warn('no feature vtp')
   end
 
   def setup


### PR DESCRIPTION
**Fixes the following errors related to:** `test_mode_with_pvlan`.

*\* General failure, all Nexus Platforms**

```
TestVlan#test_mode_with_pvlan = 6.60 s = E

Finished in 9.541596s, 0.1048 runs/s, 0.0000 assertions/s.

  1) Error:
TestVlan#test_mode_with_pvlan:
RuntimeError: ERROR: Private VLANs can only be configured in transparent/off modes in VTP version 1 or 2, and in VTP version 3 when pruning is turned off
ERROR : cli_process_vlan_config_exit(302), command private-vlan primary FAILED
Cannot run commands in the mode at this moment. Please try again.
```

*\* N8K Specific Issue **

```
** FIX: Cleanup vtp before running tests.**


Node under test:
  - name  - agent-lab3-nx
  - type  - N8K-NXOSV
  - image - bootflash:///n8500-dk9.7.0.3.F1.0.258.bin

TestVlan#test_mode_with_pvlan = 11.08 s = E

Finished in 12.509586s, 0.0799 runs/s, 0.0000 assertions/s.

  1) Error:
TestVlan#test_mode_with_pvlan:
Cisco::UnsupportedError: Feature 'feature', attribute 'private_vlan', operation 'setter' is unsupported on this node
    /nobackup/mwiebe/REPOS_NODE_UTILS/release130/cisco-network-node-utils/lib/cisco_node_utils/command_reference.rb:153:in `setter'
    /nobackup/mwiebe/REPOS_NODE_UTILS/release130/cisco-network-node-utils/lib/cisco_node_utils/node.rb:136:in `config_set'
    /nobackup/mwiebe/REPOS_NODE_UTILS/release130/cisco-network-node-utils/lib/cisco_node_utils/node_util.rb:64:in `config_set'
    /nobackup/mwiebe/REPOS_NODE_UTILS/release130/cisco-network-node-utils/lib/cisco_node_utils/feature.rb:164:in `private_vlan_enable'
    /nobackup/mwiebe/REPOS_NODE_UTILS/release130/cisco-network-node-utils/lib/cisco_node_utils/vlan.rb:230:in `private_vlan_type='
    tests/test_vlan.rb:324:in `test_mode_with_pvlan'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

*\* FIX: Add `validate_property_excluded?() check**

Tested on: n3k, n5k, n6k, n7k, n8k, n9k
