### PR TITLE
Fix test_mode_with_pvlan vlan.rb test case

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vlan.yaml
@@ -25,9 +25,7 @@ mapped_vni:
   N9k: *mapped_vni_n3k_n9k
 
 mode:
-  _exclude:
-    - N3k
-    - N9k
+  _exclude: [N3k, N9k]
   multiple: true
   get_command: "show vlan"
   # TBD: 'show vlan' is problematic and should be converted to use show run

--- a/tests/test_vlan.rb
+++ b/tests/test_vlan.rb
@@ -320,12 +320,10 @@ class TestVlan < CiscoTestCase
 
   def test_mode_with_pvlan
     v = Vlan.new(1000)
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v.private_vlan_type)
-      assert_raises(Cisco::UnsupportedError) do
-        v.private_vlan_type = 'primary'
-      end
-      return
+    if validate_property_excluded?('vlan', 'private_vlan_type') ||
+       validate_property_excluded?('vlan', 'mode')
+      features = 'private_vlan_type and/or vlan mode'
+      skip("Skip test: Features #{features} are not supported on this device")
     end
     result = 'CE'
     v.private_vlan_type = 'primary'


### PR DESCRIPTION
This test case can only be run on platforms that support both vlan mode and private_vlan_type.

All vlan.rb tests pass on: n3k, n5k, n6k, n7k, n8k, n9k(I2)(I3)

Skip Message:

```
  1) Skipped:
TestVlan#test_mode_with_pvlan [tests/test_vlan.rb:326]:
Skip test: Features private_vlan_type and/or vlan mode are not supported on this device
```
