### PR TITLE
Fix a bug for default api for pvlan association

### DIFF
--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -272,7 +272,7 @@ module Cisco
     end
 
     def default_private_vlan_association
-      config_get_default('vlan', 'private_vlan_type')
+      config_get_default('vlan', 'private_vlan_association')
     end
 
     # --------------------------


### PR DESCRIPTION
Discovered a bug in pvlan association where the pvlan type was used in place of pvlan association.
