### PR TITLE
portchannel_global support for N3k natively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Changelog
   * `port_channel_limit` (only on Nexus 7k)
 * Extend vlan with attributes:
   * `private_vlan_association`, `private_vlan_type`
+* Added N3k native support for portchannel_global
 
 ### Changed
 

--- a/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
@@ -10,25 +10,26 @@ asymmetric:
   default_value: false
 
 bundle_hash:
-  N3k: &bundle_hash_ip_l4port
-    default_value: 'ip-l4port'
-  N5k: &bundle_hash_ip
+  N3k: &bundle_hash_ip
     default_value: 'ip'
+  N5k: *bundle_hash_ip
   N6k: *bundle_hash_ip
   N7k: *bundle_hash_ip
-  N8k: *bundle_hash_ip_l4port
+  N8k: &bundle_hash_ip_l4port
+    default_value: 'ip-l4port'
   N9k: *bundle_hash_ip_l4port
 
 bundle_select:
   default_value: 'src-dst'
 
 concatenation:
-  _exclude: [N5k, N6k, N7k, N8k]
+  _exclude: [N3k, N5k, N6k, N7k, N8k]
   default_value: false
 
 hash_distribution:
   _exclude: [N3k, N5k, N6k, N8k, N9k]
   get_value: '/^port.channel hash.distribution (.*)$/'
+  set_context:  ['terminal dont-ask']
   set_value: "port-channel hash-distribution %s"
   default_value: 'adaptive'
 
@@ -38,8 +39,8 @@ hash_poly:
 
 load_balance_type:
   kind: string
-  N3k: &load_balance_type_symmetry
-    default_only: "symmetry"
+  N3k: &load_balance_type_symmetric
+    default_only: "no_rotate"
   N5k: &load_balance_type_ethernet
     default_only: "ethernet"
   N6k: *load_balance_type_ethernet
@@ -47,7 +48,8 @@ load_balance_type:
     default_only: "asymmetric"
   N8k: &load_balance_type_no_hash
     default_only: "no_hash"
-  N9k: *load_balance_type_symmetry
+  N9k: &load_balance_type_symmetry
+    default_only: "symmetry"
 
 load_defer:
   _exclude: [N3k, N5k, N6k, N8k, N9k]
@@ -66,10 +68,14 @@ resilient:
   kind: boolean
   get_value: '/^port-channel load-balance resilient$/'
   set_value: "%s port-channel load-balance resilient"
-  default_value: false
+  N3k:
+    auto_default: false
+    default_value: true
+  N9k:
+    default_value: false
 
 rotate:
-  _exclude: [N5k, N6k]
+  _exclude: [N3k, N5k, N6k]
   kind: int
   default_value: 0
 

--- a/tests/test_itd_service.rb
+++ b/tests/test_itd_service.rb
@@ -91,6 +91,8 @@ class TestItdService < CiscoTestCase
     config 'interface port-channel 100 ; no switchport'
     itd = ItdService.new('new_group')
     intf = interfaces[0].dup
+    new_intf = Interface.new(interfaces[0])
+    new_intf.switchport_mode = :disabled
     ii = [['vlan 2', '1.1.1.1'],
           [intf.insert(8, ' '), '2.2.2.2'],
           ['port-channel 100', '3.3.3.3']]
@@ -204,6 +206,8 @@ class TestItdService < CiscoTestCase
     itd.device_group = 'abc'
     itd.virtual_ip = ['ip 2.2.2.2 255.255.255.0']
     intf = interfaces[0].dup
+    new_intf = Interface.new(interfaces[0])
+    new_intf.switchport_mode = :disabled
     ii = [[intf.insert(8, ' '), '2.2.2.2']]
     itd.ingress_interface = ii
     itd.nat_destination = true
@@ -219,6 +223,8 @@ class TestItdService < CiscoTestCase
     itd.device_group = 'abc'
     itd.virtual_ip = ['ip 2.2.2.2 255.255.255.0']
     intf = Interface.new(interfaces[0])
+    new_intf = Interface.new(interfaces[0])
+    new_intf.switchport_mode = :disabled
     intf.switchport_mode = :disabled
     intf_dup = interfaces[0].dup
     ii = [[intf_dup.insert(8, ' '), '2.2.2.2']]

--- a/tests/test_portchannel_global.rb
+++ b/tests/test_portchannel_global.rb
@@ -98,14 +98,52 @@ class TestPortchannelGlobal < CiscoTestCase
     cmd = 'port-channel load-balance resilient'
     skip('Skip test: Feature is not supported on this device') if
       config(cmd)[/Resilient Hashing Mode unsupported/]
-    config('no ' + cmd)
+    global = create_portchannel_global
+    # For n3k the default is different from n9k
+    if n3k_in_n3k_mode?
+      global.resilient = false
+      assert_equal(false, global.resilient)
+      global.resilient = global.default_resilient
+      assert_equal(global.default_resilient, global.resilient)
+    else
+      config('no ' + cmd)
+      global = create_portchannel_global
+      global.resilient = true
+      assert_equal(true, global.resilient)
+      global.resilient = global.default_resilient
+      assert_equal(global.default_resilient, global.resilient)
+    end
+  end
+
+  def test_load_balance_no_rotate
+    skip('Test not supported on this platform') unless n3k_in_n3k_mode?
 
     global = create_portchannel_global
-    global.resilient = true
-    assert_equal(true, global.resilient)
-
-    global.resilient = global.default_resilient
-    assert_equal(global.default_resilient, global.resilient)
+    global.send(:port_channel_load_balance=,
+                'src-dst', 'ip-only', nil, nil, true, nil, nil)
+    assert_equal('src-dst',
+                 global.bundle_select)
+    assert_equal('ip-only',
+                 global.bundle_hash)
+    assert_equal(true, global.symmetry)
+    global.send(
+      :port_channel_load_balance=,
+      global.default_bundle_select,
+      global.default_bundle_hash,
+      nil,
+      nil,
+      global.default_symmetry,
+      nil,
+      nil)
+    assert_equal(
+      global.default_bundle_select,
+      global.bundle_select)
+    assert_equal(
+      global.default_bundle_hash,
+      global.bundle_hash)
+    assert_equal(
+      global.default_symmetry,
+      global.symmetry)
   end
 
   def test_load_balance_sym_concat_rot

--- a/tests/test_portchannel_global.rb
+++ b/tests/test_portchannel_global.rb
@@ -102,14 +102,14 @@ class TestPortchannelGlobal < CiscoTestCase
     # For n3k the default is different from n9k
     if n3k_in_n3k_mode?
       global.resilient = false
-      assert_equal(false, global.resilient)
+      refute(global.resilient)
       global.resilient = global.default_resilient
       assert_equal(global.default_resilient, global.resilient)
     else
       config('no ' + cmd)
       global = create_portchannel_global
       global.resilient = true
-      assert_equal(true, global.resilient)
+      assert(global.resilient)
       global.resilient = global.default_resilient
       assert_equal(global.default_resilient, global.resilient)
     end


### PR DESCRIPTION
This PR is for supporting portchannel_global on n3k natively and fixing a minitest issue for itd_service.
# portchannel_global:

The CLIs are different from n9k in this case and they are quite similar with n6k with bundle-select similar to n9k.
For ex:
on n3k the CLIs look like:
port-channel load-balance ethernet source-dest-ip-gre
and there is no "rotate or concatenation" for n3k. 

The resilient mode is true by default on n3k unlike n9k where it is false by default.

on n7k:
hash_distribution needs "terminal dont ask" which was missing in 1.3.0 code. Added it back.

All the mini tests have passed on all platforms. The minitests on n3k running in n9k mode have failed because of infra issues and these will be addressed in 1.4.0 or later.
# itd_service:

The ingress ethernet interfaces for itd_service  must be layer-3 and so we need to turn off switchport mode for these.
