### PR TITLE
Treat speed as string

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -266,16 +266,14 @@ shutdown_vlan:
 
 speed:
   _exclude: [ios_xr, C3132]
+  kind: string
   get_value: '/^speed (.*)$/'
   set_value: "speed <speed>"
-  C3064:
-    default_value: 10000
-  C3172:
-    default_value: 10000
-  N5k:
-    default_value: 10000
-  N6k:
-    default_value: 10000
+  C3064: &non_auto
+    default_value: '10000'
+  C3172: *non_auto
+  N5k: *non_auto
+  N6k: *non_auto
   else:
     default_value: 'auto'
 

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -530,9 +530,7 @@ module Cisco
     end
 
     def speed
-      val = config_get('interface', 'speed', name: @name)
-      return val if val.nil?
-      val == 'auto' ? val : val.to_i
+      config_get('interface', 'speed', name: @name)
     end
 
     def speed=(val)

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -596,7 +596,7 @@ class TestInterface < CiscoTestCase
       break if successful_runs >= 2
       begin
         interface.speed = value
-        assert_equal(value.to_i, interface.speed)
+        assert_equal(value, interface.speed)
         successful_runs += 1
       rescue Cisco::CliError => e
         # Many of the 'capable' speeds are actually not valid values


### PR DESCRIPTION
Fix needed to fix puppet idempotence issue:

```
Notice: /Stage[main]/Main/Node[default]/Cisco_interface[ethernet3/10]/speed: speed changed '10000' to '10000'
```
