### PR TITLE
For private vlan interface properties, the return value when feature …

### DIFF
--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -965,7 +965,7 @@ module Cisco
     end
 
     def switchport_mode_private_vlan_host
-      return nil unless Feature.private_vlan_enabled?
+      return [] unless Feature.private_vlan_enabled?
       mode = config_get('interface',
                         'switchport_mode_private_vlan_host',
                         name: @name)
@@ -992,7 +992,7 @@ module Cisco
     end
 
     def switchport_mode_private_vlan_host_association
-      return nil unless Feature.private_vlan_enabled?
+      return [] unless Feature.private_vlan_enabled?
       result = config_get('interface',
                           'switchport_mode_private_vlan_host_association',
                           name: @name)
@@ -1169,7 +1169,7 @@ module Cisco
     end
 
     def switchport_mode_private_vlan_host_promisc
-      return nil unless Feature.private_vlan_enabled?
+      return [] unless Feature.private_vlan_enabled?
       result = config_get('interface',
                           'switchport_mode_private_vlan_host_promiscous',
                           name: @name)
@@ -1191,7 +1191,7 @@ module Cisco
     end
 
     def switchport_mode_private_vlan_trunk_promiscuous
-      return nil unless Feature.private_vlan_enabled?
+      return [] unless Feature.private_vlan_enabled?
       mode = config_get('interface',
                         'switchport_mode_private_vlan_trunk_promiscuous',
                         name: @name)
@@ -1225,7 +1225,7 @@ module Cisco
     end
 
     def switchport_mode_private_vlan_trunk_secondary
-      return nil unless Feature.private_vlan_enabled?
+      return [] unless Feature.private_vlan_enabled?
       mode = config_get('interface',
                         'switchport_mode_private_vlan_trunk_secondary',
                         name: @name)
@@ -1257,7 +1257,7 @@ module Cisco
     end
 
     def switchport_private_vlan_trunk_allowed_vlan
-      return nil unless Feature.private_vlan_enabled?
+      return [] unless Feature.private_vlan_enabled?
       result = config_get('interface',
                           'switchport_private_vlan_trunk_allowed_vlan',
                           name: @name)
@@ -1293,7 +1293,7 @@ module Cisco
     end
 
     def switchport_private_vlan_trunk_native_vlan
-      return nil unless Feature.private_vlan_enabled?
+      return [] unless Feature.private_vlan_enabled?
       config_get('interface',
                  'switchport_private_vlan_trunk_native_vlan',
                  name: @name)
@@ -1320,7 +1320,7 @@ module Cisco
     end
 
     def switchport_private_vlan_association_trunk
-      return nil unless Feature.private_vlan_enabled?
+      return [] unless Feature.private_vlan_enabled?
       result = config_get('interface',
                           'switchport_private_vlan_association_trunk',
                           name: @name)
@@ -1349,7 +1349,7 @@ module Cisco
     end
 
     def switchport_private_vlan_mapping_trunk
-      return nil unless Feature.private_vlan_enabled?
+      return [] unless Feature.private_vlan_enabled?
       result = config_get('interface',
                           'switchport_private_vlan_mapping_trunk',
                           name: @name)
@@ -1378,7 +1378,7 @@ module Cisco
     end
 
     def private_vlan_mapping
-      return nil unless Feature.private_vlan_enabled?
+      return [] unless Feature.private_vlan_enabled?
       match = config_get('interface',
                          'private_vlan_mapping',
                          name: @name)

--- a/tests/test_interface_private_vlan.rb
+++ b/tests/test_interface_private_vlan.rb
@@ -61,8 +61,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_private_host_mode
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -84,8 +82,6 @@ class TestSwitchport < TestInterfaceSwitchport
     if validate_property_excluded?(
       'interface',
       'switchport_mode_private_vlan_trunk_secondary')
-      assert_equal([], interface.switchport_mode_private_vlan_trunk_promiscuous,
-                   'Err: should not be supported ')
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_trunk_promiscuous = true
       end
@@ -100,8 +96,6 @@ class TestSwitchport < TestInterfaceSwitchport
     if validate_property_excluded?(
       'interface',
       'switchport_mode_private_vlan_trunk_secondary')
-      assert_equal([], interface.switchport_mode_private_vlan_trunk_secondary,
-                   'Err: should not be supported ')
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_trunk_secondary = true
       end
@@ -115,8 +109,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_no_switchport_private_host_mode
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -141,8 +133,6 @@ class TestSwitchport < TestInterfaceSwitchport
     if validate_property_excluded?(
       'interface',
       'switchport_mode_private_vlan_trunk_secondary')
-      assert_equal([], interface.switchport_mode_private_vlan_trunk_secondary,
-                   'Err: should not be supported ')
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_trunk_secondary = true
       end
@@ -159,8 +149,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_private_host_association
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -187,9 +175,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_host_assoc_change
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
-
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -235,8 +220,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_no_pvlan_host_assoc
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
@@ -267,8 +250,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_host_assoc_default
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
@@ -283,8 +264,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_host_assoc_bad_arg
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
@@ -320,8 +299,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_host_primisc_default
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
@@ -336,8 +313,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_private_host_promisc
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
@@ -393,8 +368,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_private_host_promisc_bad_arg
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
@@ -442,8 +415,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_no_switchport_private_host_promisc
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
@@ -474,8 +445,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_allow_default
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
@@ -489,8 +458,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_allow_bad_arg
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
@@ -511,8 +478,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_allow
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
@@ -545,8 +510,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_native_vlan_bad_arg
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
@@ -567,8 +530,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_native_default
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
@@ -582,8 +543,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_native_vlan
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_equal([], interface.switchport_mode_private_vlan_host,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
@@ -615,8 +574,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_association_trunk
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_association_trunk')
-      assert_equal([], interface.switchport_private_vlan_association_trunk,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_private_vlan_association_trunk = %w(10 12)
@@ -652,8 +609,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_assoc_vlan_bad_arg
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_association_trunk')
-      assert_equal([], interface.switchport_private_vlan_association_trunk,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_private_vlan_association_trunk = %w(10 10)
@@ -685,8 +640,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_assocciation_default
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_association_trunk')
-      assert_equal([], interface.switchport_private_vlan_association_trunk,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_private_vlan_association_trunk = %w(10 10)
@@ -700,8 +653,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_mapping_trunk_default
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_mapping_trunk')
-      assert_equal([], interface.switchport_private_vlan_mapping_trunk,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_private_vlan_mapping_trunk = %w(10)
@@ -715,8 +666,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_mapping_trunk
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_mapping_trunk')
-      assert_equal([], interface.switchport_private_vlan_mapping_trunk,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_private_vlan_mapping_trunk = %w(10 10)
@@ -752,8 +701,6 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_mapping_trunk_bad_arg
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_mapping_trunk')
-      assert_equal([], interface.switchport_private_vlan_mapping_trunk,
-                   'Err: should not be supported ')
 
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_private_vlan_mapping_trunk = %w(10 10)

--- a/tests/test_interface_private_vlan.rb
+++ b/tests/test_interface_private_vlan.rb
@@ -61,7 +61,8 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_private_host_mode
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -83,9 +84,10 @@ class TestSwitchport < TestInterfaceSwitchport
     if validate_property_excluded?(
       'interface',
       'switchport_mode_private_vlan_trunk_secondary')
-      assert_nil(interface.switchport_mode_private_vlan_trunk_secondary)
+      assert_equal([], interface.switchport_mode_private_vlan_trunk_promiscuous,
+                   'Err: should not be supported ')
       assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_trunk_secondary = true
+        interface.switchport_mode_private_vlan_trunk_promiscuous = true
       end
       return
     end
@@ -98,7 +100,8 @@ class TestSwitchport < TestInterfaceSwitchport
     if validate_property_excluded?(
       'interface',
       'switchport_mode_private_vlan_trunk_secondary')
-      assert_nil(interface.switchport_mode_private_vlan_trunk_secondary)
+      assert_equal([], interface.switchport_mode_private_vlan_trunk_secondary,
+                   'Err: should not be supported ')
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_trunk_secondary = true
       end
@@ -112,7 +115,8 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_no_switchport_private_host_mode
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -137,7 +141,8 @@ class TestSwitchport < TestInterfaceSwitchport
     if validate_property_excluded?(
       'interface',
       'switchport_mode_private_vlan_trunk_secondary')
-      assert_nil(interface.switchport_mode_private_vlan_trunk_secondary)
+      assert_equal([], interface.switchport_mode_private_vlan_trunk_secondary,
+                   'Err: should not be supported ')
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_trunk_secondary = true
       end
@@ -154,7 +159,8 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_private_host_association
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -181,7 +187,9 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_host_assoc_change
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -227,7 +235,9 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_no_pvlan_host_assoc
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -257,20 +267,25 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_host_assoc_default
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
       return
     end
 
-    assert_nil(interface.switchport_mode_private_vlan_host_association)
+    assert_equal([], interface.switchport_mode_private_vlan_host_association,
+                 'Err: host association failed')
   end
 
   def test_interface_switchport_pvlan_host_assoc_bad_arg
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -305,20 +320,25 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_host_primisc_default
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
       return
     end
 
-    assert_nil(interface.switchport_mode_private_vlan_host_promisc)
+    assert_equal([], interface.switchport_mode_private_vlan_host_promisc,
+                 'Err: promisc association failed')
   end
 
   def test_interface_switchport_private_host_promisc
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -373,7 +393,9 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_private_host_promisc_bad_arg
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -420,7 +442,9 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_no_switchport_private_host_promisc
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -450,19 +474,24 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_allow_default
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
       return
     end
-    assert_nil(interface.switchport_private_vlan_trunk_allowed_vlan)
+    assert_equal([], interface.switchport_private_vlan_trunk_allowed_vlan,
+                 'Err: trunk allowed vlan failed')
   end
 
   def test_interface_switchport_pvlan_trunk_allow_bad_arg
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -482,7 +511,9 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_allow
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -514,7 +545,9 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_native_vlan_bad_arg
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -534,19 +567,24 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_native_default
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
       return
     end
-    assert_nil(interface.switchport_private_vlan_trunk_native_vlan)
+    assert_equal([], interface.switchport_private_vlan_trunk_native_vlan,
+                 'Err: trunk native vlan failed')
   end
 
   def test_interface_switchport_pvlan_trunk_native_vlan
     if validate_property_excluded?('interface',
                                    'switchport_mode_private_vlan_host')
-      assert_nil(interface.switchport_mode_private_vlan_host)
+      assert_equal([], interface.switchport_mode_private_vlan_host,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_mode_private_vlan_host = :host
       end
@@ -577,7 +615,9 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_association_trunk
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_association_trunk')
-      assert_nil(interface.switchport_private_vlan_association_trunk)
+      assert_equal([], interface.switchport_private_vlan_association_trunk,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_private_vlan_association_trunk = %w(10 12)
       end
@@ -612,7 +652,9 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_assoc_vlan_bad_arg
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_association_trunk')
-      assert_nil(interface.switchport_private_vlan_association_trunk)
+      assert_equal([], interface.switchport_private_vlan_association_trunk,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_private_vlan_association_trunk = %w(10 10)
       end
@@ -643,31 +685,39 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_assocciation_default
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_association_trunk')
-      assert_nil(interface.switchport_private_vlan_association_trunk)
+      assert_equal([], interface.switchport_private_vlan_association_trunk,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_private_vlan_association_trunk = %w(10 10)
       end
       return
     end
-    assert_nil(interface.switchport_private_vlan_association_trunk)
+    assert_equal([], interface.switchport_private_vlan_association_trunk,
+                 'Err: association trunk failed')
   end
 
   def test_interface_switchport_pvlan_mapping_trunk_default
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_mapping_trunk')
-      assert_nil(interface.switchport_private_vlan_mapping_trunk)
+      assert_equal([], interface.switchport_private_vlan_mapping_trunk,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_private_vlan_mapping_trunk = %w(10)
       end
       return
     end
-    assert_nil(interface.switchport_private_vlan_mapping_trunk)
+    assert_equal([], interface.switchport_private_vlan_mapping_trunk,
+                 'Err: mapping trunk failed')
   end
 
   def test_interface_switchport_pvlan_mapping_trunk
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_mapping_trunk')
-      assert_nil(interface.switchport_private_vlan_mapping_trunk)
+      assert_equal([], interface.switchport_private_vlan_mapping_trunk,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_private_vlan_mapping_trunk = %w(10 10)
       end
@@ -702,7 +752,9 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_mapping_trunk_bad_arg
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_mapping_trunk')
-      assert_nil(interface.switchport_private_vlan_mapping_trunk)
+      assert_equal([], interface.switchport_private_vlan_mapping_trunk,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         interface.switchport_private_vlan_mapping_trunk = %w(10 10)
       end

--- a/tests/test_interface_svi.rb
+++ b/tests/test_interface_svi.rb
@@ -70,9 +70,6 @@ class TestSvi < CiscoTestCase
   def test_private_vlan_mapping
     if validate_property_excluded?('interface',
                                    'private_vlan_mapping')
-      assert_equal([], svi.private_vlan_mapping,
-                   'Err: should not be supported ')
-
       assert_raises(Cisco::UnsupportedError) do
         svi.private_vlan_mapping = %w(11-13)
       end
@@ -103,9 +100,6 @@ class TestSvi < CiscoTestCase
   def test_private_vlan_mapping_bad_args
     if validate_property_excluded?('interface',
                                    'private_vlan_mapping')
-      assert_equal([], svi.private_vlan_mapping,
-                   'Err: should not be supported ')
-
       assert_raises(Cisco::UnsupportedError) do
         svi.private_vlan_mapping = %w(10 20)
       end

--- a/tests/test_interface_svi.rb
+++ b/tests/test_interface_svi.rb
@@ -70,7 +70,9 @@ class TestSvi < CiscoTestCase
   def test_private_vlan_mapping
     if validate_property_excluded?('interface',
                                    'private_vlan_mapping')
-      assert_nil(svi.private_vlan_mapping)
+      assert_equal([], svi.private_vlan_mapping,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         svi.private_vlan_mapping = %w(11-13)
       end
@@ -101,7 +103,9 @@ class TestSvi < CiscoTestCase
   def test_private_vlan_mapping_bad_args
     if validate_property_excluded?('interface',
                                    'private_vlan_mapping')
-      assert_nil(svi.private_vlan_mapping)
+      assert_equal([], svi.private_vlan_mapping,
+                   'Err: should not be supported ')
+
       assert_raises(Cisco::UnsupportedError) do
         svi.private_vlan_mapping = %w(10 20)
       end


### PR DESCRIPTION
For private vlan interface properties the return value should be an empty array when the feature is not enabled since the show run interface output is available even if feature private-vlan is not configured.
Change the minitest accordingly .
Ran test towards 3k/5-6k/7k/9k 
