### PR TITLE
Fix for n8k vrf context

### DIFF
--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -225,6 +225,10 @@ class CiscoTestCase < TestCase
     require_relative '../lib/cisco_node_utils/vrf'
     Vrf.vrfs.each do |vrf, obj|
       next if vrf[/management/]
+      # this is for n8k only for bug
+      # CSCuz56697 unable to remove vrf context sometimes
+      # TBD: remove it once the ddts is fixed
+      config 'vrf context ' + vrf if node.product_id[/N8/]
       obj.destroy
     end
   end


### PR DESCRIPTION
This PR is for n8k workaround for removing vrf context (which sometimes cannot be removed).
DDTS is raised and included in the comments.
test_vrf was on all platforms and the results are ok.
