### PR TITLE
Remove skip for CSCuz44696

### DIFF
--- a/tests/test_aaa_authentication_login_service.rb
+++ b/tests/test_aaa_authentication_login_service.rb
@@ -23,13 +23,6 @@ AAA_AUTH_LOGIN_SERVICE_METHOD_UNSELECTED = :unselected
 class TestAaaAuthenticationLoginService < CiscoTestCase
   @skip_unless_supported = 'aaa_auth_login_service'
 
-  def setup
-    super
-    # TBD: Remove once CSCuz44696 is resolved.
-    skip('This test is not currently supported on 7.0(3)I3 images') if
-      node.os_version[/7.0\(3\)I3\(/]
-  end
-
   def unconfig_tacacs
     config('no feature tacacs+')
   end

--- a/tests/test_aaa_authorization_service.rb
+++ b/tests/test_aaa_authorization_service.rb
@@ -22,9 +22,6 @@ class TestAaaAuthorizationService < CiscoTestCase
 
   def setup
     super
-    # TBD: Remove once CSCuz44696 is resolved.
-    skip('This test is not currently supported on 7.0(3)I3 images') if
-      node.os_version[/7.0\(3\)I3\(/]
 
     cleanup_aaa if @@pre_clean_needed
     @@pre_clean_needed = false # rubocop:disable Style/ClassVars

--- a/tests/test_tacacs_server_group.rb
+++ b/tests/test_tacacs_server_group.rb
@@ -20,13 +20,6 @@ require_relative '../lib/cisco_node_utils/tacacs_server_host'
 class TestTacacsServerGroup < CiscoTestCase
   @skip_unless_supported = 'tacacs_server_group'
 
-  def setup
-    super
-    # TBD: Remove once CSCuz44696 is resolved.
-    skip('This test is not currently supported on 7.0(3)I3 images') if
-      node.os_version[/7.0\(3\)I3\(/]
-  end
-
   def clean_tacacs_config
     config('no feature tacacs',
            'feature tacacs')


### PR DESCRIPTION
CSCuz44696 is fixed on latest I3 and I4 images now.

All tests re-run on I3/I4 images and they now pass.
