### PR TITLE
encapsulation: dot1q idempotence, nil object fails

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/encapsulation.yaml
+++ b/lib/cisco_node_utils/cmd_ref/encapsulation.yaml
@@ -22,4 +22,4 @@ dot1q_map:
   get_value: '/^.* vni <profile>\s+dot1q ([\d\s,-]+) vni ([\d\s,-]+)$/'
   set_context: ['encapsulation profile vni <profile>']
   set_value: '<state> dot1q <vlans> vni <vnis>'
-  default_value: ~
+  default_value: []

--- a/lib/cisco_node_utils/encapsulation.rb
+++ b/lib/cisco_node_utils/encapsulation.rb
@@ -86,17 +86,23 @@ module Cisco
 
     def dot1q_map
       result = config_get('encapsulation', 'dot1q_map', profile: @encap_name)
-      return default_dot1q_map if result.to_s.empty?
+      return default_dot1q_map if result.empty?
+
       result[0] = range_summarize(result[0])
       result[1] = range_summarize(result[1])
       result
     end
 
-    def dot1q_map=(val)
-      no_cmd = (val.empty?) ? 'no' : ''
-      val = dot1q_map if val.empty?
+    def dot1q_map=(map)
+      state = ''
+      if map.empty?
+        state = 'no'
+        map = dot1q_map
+        return if map.empty?
+      end
+      vlans, vnis = map
       config_set('encapsulation', 'dot1q_map', profile: @encap_name,
-                 state: no_cmd, vlans: val[0], vnis: val[1])
+                 state: state, vlans: vlans, vnis: vnis)
     end
 
     def default_dot1q_map


### PR DESCRIPTION
- puppet testing revealed a couple of issues on the NU side:
  - No support for 'default' and default yaml wrongly returned nil
  - Changing default to [] broke the getter's default check
  - Cleaned up the setter code
