### PR TITLE
vtp password fix to use structured output

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vtp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vtp.yaml
@@ -18,8 +18,9 @@ filename:
   default_value: "bootflash:/vlan.dat"
 
 password:
+  get_data_format: nxapi_structured
   get_command: "show vtp password"
-  get_value: '/VTP\s+Password:\s+(\S+)/i'
+  get_value: "passwd"
   set_value: "<state> vtp password <password>"
   default_value: ""
 

--- a/lib/cisco_node_utils/vtp.rb
+++ b/lib/cisco_node_utils/vtp.rb
@@ -62,6 +62,11 @@ module Cisco
       password = config_get('vtp', 'password') if Feature.vtp_enabled?
       return '' if password.nil? || password == '\\'
       password
+    rescue Cisco::RequestNotSupported => e
+      # Certain platforms generate a Cisco::RequestNotSupported when the
+      # vtp password is not set.  We catch this specific error and
+      # return empty '' for the password.
+      return '' if e.message[/Structured output not supported/]
     end
 
     # Set vtp password


### PR DESCRIPTION
**Summary**
Update vtp password property to use structured output so that passwords that contain the `&` character don't get stripped like they do when using non-structured.

Tests Pass On: n3k, n5k, n6k, n7k, n8k, n9k (I2 and I3)
