### PR TITLE
Add Interface.capabilities helper

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -27,6 +27,7 @@ capabilities:
   get_context: ["<name>"]
   get_command: "show interface capabilities"
   get_value: '/(.*)/'
+  default_value: [] # :raw default
 
 create:
   set_context: ~

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -21,6 +21,13 @@ all_interfaces:
   get_context: ~
   get_value: '/^interface (.*)/'
 
+capabilities:
+  _exclude: [ios_xr]
+  multiple:
+  get_context: ["<name>"]
+  get_command: "show interface capabilities"
+  get_value: '/(.*)/'
+
 create:
   set_context: ~
   set_value: "interface <name>"

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -95,6 +95,38 @@ module Cisco
       true
     end
 
+    # 'capabilities' is a getter-only helper for minitest and beaker.
+    # mode values:
+    #   :hash = Transform the output into a hash
+    #   :raw  = The raw output from 'show int capabilities'. Some multi-line
+    #           values do not translate easily so this option allows the
+    #           caller to extract the data it needs.
+    #
+    # Sample cli output:
+    #    Model:                 N7K-M132XP-12L
+    #    Type (SFP capable):    10Gbase-SR
+    #    Speed:                 10,100,1000
+    #
+    # Sample hash output:
+    # {"Model"=>"N7K-M132XP-12L", "Type"=>"10Gbase-SR", "Speed"=>"10,100,1000"}
+    #
+    def self.capabilities(intf, mode=:hash)
+      array = config_get('interface', 'capabilities', name: intf)
+      return array if mode == :raw
+      hash = {}
+      if array
+        array.delete('')
+        array.each do |line|
+          k, v = line.split(':')
+          next if k.nil? || v.nil?
+          k.gsub!(/ \(.*\)/, '')
+          v.gsub!(/\s/, '')
+          hash[k] = v
+        end
+      end
+      hash
+    end
+
     def create
       feature_vlan_set(true) if @name[/(vlan|bdi)/i]
       config_set('interface', 'create', name: @name)

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -119,8 +119,8 @@ module Cisco
         array.each do |line|
           k, v = line.split(':')
           next if k.nil? || v.nil?
-          k.gsub!(/ \(.*\)/, '')
-          v.gsub!(/\s/, '')
+          k.gsub!(/ \(.*\)/, '') # Remove any parenthetical text from key
+          v.strip!
           hash[k] = v
         end
       end

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -137,20 +137,27 @@ class TestInterface < CiscoTestCase
     arr.count
   end
 
+  def test_interface_capabilities
+    if validate_property_excluded?('interface', 'capabilities')
+      assert_empty(Interface.capabilities(interfaces[0]))
+    else
+      refute_nil(Interface.capabilities(interfaces[0]),
+                 'Interface.capabilities should not return an empty hash')
+    end
+  end
+
   # Helper to get valid speeds for port
   def capable_speed_values(interface)
-    capabilities = config("show interface #{interface.name} capabilities")
-    speed_capa = capabilities.match(/Speed:\s+(\S+)/)
-    return [] if speed_capa.nil? || speed_capa[1].nil?
-    speed_capa[1].split(',')
+    speed_capa = Interface.capabilities(interface.name)['Speed']
+    return [] if speed_capa.nil?
+    speed_capa.split(',')
   end
 
   # Helper to get valid duplex values for port
   def capable_duplex_values(interface)
-    capabilities = config("show interface #{interface.name} capabilities")
-    duplex_capa = capabilities.match(/Duplex:\s+(\S+)/)
-    return [] if duplex_capa.nil? || duplex_capa[1].nil?
-    duplex_capa[1].split(',')
+    duplex_capa = Interface.capabilities(interface.name)['Duplex']
+    return [] if duplex_capa.nil?
+    duplex_capa.split(',')
   end
 
   def create_interface(ifname=interfaces[0])
@@ -1344,6 +1351,7 @@ class TestInterface < CiscoTestCase
 
     # pre-configure
     begin
+      interface_ethernet_default(interfaces[1])
       InterfaceChannelGroup.new(interfaces[1]).channel_group = 48
     rescue Cisco::UnsupportedError
       raise unless platform == :ios_xr

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -137,12 +137,19 @@ class TestInterface < CiscoTestCase
     arr.count
   end
 
-  def test_interface_capabilities
+  def test_capabilities
     if validate_property_excluded?('interface', 'capabilities')
       assert_empty(Interface.capabilities(interfaces[0]))
     else
-      refute_nil(Interface.capabilities(interfaces[0]),
-                 'Interface.capabilities should not return an empty hash')
+      refute_empty(Interface.capabilities(interfaces[0], :hash),
+                   'A valid interface should return a non-empty hash')
+      assert_empty(Interface.capabilities('foo', :hash),
+                   'An Invalid interface should return an empty hash')
+
+      refute_empty(Interface.capabilities(interfaces[0], :raw),
+                   'A valid interface should return a non-empty array')
+      assert_empty(Interface.capabilities('foo', :raw),
+                   'An Invalid interface should return an empty array')
     end
   end
 


### PR DESCRIPTION
- Minitest and beaker need an easy way to determine interface capabilities for properties like speed, duplex, etc
- show interface capabilities supplies this info for NX platforms
- `capable_speed_values` and `capable_duplex_values` already does this in minitest using config() so I just took this a step further and created a class method getter in Interface that converts the output into hashed values; it also has an option to return the raw output instead since some of the lesser-used values are multi-line and don't convert easily to key-values.
- Minitest tested with n3,5,6,7,9k. I intend to use this in beaker next.
