### PR TITLE
Feature/vxlan fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -69,17 +69,11 @@ tacacs:
   set_value: "feature tacacs"
 
 vn_segment_vlan_based:
-  # MT-lite only
-  N3k: &vn_segment_vlan_based_mt_lite
-    # Note: Some N3k are not hardware-capable
-    kind: boolean
-    get_value: '/^feature vn-segment-vlan-based$/'
-    set_value: 'feature vn-segment-vlan-based'
-    default_value: false
-  N9k: *vn_segment_vlan_based_mt_lite
-  N8k: *vn_segment_vlan_based_mt_lite
-  N6k: *vn_segment_vlan_based_mt_lite
-  N5k: *vn_segment_vlan_based_mt_lite
+  _exclude: [N7k]
+  kind: boolean
+  get_value: '/^feature vn-segment-vlan-based$/'
+  set_value: 'feature vn-segment-vlan-based'
+  default_value: false
 
 vni:
   kind: boolean
@@ -87,13 +81,9 @@ vni:
     # MT-Full only
     get_value: '/^feature vni$/'
     set_value: 'feature vni'
-  N3k: &feature_mt_lite
-    # MT-lite only
-    # Note: Some N3k are not hardware-capable
+  else:
     get_value: '/^feature vn-segment-vlan-based$/'
     set_value: 'feature vn-segment-vlan-based'
-  N8k: *feature_mt_lite
-  N9k: *feature_mt_lite
 
 vtp:
   kind: boolean

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -110,6 +110,7 @@ module Cisco
       # Note: vdc platforms restrict this feature to F3 or newer linecards
       return if nv_overlay_enabled?
       config_set('feature', 'nv_overlay', state: '')
+      sleep 1
     end
 
     def self.nv_overlay_disable
@@ -117,6 +118,7 @@ module Cisco
       # Note: this is for test purposes only
       return unless nv_overlay_enabled?
       config_set('feature', 'nv_overlay', state: 'no')
+      sleep 1
     end
 
     def self.nv_overlay_enabled?

--- a/tests/test_bridge_domain_vni.rb
+++ b/tests/test_bridge_domain_vni.rb
@@ -35,6 +35,10 @@ class TestBridgeDomainVNI < CiscoTestCase
     super
     cleanup unless @@cleaned
     @@cleaned = true # rubocop:disable Style/ClassVars
+    mt_full_interface?
+    v = Vdc.new('default')
+    v.limit_resource_module_type = 'f3' unless
+      v.limit_resource_module_type == 'f3'
   end
 
   def teardown

--- a/tests/test_vxlan_vtep.rb
+++ b/tests/test_vxlan_vtep.rb
@@ -31,8 +31,6 @@ class TestVxlanVtep < CiscoTestCase
 
   def teardown
     Feature.nv_overlay_disable
-    # nv overlay is slow on some platforms
-    sleep 1
     return unless Vdc.vdc_support
     # Reset the vdc module type back to default
     v = Vdc.new('default')
@@ -46,16 +44,12 @@ class TestVxlanVtep < CiscoTestCase
     v.limit_resource_module_type = 'f3' unless
       v.limit_resource_module_type == 'f3'
     Feature.nv_overlay_disable
-    # nv overlay is slow on some platforms
-    sleep 1
   end
 
   def mt_lite_env_setup
     skip('Platform does not support MT-lite') unless VxlanVtep.mt_lite_support
     vxlan_linecard?
     Feature.nv_overlay_disable
-    # nv overlay is slow on some platforms
-    sleep 1
     config('no feature vn-segment-vlan-based')
   end
 


### PR DESCRIPTION
### Changes
- Explicitly include n5k and n6k in yaml
- Add delay after `nv_overlay_enable` to prevent crash on N5k
- Add check for vxlan linecard
### Testing
- Validated against vxlan-supported platforms: N5k and N7k
- Validated against non-supported platforms (skipped)
