### PR TITLE
Fix another bug in pvlan association

### DIFF
--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -246,6 +246,7 @@ module Cisco
       fail TypeError unless type && type.is_a?(String)
 
       if type == default_private_vlan_type
+        return if private_vlan_type.empty?
         set_args_keys(state: 'no', type: private_vlan_type)
         ignore_msg = 'Warning: Private-VLAN CLI removed'
       else

--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -262,8 +262,7 @@ module Cisco
 
     def private_vlan_association
       return nil unless Feature.private_vlan_enabled?
-      result = config_get('vlan', 'private_vlan_association', id: @vlan_id)
-      result.sort
+      config_get('vlan', 'private_vlan_association', id: @vlan_id)
     end
 
     def private_vlan_association=(vlan_list)


### PR DESCRIPTION
Found two bug during beaker testing. The output of the getter is already sorted. Sorting again will result in beaker resource to fail. 
For type default case if the user uses default for non private vlan, setter should just return since the no private-vlan requires a type bu in this case there is none presently configured.

Re ran tests for 3k/5-6k/7k/9k
