### PR TITLE
Fix minitest for aaa feature

### DIFF
--- a/lib/cisco_node_utils/aaa_authentication_login_service.rb
+++ b/lib/cisco_node_utils/aaa_authentication_login_service.rb
@@ -58,8 +58,10 @@ module Cisco
       if g_str.empty?
         # cannot remove default local, so do nothing in this case
         unless m == :local && @name == 'default'
-          config_set('aaa_auth_login_service', 'method',
-                     'no', @name, m_str)
+          unless node.product_id[/N8/]
+            config_set('aaa_auth_login_service', 'method',
+                       'no', @name, m_str)
+          end
         end
       else
         config_set('aaa_auth_login_service', 'groups',


### PR DESCRIPTION
In N8k these two command
no aaa authentication login console local
no aaa authentication login console none
throw errors. I have asked aaa team to let us know if this is intentional or if this is a bug. For the time being we can skip these two commands in the clean up api for aaa minitest.
We the new change, I have ran test for 3k,9k,5-6k,7k,8k
