### PR TITLE
Fix domain resolv.conf cleanup issues

### DIFF
--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -242,4 +242,32 @@ class CiscoTestCase < TestCase
 
     "ethernet#{slot}/1"
   end
+
+  # Wrapper api that can be used to execute bash shell or guestshell
+  # commands.
+  # Returns the output of the command.
+  def shell_command(command, context='bash')
+    fail "shell_command api not supported on #{node.product_id}" unless
+      node.product_id[/N3K|N8K|N9K/]
+    unless context == 'bash' || context == 'guestshell'
+      fail "Context must be either 'bash' or 'guestshell'"
+    end
+    config("run #{context} #{command}")
+  end
+
+  def backup_resolv_file(context='bash')
+    # Configuration bleeding is only a problem on some platforms, so
+    # only backup the resolv.conf file on required plaforms.
+    return unless node.product_id[/N3K|N8K|N9K/]
+    time_stamp = Time.now.strftime('%Y-%m-%d_%H-%M-%S')
+    backup_filename = "/tmp/resolv.conf.#{time_stamp}"
+    shell_command("cp /etc/resolv.conf #{backup_filename}", context)
+    backup_filename
+  end
+
+  def restore_resolv_file(filename, context='bash')
+    return unless node.product_id[/N3K|N8K|N9K/]
+    shell_command("sudo cp #{filename} /etc/resolv.conf", context)
+    shell_command("rm #{filename}", context)
+  end
 end

--- a/tests/test_dns_domain.rb
+++ b/tests/test_dns_domain.rb
@@ -25,12 +25,14 @@ class TestDnsDomain < CiscoTestCase
   def setup
     # setup runs at the beginning of each test
     super
+    @backup_resolve = backup_resolv_file
     no_dnsdomain_tests
   end
 
   def teardown
     # teardown runs at the end of each test
     no_dnsdomain_tests
+    restore_resolv_file(@backup_resolve)
     super
   end
 

--- a/tests/test_domain_name.rb
+++ b/tests/test_domain_name.rb
@@ -25,12 +25,14 @@ class TestDomainName < CiscoTestCase
   def setup
     # setup runs at the beginning of each test
     super
+    @backup_resolve = backup_resolv_file
     no_domainname_test_xyz
   end
 
   def teardown
     # teardown runs at the end of each test
     no_domainname_test_xyz
+    restore_resolv_file(@backup_resolve)
     super
   end
 

--- a/tests/test_name_server.rb
+++ b/tests/test_name_server.rb
@@ -25,12 +25,14 @@ class TestNameServer < CiscoTestCase
   def setup
     # setup runs at the beginning of each test
     super
+    @backup_resolve = backup_resolv_file
     no_nameserver_google
   end
 
   def teardown
     # teardown runs at the end of each test
     no_nameserver_google
+    restore_resolv_file(@backup_resolve)
     super
   end
 


### PR DESCRIPTION
**Problem:**
The following minitests, `tests/test_domain_name.rb`, `tests/test_dns_domain` and `tests/test_name_server.rb` cause test configuration to bleed through to the `/etc/resolv.conf` file.  This can prevent proper dns lookups etc.  This is only a problem on `n3|8|9k` platforms.

**Solution**
For each of these tests, we first backup `/etc/resolv.conf` run  the test and then restore it at the end of the test.

**Tests Pass On:**\* n3k, n5k, n6k, n7k, n8k, n9k(I2 and I3)
