### PR TITLE
skip itd tests for i2

### DIFF
--- a/tests/test_itd_device_group.rb
+++ b/tests/test_itd_device_group.rb
@@ -33,6 +33,7 @@ class TestItdDeviceGroup < CiscoTestCase
   end
 
   def test_itd_device_group_create_destroy
+    skip_nexus_i2_image?
     i1 = ItdDeviceGroup.new('abc')
     i2 = ItdDeviceGroup.new('BCD')
     i3 = ItdDeviceGroup.new('xyzABC')
@@ -60,6 +61,7 @@ class TestItdDeviceGroup < CiscoTestCase
   end
 
   def test_probe_icmp
+    skip_nexus_i2_image?
     idg = probe_helper(probe_type: 'icmp')
     assert_equal('icmp', idg.probe_type)
     assert_equal(9, idg.probe_frequency)
@@ -81,6 +83,7 @@ class TestItdDeviceGroup < CiscoTestCase
   end
 
   def test_probe_dns
+    skip_nexus_i2_image?
     host = 'resolver1.opendns.com'
     idg = probe_helper(probe_type: 'dns', probe_dns_host: host)
     assert_equal('dns', idg.probe_type)
@@ -111,6 +114,7 @@ class TestItdDeviceGroup < CiscoTestCase
   end
 
   def test_probe_tcp_udp
+    skip_nexus_i2_image?
     port = 11_111
     type = 'tcp'
     idg = probe_helper(probe_type: type, probe_port: port,

--- a/tests/test_itd_device_group_node.rb
+++ b/tests/test_itd_device_group_node.rb
@@ -33,6 +33,7 @@ class TestItdDeviceGroupNode < CiscoTestCase
   end
 
   def test_itd_device_group_node_create_destroy
+    skip_nexus_i2_image?
     itddg1 = ItdDeviceGroup.new('abc')
     n1 = ItdDeviceGroupNode.new(itddg1.name, '1.1.1.1', 'ip')
     n2 = ItdDeviceGroupNode.new(itddg1.name, '2.2.2.2', 'ip')
@@ -73,6 +74,7 @@ class TestItdDeviceGroupNode < CiscoTestCase
   end
 
   def test_probe_icmp
+    skip_nexus_i2_image?
     idg = probe_helper(probe_type: 'icmp')
     assert_equal('icmp', idg.probe_type)
     assert_equal(9, idg.probe_frequency)
@@ -94,6 +96,7 @@ class TestItdDeviceGroupNode < CiscoTestCase
   end
 
   def test_probe_dns
+    skip_nexus_i2_image?
     host = 'resolver1.opendns.com'
     idg = probe_helper(probe_type: 'dns', probe_dns_host: host)
     assert_equal('dns', idg.probe_type)
@@ -124,6 +127,7 @@ class TestItdDeviceGroupNode < CiscoTestCase
   end
 
   def test_probe_tcp_udp
+    skip_nexus_i2_image?
     port = 11_111
     type = 'tcp'
     idg = probe_helper(probe_type: type, probe_port: port,
@@ -153,6 +157,7 @@ class TestItdDeviceGroupNode < CiscoTestCase
   end
 
   def test_hot_standby_weight
+    skip_nexus_i2_image?
     itddg = ItdDeviceGroup.new('new_group')
     idg = ItdDeviceGroupNode.new('new_group', '1.1.1.1', 'ip')
     hot_standby = true

--- a/tests/test_itd_service.rb
+++ b/tests/test_itd_service.rb
@@ -34,6 +34,7 @@ class TestItdService < CiscoTestCase
   end
 
   def test_itd_service_create_destroy
+    skip_nexus_i2_image?
     i1 = ItdService.new('abc')
     i2 = ItdService.new('BCD')
     i3 = ItdService.new('xyzABC')
@@ -48,6 +49,7 @@ class TestItdService < CiscoTestCase
   end
 
   def test_access_list
+    skip_nexus_i2_image?
     itd = ItdService.new('new_group')
     config 'ip access-list include'
     config 'ip access-list exclude'
@@ -66,6 +68,7 @@ class TestItdService < CiscoTestCase
   end
 
   def test_device_group
+    skip_nexus_i2_image?
     itd = ItdService.new('new_group')
     ItdDeviceGroup.new('myGroup')
     itd.device_group = 'myGroup'
@@ -76,6 +79,7 @@ class TestItdService < CiscoTestCase
   end
 
   def test_fail_action
+    skip_nexus_i2_image?
     itd = ItdService.new('new_group')
     itd.fail_action = true
     assert_equal(true, itd.fail_action)
@@ -85,6 +89,7 @@ class TestItdService < CiscoTestCase
   end
 
   def test_ingress_interface
+    skip_nexus_i2_image?
     config 'feature interface-vlan'
     config 'vlan 2'
     config 'interface vlan 2'
@@ -122,6 +127,7 @@ class TestItdService < CiscoTestCase
   end
 
   def test_load_balance
+    skip_nexus_i2_image?
     itd = lb_helper(load_bal_method_bundle_select: 'src',
                     load_bal_method_bundle_hash:   'ip',
                     load_bal_buckets:              16,
@@ -193,6 +199,7 @@ class TestItdService < CiscoTestCase
   end
 
   def test_nat_destination
+    skip_nexus_i2_image?
     itd = ItdService.new('new_group')
     if validate_property_excluded?('itd_service', 'nat_destination')
       assert_nil(itd.nat_destination)
@@ -217,6 +224,7 @@ class TestItdService < CiscoTestCase
   end
 
   def test_shutdown
+    skip_nexus_i2_image?
     itd = ItdService.new('new_group')
     itddg = ItdDeviceGroup.new('abc')
     ItdDeviceGroupNode.new(itddg.name, '1.1.1.1', 'ip')
@@ -237,6 +245,7 @@ class TestItdService < CiscoTestCase
   end
 
   def test_peer_vdc
+    skip_nexus_i2_image?
     itd = ItdService.new('new_group')
     parray = %w(vdc1 ser1)
     if validate_property_excluded?('itd_service', 'peer_vdc')
@@ -254,6 +263,7 @@ class TestItdService < CiscoTestCase
   end
 
   def test_peer_local
+    skip_nexus_i2_image?
     itd = ItdService.new('new_group')
     service = 'ser1'
     if validate_property_excluded?('itd_service', 'peer_local')
@@ -271,6 +281,7 @@ class TestItdService < CiscoTestCase
   end
 
   def test_virtual_ip
+    skip_nexus_i2_image?
     itd = ItdService.new('new_group')
     ItdDeviceGroup.new('myGroup1')
     ItdDeviceGroup.new('myGroup2')


### PR DESCRIPTION
This PR is for skipping all itd related mini tests for n9k switches running I2 images as this feature is not compatible with that image. 
tested on all nexus platforms (it skips on all platforms except n7k and n9k). For n9k running I2 image, it skips the tests individually. 
