### PR TITLE
Test/pc

### DIFF
--- a/lib/cisco_node_utils/portchannel_global.rb
+++ b/lib/cisco_node_utils/portchannel_global.rb
@@ -39,6 +39,10 @@ module Cisco
     #                      PROPERTIES                      #
     ########################################################
 
+    def load_balance_type
+      config_get('portchannel_global', 'load_balance_type')
+    end
+
     def hash_distribution
       config_get('portchannel_global', 'hash_distribution')
     end

--- a/lib/cisco_node_utils/snmpserver.rb
+++ b/lib/cisco_node_utils/snmpserver.rb
@@ -24,12 +24,7 @@ module Cisco
     end
 
     def aaa_user_cache_timeout=(timeout)
-      if timeout == default_aaa_user_cache_timeout
-        config_set('snmp_server', 'aaa_user_cache_timeout', 'no',
-                   aaa_user_cache_timeout)
-      else
-        config_set('snmp_server', 'aaa_user_cache_timeout', '', timeout)
-      end
+      config_set('snmp_server', 'aaa_user_cache_timeout', '', timeout)
     end
 
     def default_aaa_user_cache_timeout


### PR DESCRIPTION
1. Added a method to get load_balance_type from the agent to be used in the puppet module. This is needed for n8k especially but also used for other switches.
2. removed the "no" cmd set for aaa-user-cache-timeout. This is a workaround for snmp-server code because the 'no' cmd is not working on n6k and n5k.
   Mike and I had a conversation about this and he can pick up this PR, it will be easier.
