### PR TITLE
netdev tacacs_server_host fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -63,6 +63,12 @@ private_vlan:
   get_value: '/^feature private-vlan$/'
   set_value: "feature private-vlan"
 
+tacacs:
+  kind: boolean
+  get_command: "show running | i ^feature"
+  get_value: '/^feature tacacs\+$/'
+  set_value: "feature tacacs"
+
 vn_segment_vlan_based:
   # MT-lite only
   N3k: &vn_segment_vlan_based_mt_lite

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -59,13 +59,11 @@ pim:
 private_vlan:
   _exclude: [N8k]
   kind: boolean
-  get_command: "show running | i ^feature"
   get_value: '/^feature private-vlan$/'
   set_value: "feature private-vlan"
 
 tacacs:
   kind: boolean
-  get_command: "show running | i ^feature"
   get_value: '/^feature tacacs\+$/'
   set_value: "feature tacacs"
 

--- a/lib/cisco_node_utils/cmd_ref/tacacs_server_host.yaml
+++ b/lib/cisco_node_utils/cmd_ref/tacacs_server_host.yaml
@@ -8,7 +8,7 @@ _template:
 
 encryption:
   nexus:
-    set_value: "<state> tacacs-server host <ip> key <enc_type> <key>"
+    set_value: "<state> tacacs-server host <ip> key <enc_type> <password>"
   ios_xr:
     context: ["tacacs-server host <ip> port <port>"]
     set_value: '<state> key <enc_type> <password>'
@@ -47,7 +47,7 @@ hosts:
 
 port:
   default_value: 49
-  multiple: true
+  kind: int
   get_value: '/^tacacs-server host <ip>.* port (\d+).*$/'
   nexus:
     set_value: "tacacs-server host <ip> port <port>"

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -170,7 +170,7 @@ module Cisco
 
     # ---------------------------
     def self.tacacs_enable
-      return if tacacs_enabled?
+      return if tacacs_enabled? || platform == :ios_xr
       config_set('feature', 'tacacs')
     end
 

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -169,6 +169,16 @@ module Cisco
     end
 
     # ---------------------------
+    def self.tacacs_enable
+      return if tacacs_enabled?
+      config_set('feature', 'tacacs')
+    end
+
+    def self.tacacs_enabled?
+      config_get('feature', 'tacacs')
+    end
+
+    # ---------------------------
     def self.vn_segment_vlan_based_enable
       return if vn_segment_vlan_based_enabled?
       result = config_set('feature', 'vn_segment_vlan_based')

--- a/lib/cisco_node_utils/tacacs_server_host.rb
+++ b/lib/cisco_node_utils/tacacs_server_host.rb
@@ -71,7 +71,7 @@ module Cisco
 
     def create
       destroy if platform == :ios_xr
-      Feature.tacacs_enable unless platform == :ios_xr
+      Feature.tacacs_enable
       config_set('tacacs_server_host',
                  'host',
                  state: '',

--- a/lib/cisco_node_utils/tacacs_server_host.rb
+++ b/lib/cisco_node_utils/tacacs_server_host.rb
@@ -50,6 +50,7 @@ module Cisco
 
     def self.hosts
       hosts = {}
+      return hosts unless Feature.tacacs_enabled?
 
       hosts_list = config_get('tacacs_server_host', 'hosts')
       return hosts if hosts_list.nil? || hosts_list.empty?

--- a/lib/cisco_node_utils/tacacs_server_host.rb
+++ b/lib/cisco_node_utils/tacacs_server_host.rb
@@ -70,6 +70,7 @@ module Cisco
 
     def create
       destroy if platform == :ios_xr
+      Feature.tacacs_enable unless platform == :ios_xr
       config_set('tacacs_server_host',
                  'host',
                  state: '',

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -141,6 +141,10 @@ class TestFeature < CiscoTestCase
     feature('private_vlan')
   end
 
+  def test_tacacs
+    feature('tacacs')
+  end
+
   def test_vn_segment_vlan_based
     if node.product_id[/N(5|6|7)/]
       assert_nil(Feature.vn_segment_vlan_based_enabled?)


### PR DESCRIPTION
**Summary of changes:**
- Added tacacs to `feature.rb`
- Fixed bug in `tacacs_server_host.yaml` which referenced the wrong key.
- `port` attribute incorrectly returned an array of ports instead of a single port.

Tests Pass On: n3k, n5k, n6k, n7k, n8k, n9k(I2 and I3)
