### PR TITLE
Utils.normalize_range_array

### DIFF
--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -231,7 +231,7 @@ module Cisco
     # them as a string that can be used directly on the switch.
     #
     # Note: The ranges are converted to ruby ranges for easy merging,
-    # then converted back to a cli-syntax ranges.
+    # then converted back to a cli-syntax range.
     #
     # Accepts an array or string:
     #   ["2-5", "9", "4-6"]  -or-  '2-5, 9, 4-6'  -or-  ["2-5, 9, 4-6"]

--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -263,12 +263,15 @@ module Cisco
 
     def private_vlan_association
       return nil unless Feature.private_vlan_enabled?
-      config_get('vlan', 'private_vlan_association', id: @vlan_id)
+      range = config_get('vlan', 'private_vlan_association', id: @vlan_id)
+      Utils.normalize_range_array(range)
     end
 
-    def private_vlan_association=(vlan_list)
+    def private_vlan_association=(range)
       Feature.private_vlan_enable
-      vlan_list_delta(private_vlan_association, vlan_list)
+      is = Utils.dash_range_to_elements(private_vlan_association)
+      should = Utils.dash_range_to_elements(range)
+      association_delta(is, should)
     end
 
     def default_private_vlan_association
@@ -276,48 +279,12 @@ module Cisco
     end
 
     # --------------------------
-    # vlan_list_delta is a helper function for the private_vlan_association
+    # association_delta is a helper function for the private_vlan_association
     # property. It walks the delta hash and adds/removes each target private
     # vlan.
-    # This api is used by private vlan to prepare the input to the setter
-    # method. The input can be in the following formats for vlans:
-    # 10-12,14. Prepare_array api is transforming this input into a flat array.
-    # In the example above the returned array will be 10, 11, 12, 14. Prepare
-    # array is first splitting the input on ',' and the than expanding the vlan
-    # range element like 10-12 into a flat array. The final result will
-    # be a  flat array.
-    # This way we can later used the lib utility to check the delta from
-    # the input vlan value and the vlan configured to apply the right config.
-
-    def vlan_list_delta(is_list, should_list)
-      new_list = []
-      should_list.each do |item|
-        if item.include?(',')
-          new_list.push(item.split(','))
-        else
-          new_list.push(item)
-        end
-      end
-      new_list.flatten!
-      new_list.sort!
-
-      new_list.each { |item| item.gsub!('-', '..') }
-
-      should_list_new = []
-      new_list.each do |elem|
-        if elem.include?('..')
-          elema = elem.split('..').map { |d| Integer(d) }
-          elema.sort!
-          tr = elema[0]..elema[1]
-          tr.to_a.each do |item|
-            should_list_new.push(item.to_s)
-          end
-        else
-          should_list_new.push(elem)
-        end
-      end
-
-      delta_hash = Utils.delta_add_remove(should_list_new, is_list)
+    def association_delta(is, should)
+      delta_hash = Utils.delta_add_remove(should, is)
+      Cisco::Logger.debug("association_delta: #{@vlan_id}: #{delta_hash}")
       [:add, :remove].each do |action|
         delta_hash[action].each do |vlans|
           state = (action == :add) ? '' : 'no'

--- a/tests/test_cmn_utils.rb
+++ b/tests/test_cmn_utils.rb
@@ -22,6 +22,9 @@ require_relative '../lib/cisco_node_utils/cisco_cmn_utils'
 
 # Test utility methods in cisco_cmn_utils
 class TestCmnUtils < CiscoTestCase
+  #
+  # TBD: Add tests for *all* methods in cisco_cmn_utils
+  #
   def test_dash_range_to_ruby_range
     expected = [2..5, 9..9, 4..6]
 

--- a/tests/test_cmn_utils.rb
+++ b/tests/test_cmn_utils.rb
@@ -1,0 +1,73 @@
+#!/usr/bin/env ruby
+# cisco_cmn_utils Unit Tests
+#
+# Chris Van Heuveln, May, 2016
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/cisco_cmn_utils'
+
+# Test utility methods in cisco_cmn_utils
+class TestCmnUtils < CiscoTestCase
+  def test_dash_range_to_ruby_range
+    expected = [2..5, 9..9, 4..6]
+
+    str_input = '2-5, 9, 4-6'
+    assert_equal(expected, Utils.dash_range_to_ruby_range(str_input))
+
+    arr_input = ['2-5', '9', '4-6']
+    assert_equal(expected, Utils.dash_range_to_ruby_range(arr_input))
+  end
+
+  def test_ruby_range_to_dash_range
+    str_expected = '2-5, 9, 4-6'
+    arr_expected = ['2-5', '9', '4-6']
+
+    input1 = [2..5, 9..9, 4..6]
+    input2 = input1.clone
+    assert_equal(str_expected, Utils.ruby_range_to_dash_range(input1, :string))
+    assert_equal(arr_expected, Utils.ruby_range_to_dash_range(input2, :array))
+  end
+
+  def test_dash_range_to_elements
+    expected = %w(2 3 4 5 6 9)
+
+    str_input = '2-5, 9, 4-6'
+    str_arr_input = ['2-5, 9, 4-6']
+    arr_input = str_input.split(', ')
+
+    assert_equal(expected, Utils.dash_range_to_elements(str_input))
+    assert_equal(expected, Utils.dash_range_to_elements(str_arr_input))
+    assert_equal(expected, Utils.dash_range_to_elements(arr_input))
+  end
+
+  def test_merge_range
+    expected = [2..6, 9..9]
+    input = [2..5, 9..9, 4..6]
+    assert_equal(expected, Utils.merge_range(input))
+  end
+
+  def test_normalize_range_array
+    expected = ['2-6', '9']
+
+    str_input = '2-5, 9, 4-6'
+    str_arr_input = ['2-5, 9, 4-6']
+    arr_input = str_input.split(', ')
+    assert_equal(expected, Utils.normalize_range_array(str_input))
+    assert_equal(expected, Utils.normalize_range_array(str_arr_input))
+    assert_equal(expected, Utils.normalize_range_array(arr_input))
+  end
+end

--- a/tests/test_vlan_private.rb
+++ b/tests/test_vlan_private.rb
@@ -607,63 +607,55 @@ class TestVlan < CiscoTestCase
 
   def test_private_vlan_multi_isolate_community_association
     vlan_list = %w(100 101 102 104 105 200 201 202)
-    result = %w(101 104 105 200 202)
     v1 = Vlan.new(vlan_list[0])
 
     pv_type = 'primary'
     if validate_property_excluded?('vlan', 'private_vlan_type')
       assert_nil(v1.private_vlan_type)
-      assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
-      end
+      assert_raises(Cisco::UnsupportedError) { v1.private_vlan_type = pv_type }
       return
-    else
-      v2 = Vlan.new(vlan_list[1])
-      v3 = Vlan.new(vlan_list[2])
-      v4 = Vlan.new(vlan_list[3])
-      v5 = Vlan.new(vlan_list[4])
-      v6 = Vlan.new(vlan_list[5])
-      v7 = Vlan.new(vlan_list[6])
-
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
-
-      pv_type = 'isolated'
-      v2.private_vlan_type = pv_type
-      assert_equal(pv_type, v2.private_vlan_type)
-
-      pv_type = 'isolated'
-      v3.private_vlan_type = pv_type
-      assert_equal(pv_type, v3.private_vlan_type)
-
-      pv_type = 'community'
-      v4.private_vlan_type = pv_type
-      assert_equal(pv_type, v4.private_vlan_type)
-
-      pv_type = 'community'
-      v5.private_vlan_type = pv_type
-      assert_equal(pv_type, v5.private_vlan_type)
-
-      pv_type = 'community'
-      v6.private_vlan_type = pv_type
-      assert_equal(pv_type, v6.private_vlan_type)
-
-      pv_type = 'primary'
-      v7.private_vlan_type = pv_type
-      assert_equal(pv_type, v7.private_vlan_type)
-
-      v1.private_vlan_association = ['101', '104-105', '200', '202']
-
-      assert_equal(result, v1.private_vlan_association)
-
-      v1.private_vlan_association = ['101', '103-105', '108']
-
-      result = %w(101 103 104 105 108)
-      assert_equal(result, v1.private_vlan_association)
-
-      v1.private_vlan_association = ['101', '103-105', '108']
-      result = %w(101 103 104 105 108)
-      assert_equal(result, v1.private_vlan_association)
     end
+
+    v2 = Vlan.new(vlan_list[1])
+    v3 = Vlan.new(vlan_list[2])
+    v4 = Vlan.new(vlan_list[3])
+    v5 = Vlan.new(vlan_list[4])
+    v6 = Vlan.new(vlan_list[5])
+    v7 = Vlan.new(vlan_list[6])
+
+    v1.private_vlan_type = pv_type
+    assert_equal(pv_type, v1.private_vlan_type)
+
+    pv_type = 'isolated'
+    v2.private_vlan_type = pv_type
+    assert_equal(pv_type, v2.private_vlan_type)
+
+    pv_type = 'isolated'
+    v3.private_vlan_type = pv_type
+    assert_equal(pv_type, v3.private_vlan_type)
+
+    pv_type = 'community'
+    v4.private_vlan_type = pv_type
+    assert_equal(pv_type, v4.private_vlan_type)
+
+    pv_type = 'community'
+    v5.private_vlan_type = pv_type
+    assert_equal(pv_type, v5.private_vlan_type)
+
+    pv_type = 'community'
+    v6.private_vlan_type = pv_type
+    assert_equal(pv_type, v6.private_vlan_type)
+
+    pv_type = 'primary'
+    v7.private_vlan_type = pv_type
+    assert_equal(pv_type, v7.private_vlan_type)
+
+    v1.private_vlan_association = %w(101 104 105 200 202)
+    result = %w(101 104-105 200 202)
+    assert_equal(result, v1.private_vlan_association)
+
+    v1.private_vlan_association = %w(101 103 104-105 108)
+    result = %w(101 103-105 108)
+    assert_equal(result, v1.private_vlan_association)
   end
 end


### PR DESCRIPTION
- The motivation for this change was finding yet another array normalizer in the private vlan code so these changes are initially meant to address fixes there. IMO our range summarize methods were getting a bit long and difficult to maintain; these new methods will hopefully simplify things somewhat.
- The main problem these methods are trying to solve is reconciling manifest inputs with getter results when there are overlapping ranges; e.g.:
  - '2-5, 9, 4-6'     needs to be ['2-6', '9']
  - ['2', '3', '4-6'] needs to be ['2-6']
  - ['2', '3', '4']   needs to be ['2-4']
- It's fairly easy to merge the ranges if they are actual ruby ranges instead of the dash-syntax ranges, so the new methods just convert to ruby ranges, merge, and convert back.
- There's also a method that breaks the ranges down into individual elements so that delta_add_remove can add or remove specific elements on the switch.
- I have a related commit for Puppet on the way.
- Tested on n9k
