### PR TITLE
N7K F3 errors

### DIFF
--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -327,4 +327,16 @@ class CiscoTestCase < TestCase
     shell_command("sudo cp #{filename} /etc/resolv.conf", context)
     shell_command("rm #{filename}", context)
   end
+
+  # VDC helper for features that require a specific linecard.
+  # Allows caller to get current state or change it to a new value.
+  def vdc_lc_state(type=nil)
+    v = Vdc.new('default')
+    if type
+      # This action may be time consuming, use only if necessary.
+      v.limit_resource_module_type = type
+    else
+      v.limit_resource_module_type
+    end
+  end
 end

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -333,6 +333,7 @@ class CiscoTestCase < TestCase
   # VDC helper for features that require a specific linecard.
   # Allows caller to get current state or change it to a new value.
   def vdc_lc_state(type=nil)
+    return unless node.product_id[/N7/]
     v = Vdc.new('default')
     if type
       # This action may be time consuming, use only if necessary.

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -26,18 +26,6 @@ class TestFeature < CiscoTestCase
   # Helpers #
   ###########
 
-  # VDC helper for features that require a specific linecard.
-  # Allows caller to get current state or change it to a new value.
-  def vdc_lc_state(type=nil)
-    v = Vdc.new('default')
-    if type
-      # This action may be time consuming, use only if necessary.
-      v.limit_resource_module_type = type
-    else
-      v.limit_resource_module_type
-    end
-  end
-
   # feature test helper
   def feature(feat)
     # Get the feature name string from the yaml
@@ -97,7 +85,13 @@ class TestFeature < CiscoTestCase
       assert_raises(Cisco::UnsupportedError) { Feature.nv_overlay_enable }
       return
     end
+    # Test if VxLAN can be configured 
+    vxlan_linecard?
+    vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
+    vdc_lc_state('f3') if vdc_current
     feature('nv_overlay')
+    # Return testbed to pre-clean state
+    vdc_lc_state(vdc_current) if vdc_current
   end
 
   def test_nv_overlay_evpn

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -85,7 +85,7 @@ class TestFeature < CiscoTestCase
       assert_raises(Cisco::UnsupportedError) { Feature.nv_overlay_enable }
       return
     end
-    # Test if VxLAN can be configured 
+    # Test if VxLAN can be configured
     vxlan_linecard?
     vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
     vdc_lc_state('f3') if vdc_current

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -87,11 +87,8 @@ class TestFeature < CiscoTestCase
     end
     # Test if VxLAN can be configured
     vxlan_linecard?
-    vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
-    vdc_lc_state('f3') if vdc_current
+    vdc_lc_state('f3')
     feature('nv_overlay')
-    # Return testbed to pre-clean state
-    vdc_lc_state(vdc_current) if vdc_current
   end
 
   def test_nv_overlay_evpn
@@ -100,8 +97,7 @@ class TestFeature < CiscoTestCase
       assert_raises(Cisco::UnsupportedError) { Feature.nv_overlay_evpn_enable }
       return
     end
-    vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
-    vdc_lc_state('f3') if vdc_current
+    vdc_lc_state('f3')
 
     # nv_overlay_evpn can't use the 'feature' helper so test it explicitly here
     # Get current state of feature, then disable it
@@ -117,10 +113,6 @@ class TestFeature < CiscoTestCase
     Feature.nv_overlay_evpn_enable
     assert(Feature.nv_overlay_evpn_enabled?,
            "(#{feat_str}) is not enabled")
-
-    # Return testbed to pre-clean state
-    config("no #{feat_str}") unless pre_clean_enabled
-    vdc_lc_state(vdc_current) if vdc_current
   end
 
   def test_ospf
@@ -160,8 +152,7 @@ class TestFeature < CiscoTestCase
       end
       return
     end
-    vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
-    vdc_lc_state('f3') if vdc_current
+    vdc_lc_state('f3')
 
     # vni can't be removed if nv overlay is present
     config('no feature nv overlay')
@@ -170,7 +161,6 @@ class TestFeature < CiscoTestCase
     # nv overlay. This minor delay avoids the hang.
     sleep 1
     feature('vni')
-    vdc_lc_state(vdc_current) if vdc_current
   rescue RuntimeError => e
     hardware_supports_feature?(e.message)
   end
@@ -193,10 +183,8 @@ class TestFeature < CiscoTestCase
     # Get current state of the feature-set
     feature_set_installed = Feature.fabric_installed?
     feature_enabled = Feature.fabric_enabled?
-    vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
 
-    # clean
-    vdc_lc_state('f3') if vdc_current
+    vdc_lc_state('f3')
     config("no #{fs} ; no install #{fs}") if feature_set_installed
     refute_show_match(
       command: "show running | i '^install #{fs}$'",
@@ -210,7 +198,6 @@ class TestFeature < CiscoTestCase
     # Return testbed to pre-clean state
     config("no #{fs}") unless feature_enabled
     config("no install #{fs}") unless feature_set_installed
-    vdc_lc_state(vdc_current) if vdc_current
   end
 
   def test_feature_set_fex

--- a/tests/test_overlay_global.rb
+++ b/tests/test_overlay_global.rb
@@ -44,6 +44,11 @@ class TestOverlayGlobal < CiscoTestCase
     assert_nil(o.dup_host_ip_addr_detection_host_moves)
     assert_nil(o.dup_host_ip_addr_detection_timeout)
 
+    # Test if VxLAN can be configured 
+    vxlan_linecard?
+    vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
+    vdc_lc_state('f3') if vdc_current
+
     # Set them to the default value and they should now be present
     default = [o.default_dup_host_ip_addr_detection_host_moves,
                o.default_dup_host_ip_addr_detection_timeout]
@@ -58,6 +63,9 @@ class TestOverlayGlobal < CiscoTestCase
     assert_equal(val, o.dup_host_ip_addr_detection)
     assert_equal(val[0], o.dup_host_ip_addr_detection_host_moves)
     assert_equal(val[1], o.dup_host_ip_addr_detection_timeout)
+
+    # Return testbed to pre-clean state
+    vdc_lc_state(vdc_current) if vdc_current
   end
 
   def test_dup_host_mac_detection
@@ -95,6 +103,11 @@ class TestOverlayGlobal < CiscoTestCase
     # Before enabling 'nv overlay evpn', this property does not exist
     assert_nil(o.anycast_gateway_mac)
 
+    # Test if VxLAN can be configured 
+    vxlan_linecard?
+    vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
+    vdc_lc_state('f3') if vdc_current
+
     # Explicitly set to default and it should be enabled
     o.anycast_gateway_mac = o.default_anycast_gateway_mac
     assert_equal(o.default_anycast_gateway_mac, o.anycast_gateway_mac)
@@ -105,5 +118,8 @@ class TestOverlayGlobal < CiscoTestCase
       o.anycast_gateway_mac = mac
       assert_equal(Utils.zero_pad_macaddr(mac), o.anycast_gateway_mac)
     end
+
+    # Return testbed to pre-clean state
+    vdc_lc_state(vdc_current) if vdc_current
   end
 end

--- a/tests/test_overlay_global.rb
+++ b/tests/test_overlay_global.rb
@@ -44,7 +44,7 @@ class TestOverlayGlobal < CiscoTestCase
     assert_nil(o.dup_host_ip_addr_detection_host_moves)
     assert_nil(o.dup_host_ip_addr_detection_timeout)
 
-    # Test if VxLAN can be configured 
+    # Test if VxLAN can be configured
     vxlan_linecard?
     vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
     vdc_lc_state('f3') if vdc_current
@@ -103,7 +103,7 @@ class TestOverlayGlobal < CiscoTestCase
     # Before enabling 'nv overlay evpn', this property does not exist
     assert_nil(o.anycast_gateway_mac)
 
-    # Test if VxLAN can be configured 
+    # Test if VxLAN can be configured
     vxlan_linecard?
     vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
     vdc_lc_state('f3') if vdc_current

--- a/tests/test_overlay_global.rb
+++ b/tests/test_overlay_global.rb
@@ -46,8 +46,7 @@ class TestOverlayGlobal < CiscoTestCase
 
     # Test if VxLAN can be configured
     vxlan_linecard?
-    vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
-    vdc_lc_state('f3') if vdc_current
+    vdc_lc_state('f3')
 
     # Set them to the default value and they should now be present
     default = [o.default_dup_host_ip_addr_detection_host_moves,
@@ -63,9 +62,6 @@ class TestOverlayGlobal < CiscoTestCase
     assert_equal(val, o.dup_host_ip_addr_detection)
     assert_equal(val[0], o.dup_host_ip_addr_detection_host_moves)
     assert_equal(val[1], o.dup_host_ip_addr_detection_timeout)
-
-    # Return testbed to pre-clean state
-    vdc_lc_state(vdc_current) if vdc_current
   end
 
   def test_dup_host_mac_detection
@@ -105,8 +101,7 @@ class TestOverlayGlobal < CiscoTestCase
 
     # Test if VxLAN can be configured
     vxlan_linecard?
-    vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
-    vdc_lc_state('f3') if vdc_current
+    vdc_lc_state('f3')
 
     # Explicitly set to default and it should be enabled
     o.anycast_gateway_mac = o.default_anycast_gateway_mac
@@ -118,8 +113,5 @@ class TestOverlayGlobal < CiscoTestCase
       o.anycast_gateway_mac = mac
       assert_equal(Utils.zero_pad_macaddr(mac), o.anycast_gateway_mac)
     end
-
-    # Return testbed to pre-clean state
-    vdc_lc_state(vdc_current) if vdc_current
   end
 end

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -203,6 +203,11 @@ class TestVrf < CiscoTestCase
       v.destroy
       return
     end
+    # Test if VxLAN can be configured 
+    vxlan_linecard?
+    vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
+    vdc_lc_state('f3') if vdc_current
+
     v.route_distinguisher = 'auto'
     assert_equal('auto', v.route_distinguisher)
 
@@ -216,6 +221,8 @@ class TestVrf < CiscoTestCase
     assert_empty(v.route_distinguisher,
                  'v route_distinguisher should *NOT* be configured')
     v.destroy
+    # Return testbed to pre-clean state
+    vdc_lc_state(vdc_current) if vdc_current
   end
 
   def test_vpn_id

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -203,7 +203,7 @@ class TestVrf < CiscoTestCase
       v.destroy
       return
     end
-    # Test if VxLAN can be configured 
+    # Test if VxLAN can be configuredf
     vxlan_linecard?
     vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
     vdc_lc_state('f3') if vdc_current

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -205,8 +205,7 @@ class TestVrf < CiscoTestCase
     end
     # Test if VxLAN can be configuredf
     vxlan_linecard?
-    vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
-    vdc_lc_state('f3') if vdc_current
+    vdc_lc_state('f3')
 
     v.route_distinguisher = 'auto'
     assert_equal('auto', v.route_distinguisher)
@@ -221,8 +220,6 @@ class TestVrf < CiscoTestCase
     assert_empty(v.route_distinguisher,
                  'v route_distinguisher should *NOT* be configured')
     v.destroy
-    # Return testbed to pre-clean state
-    vdc_lc_state(vdc_current) if vdc_current
   end
 
   def test_vpn_id

--- a/tests/test_vrf_af.rb
+++ b/tests/test_vrf_af.rb
@@ -136,7 +136,7 @@ class TestVrfAf < CiscoTestCase
       assert_raises(Cisco::UnsupportedError) { v.route_target_both_auto = true }
     else
 
-      # Test if VxLAN can be configured 
+      # Test if VxLAN can be configured
       vxlan_linecard?
       vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
       vdc_lc_state('f3') if vdc_current

--- a/tests/test_vrf_af.rb
+++ b/tests/test_vrf_af.rb
@@ -135,6 +135,12 @@ class TestVrfAf < CiscoTestCase
     if validate_property_excluded?('vrf_af', 'route_target_both_auto')
       assert_raises(Cisco::UnsupportedError) { v.route_target_both_auto = true }
     else
+
+      # Test if VxLAN can be configured 
+      vxlan_linecard?
+      vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
+      vdc_lc_state('f3') if vdc_current
+
       v.route_target_both_auto = true
       assert(v.route_target_both_auto, "vrf context #{vrf} af #{af}: "\
              'v route-target both auto should be enabled')
@@ -180,6 +186,8 @@ class TestVrfAf < CiscoTestCase
     should = v.default_route_target_import
     route_target_tester(v, af, opts, should, 'Test 4')
     v.destroy
+    # Return testbed to pre-clean state
+    vdc_lc_state(vdc_current) if vdc_current
   end
 
   def route_target_tester(v, af, opts, should, test_id)

--- a/tests/test_vrf_af.rb
+++ b/tests/test_vrf_af.rb
@@ -138,8 +138,7 @@ class TestVrfAf < CiscoTestCase
 
       # Test if VxLAN can be configured
       vxlan_linecard?
-      vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
-      vdc_lc_state('f3') if vdc_current
+      vdc_lc_state('f3')
 
       v.route_target_both_auto = true
       assert(v.route_target_both_auto, "vrf context #{vrf} af #{af}: "\
@@ -186,8 +185,6 @@ class TestVrfAf < CiscoTestCase
     should = v.default_route_target_import
     route_target_tester(v, af, opts, should, 'Test 4')
     v.destroy
-    # Return testbed to pre-clean state
-    vdc_lc_state(vdc_current) if vdc_current
   end
 
   def route_target_tester(v, af, opts, should, test_id)


### PR DESCRIPTION
The following minitests are fixed using the function - vdc_lc_state.
- TestOverlayGlobal##test_anycast_gateway_mac
- TestOverlayGlobal##test_dup_host_ip_addr_detection
- TestFeature##test_nv_overlay
- TestVrfAf#test_route_target
- TestVrf#test_route_distinguisher
  Here are the minitest runs:

```
###ruby tests/test_vrf_af.rb -e n7k -v -n test_route_target
Run options: -e n7k -v -n test_route_target --seed 52231

Running:


Node under test:
  - name  - core
  - type  - N7F-C7018
  - image - bootflash:///aneesh-s.bin

TestVrfAf#test_route_target = 81.66 s = .

Finished in 81.665799s, 0.0122 runs/s, 0.9306 assertions/s.

1 runs, 76 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/anramgop/puppet/cisco-network-node-utils/coverage. 1339 / 2725 LOC (49.14%) covered.
ruby tests/test_vrf_af.rb -e lab7k -v -n test_route_target
Run options: -e lab7k -v -n test_route_target --seed 62205

Running:


Node under test:
  - name  - n7k-j
  - type  - N7K-C7009
  - image - bootflash:///n7000-s2-dk9.7.3.1.D1.0.48.bin

TestVrfAf#test_route_target = 8.85 s = S

Finished in 8.851257s, 0.1130 runs/s, 0.2260 assertions/s.

  1) Skipped:
TestVrfAf#test_route_target [/nobackup/anramgop/puppet/cisco-network-node-utils/tests/ciscotest.rb:279]:
Unable to find compatible interface in chassis

1 runs, 2 assertions, 0 failures, 0 errors, 1 skips
Coverage report generated for MiniTest to /nobackup/anramgop/puppet/cisco-network-node-utils/coverage. 1220 / 2725 LOC (44.77%) covered.
###ruby tests/test_vrf.rb -e n7k -v -n test_route_distinguisher
Run options: -e n7k -v -n test_route_distinguisher --seed 49327

Running:


Node under test:
  - name  - core
  - type  - N7F-C7018
  - image - bootflash:///aneesh-s.bin

TestVrf#test_route_distinguisher = 11.97 s = .

Finished in 11.973159s, 0.0835 runs/s, 0.4176 assertions/s.

1 runs, 5 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/anramgop/puppet/cisco-network-node-utils/coverage. 1247 / 2654 LOC (46.99%) covered.
###ruby tests/test_vrf.rb -e lab7k -v -n test_route_distinguisher
Run options: -e lab7k -v -n test_route_distinguisher --seed 11613

Running:


Node under test:
  - name  - n7k-j
  - type  - N7K-C7009
  - image - bootflash:///n7000-s2-dk9.7.3.1.D1.0.48.bin

TestVrf#test_route_distinguisher = 6.70 s = S

Finished in 6.701152s, 0.1492 runs/s, 0.0000 assertions/s.

  1) Skipped:
TestVrf#test_route_distinguisher [/nobackup/anramgop/puppet/cisco-network-node-utils/tests/ciscotest.rb:279]:
Unable to find compatible interface in chassis

1 runs, 0 assertions, 0 failures, 0 errors, 1 skips
Coverage report generated for MiniTest to /nobackup/anramgop/puppet/cisco-network-node-utils/coverage. 1172 / 2654 LOC (44.16%) covered.
###ruby tests/test_feature.rb -e n7k -v -n test_nv_overlay
Run options: -e n7k -v -n test_nv_overlay --seed 54580

Running:


Node under test:
  - name  - core
  - type  - N7F-C7018
  - image - bootflash:///aneesh-s.bin

TestFeature#test_nv_overlay = 137.91 s = .

Finished in 139.432711s, 0.0072 runs/s, 0.0287 assertions/s.

1 runs, 4 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/anramgop/puppet/cisco-network-node-utils/coverage. 1190 / 2586 LOC (46.02%) covered.
###ruby tests/test_feature.rb -e lab7k -v -n test_nv_overlay
Run options: -e lab7k -v -n test_nv_overlay --seed 17886

Running:


Node under test:
  - name  - n7k-j
  - type  - N7K-C7009
  - image - bootflash:///n7000-s2-dk9.7.3.1.D1.0.48.bin

TestFeature#test_nv_overlay = 2.18 s = S

Finished in 4.521810s, 0.2212 runs/s, 0.0000 assertions/s.

  1) Skipped:
TestFeature#test_nv_overlay [/nobackup/anramgop/puppet/cisco-network-node-utils/tests/ciscotest.rb:279]:
Unable to find compatible interface in chassis

1 runs, 0 assertions, 0 failures, 0 errors, 1 skips
Coverage report generated for MiniTest to /nobackup/anramgop/puppet/cisco-network-node-utils/coverage. 1092 / 2586 LOC (42.23%) covered.
###ruby tests/test_overlay_global.rb -e n7k -v
Run options: -e n7k -v --seed 55231

Running:


Node under test:
  - name  - core
  - type  - N7F-C7018
  - image - bootflash:///aneesh-s.bin

TestOverlayGlobal#test_dup_host_mac_detection = 4.63 s = .
TestOverlayGlobal#test_dup_host_ip_addr_detection = 14.51 s = .
TestOverlayGlobal#test_anycast_gateway_mac = 21.07 s = .

Finished in 41.760865s, 0.0718 runs/s, 0.5268 assertions/s.

3 runs, 22 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/anramgop/puppet/cisco-network-node-utils/coverage. 1249 / 2586 LOC (48.3%) covered.
###ruby tests/test_overlay_global.rb -e lab7k -v
Run options: -e lab7k -v --seed 8935

Running:


Node under test:
  - name  - n7k-j
  - type  - N7K-C7009
  - image - bootflash:///n7000-s2-dk9.7.3.1.D1.0.48.bin

TestOverlayGlobal#test_dup_host_mac_detection = 7.63 s = .
TestOverlayGlobal#test_dup_host_ip_addr_detection = 3.79 s = S
TestOverlayGlobal#test_anycast_gateway_mac = 3.78 s = S

Finished in 17.583739s, 0.1706 runs/s, 0.6256 assertions/s.

  1) Skipped:
TestOverlayGlobal#test_dup_host_ip_addr_detection [/nobackup/anramgop/puppet/cisco-network-node-utils/tests/ciscotest.rb:279]:
Unable to find compatible interface in chassis


  2) Skipped:
TestOverlayGlobal#test_anycast_gateway_mac [/nobackup/anramgop/puppet/cisco-network-node-utils/tests/ciscotest.rb:279]:
Unable to find compatible interface in chassis

3 runs, 11 assertions, 0 failures, 0 errors, 2 skips
Coverage report generated for MiniTest to /nobackup/anramgop/puppet/cisco-network-node-utils/coverage. 1168 / 2586 LOC (45.17%) covered.
```
