### PR TITLE
Fix N3k minitest and fir prepare array api to incorporate comma separ…

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -421,28 +421,29 @@ switchport_mode_private_vlan_host_promiscous:
 
 
 switchport_mode_private_vlan_trunk_promiscuous:
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N3k, N8k]
   kind: boolean
   get_value: '/^switchport mode private-vlan trunk promiscuous$/'
   set_value: "<state> switchport mode private-vlan trunk promiscuous"
   default_value: false
 
 switchport_mode_private_vlan_trunk_secondary:
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N3k, N8k]
   kind: boolean
   get_value: '/^switchport mode private-vlan trunk secondary$/'
   set_value: "<state> switchport mode private-vlan trunk secondary"
   default_value: false
 
 switchport_private_vlan_association_trunk:
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N3k, N8k]
   multiple: true
+  #get_value: '/^switchport private-vlan association trunk (.*) (.*)$/'
   get_value: '/^switchport private-vlan association trunk (.*)$/'
   set_value: "<state> switchport private-vlan association trunk <vlan_pr> <vlan>"
   default_value: []
 
 switchport_private_vlan_mapping_trunk:
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N3k, N8k]
   multiple: true
   get_value: '/^switchport private-vlan mapping trunk (.*)$/'
   set_value: "<state> switchport private-vlan mapping trunk <vlan_pr> <vlans>"

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -1018,6 +1018,15 @@ module Cisco
                          'switchport_mode_private_vlan_host_association')
     end
 
+    # This api is used by private vlan to prepare the input to the setter
+    # method. The input can be in the following formats for vlans:
+    # 10-12,14. Prepare_array api is transforming this input into a flat array.
+    # In the example above the returned array will be 10, 11, 12, 13. Prepare
+    # array is first splitting the input on ',' and the than expanding the vlan
+    # range element like 10-12 into a flat array. The final result will
+    # be a  flat array.
+    # This way we can later used the lib utility to check the delta from
+    # the input vlan value and the vlan configured to apply the right config.
     def prepare_array(is_list)
       new_list = []
       is_list.each do |item|
@@ -1084,7 +1093,6 @@ module Cisco
         is_list.each do |vlans|
           vlans = vlans.split(' ')
           if vlans[0].eql? should_list_new[0]
-            # if vlans[0].eql? pr_vlan
             config_set('interface',
                        'switchport_private_vlan_association_trunk',
                        name: @name, state: 'no',
@@ -1096,7 +1104,6 @@ module Cisco
         end
         result = config_set('interface', PVLAN_PROPERTY[property], name: @name,
                             state: '', vlan_pr: should_list_new[0],
-                            # state: '', vlan_pr: pr_vlan,
                             vlan: should_list_new[1])
       when :mapping_trunk
         @match_found = false

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -1019,9 +1019,19 @@ module Cisco
     end
 
     def prepare_array(is_list)
-      is_list.each { |item| item.gsub!('-', '..') }
+      new_list = []
+      is_list.each do |item|
+        if item.include?(',')
+          new_list.push(item.split(','))
+        else
+          new_list.push(item)
+        end
+      end
+      new_list.flatten!
+      new_list.sort!
+      new_list.each { |item| item.gsub!('-', '..') }
       is_list_new = []
-      is_list.each do |elem|
+      new_list.each do |elem|
         if elem.include?('..')
           elema = elem.split('..').map { |d| Integer(d) }
           elema.sort!
@@ -1074,6 +1084,7 @@ module Cisco
         is_list.each do |vlans|
           vlans = vlans.split(' ')
           if vlans[0].eql? should_list_new[0]
+            # if vlans[0].eql? pr_vlan
             config_set('interface',
                        'switchport_private_vlan_association_trunk',
                        name: @name, state: 'no',
@@ -1085,6 +1096,7 @@ module Cisco
         end
         result = config_set('interface', PVLAN_PROPERTY[property], name: @name,
                             state: '', vlan_pr: should_list_new[0],
+                            # state: '', vlan_pr: pr_vlan,
                             vlan: should_list_new[1])
       when :mapping_trunk
         @match_found = false
@@ -1347,8 +1359,7 @@ module Cisco
                          name: @name)
       return [] if match.nil? || match.empty?
       match[0].delete!(' ')
-      result = match[0].split(',')
-      result
+      match
     end
 
     def private_vlan_mapping=(vlans)

--- a/tests/test_interface_private_vlan.rb
+++ b/tests/test_interface_private_vlan.rb
@@ -38,8 +38,8 @@ class TestInterfaceSwitchport < CiscoTestCase
 
   def cleanup
     remove_svis
-    remove_all_vlans
     cleanup_pvlan_intfs
+    remove_all_vlans
     config('no feature private-vlan', 'no feature vtp')
   end
 
@@ -85,7 +85,7 @@ class TestSwitchport < TestInterfaceSwitchport
       'switchport_mode_private_vlan_trunk_secondary')
       assert_nil(interface.switchport_mode_private_vlan_trunk_secondary)
       assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_trunk_secondary = ''
+        interface.switchport_mode_private_vlan_trunk_secondary = true
       end
       return
     end
@@ -176,8 +176,6 @@ class TestSwitchport < TestInterfaceSwitchport
     assert_equal(input,
                  interface.switchport_mode_private_vlan_host_association,
                  'Err: switchport private host_association not configured')
-    v1.destroy
-    v2.destroy
   end
 
   def test_interface_switchport_pvlan_host_assoc_change
@@ -205,23 +203,19 @@ class TestSwitchport < TestInterfaceSwitchport
     assert_equal(input,
                  interface.switchport_mode_private_vlan_host_association,
                  'Err: switchport private host_association not configured')
-    v1.destroy
-    v2.destroy
 
-    v1 = Vlan.new(20)
-    v1.private_vlan_type = 'primary'
+    v3 = Vlan.new(20)
+    v3.private_vlan_type = 'primary'
 
-    v2 = Vlan.new(21)
-    v2.private_vlan_type = 'community'
-    v1.private_vlan_association = ['21']
+    v4 = Vlan.new(21)
+    v4.private_vlan_type = 'community'
+    v3.private_vlan_association = ['21']
 
     input = %w(20 21)
     interface.switchport_mode_private_vlan_host_association = input
     assert_equal(input,
                  interface.switchport_mode_private_vlan_host_association,
                  'Err: switchport private host_association not configured')
-    v1.destroy
-    v2.destroy
 
     input = []
     interface.switchport_mode_private_vlan_host_association = input
@@ -253,9 +247,6 @@ class TestSwitchport < TestInterfaceSwitchport
     assert_equal(input,
                  interface.switchport_mode_private_vlan_host_association,
                  'Err: switchport private host_association not configured')
-    v1.destroy
-    v2.destroy
-
     input = []
     interface.switchport_mode_private_vlan_host_association = input
     assert_equal(input,
@@ -348,10 +339,9 @@ class TestSwitchport < TestInterfaceSwitchport
     assert_equal(input,
                  interface.switchport_mode_private_vlan_host_promisc,
                  'Error: switchport private host promisc not configured')
-    v2.destroy
 
-    v2 = Vlan.new(12)
-    v2.private_vlan_type = 'community'
+    v3 = Vlan.new(12)
+    v3.private_vlan_type = 'community'
 
     v1.private_vlan_association = ['12']
     input = %w(10 12)
@@ -359,19 +349,18 @@ class TestSwitchport < TestInterfaceSwitchport
     assert_equal(input,
                  interface.switchport_mode_private_vlan_host_promisc,
                  'Error: switchport private host promisc not configured')
-    v2.destroy
 
-    v2 = Vlan.new(12)
-    v2.private_vlan_type = 'community'
-
-    v3 = Vlan.new(13)
-    v3.private_vlan_type = 'community'
-
-    v4 = Vlan.new(18)
+    v4 = Vlan.new(12)
     v4.private_vlan_type = 'community'
 
-    v5 = Vlan.new(30)
+    v5 = Vlan.new(13)
     v5.private_vlan_type = 'community'
+
+    v6 = Vlan.new(18)
+    v6.private_vlan_type = 'community'
+
+    v7 = Vlan.new(30)
+    v7.private_vlan_type = 'community'
 
     v1.private_vlan_association = ['12-13', '18', '30']
     input = %w(10 12-13,18,30)
@@ -379,11 +368,6 @@ class TestSwitchport < TestInterfaceSwitchport
     assert_equal(input,
                  interface.switchport_mode_private_vlan_host_promisc,
                  'Error: switchport private host promisc not configured')
-    v1.destroy
-    v2.destroy
-    v3.destroy
-    v4.destroy
-    v5.destroy
   end
 
   def test_interface_switchport_private_host_promisc_bad_arg
@@ -457,8 +441,6 @@ class TestSwitchport < TestInterfaceSwitchport
     interface.switchport_mode_private_vlan_host_promisc = input
     assert_equal(input, interface.switchport_mode_private_vlan_host_promisc,
                  'Error: switchport private host promisc not configured')
-    v1.destroy
-    v2.destroy
     input = []
     interface.switchport_mode_private_vlan_host_promisc = input
     assert_equal(input, interface.switchport_mode_private_vlan_host_promisc,
@@ -594,10 +576,10 @@ class TestSwitchport < TestInterfaceSwitchport
 
   def test_interface_switchport_pvlan_association_trunk
     if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+                                   'switchport_private_vlan_association_trunk')
+      assert_nil(interface.switchport_private_vlan_association_trunk)
       assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
+        interface.switchport_private_vlan_association_trunk = %w(10 12)
       end
       return
     end
@@ -629,10 +611,10 @@ class TestSwitchport < TestInterfaceSwitchport
 
   def test_interface_switchport_pvlan_trunk_assoc_vlan_bad_arg
     if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+                                   'switchport_private_vlan_association_trunk')
+      assert_nil(interface.switchport_private_vlan_association_trunk)
       assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
+        interface.switchport_private_vlan_association_trunk = %w(10 10)
       end
       return
     end
@@ -660,10 +642,10 @@ class TestSwitchport < TestInterfaceSwitchport
 
   def test_interface_switchport_pvlan_trunk_assocciation_default
     if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+                                   'switchport_private_vlan_association_trunk')
+      assert_nil(interface.switchport_private_vlan_association_trunk)
       assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
+        interface.switchport_private_vlan_association_trunk = %w(10 10)
       end
       return
     end
@@ -672,10 +654,10 @@ class TestSwitchport < TestInterfaceSwitchport
 
   def test_interface_switchport_pvlan_mapping_trunk_default
     if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+                                   'switchport_private_vlan_mapping_trunk')
+      assert_nil(interface.switchport_private_vlan_mapping_trunk)
       assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
+        interface.switchport_private_vlan_mapping_trunk = %w(10)
       end
       return
     end
@@ -684,10 +666,10 @@ class TestSwitchport < TestInterfaceSwitchport
 
   def test_interface_switchport_pvlan_mapping_trunk
     if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+                                   'switchport_private_vlan_mapping_trunk')
+      assert_nil(interface.switchport_private_vlan_mapping_trunk)
       assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
+        interface.switchport_private_vlan_mapping_trunk = %w(10 10)
       end
       return
     end
@@ -719,10 +701,10 @@ class TestSwitchport < TestInterfaceSwitchport
 
   def test_interface_switchport_pvlan_mapping_trunk_bad_arg
     if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+                                   'switchport_private_vlan_mapping_trunk')
+      assert_nil(interface.switchport_private_vlan_mapping_trunk)
       assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
+        interface.switchport_private_vlan_mapping_trunk = %w(10 10)
       end
       return
     end

--- a/tests/test_interface_svi.rb
+++ b/tests/test_interface_svi.rb
@@ -71,7 +71,7 @@ class TestSvi < CiscoTestCase
                                    'private_vlan_mapping')
       assert_nil(svi.private_vlan_mapping)
       assert_raises(Cisco::UnsupportedError) do
-        svi.private_vlan_mapping = 10
+        svi.private_vlan_mapping = %w(11-13)
       end
       return
     end
@@ -102,7 +102,7 @@ class TestSvi < CiscoTestCase
                                    'private_vlan_mapping')
       assert_nil(svi.private_vlan_mapping)
       assert_raises(Cisco::UnsupportedError) do
-        svi.private_vlan_mapping = 10
+        svi.private_vlan_mapping = %w(10 20)
       end
       return
     end


### PR DESCRIPTION
Fix N3k minitest, excluding pvlan trunk properties in the yaml file since they are not supported.
In test_interface_private_vlan.rb make sure to default the interfaces before removing the vlans since N3k does not allowed this.
In interface.rb fix the prepare_array utility, since the comma separated vlan were not included.

Run test against N3k(l2), N9k, N6k, N5k and N7k
