### PR TITLE
ciscotest.rb: Add skip_nexus_i2_image helper

### DIFF
--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -143,6 +143,11 @@ class CiscoTestCase < TestCase
     !node.cmd_ref.supports?(feature, property)
   end
 
+  def skip_nexus_i2_image?
+    skip("This property is not supported on Nexus 'I2' images") if
+      Utils.nexus_i2_image
+  end
+
   def interfaces
     unless @@interfaces
       # Build the platform_info, used for interface lookup

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -1064,6 +1064,7 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_route_distinguisher
+    skip_nexus_i2_image?
     remove_all_vrfs
 
     bgp = setup_vrf

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -193,6 +193,7 @@ class TestVrf < CiscoTestCase
   end
 
   def test_route_distinguisher
+    skip_nexus_i2_image?
     v = Vrf.new('green')
     if validate_property_excluded?('vrf', 'route_distinguisher')
       # Must be configured under BGP in IOS XR


### PR DESCRIPTION
- Tested on n3-i2 and n3-i3 (no skip of course)
  
  1) Skipped:
  TestVrf#test_route_distinguisher [/nobackup/cvanheuv/git.nu.cvh.merge/cisco-network-node-utils/tests/ciscotest.rb:147]:
  This property is not supported on Nexus 'I2' images
