### PR TITLE
Skip mode test for 9k and 3k platform

### DIFF
--- a/tests/test_vlan.rb
+++ b/tests/test_vlan.rb
@@ -318,6 +318,7 @@ class TestVlan < CiscoTestCase
   end
 
   def test_mode_with_pvlan
+    return if node.product_id[/N9K|N3K/]
     v = Vlan.new(1000)
     result = 'CE'
     v.private_vlan_type = 'primary'


### PR DESCRIPTION
One of the minitest for test_vlan.rb is failing for 9k and 3k. Reason is the mode property is excluded
from these two platform. The mode is supported in both platform but since the mode property was introduced for fabricpath ( not supported in 9k and 3k) the property was excluded from 9k and 3k.
To avoid the failure, I'm proposing for now to return when the platform is either 3k or 9k.
