### PR TITLE
vxlan/f3 test dependencies

### DIFF
--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -329,4 +329,18 @@ class CiscoTestCase < TestCase
     shell_command("sudo cp #{filename} /etc/resolv.conf", context)
     shell_command("rm #{filename}", context)
   end
+
+  # VDC helper for features that require a specific linecard.
+  # Allows caller to get current state or change it to a new value.
+  def vdc_lc_state(type=nil)
+    return unless node.product_id[/N7/]
+    vxlan_linecard? if type && type[/F3/i]
+    v = Vdc.new('default')
+    if type
+      # This action may be time consuming, use only if necessary.
+      v.limit_resource_module_type = type
+    else
+      v.limit_resource_module_type
+    end
+  end
 end

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -26,18 +26,6 @@ class TestFeature < CiscoTestCase
   # Helpers #
   ###########
 
-  # VDC helper for features that require a specific linecard.
-  # Allows caller to get current state or change it to a new value.
-  def vdc_lc_state(type=nil)
-    v = Vdc.new('default')
-    if type
-      # This action may be time consuming, use only if necessary.
-      v.limit_resource_module_type = type
-    else
-      v.limit_resource_module_type
-    end
-  end
-
   # feature test helper
   def feature(feat)
     # Get the feature name string from the yaml
@@ -97,8 +85,12 @@ class TestFeature < CiscoTestCase
       assert_raises(Cisco::UnsupportedError) { Feature.nv_overlay_enable }
       return
     end
+
+    # Dependency setup
     vxlan_linecard?
+    vdc_lc_state('f3')
     config_no_warn('no feature-set fabricpath')
+
     feature('nv_overlay')
   end
 
@@ -108,8 +100,8 @@ class TestFeature < CiscoTestCase
       assert_raises(Cisco::UnsupportedError) { Feature.nv_overlay_evpn_enable }
       return
     end
-    vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
-    vdc_lc_state('f3') if vdc_current
+    vxlan_linecard?
+    vdc_lc_state('f3')
 
     # nv_overlay_evpn can't use the 'feature' helper so test it explicitly here
     # Get current state of feature, then disable it
@@ -125,10 +117,6 @@ class TestFeature < CiscoTestCase
     Feature.nv_overlay_evpn_enable
     assert(Feature.nv_overlay_evpn_enabled?,
            "(#{feat_str}) is not enabled")
-
-    # Return testbed to pre-clean state
-    config("no #{feat_str}") unless pre_clean_enabled
-    vdc_lc_state(vdc_current) if vdc_current
   end
 
   def test_ospf
@@ -156,9 +144,9 @@ class TestFeature < CiscoTestCase
   end
 
   def test_vni
+    # Dependency setup
     vxlan_linecard?
-    vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
-    vdc_lc_state('f3') if vdc_current
+    vdc_lc_state('f3')
 
     if node.product_id[/N(5|6)/]
       Feature.nv_overlay_enable
@@ -167,7 +155,6 @@ class TestFeature < CiscoTestCase
       config_no_warn('no feature nv overlay')
     end
     feature('vni')
-    vdc_lc_state(vdc_current) if vdc_current
   rescue RuntimeError => e
     hardware_supports_feature?(e.message)
   end
@@ -190,10 +177,7 @@ class TestFeature < CiscoTestCase
     # Get current state of the feature-set
     feature_set_installed = Feature.fabric_installed?
     feature_enabled = Feature.fabric_enabled?
-    vdc_current = node.product_id[/N7/] ? vdc_lc_state : nil
 
-    # clean
-    vdc_lc_state('f3') if vdc_current
     config("no #{fs} ; no install #{fs}") if feature_set_installed
     refute_show_match(
       command: "show running | i '^install #{fs}$'",
@@ -207,7 +191,6 @@ class TestFeature < CiscoTestCase
     # Return testbed to pre-clean state
     config("no #{fs}") unless feature_enabled
     config("no install #{fs}") unless feature_set_installed
-    vdc_lc_state(vdc_current) if vdc_current
   end
 
   def test_feature_set_fex

--- a/tests/test_overlay_global.rb
+++ b/tests/test_overlay_global.rb
@@ -25,6 +25,8 @@ class TestOverlayGlobal < CiscoTestCase
 
   def setup
     super
+    vxlan_linecard?
+    vdc_lc_state('f3')
     config_no_warn('no feature fabric forwarding')
     config_no_warn('no nv overlay evpn')
     config_no_warn('l2rib dup-host-mac-detection default')

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -194,6 +194,10 @@ class TestVrf < CiscoTestCase
 
   def test_route_distinguisher
     skip_nexus_i2_image?
+    # Check for compatible linecard (if platform requires it) and set it up
+    vxlan_linecard?
+    vdc_lc_state('f3')
+
     v = Vrf.new('green')
     if validate_property_excluded?('vrf', 'route_distinguisher')
       # Must be configured under BGP in IOS XR

--- a/tests/test_vrf_af.rb
+++ b/tests/test_vrf_af.rb
@@ -115,6 +115,11 @@ class TestVrfAf < CiscoTestCase
   end
 
   def route_target(af)
+    #
+    # TBD: The evpn parts of this test need to check for compatible linecards to
+    # skip the evpn portions. Don't use vxlan_linecard? as that will cause all
+    # tests to be skipped.
+    #
     # Common tester for route-target properties. Tests evpn and non-evpn.
     #   route_target_both_auto
     #   route_target_both_auto_evpn


### PR DESCRIPTION
- Committing on behalf on #385, which had merge conflicts and we wanted this fix prior to releasing 1.3.0
- One issue with #385 was the route_target tests in vrf_af: Aneesh had placed a check for vxlan_linecard there, which solves the problem with platforms that don't have the requisite linecards to do evpn; but that call will also doa skip which in this case would skip all tests instead of just the evpn ones. I added a TBD breadcrumb there for now. We will ultimately need to either add a non-skip check or move the evpn tests out of that testcase.
- Tested on n3,n5(LC capable),n6(non-LC cap),n7(LC cap),n7(non-LC cap),n9
