### PR TITLE
fix vpc_id minitest failure by adding phyport vpc compatible modules

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vpc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vpc.yaml
@@ -160,6 +160,10 @@ peer_keepalive_vrf:
   get_value:  '/^peer-keepalive .*vrf (\S+)/'
   default_value: 'management'
 
+phy_port_vpc_module_pids:
+  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  default_only: 'N7[K7]-(?:F2|F3|F4|M3)'
+
 port_channel_limit:
   _exclude: [N3k, N5k, N6k, N8k, N9k]
   auto_default: false

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -239,11 +239,11 @@ module Cisco
     end
 
     # ---------------------------
-    def self.compatible_interfaces(feature)
+    def self.compatible_interfaces(feature, property='supported_module_pids')
       # Figure out the interfaces in a modular switch that are
-      # compatible with the given feature and return an array of
-      # such interfaces
-      module_pids = config_get(feature, 'supported_module_pids')
+      # compatible with the given feature (or property within a feature)
+      # and return an array of such interfaces
+      module_pids = config_get(feature, property)
       return [] if module_pids.nil?
       module_regex = Regexp.new module_pids
       # first get the compatible modules present in the switch

--- a/tests/test_vpc.rb
+++ b/tests/test_vpc.rb
@@ -318,22 +318,26 @@ class TestVpc < CiscoTestCase
     interface.channel_group = false if interface.channel_group
     # Phy port vPC is supported only on N7K
     if /N7/ =~ node.product_id
-      phy_interface = Interface.new(interfaces[0])
-      assert_equal(phy_interface.vpc_id, phy_interface.default_vpc_id,
-                   'default vpc_id should be null')
-      phy_interface.switchport_mode = :trunk
-      phy_interface.vpc_id = 10
-      assert_equal(10, phy_interface.vpc_id, 'vpc_id should be 10')
+      phy_port_iflist =
+        Feature.compatible_interfaces('vpc', 'phy_port_vpc_module_pids')
+      unless phy_port_iflist.empty?
+        phy_interface = Interface.new(phy_port_iflist[0])
+        assert_equal(phy_interface.vpc_id, phy_interface.default_vpc_id,
+                     'default vpc_id should be null')
+        phy_interface.switchport_mode = :trunk
+        phy_interface.vpc_id = 10
+        assert_equal(10, phy_interface.vpc_id, 'vpc_id should be 10')
 
-      # negative - cannot config peer link on this
-      e = assert_raises(CliError) do
-        phy_interface.vpc_peer_link = true
+        # negative - cannot config peer link on this
+        e = assert_raises(CliError) do
+          phy_interface.vpc_peer_link = true
+        end
+        assert_match(/Invalid number/i, e.message)
+
+        # turn off vpc id
+        phy_interface.vpc_id = false
+        refute(phy_interface.vpc_id, 'vpc_id should be unset')
       end
-      assert_match(/Invalid number/i, e.message)
-
-      # turn off vpc id
-      phy_interface.vpc_id = false
-      refute(phy_interface.vpc_id, 'vpc_id should be unset')
     end
     # test port-channel vpc
     interface.channel_group = 10


### PR DESCRIPTION
phyport vpc is a property within vpc which is available only on F2 and newer modules on N7K. Since this is a sub-feature requirement and not a whole vpc feature requirement, we need to have a more granular level filter in the Feature.compatible_interfaces method. So we now provide an optional parameter called 'property' to this method:

def self.compatible_interfaces(feature, property='supported_module_pids')

So if 'property' is not supplied in the call, it will look for the default feature-level 'supported_module_pids' property and apply a feature level filter. Otherwise, the default parameter is overridden with the sub-feature or property specific module_pids.

In the phyport vpc case, the call will be:
Feature.compatible_interfaces('vpc',  'phy_port_vpc_module_pids')

where the vpc.yaml will have an entry such as:
 phy_port_vpc_module_pids:
  _exclude: [N3k, N5k, N6k, N8k, N9k]
  default_only: 'N7[K7]-(?:F2|F3|F4|M3)'

For the facter commands, we will only using the feature-level granularity of the above method with calls like: Feature.compatible_interfaces('fabricpath') 
