### PR TITLE
fix vni for all supported platforms

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vlan.yaml
@@ -24,15 +24,21 @@ fabric_control:
   default_value: false
 
 mapped_vni:
-  N3k: &mapped_vni_n3k_n9k
-    kind: int
+  _exclude: [N7k]
+  N3k: &mapped_vni_n3_8_9k
     get_command: 'show running vlan'
-    get_context: ['/^vlan <vlan>$/']
-    get_value: '/^vn-segment (\d+)$/'
-    set_context: ['vlan <vlan>']
-    set_value:  '<state> vn-segment <vni> ; end'
-    default_value: ''
-  N9k: *mapped_vni_n3k_n9k
+  N8k: *mapped_vni_n3_8_9k
+  N9k: *mapped_vni_n3_8_9k
+  N5k: &mapped_vni_n5_6k
+    get_command: 'show running vlan 1-4094'
+  N6k: *mapped_vni_n5_6k
+  kind: int
+  get_command: 'show running vlan'
+  get_context: ['/^vlan <vlan>$/']
+  get_value: '/^vn-segment (\d+)$/'
+  set_context: ['vlan <vlan>']
+  set_value:  '<state> vn-segment <vni> ; end'
+  default_value: ''
 
 mode:
   _exclude: [N3k, N9k]

--- a/lib/cisco_node_utils/cmd_ref/vlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vlan.yaml
@@ -33,7 +33,6 @@ mapped_vni:
     get_command: 'show running vlan 1-4094'
   N6k: *mapped_vni_n5_6k
   kind: int
-  get_command: 'show running vlan'
   get_context: ['/^vlan <vlan>$/']
   get_value: '/^vn-segment (\d+)$/'
   set_context: ['vlan <vlan>']

--- a/tests/test_vlan.rb
+++ b/tests/test_vlan.rb
@@ -290,6 +290,12 @@ class TestVlan < CiscoTestCase
   end
 
   def test_mapped_vnis
+    if validate_property_excluded?('vlan', 'mapped_vni')
+      assert_raises(Cisco::UnsupportedError) do
+        Vlan.new(100).mapped_vni = 10_000
+      end
+      return
+    end
     # Map
     v1 = Vlan.new(100)
     vni1 = 10_000


### PR DESCRIPTION
The `mapped_vni` property should be supported on all nexus platforms except n7k.  Previously we only had support for n3/n9k.  This update fixes that.

Tested on all nxos platforms.

The show command for `n5k` and `n6k` differs in that you have to specify the vlan range to complete the command :(
