### PR TITLE
test_interface: negotiate_auto platform fixes

### DIFF
--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -707,70 +707,57 @@ class TestInterface < CiscoTestCase
   #     prefixes = nil
   #   end
 
-  def negotiate_auto_helper(interface, default)
-    inf_name = interface.name
-
-    negotiate_auto_intf = interface.negotiate_auto_lookup_string
-    if validate_property_excluded?('interface', negotiate_auto_intf)
-      assert_raises(Cisco::UnsupportedError) do
-        interface.negotiate_auto = true
-      end
+  def negotiate_auto_helper(interface, default, speed)
+    if validate_property_excluded?('interface',
+                                   interface.negotiate_auto_lookup_string)
+      assert_raises(Cisco::UnsupportedError) { interface.negotiate_auto = true }
       return
     end
-
-    # Test default
+    # Check current default state before any other changes
+    inf_name = interface.name
     assert_equal(default, interface.default_negotiate_auto,
                  "Error: #{inf_name} negotiate auto default value mismatch")
 
-    interface.negotiate_auto = default
-    assert_equal(default, interface.negotiate_auto,
-                 "Error: #{inf_name} negotiate auto value " \
-                 'should be same as default')
-
-    interface.negotiate_auto = default
-    assert_equal(default, interface.negotiate_auto,
-                 "Error: #{inf_name} negotiate auto value not #{default}")
-
-    if default
-      pattern = /^\s+negotiate auto/
+    # Test non-defaults: Note that 'speed' and 'negotiate' are tightly coupled
+    # on some platforms. Some platforms need the speed command to be toggled
+    # before negotiate will work without raising an error; while others just
+    # need a non-'auto' speed value or may not support 'auto' at all; therefore
+    # just set a static speed value before setting any negotiate settings.
+    if default == true
+      negotiate_false(interface, speed)
+      negotiate_true(interface, speed)
     else
-      pattern = /^\s+no negotiate auto/
+      negotiate_true(interface, speed)
+      negotiate_false(interface, speed)
     end
-    assert_show_match(pattern: pattern)
+  end
 
-    non_default = !default
+  def negotiate_true(interface, speed)
+    # puts " true: 'speed #{speed}', 'negotiate auto'"
+    intf = interface.name
+    interface.speed = speed
+    interface.negotiate_auto = true
+    assert(interface.negotiate_auto,
+           "#{intf} negotiate auto value should be true")
+    assert_show_match(pattern: /^\s+negotiate auto/)
+  rescue Cisco::CliError => e
+    # 10G+ interfaces do not support negotiation
+    interface_supports_property?(intf, e.message)
+  end
 
-    # Some 'supported' platforms let us set the negotiate value to its
-    # default but not actually change it.
-    begin
-      interface.negotiate_auto = non_default
-    rescue RuntimeError
-      assert_equal(default, interface.negotiate_auto,
-                   "Error: #{inf_name} negotiate auto value not #{default}")
-      return
-    end
-
-    assert_equal(non_default, interface.negotiate_auto,
-                 "Error: #{inf_name} negotiate auto value not #{non_default}")
-
-    if non_default
-      pattern = /^\s+negotiate auto/
-    else
-      pattern = /^\s+no negotiate auto/
-    end
-    assert_show_match(pattern: pattern)
-
-    # Clean up after ourselves
-    interface.negotiate_auto = default
-    assert_equal(default, interface.negotiate_auto,
-                 "Error: #{inf_name} negotiate auto value not #{default}")
-
-    if default
-      pattern = /^\s+negotiate auto/
-    else
-      pattern = /^\s+no negotiate auto/
-    end
-    assert_show_match(pattern: pattern)
+  # Yes, this method is nearly identical to negotiate_true.
+  # The negotiate property is evil to troubleshoot. Keep them separate.
+  def negotiate_false(interface, speed)
+    # puts "false: 'speed #{speed}', 'no negotiate auto'"
+    intf = interface.name
+    interface.speed = speed
+    interface.negotiate_auto = false
+    refute(interface.negotiate_auto,
+           "#{intf} negotiate auto value should be false")
+    assert_show_match(pattern: /^\s+no negotiate auto/)
+  rescue Cisco::CliError => e
+    # 10G+ interfaces do not support negotiation
+    interface_supports_property?(intf, e.message)
   end
 
   def test_negotiate_auto_portchannel
@@ -784,7 +771,10 @@ class TestInterface < CiscoTestCase
       raise
     end
 
+    # Clean up any stale config first
     inf_name = "#{@port_channel}10"
+    Interface.new(inf_name).destroy
+
     interface = Interface.new(inf_name)
     if validate_property_excluded?('interface', 'negotiate_auto_portchannel')
       assert_nil(interface.negotiate_auto)
@@ -796,13 +786,17 @@ class TestInterface < CiscoTestCase
       default = interface.default_negotiate_auto
       @default_show_command = show_cmd(inf_name)
 
+      # Port-channels will raise an error on some platforms unless they
+      # have a static speed value set first.
+      speed = '100'
+
       # Test with switchport
       interface.switchport_mode = :access
-      negotiate_auto_helper(interface, default)
+      negotiate_auto_helper(interface, default, speed)
 
       # Test with no switchport
       interface.switchport_mode = :disabled
-      negotiate_auto_helper(interface, default)
+      negotiate_auto_helper(interface, default, speed)
     end
 
     # Cleanup
@@ -822,25 +816,20 @@ class TestInterface < CiscoTestCase
       return
     end
 
-    # Some platforms/interfaces/versions do not support negotiation changes
-    begin
-      interface.negotiate_auto = false
-    rescue Cisco::CliError => e
-      skip('Skip test: Interface type does not allow config change') if
-        e.message[/requested config change not allowed/]
-      flunk(e.message)
-    end
+    # Find a static speed. Some platforms will raise an error unless
+    # speed is configured before setting negotiate auto.
+    speed = valid_speed_set(interface)
 
     default = interface.default_negotiate_auto
     @default_show_command = show_cmd(inf_name)
 
     # Test with switchport
     interface.switchport_mode = :access
-    negotiate_auto_helper(interface, default)
+    negotiate_auto_helper(interface, default, speed)
 
     # Test with no switchport
     interface.switchport_mode = :disabled
-    negotiate_auto_helper(interface, default)
+    negotiate_auto_helper(interface, default, speed)
   end
 
   def test_negotiate_auto_loopback


### PR DESCRIPTION
- This was mostly solved by simply setting a speed value before trying to change the negotiate auto settings.
- Note that negotiate is not supported on 10G and larger interfaces
- Tested on n3-i2,n3-i3,n5,n6,n7(skips),n8,n9
