### PR TITLE
adding n77 modules in the supported_module_pids regex for fabricpath

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
+++ b/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
@@ -146,7 +146,7 @@ mode:
 
 supported_module_pids:
   _exclude: [N5k, N6k]
-  default_only: 'N7K-(?:F2.*25E|F3|F4|M3)'
+  default_only: 'N7[K7]-(?:F2.*2.E|F3|F4|M3)'
 
 supported_modules:
   _exclude: [N5k, N6k]


### PR DESCRIPTION
N77 chassis have a different pattern for the modules like 
N77-(?:F|M).+

Add this pattern into the regex for including n77 modules
