### PR TITLE
bgp process init error fix

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -272,7 +272,7 @@ nsr:
   set_value: '<state> nsr'
 
 process_initialized:
-  _exclude: [ios_xr, N3k, N7k, N8k, N9k]
+  _exclude: [ios_xr, N3k, N7k, N9k]
   # bgp process initialization state
   kind: boolean
   context: ~


### PR DESCRIPTION
This PR is for including process_initialized property for n8k. The only change is in the yaml. This is required as the NU code is looking for this property during init after a certain timeout.
All minitests passed.
