### PR TITLE
N5|6k fix for vlan mapped_vni property

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vlan.yaml
@@ -44,11 +44,8 @@ mapped_vni_requires_nv_overlay:
   N5k: &requires_nv_overlay_true
     default_only: true
   N6k: *requires_nv_overlay_true
-  N3k: &requires_nv_overlay_false
+  else:
     default_only: false
-  N7k: *requires_nv_overlay_false
-  N8k: *requires_nv_overlay_false
-  N9k: *requires_nv_overlay_false
 
 mode:
   _exclude: [N3k, N9k]

--- a/lib/cisco_node_utils/cmd_ref/vlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vlan.yaml
@@ -39,6 +39,11 @@ mapped_vni:
   set_value:  '<state> vn-segment <vni> ; end'
   default_value: ''
 
+mapped_vni_requires_nv_overlay:
+  _exclude: [N3k, N7k, N8k, N9k]
+  kind: boolean
+  default_value: true
+
 mode:
   _exclude: [N3k, N9k]
   multiple: true

--- a/lib/cisco_node_utils/cmd_ref/vlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vlan.yaml
@@ -40,9 +40,15 @@ mapped_vni:
   default_value: ''
 
 mapped_vni_requires_nv_overlay:
-  _exclude: [N3k, N7k, N8k, N9k]
   kind: boolean
-  default_value: true
+  N5k: &requires_nv_overlay_true
+    default_only: true
+  N6k: *requires_nv_overlay_true
+  N3k: &requires_nv_overlay_false
+    default_only: false
+  N7k: *requires_nv_overlay_false
+  N8k: *requires_nv_overlay_false
+  N9k: *requires_nv_overlay_false
 
 mode:
   _exclude: [N3k, N9k]

--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -221,7 +221,13 @@ module Cisco
       config_get('vlan', 'mapped_vni', vlan: @vlan_id)
     end
 
+    def requires_nv_overlay?
+      config_get('vlan', 'mapped_vni_requires_nv_overlay')
+    end
+
     def mapped_vni=(vni)
+      # Some platforms require feature nv_overlay to be enabled first.
+      Feature.nv_overlay_enable if requires_nv_overlay?
       Feature.vn_segment_vlan_based_enable
       # Remove the existing mapping first as cli doesn't support overwriting.
       config_set('vlan', 'mapped_vni', vlan: @vlan_id,


### PR DESCRIPTION
On `n5k` and `n6k` platforms, `feature nv overlay` is required before `feature vn_segment_vlan_based` can be enabled.  This is needed for `mapped_vni` property support.

Tested on: n3k(I3), n5k, n6k, n7k, n8k, n9k (I2 and I3)

**NOTE:** This NU PR is paired with Puppet PR: https://github.com/cisco/cisco-network-puppet-module/pull/322
