### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ Changelog
   * `switchport_mode_private_vlan_host_promiscous`, `switchport_mode_private_vlan_trunk_promiscous`, `switchport_mode_private_vlan_trunk_secondary`
   * `switchport_private_vlan_association_trunk`, `switchport_private_vlan_mapping_trunk`
   * `private_vlan_mapping`
+* Extend Feature class with a class method to list feature compatible interfaces
+* Extend vdc with interface_membership methods
 * Extend vpc with vpc+ attributes on Nexus 5k/6k/7k:
   * `fabricpath_emulated_switch_id`
   * `fabricpath_multicast_load_balance` (only on Nexus 7k)

--- a/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
+++ b/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
@@ -144,6 +144,10 @@ mode:
   set_value: "<state> fabricpath mode transit"
   default_value: "normal"
 
+supported_module_pids:
+  _exclude: [N5k, N6k]
+  default_only: 'N7K-(?:F2.*25E|F3|F4|M3)'
+
 supported_modules:
   _exclude: [N5k, N6k]
   default_only: "f2e f3"

--- a/lib/cisco_node_utils/cmd_ref/vdc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vdc.yaml
@@ -30,6 +30,14 @@ limit_resource_module_type:
   set_value: '<state> limit-resource module-type <mods>'
   default_value: ''
 
+membership:
+  multiple:
+  get_command: 'show vdc membership'
+  get_context: ['/^vdc_id: \d+ vdc_name: <vdc> interfaces:$/']
+  get_value: '/(Ethernet\d+\/\d+)/'
+  set_value: 'allocate interface <intf>'
+  default_value: []
+
 vdc_support:
   # This is a only used for determining support for VDCs
   kind: boolean

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -237,16 +237,17 @@ module Cisco
         result.is_a?(String) &&
         /Hardware is not capable of supporting/.match(result)
     end
+
     # ---------------------------
     def self.compatible_interfaces(feature)
       # Figure out the interfaces in a modular switch that are
-      # compatible with the given feature and return an array of 
+      # compatible with the given feature and return an array of
       # such interfaces
       module_regex = Regexp.new config_get(feature, 'supported_module_pids')
       return [] if module_regex.nil?
       # first get the compatible modules present in the switch
-      slots = Platform.slots.select do |slot, filt_mod| 
-        filt_mod['pid']  =~ module_regex
+      slots = Platform.slots.select do |_slot, filt_mod|
+        filt_mod['pid'] =~ module_regex
       end
       return [] if slots.empty?
       # get the slot numbers only into filtered slots array
@@ -254,7 +255,7 @@ module Cisco
       # now filter interfaces in the vdc based on compatible slots
       vdc = Vdc.new(Vdc.default_vdc_name)
       filt_intfs = vdc.interface_membership.select do |intf|
-          filt_slots.include? intf[/\d+/]
+        filt_slots.include? intf[/\d+/]
       end
       filt_intfs
     end

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -243,8 +243,9 @@ module Cisco
       # Figure out the interfaces in a modular switch that are
       # compatible with the given feature and return an array of
       # such interfaces
-      module_regex = Regexp.new config_get(feature, 'supported_module_pids')
-      return [] if module_regex.nil?
+      module_pids = config_get(feature, 'supported_module_pids')
+      return [] if module_pids.nil?
+      module_regex = Regexp.new module_pids
       # first get the compatible modules present in the switch
       slots = Platform.slots.select do |_slot, filt_mod|
         filt_mod['pid'] =~ module_regex

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -237,5 +237,26 @@ module Cisco
         result.is_a?(String) &&
         /Hardware is not capable of supporting/.match(result)
     end
+    # ---------------------------
+    def self.compatible_interfaces(feature)
+      # Figure out the interfaces in a modular switch that are
+      # compatible with the given feature and return an array of 
+      # such interfaces
+      module_regex = Regexp.new config_get(feature, 'supported_module_pids')
+      return [] if module_regex.nil?
+      # first get the compatible modules present in the switch
+      slots = Platform.slots.select do |slot, filt_mod| 
+        filt_mod['pid']  =~ module_regex
+      end
+      return [] if slots.empty?
+      # get the slot numbers only into filtered slots array
+      filt_slots = slots.keys.map { |key| key[/\d+/] }
+      # now filter interfaces in the vdc based on compatible slots
+      vdc = Vdc.new(Vdc.default_vdc_name)
+      filt_intfs = vdc.interface_membership.select do |intf|
+          filt_slots.include? intf[/\d+/]
+      end
+      filt_intfs
+    end
   end
 end

--- a/lib/cisco_node_utils/vdc.rb
+++ b/lib/cisco_node_utils/vdc.rb
@@ -96,6 +96,5 @@ module Cisco
     def default_interface_membership
       config_get_default('vdc', 'membership')
     end
-
   end  # Class
 end    # Module

--- a/lib/cisco_node_utils/vdc.rb
+++ b/lib/cisco_node_utils/vdc.rb
@@ -84,5 +84,18 @@ module Cisco
     def default_limit_resource_module_type
       config_get_default('vdc', 'limit_resource_module_type')
     end
+
+    def interface_membership
+      config_get('vdc', 'membership', vdc: @vdc)
+    end
+
+    def interface_membership=(intf)
+      config_set('vdc', 'membership', vdc: @vdc, intf: intf)
+    end
+
+    def default_interface_membership
+      config_get_default('vdc', 'membership')
+    end
+
   end  # Class
 end    # Module

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -232,9 +232,10 @@ class CiscoTestCase < TestCase
     intf_array = Feature.compatible_interfaces('fabricpath')
     vdc = Vdc.new(Vdc.default_vdc_name)
     save_lr = vdc.limit_resource_module_type
-    if intf_array.empty? || save_lr != 'f2e f3'
+    fabricpath_lr = node.config_get('fabricpath', 'supported_modules')
+    if intf_array.empty? || save_lr != fabricpath_lr
       # try getting the required modules into the default vdc
-      vdc.limit_resource_module_type = 'f2e f3'
+      vdc.limit_resource_module_type = fabricpath_lr
       intf_array = Feature.compatible_interfaces('fabricpath')
     end
     if intf_array.empty?

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -225,6 +225,27 @@ class CiscoTestCase < TestCase
     config(*cfg)
   end
 
+  # setup fabricpath env if possibel and populate the interfaces array
+  # otherwise cause a global skip
+  def fabricpath_testenv_setup
+    if node.product_id[/N7K/]
+      intf_array = Feature.compatible_interfaces('fabricpath')
+      vdc = Vdc.new(Vdc.default_vdc_name)
+      save_lr = vdc.limit_resource_module_type
+      if intf_array.empty? || save_lr != 'f2e f3'
+        # try getting the required modules into the default vdc
+        vdc.limit_resource_module_type = 'f2e f3'
+        intf_array = Feature.compatible_interfaces('fabricpath')
+      end
+      if intf_array.empty?
+        vdc.limit_resource_module_type = save_lr
+        skip('FabricPath compatible interfaces not found in this switch')
+      else
+        interfaces = intf_array 
+      end
+    end
+  end
+
   # Returns an array of commands to remove all configurations from
   # an interface.
   def get_interface_cleanup_config(intf_name)

--- a/tests/test_fabricpath_global.rb
+++ b/tests/test_fabricpath_global.rb
@@ -16,6 +16,7 @@ require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/cisco_cmn_utils'
 require_relative '../lib/cisco_node_utils/fabricpath_global'
 require_relative '../lib/cisco_node_utils/interface'
+require_relative '../lib/cisco_node_utils/platform'
 
 include Cisco
 
@@ -26,6 +27,7 @@ class TestFabricpathGlobal < CiscoTestCase
   def setup
     # setup runs at the beginning of each test
     super
+    fabricpath_testenv_setup
     no_feature_fabricpath
   end
 
@@ -36,9 +38,14 @@ class TestFabricpathGlobal < CiscoTestCase
   end
 
   def no_feature_fabricpath
-    # Turn the feature off for a clean test.
-    config('no feature-set fabricpath')
+    fg = FabricpathGlobal.globals
+    fg.each { |_key, elem| elem.destroy } unless fg.empty?
   end
+
+#  def no_feature_fabricpath
+#    # Turn the feature off for a clean test.
+#    config('no feature-set fabricpath')
+#  end
 
   # TESTS
 

--- a/tests/test_fabricpath_global.rb
+++ b/tests/test_fabricpath_global.rb
@@ -42,10 +42,10 @@ class TestFabricpathGlobal < CiscoTestCase
     fg.each { |_key, elem| elem.destroy } unless fg.empty?
   end
 
-#  def no_feature_fabricpath
-#    # Turn the feature off for a clean test.
-#    config('no feature-set fabricpath')
-#  end
+  #  def no_feature_fabricpath
+  #    # Turn the feature off for a clean test.
+  #    config('no feature-set fabricpath')
+  #  end
 
   # TESTS
 

--- a/tests/test_vpc.rb
+++ b/tests/test_vpc.rb
@@ -15,6 +15,7 @@ require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/vpc'
 require_relative '../lib/cisco_node_utils/interface'
 require_relative '../lib/cisco_node_utils/interface_channel_group'
+require_relative '../lib/cisco_node_utils/platform'
 
 include Cisco
 
@@ -472,6 +473,7 @@ class TestVpc < CiscoTestCase
 
   def test_interface_vpc_plus_peer_link
     vpc = Vpc.new(100)
+    fabricpath_testenv_setup
     if validate_property_excluded?('vpc', 'fabricpath_emulated_switch_id')
       assert_raises(Cisco::UnsupportedError) do
         vpc.fabricpath_emulated_switch_id = true


### PR DESCRIPTION
Added 'compatible_interfaces' class method which list the compatible interfaces on a per feature basis for modular systems. This infra will be made available via 'facter' to be accessed by puppet layer.

In each feature where it is required, a property 'supported_module_pids' should be made available in its YAML file which lists the regex for the supported modules.

For example with 'fabricpath' feature on N7K:

supported_module_pids:
  _exclude: [N5k, N6k]
  default_only: 'N7K-(?:F2.*25E|F3|F4|M3)'

specifies the supported modules as F2E, F3, F4 and M3
