### PR TITLE
Add default method for pvlan trunk allow vlan

### DIFF
--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -986,6 +986,11 @@ module Cisco
       switchport_enable_and_mode_private_vlan_host(mode_set)
     end
 
+    def default_switchport_mode_private_vlan_host
+      config_get_default('interface',
+                         'switchport_mode_private_vlan_host')
+    end
+
     def switchport_mode_private_vlan_host_association
       return nil unless Feature.private_vlan_enabled?
       result = config_get('interface',

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -1268,10 +1268,18 @@ module Cisco
       fail TypeError unless vlans.is_a?(Array)
       Feature.private_vlan_enable
       switchport_enable unless switchport
-      vlans = prepare_array(vlans)
-      is_list = prepare_array(switchport_private_vlan_trunk_allowed_vlan)
-      configure_private_vlan_host_property(:allow_vlan, vlans,
-                                           is_list, '')
+      if vlans == default_switchport_private_vlan_trunk_allowed_vlan
+        vlans = prepare_array(switchport_private_vlan_trunk_allowed_vlan)
+        # If there are no vlan presently configured, we can simply return
+        return if vlans == default_switchport_private_vlan_trunk_allowed_vlan
+        configure_private_vlan_host_property(:allow_vlan, [],
+                                             vlans, '')
+      else
+        vlans = prepare_array(vlans)
+        is_list = prepare_array(switchport_private_vlan_trunk_allowed_vlan)
+        configure_private_vlan_host_property(:allow_vlan, vlans,
+                                             is_list, '')
+      end
     end
 
     def default_switchport_private_vlan_trunk_allowed_vlan

--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -279,11 +279,32 @@ module Cisco
     # vlan_list_delta is a helper function for the private_vlan_association
     # property. It walks the delta hash and adds/removes each target private
     # vlan.
+    # This api is used by private vlan to prepare the input to the setter
+    # method. The input can be in the following formats for vlans:
+    # 10-12,14. Prepare_array api is transforming this input into a flat array.
+    # In the example above the returned array will be 10, 11, 12, 13. Prepare
+    # array is first splitting the input on ',' and the than expanding the vlan
+    # range element like 10-12 into a flat array. The final result will
+    # be a  flat array.
+    # This way we can later used the lib utility to check the delta from
+    # the input vlan value and the vlan configured to apply the right config.
+
     def vlan_list_delta(is_list, should_list)
-      should_list.each { |item| item.gsub!('-', '..') }
+      new_list = []
+      should_list.each do |item|
+        if item.include?(',')
+          new_list.push(item.split(','))
+        else
+          new_list.push(item)
+        end
+      end
+      new_list.flatten!
+      new_list.sort!
+
+      new_list.each { |item| item.gsub!('-', '..') }
 
       should_list_new = []
-      should_list.each do |elem|
+      new_list.each do |elem|
         if elem.include?('..')
           elema = elem.split('..').map { |d| Integer(d) }
           elema.sort!


### PR DESCRIPTION
Explanation for this code change:
no switchport private-vlan trunk allow <vlan> requires vlan as parameter. Since the manifest config
is the final configuration, we usually calculate the delta to be applied as the final configuration.
The default keyword in the manifest for this property, will have the meaning of removing all the allow vlans. If there are no vlan configured and the default keyword is entered, the setter can simply return 
since there is no cli support for 'all'.

Add the default method for host and promisc port

vlan_list_delta api was not handling input with comma present.

Re-ran the tests for 3k/5-6k/7k/9k
