### PR TITLE
ospf: fix for slow-start platforms

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/ospf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf.yaml
@@ -25,6 +25,14 @@ log_adjacency:
   set_value: "<state> log-adjacency-changes <type>"
   default_value: :none
 
+process_initialized:
+  _exclude: [ios_xr, N3k, N7k, N8k, N9k]
+  # ospf process initialization state
+  kind: boolean
+  context: ~
+  get_command: "show ip ospf stat"
+  get_value: '/^No SAP is registered/' # Ospf is not initialized when seen
+
 router:
   multiple: true
   get_command: "show running ospf"

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -191,6 +191,14 @@ class CiscoTestCase < TestCase
     end
   end
 
+  # Remove all router ospfs.
+  def remove_all_ospfs
+    require_relative '../lib/cisco_node_utils/router_ospf'
+    RouterOspf.routers.each do |_, obj|
+      obj.destroy
+    end
+  end
+
   # This testcase will remove all the bds existing in the system
   # specifically in cleanup for minitests
   def remove_all_bridge_domains

--- a/tests/test_router_ospf.rb
+++ b/tests/test_router_ospf.rb
@@ -21,7 +21,7 @@ class TestRouterOspf < CiscoTestCase
 
   def setup
     super
-    config_no_warn('no feature ospf')
+    remove_all_ospfs
   end
 
   def test_create_destroy

--- a/tests/test_router_ospf_vrf.rb
+++ b/tests/test_router_ospf_vrf.rb
@@ -23,17 +23,13 @@ class TestRouterOspfVrf < CiscoTestCase
 
   def setup
     super
-    cleanup if @@pre_clean_needed
+    remove_all_ospfs if @@pre_clean_needed
     @@pre_clean_needed = false # rubocop:disable Style/ClassVars
   end
 
   def teardown
-    cleanup
+    remove_all_ospfs
     super
-  end
-
-  def cleanup
-    RouterOspf.routers.each { |_name, obj| obj.destroy }
   end
 
   def assert_match_vrf_line(routername, vrfname, cmd=nil)


### PR DESCRIPTION
- This is similar to the slow-start bgp issue; fixing it the same way
- Remove 'no feature' calls
- Tested on n6k (problem specific to n5/n6)
