### PR TITLE
Fix vlan ordering array

### DIFF
--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -1024,6 +1024,7 @@ module Cisco
       is_list.each do |elem|
         if elem.include?('..')
           elema = elem.split('..').map { |d| Integer(d) }
+          elema.sort!
           tr = elema[0]..elema[1]
           tr.to_a.each do |item|
             is_list_new.push(item.to_s)

--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -286,6 +286,7 @@ module Cisco
       should_list.each do |elem|
         if elem.include?('..')
           elema = elem.split('..').map { |d| Integer(d) }
+          elema.sort!
           tr = elema[0]..elema[1]
           tr.to_a.each do |item|
             should_list_new.push(item.to_s)


### PR DESCRIPTION
Vlan range can be entered in the following way 5-10 or 10-5. Both range are accepted by cli. Need to make sure to order the array after split operation.

Ran tests for interface_private_vlan and vlan_private_vlan on 7k,9k,5k,6k
