### PR TITLE
Refactored private vlan getters

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -409,7 +409,7 @@ switchport_mode_private_vlan_host:
   _exclude: [ios_xr, N8k]
   get_value: '/^switchport mode private-vlan (.*)$/'
   set_value: "<state> switchport mode private-vlan <mode>"
-  default_value: ""
+  default_value: :disabled
 
 switchport_mode_private_vlan_host_association:
   _exclude: [ios_xr, N8k]

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -995,19 +995,19 @@ module Cisco
     end
 
     def switchport_mode_private_vlan_host
-      return [] unless Feature.private_vlan_enabled?
       mode = config_get('interface',
                         'switchport_mode_private_vlan_host',
                         name: @name)
-
-      return mode.nil? ? :disabled : IF_SWITCHPORT_MODE.key(mode)
-
+      unless mode == default_switchport_mode_private_vlan_host
+        mode = IF_SWITCHPORT_MODE.key(mode)
+      end
+      mode
     rescue IndexError
       # Assume this is an interface that doesn't support switchport.
       # Do not raise exception since the providers will prefetch this property
       # regardless of interface type.
       # TODO: this should probably be nil instead
-      return :disabled
+      return default_switchport_mode_private_vlan_host
     end
 
     def switchport_mode_private_vlan_host=(mode_set)
@@ -1022,11 +1022,13 @@ module Cisco
     end
 
     def switchport_mode_private_vlan_host_association
-      return [] unless Feature.private_vlan_enabled?
       result = config_get('interface',
                           'switchport_mode_private_vlan_host_association',
                           name: @name)
-      result.empty? ? [] : result[0].split(' ')
+      unless result == default_switchport_mode_private_vlan_host_association
+        result = result[0].split(' ')
+      end
+      result
     end
 
     def switchport_mode_private_vlan_host_association=(vlans)
@@ -1199,11 +1201,13 @@ module Cisco
     end
 
     def switchport_mode_private_vlan_host_promisc
-      return [] unless Feature.private_vlan_enabled?
       result = config_get('interface',
                           'switchport_mode_private_vlan_host_promiscous',
                           name: @name)
-      result.empty? ? [] : result[0].split(' ')
+      unless result == default_switchport_mode_private_vlan_host_promisc
+        result = result[0].split(' ')
+      end
+      result
     end
 
     def switchport_mode_private_vlan_host_promisc=(vlans)
@@ -1221,18 +1225,15 @@ module Cisco
     end
 
     def switchport_mode_private_vlan_trunk_promiscuous
-      return [] unless Feature.private_vlan_enabled?
-      mode = config_get('interface',
-                        'switchport_mode_private_vlan_trunk_promiscuous',
-                        name: @name)
-      return mode.nil? ? false : mode
-
+      config_get('interface',
+                 'switchport_mode_private_vlan_trunk_promiscuous',
+                 name: @name)
     rescue IndexError
       # Assume this is an interface that doesn't support switchport.
       # Do not raise exception since the providers will prefetch this property
       # regardless of interface type.
       # TODO: this should probably be nil instead
-      return :disabled
+      return default_switchport_mode_private_vlan_trunk_promiscuous
     end
 
     def switchport_mode_private_vlan_trunk_promiscuous=(state)
@@ -1255,18 +1256,15 @@ module Cisco
     end
 
     def switchport_mode_private_vlan_trunk_secondary
-      return [] unless Feature.private_vlan_enabled?
-      mode = config_get('interface',
-                        'switchport_mode_private_vlan_trunk_secondary',
-                        name: @name)
-      return mode.nil? ? false : mode
-
+      config_get('interface',
+                 'switchport_mode_private_vlan_trunk_secondary',
+                 name: @name)
     rescue IndexError
       # Assume this is an interface that doesn't support switchport.
       # Do not raise exception since the providers will prefetch this property
       # regardless of interface type.
       # TODO: this should probably be nil instead
-      return :disabled
+      return default_switchport_mode_private_vlan_trunk_secondary
     end
 
     def switchport_mode_private_vlan_trunk_secondary=(state)
@@ -1287,16 +1285,18 @@ module Cisco
     end
 
     def switchport_private_vlan_trunk_allowed_vlan
-      return [] unless Feature.private_vlan_enabled?
       result = config_get('interface',
                           'switchport_private_vlan_trunk_allowed_vlan',
                           name: @name)
-      return [] if result.nil? || result.empty?
-      if result[0].eql? 'none'
-        return []
-      else
-        return result[0].split(',')
+
+      unless result == default_switchport_private_vlan_trunk_allowed_vlan
+        if result[0].eql? 'none'
+          result = default_switchport_private_vlan_trunk_allowed_vlan
+        else
+          result = result[0].split(',')
+        end
       end
+      result
     end
 
     def switchport_private_vlan_trunk_allowed_vlan=(vlans)
@@ -1323,7 +1323,6 @@ module Cisco
     end
 
     def switchport_private_vlan_trunk_native_vlan
-      return [] unless Feature.private_vlan_enabled?
       config_get('interface',
                  'switchport_private_vlan_trunk_native_vlan',
                  name: @name)
@@ -1350,12 +1349,9 @@ module Cisco
     end
 
     def switchport_private_vlan_association_trunk
-      return [] unless Feature.private_vlan_enabled?
-      result = config_get('interface',
-                          'switchport_private_vlan_association_trunk',
-                          name: @name)
-      return [] if result.nil? || result.empty?
-      result
+      config_get('interface',
+                 'switchport_private_vlan_association_trunk',
+                 name: @name)
     end
 
     def switchport_private_vlan_association_trunk=(vlans)
@@ -1379,12 +1375,9 @@ module Cisco
     end
 
     def switchport_private_vlan_mapping_trunk
-      return [] unless Feature.private_vlan_enabled?
-      result = config_get('interface',
-                          'switchport_private_vlan_mapping_trunk',
-                          name: @name)
-      return [] if result.nil? || result.empty?
-      result
+      config_get('interface',
+                 'switchport_private_vlan_mapping_trunk',
+                 name: @name)
     end
 
     def switchport_private_vlan_mapping_trunk=(vlans)
@@ -1408,12 +1401,10 @@ module Cisco
     end
 
     def private_vlan_mapping
-      return [] unless Feature.private_vlan_enabled?
       match = config_get('interface',
                          'private_vlan_mapping',
                          name: @name)
-      return [] if match.nil? || match.empty?
-      match[0].delete!(' ')
+      match[0].delete!(' ') unless match == default_private_vlan_mapping
       match
     end
 

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -202,6 +202,7 @@ class CiscoTestCase < TestCase
   # This testcase will remove all the bds existing in the system
   # specifically in cleanup for minitests
   def remove_all_bridge_domains
+    config 'system bridge-domain none' if /N7/ =~ node.product_id
     BridgeDomain.bds.each do |_bd, obj|
       obj.destroy
     end
@@ -210,6 +211,7 @@ class CiscoTestCase < TestCase
   # This testcase will remove all the vlans existing in the system
   # specifically in cleanup for minitests
   def remove_all_vlans
+    remove_all_bridge_domains
     Vlan.vlans.each do |vlan, obj|
       # skip reserved vlan
       next if vlan == '1'

--- a/tests/test_interface_private_vlan.rb
+++ b/tests/test_interface_private_vlan.rb
@@ -256,8 +256,8 @@ class TestSwitchport < TestInterfaceSwitchport
       end
       return
     end
-
-    assert_equal([], interface.switchport_mode_private_vlan_host_association,
+    val = interface.default_switchport_mode_private_vlan_host_association
+    assert_equal(val, interface.switchport_mode_private_vlan_host_association,
                  'Err: host association failed')
   end
 
@@ -305,8 +305,8 @@ class TestSwitchport < TestInterfaceSwitchport
       end
       return
     end
-
-    assert_equal([], interface.switchport_mode_private_vlan_host_promisc,
+    val = interface.default_switchport_mode_private_vlan_host_promisc
+    assert_equal(val, interface.switchport_mode_private_vlan_host_promisc,
                  'Err: promisc association failed')
   end
 
@@ -451,7 +451,8 @@ class TestSwitchport < TestInterfaceSwitchport
       end
       return
     end
-    assert_equal([], interface.switchport_private_vlan_trunk_allowed_vlan,
+    val = interface.default_switchport_private_vlan_trunk_allowed_vlan
+    assert_equal(val, interface.switchport_private_vlan_trunk_allowed_vlan,
                  'Err: trunk allowed vlan failed')
   end
 
@@ -536,7 +537,8 @@ class TestSwitchport < TestInterfaceSwitchport
       end
       return
     end
-    assert_equal([], interface.switchport_private_vlan_trunk_native_vlan,
+    val = interface.default_switchport_private_vlan_trunk_native_vlan
+    assert_equal(val, interface.switchport_private_vlan_trunk_native_vlan,
                  'Err: trunk native vlan failed')
   end
 
@@ -574,10 +576,7 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_association_trunk
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_association_trunk')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_private_vlan_association_trunk = %w(10 12)
-      end
+      assert_nil(interface.switchport_private_vlan_association_trunk)
       return
     end
     input = %w(10 12)
@@ -609,10 +608,7 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_assoc_vlan_bad_arg
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_association_trunk')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_private_vlan_association_trunk = %w(10 10)
-      end
+      assert_nil(interface.switchport_private_vlan_association_trunk)
       return
     end
     input = %w(10 10)
@@ -640,13 +636,11 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_trunk_assocciation_default
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_association_trunk')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_private_vlan_association_trunk = %w(10 10)
-      end
+      assert_nil(interface.switchport_private_vlan_association_trunk)
       return
     end
-    assert_equal([], interface.switchport_private_vlan_association_trunk,
+    val = interface.default_switchport_private_vlan_association_trunk
+    assert_equal(val, interface.switchport_private_vlan_association_trunk,
                  'Err: association trunk failed')
   end
 
@@ -654,22 +648,18 @@ class TestSwitchport < TestInterfaceSwitchport
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_mapping_trunk')
 
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_private_vlan_mapping_trunk = %w(10)
-      end
+      assert_nil(interface.switchport_private_vlan_mapping_trunk)
       return
     end
-    assert_equal([], interface.switchport_private_vlan_mapping_trunk,
+    val = interface.default_switchport_private_vlan_mapping_trunk
+    assert_equal(val, interface.switchport_private_vlan_mapping_trunk,
                  'Err: mapping trunk failed')
   end
 
   def test_interface_switchport_pvlan_mapping_trunk
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_mapping_trunk')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_private_vlan_mapping_trunk = %w(10 10)
-      end
+      assert_nil(interface.switchport_private_vlan_mapping_trunk)
       return
     end
     input = %w(10 11)
@@ -701,10 +691,7 @@ class TestSwitchport < TestInterfaceSwitchport
   def test_interface_switchport_pvlan_mapping_trunk_bad_arg
     if validate_property_excluded?('interface',
                                    'switchport_private_vlan_mapping_trunk')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_private_vlan_mapping_trunk = %w(10 10)
-      end
+      assert_nil(interface.switchport_private_vlan_mapping_trunk)
       return
     end
     input = %w(10 10)

--- a/tests/test_interface_svi.rb
+++ b/tests/test_interface_svi.rb
@@ -70,9 +70,7 @@ class TestSvi < CiscoTestCase
   def test_private_vlan_mapping
     if validate_property_excluded?('interface',
                                    'private_vlan_mapping')
-      assert_raises(Cisco::UnsupportedError) do
-        svi.private_vlan_mapping = %w(11-13)
-      end
+      assert_nil(svi.private_vlan_mapping)
       return
     end
     input = %w(10-20 30)
@@ -100,9 +98,7 @@ class TestSvi < CiscoTestCase
   def test_private_vlan_mapping_bad_args
     if validate_property_excluded?('interface',
                                    'private_vlan_mapping')
-      assert_raises(Cisco::UnsupportedError) do
-        svi.private_vlan_mapping = %w(10 20)
-      end
+      assert_nil(svi.private_vlan_mapping)
       return
     end
     input = %w(10 20)


### PR DESCRIPTION
**Summary:**
Refactored getters in `interface.rb` to use default yaml entries as single source of truth.

`tests/test_interface_private_vlan.rb` and `test_interface_svi.rb` tests pass on:
 `n3k(I2, I3), n5k, n6k, n7k, n8k, n9k(I2, I3)`
