### PR TITLE
mt_full_interface method fix

### DIFF
--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -241,7 +241,7 @@ class CiscoTestCase < TestCase
     # we will provide an appropriate interface name if the linecard is present.
     # Example 'show mod' output to match against:
     #   '9  12  10/40 Gbps Ethernet Module  N7K-F312FQ-25 ok'
-    sh_mod = @device.cmd("sh mod | i '^[0-9]+.*N7K-F3'")[/^(\d+)\s.*N7K-F3/]
+    sh_mod = @device.cmd("sh mod | i '^[0-9]+.*N7K-F3'")[/^(\d+)\s.*N7K-F3.*ok/]
     slot = sh_mod.nil? ? nil : Regexp.last_match[1]
     skip('Unable to find compatible interface in chassis') if slot.nil?
 


### PR DESCRIPTION
mt_full_interface? is used currently is to get F3 cards and then just get the slot of the first one.
This works if the first F3 card is in “ok” state. If it is in “powered-dn” state or some state other than “ok”, then it will still go ahead and pick that slot and try to get the interface anyway. This will result in failure as the intf will not work. The fix is to get the F3 card which is in "ok" state.
