### PR TITLE
interface: private_vlan refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+## [v1.3.1]
+
+### Changed
+* Deprecated `interface` private-vlan properties and replaced with new methods. New files `interface_DEPRECATED.rb` and `DEPRECATED.yaml` have been created to store the deprecated methods. The old -> new properties are:
+
+| Old Name | New Name(s) |
+|:---|:---:|
+| `private_vlan_mapping`                          | `pvlan_mapping`
+| `switchport_mode_private_vlan_host`             | `switchport_pvlan_host`, `switchport_pvlan_promiscuous`,
+| `switchport_mode_private_vlan_host_association` | `switchport_pvlan_host_association`
+| `switchport_mode_private_vlan_host_promiscous`  | `switchport_pvlan_mapping`
+| `switchport_mode_private_vlan_trunk_promiscuous`| `switchport_pvlan_trunk_promiscuous`
+| `switchport_mode_private_vlan_trunk_secondary`  | `switchport_pvlan_trunk_secondary`
+| `switchport_private_vlan_association_trunk`     | `switchport_pvlan_trunk_association`
+| `switchport_private_vlan_mapping_trunk`         | `switchport_pvlan_mapping_trunk`
+| `switchport_private_vlan_trunk_allowed_vlan`    | `switchport_pvlan_trunk_allowed_vlan`
+| `switchport_private_vlan_trunk_native_vlan`     | `switchport_pvlan_trunk_native_vlan`
+
 ## [v1.3.0]
 
 ### New feature support

--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -227,19 +227,19 @@ module Cisco
 
     # normalize_range_array
     #
-    # Given a list of ranges, merge any overlapping ranges and normalize the
-    # them as a string that can be used directly on the switch.
+    # Given a list of ranges, merge any overlapping ranges and sort them.
     #
     # Note: The ranges are converted to ruby ranges for easy merging,
     # then converted back to a cli-syntax range.
     #
     # Accepts an array or string:
     #   ["2-5", "9", "4-6"]  -or-  '2-5, 9, 4-6'  -or-  ["2-5, 9, 4-6"]
-    # Returns a merged and ordered range:
-    #   ["2-6", "9"]
+    # Returns a merged and ordered range as an array or string:
+    #   ["2-6", "9"] -or- '2-6,9'
     #
-    def self.normalize_range_array(range)
+    def self.normalize_range_array(range, fmt=:array)
       return range if range.nil? || range.empty?
+      range = range.clone
 
       # Handle string within an array: ["2-5, 9, 4-6"] to '2-5, 9, 4-6'
       range = range.shift if range.is_a?(Array) && range.length == 1
@@ -254,7 +254,10 @@ module Cisco
       merged = merge_range(range)
 
       # Convert back to cli dash-syntax
-      ruby_range_to_dash_range(merged)
+      merged_array = ruby_range_to_dash_range(merged)
+
+      return merged_array.join(',') if fmt == :string
+      merged_array
     end
 
     # Convert a cli-dash-syntax range to ruby-range. This is useful for
@@ -313,6 +316,7 @@ module Cisco
     #  ["2", "3", "4", "5", "6", "9"]
     #
     def self.dash_range_to_elements(range)
+      return [] if range.nil?
       range = range.shift if range.is_a?(Array) && range.length == 1
       range = range.split(',') if range.is_a?(String)
 

--- a/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
+++ b/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
@@ -11,12 +11,12 @@ _template:
     get_command: "show running interface all"
 
 private_vlan_any:
-  # DEPRECATED (REMOVING AT 2.0.0). USE 'pvlan_any'
+  # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'pvlan_any'
   multiple:
   get_value: '/switchport private-vlan/'
 
 private_vlan_mapping:
-  # DEPRECATED (REMOVING AT 2.0.0). USE 'pvlan_mapping'
+  # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'pvlan_mapping'
   _exclude: [ios_xr, N8k]
   multiple: true
   get_value: '/^private-vlan mapping (.*)$/'
@@ -24,14 +24,14 @@ private_vlan_mapping:
   default_value: []
 
 switchport_mode_private_vlan_host:
-  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_host'
+  # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_host'
   _exclude: [ios_xr, N8k]
   get_value: '/^switchport mode private-vlan (.*)$/'
   set_value: "<state> switchport mode private-vlan <mode>"
   default_value: :disabled
 
 switchport_mode_private_vlan_host_association:
-  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_host_association'
+  # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_host_association'
   _exclude: [ios_xr, N8k]
   multiple: true
   get_value: '/^switchport private-vlan host-association (.*)$/'
@@ -39,7 +39,7 @@ switchport_mode_private_vlan_host_association:
   default_value: []
 
 switchport_mode_private_vlan_host_promiscous:
-  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_promiscuous'
+  # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_promiscuous'
   _exclude: [ios_xr, N8k]
   multiple: true
   get_value: '/^switchport private-vlan mapping (\d+.*)$/'
@@ -47,14 +47,14 @@ switchport_mode_private_vlan_host_promiscous:
   default_value: []
 
 switchport_mode_private_vlan_trunk_promiscuous:
-  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_trunk_promiscuous'
+  # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_trunk_promiscuous'
   _exclude: [ios_xr, N3k, N8k]
   kind: boolean
   get_value: '/^switchport mode private-vlan trunk promiscuous$/'
   default_value: false
 
 switchport_mode_private_vlan_trunk_secondary:
-  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_trunk_secondary'
+  # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_trunk_secondary'
   _exclude: [ios_xr, N3k, N8k]
   kind: boolean
   get_value: '/^switchport mode private-vlan trunk secondary$/'
@@ -62,7 +62,7 @@ switchport_mode_private_vlan_trunk_secondary:
   default_value: false
 
 switchport_private_vlan_association_trunk:
-  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_trunk_association'
+  # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_trunk_association'
   _exclude: [ios_xr, N3k, N8k]
   multiple: true
   #get_value: '/^switchport private-vlan association trunk (.*) (.*)$/'
@@ -71,7 +71,7 @@ switchport_private_vlan_association_trunk:
   default_value: []
 
 switchport_private_vlan_mapping_trunk:
-  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_mapping_trunk'
+  # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_mapping_trunk'
   _exclude: [ios_xr, N3k, N8k]
   multiple: true
   get_value: '/^switchport private-vlan mapping trunk (.*)$/'
@@ -79,7 +79,7 @@ switchport_private_vlan_mapping_trunk:
   default_value: []
 
 switchport_private_vlan_trunk_allowed_vlan:
-  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_trunk_allowed_vlan'
+  # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_trunk_allowed_vlan'
   _exclude: [ios_xr, N8k]
   multiple: true
   get_value: '/^switchport private-vlan trunk allowed vlan (.*)$/'
@@ -87,7 +87,7 @@ switchport_private_vlan_trunk_allowed_vlan:
   default_value: []
 
 switchport_private_vlan_trunk_native_vlan:
-  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_trunk_native_vlan'
+  # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_trunk_native_vlan'
   _exclude: [ios_xr, N8k]
   kind: int
   get_value: '/^switchport private-vlan trunk native vlan (.*)$/'

--- a/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
+++ b/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
@@ -1,0 +1,95 @@
+# DEPRECATED
+#
+###############################################################################
+# WARNING. DO NOT USE ANY OF THE YAML TAGS IN THIS FILE.
+# These yaml tags are deprecated and will be removed in future releases.
+###############################################################################
+---
+_template:
+  context: ["interface <name>"]
+  nexus:
+    get_command: "show running interface all"
+
+private_vlan_any:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'pvlan_any'
+  multiple:
+  get_value: '/switchport private-vlan/'
+
+private_vlan_mapping:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'pvlan_mapping'
+  _exclude: [ios_xr, N8k]
+  multiple: true
+  get_value: '/^private-vlan mapping (.*)$/'
+  set_value: "<state> private-vlan mapping <vlans>"
+  default_value: []
+
+switchport_mode_private_vlan_host:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_host'
+  _exclude: [ios_xr, N8k]
+  get_value: '/^switchport mode private-vlan (.*)$/'
+  set_value: "<state> switchport mode private-vlan <mode>"
+  default_value: :disabled
+
+switchport_mode_private_vlan_host_association:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_host_association'
+  _exclude: [ios_xr, N8k]
+  multiple: true
+  get_value: '/^switchport private-vlan host-association (.*)$/'
+  set_value: "<state> switchport private-vlan host-association <vlan_pr> <vlan_sec>"
+  default_value: []
+
+switchport_mode_private_vlan_host_promiscous:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_promiscuous'
+  _exclude: [ios_xr, N8k]
+  multiple: true
+  get_value: '/^switchport private-vlan mapping (\d+.*)$/'
+  set_value: "<state> switchport private-vlan mapping <vlan_pr> <vlans>"
+  default_value: []
+
+switchport_mode_private_vlan_trunk_promiscuous:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_trunk_promiscuous'
+  _exclude: [ios_xr, N3k, N8k]
+  kind: boolean
+  get_value: '/^switchport mode private-vlan trunk promiscuous$/'
+  default_value: false
+
+switchport_mode_private_vlan_trunk_secondary:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_trunk_secondary'
+  _exclude: [ios_xr, N3k, N8k]
+  kind: boolean
+  get_value: '/^switchport mode private-vlan trunk secondary$/'
+  set_value: "<state> switchport mode private-vlan trunk secondary"
+  default_value: false
+
+switchport_private_vlan_association_trunk:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_trunk_association'
+  _exclude: [ios_xr, N3k, N8k]
+  multiple: true
+  #get_value: '/^switchport private-vlan association trunk (.*) (.*)$/'
+  get_value: '/^switchport private-vlan association trunk (.*)$/'
+  set_value: "<state> switchport private-vlan association trunk <vlan_pr> <vlan>"
+  default_value: []
+
+switchport_private_vlan_mapping_trunk:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_mapping_trunk'
+  _exclude: [ios_xr, N3k, N8k]
+  multiple: true
+  get_value: '/^switchport private-vlan mapping trunk (.*)$/'
+  set_value: "<state> switchport private-vlan mapping trunk <vlan_pr> <vlans>"
+  default_value: []
+
+switchport_private_vlan_trunk_allowed_vlan:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_trunk_allowed_vlan'
+  _exclude: [ios_xr, N8k]
+  multiple: true
+  get_value: '/^switchport private-vlan trunk allowed vlan (.*)$/'
+  set_value: "<state> switchport private-vlan trunk allowed vlan <oper> <vlans>"
+  default_value: []
+
+switchport_private_vlan_trunk_native_vlan:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_trunk_native_vlan'
+  _exclude: [ios_xr, N8k]
+  kind: int
+  get_value: '/^switchport private-vlan trunk native vlan (.*)$/'
+  set_value: "<state> switchport private-vlan trunk native vlan <vlan>"
+  default_value: 1

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -229,10 +229,11 @@ pvlan_any:
 
 # Be aware of similar vlan-mapping tags:
 # 'vlan_mapping' is the non-pvlan version of this command
-# 'pvlan_mapping' is the non-switchport private-vlan version
-# 'switchport_pvlan_mapping' is the switchport-pvlan version
-# 'switchport_pvlan_mapping_trunk' is the switchport-pvlan-trunk version
+# 'pvlan_mapping' is the SVI private-vlan command
+# 'switchport_pvlan_mapping' is the switchport-pvlan-host command
+# 'switchport_pvlan_mapping_trunk' is the switchport-pvlan-trunk command
 pvlan_mapping:
+  # SVI-only property
   _exclude: [ios_xr, N8k]
   get_value: '/^private-vlan mapping (.*)/'
   set_value: "<state> private-vlan mapping <vlan>"
@@ -431,8 +432,9 @@ switchport_pvlan_mapping:
 
 switchport_pvlan_mapping_trunk:
   _exclude: [ios_xr, N3k, N8k]
+  multiple:
   get_value: '/^switchport private-vlan mapping trunk (\d+) (.*)$/'
-  set_value: "<state> switchport private-vlan mapping trunk <primary> <vlan>"
+  set_value: "<state> switchport private-vlan mapping trunk <primary> <range>"
   default_value: []
 
 switchport_pvlan_promiscuous:

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -223,15 +223,19 @@ negotiate_auto_portchannel:
   set_value: "<state> negotiate auto"
   default_value: true
 
-private_vlan_any:
+pvlan_any:
   multiple:
   get_value: '/switchport private-vlan/'
 
-private_vlan_mapping:
+# Be aware of similar vlan-mapping tags:
+# 'vlan_mapping' is the non-pvlan version of this command
+# 'pvlan_mapping' is the non-switchport private-vlan version
+# 'switchport_pvlan_mapping' is the switchport-pvlan version
+# 'switchport_pvlan_mapping_trunk' is the switchport-pvlan-trunk version
+pvlan_mapping:
   _exclude: [ios_xr, N8k]
-  multiple: true
-  get_value: '/^private-vlan mapping (.*)$/'
-  set_value: "<state> private-vlan mapping <vlans>"
+  get_value: '/^private-vlan mapping (.*)/'
+  set_value: "<state> private-vlan mapping <vlan>"
   default_value: []
 
 shutdown:
@@ -405,75 +409,80 @@ switchport_mode_port_channel:
   set_value: "<state> switchport mode <mode>"
   default_value: ""
 
-switchport_mode_private_vlan_host:
+switchport_pvlan_host:
   _exclude: [ios_xr, N8k]
-  get_value: '/^switchport mode private-vlan (.*)$/'
-  set_value: "<state> switchport mode private-vlan <mode>"
-  default_value: :disabled
+  kind: boolean
+  get_value: '/^switchport mode private-vlan host$/'
+  set_value: "<state> switchport mode private-vlan host"
+  default_value: false
 
-switchport_mode_private_vlan_host_association:
+switchport_pvlan_host_association:
   _exclude: [ios_xr, N8k]
-  multiple: true
-  get_value: '/^switchport private-vlan host-association (.*)$/'
-  set_value: "<state> switchport private-vlan host-association <vlan_pr> <vlan_sec>"
+  # Note this is NOT a multiple, unlike trunk association.
+  get_value: '/^switchport private-vlan host-association (\d+) (\d+)$/'
+  set_value: "<state> switchport private-vlan host-association <pri> <sec>"
   default_value: []
 
-switchport_mode_private_vlan_host_promiscous:
+switchport_pvlan_mapping:
   _exclude: [ios_xr, N8k]
-  multiple: true
-  get_value: '/^switchport private-vlan mapping (\d+.*)$/'
-  set_value: "<state> switchport private-vlan mapping <vlan_pr> <vlans>"
+  get_value: '/^switchport private-vlan mapping (\d+) (.*)$/'
+  set_value: "<state> switchport private-vlan mapping <primary> <vlan>"
   default_value: []
 
+switchport_pvlan_mapping_trunk:
+  _exclude: [ios_xr, N3k, N8k]
+  get_value: '/^switchport private-vlan mapping trunk (\d+) (.*)$/'
+  set_value: "<state> switchport private-vlan mapping trunk <primary> <vlan>"
+  default_value: []
 
-switchport_mode_private_vlan_trunk_promiscuous:
+switchport_pvlan_promiscuous:
+  _exclude: [ios_xr, N8k]
+  kind: boolean
+  get_value: '/^switchport mode private-vlan promiscuous$/'
+  set_value: "<state> switchport mode private-vlan promiscuous"
+  default_value: false
+
+switchport_pvlan_trunk_allowed_vlan:
+  _exclude: [ios_xr, N8k]
+  get_value: '/^switchport private-vlan trunk allowed vlan (.*)$/'
+  set_value: "switchport private-vlan trunk allowed vlan <range>"
+  default_value: 'none'
+
+switchport_pvlan_trunk_association:
+  _exclude: [ios_xr, N3k, N8k]
+  multiple:
+  get_value: '/^switchport private-vlan association trunk (\d+) (\d+)$/'
+  set_value: "<state> switchport private-vlan association trunk <pri> <sec>"
+  default_value: []
+
+switchport_pvlan_trunk_native_vlan:
+  _exclude: [ios_xr, N8k]
+  get_value: '/^switchport private-vlan trunk native vlan (.*)$/'
+  set_value: "switchport private-vlan trunk native vlan <vlan>"
+  default_value: '1'
+
+switchport_pvlan_trunk_promiscuous:
   _exclude: [ios_xr, N3k, N8k]
   kind: boolean
   get_value: '/^switchport mode private-vlan trunk promiscuous$/'
   set_value: "<state> switchport mode private-vlan trunk promiscuous"
   default_value: false
 
-switchport_mode_private_vlan_trunk_secondary:
+switchport_pvlan_trunk_secondary:
   _exclude: [ios_xr, N3k, N8k]
   kind: boolean
   get_value: '/^switchport mode private-vlan trunk secondary$/'
   set_value: "<state> switchport mode private-vlan trunk secondary"
   default_value: false
 
-switchport_private_vlan_association_trunk:
-  _exclude: [ios_xr, N3k, N8k]
-  multiple: true
-  #get_value: '/^switchport private-vlan association trunk (.*) (.*)$/'
-  get_value: '/^switchport private-vlan association trunk (.*)$/'
-  set_value: "<state> switchport private-vlan association trunk <vlan_pr> <vlan>"
-  default_value: []
-
-switchport_private_vlan_mapping_trunk:
-  _exclude: [ios_xr, N3k, N8k]
-  multiple: true
-  get_value: '/^switchport private-vlan mapping trunk (.*)$/'
-  set_value: "<state> switchport private-vlan mapping trunk <vlan_pr> <vlans>"
-  default_value: []
-
-switchport_private_vlan_trunk_allowed_vlan:
-  _exclude: [ios_xr, N8k]
-  multiple: true
-  get_value: '/^switchport private-vlan trunk allowed vlan (.*)$/'
-  set_value: "<state> switchport private-vlan trunk allowed vlan <oper> <vlans>"
-  default_value: []
-
-switchport_private_vlan_trunk_native_vlan:
-  _exclude: [ios_xr, N8k]
-  kind: int
-  get_value: '/^switchport private-vlan trunk native vlan (.*)$/'
-  set_value: "<state> switchport private-vlan trunk native vlan <vlan>"
-  default_value: 1
-
 switchport_trunk_allowed_vlan:
   _exclude: [ios_xr]
   get_value: '/^switchport trunk allowed vlan (.*)$/'
   set_value: "<state> switchport trunk allowed vlan <vlan>"
   default_value: "1-4094"
+  # TBD: default should be 'none'; no need for state. See pvlan version.
+  # set_value: "switchport trunk allowed vlan <range>"
+  # default_value: 'none'
 
 switchport_trunk_native_vlan:
   _exclude: [ios_xr]

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -23,18 +23,21 @@ require_relative 'interface_DEPRECATED'
 # Cisco provider module
 module Cisco
   IF_SWITCHPORT_MODE = {
-    disabled:    '',
-    access:      'access',
-    trunk:       'trunk',
-    fex_fabric:  'fex-fabric',
-    tunnel:      'dot1q-tunnel',
-    fabricpath:  'fabricpath',
+    disabled:   '',
+    access:     'access',
+    trunk:      'trunk',
+    fex_fabric: 'fex-fabric',
+    tunnel:     'dot1q-tunnel',
+    fabricpath: 'fabricpath',
+  }
 
-    # DEPRECATED KEYS (REMOVE THESE WITH RELEASE 2.0.0)
+  # REMOVE THIS HASH WITH RELEASE 2.0.0
+  IF_DEPRECATED = {
     host:        'host',
     promiscuous: 'promiscuous',
     secondary:   'secondary',
   }
+  IF_SWITCHPORT_MODE.merge!(IF_DEPRECATED)
 
   # Interface - node utility class for general interface config management
   class Interface < Cisco::InterfaceDeprecated

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -18,8 +18,9 @@ require_relative 'cisco_cmn_utils'
 require_relative 'node_util'
 require_relative 'vrf'
 require_relative 'overlay_global'
+require_relative 'interface_DEPRECATED'
 
-# Add some interface-specific constants to the Cisco namespace
+# Cisco provider module
 module Cisco
   IF_SWITCHPORT_MODE = {
     disabled:    '',
@@ -28,21 +29,15 @@ module Cisco
     fex_fabric:  'fex-fabric',
     tunnel:      'dot1q-tunnel',
     fabricpath:  'fabricpath',
+
+    # DEPRECATED KEYS (REMOVE THESE WITH RELEASE 2.0.0)
     host:        'host',
     promiscuous: 'promiscuous',
     secondary:   'secondary',
   }
 
-  PVLAN_PROPERTY = {
-    host_promisc:  'switchport_mode_private_vlan_host_promiscous',
-    allow_vlan:    'switchport_private_vlan_trunk_allowed_vlan',
-    trunk_assoc:   'switchport_private_vlan_association_trunk',
-    mapping_trunk: 'switchport_private_vlan_mapping_trunk',
-    vlan_mapping:  'private_vlan_mapping',
-  }
-
   # Interface - node utility class for general interface config management
-  class Interface < NodeUtil
+  class Interface < Cisco::InterfaceDeprecated
     # Regexp to match various Ethernet interface variants:
     #                       Ethernet
     #                GigabitEthernet
@@ -83,18 +78,17 @@ module Cisco
     end
 
     # General-purpose filter for Interface.interfaces().
-    #    opt: Identifies the filter. This may be overloaded in the future to
-    #         allow a hash of filter conditions.
+    # filter: This may be overloaded in the future to allow a hash of filters.
     #     id: The interface name
     # Return: true if the interface should be filtered out, false to keep it.
-    def self.filter(opt, id)
-      case opt
-      when :private_vlan_any
-        return false if config_get('interface', 'private_vlan_any', name: id)
+    def self.filter(filter, id)
+      case filter
+      when :pvlan_any
+        return false if config_get('interface', 'pvlan_any', name: id)
 
       else
-        # opt is just a basic pattern filter (:ethernet, :loopback, etc)
-        return false if id.match(opt.to_s)
+        # Just a basic pattern filter (:ethernet, :loopback, etc)
+        return false if id.match(filter.to_s)
       end
       true
     end
@@ -144,6 +138,11 @@ module Cisco
 
     def destroy
       config_set('interface', 'destroy', name: @name)
+    end
+
+    def pvlan_enable
+      switchport_enable
+      Feature.private_vlan_enable
     end
 
     ########################################################
@@ -836,6 +835,7 @@ module Cisco
     end
 
     def switchport_enable(val=true)
+      return if switchport
       config_set('interface', 'switchport', name: @name, state: val ? '' : 'no')
     end
 
@@ -886,7 +886,7 @@ module Cisco
     end
 
     def switchport_enable_and_mode(mode_set)
-      switchport_enable unless switchport
+      switchport_enable
 
       if :fabricpath == mode_set
         fabricpath_feature_set(:enabled) unless :enabled == fabricpath_feature
@@ -962,19 +962,14 @@ module Cisco
       end
     end
 
-    # Interface private vlan configuration properties
-    # private vlan mode (host, promisc, trunk promisc , trunk sec)
-    # private vlan mapping
-    # private vlan native vlan
-    # private vlan allow vlan
-
+    # --------------------------
     def cli_error_check(result)
-      # The NXOS interface private vlan cli does not raise an exception
+      # Check for messages that can be safely ignored.
+      # The NXOS interface private-vlan cli does not raise an exception
       # in some conditions and instead just displays a STDOUT error message
       # thus NXAPI does not detect the failure.
-      # We must catch it by inspecting the "body" hash entry
-      # returned by NXAPI. This vlan cli behavior is unlikely to change.
-      # Check for messages that can be safely ignored.
+      # We must catch it by inspecting the "body" hash entry returned by NXAPI.
+      # This vlan cli behavior is unlikely to change.
 
       errors = /(ERROR:|VLAN:|Eth)/
       return unless
@@ -987,452 +982,287 @@ module Cisco
       end
     end
 
-    def switchport_enable_and_mode_private_vlan_host(mode_set)
-      switchport_enable unless switchport
-      if mode_set[/(host|promiscuous)/]
-        config_set('interface', 'switchport_mode_private_vlan_host',
-                   name: @name, state: '', mode: IF_SWITCHPORT_MODE[mode_set])
-      else
-        config_set('interface', 'switchport_mode_private_vlan_host',
-                   name: @name, state: 'no', mode: IF_SWITCHPORT_MODE[mode_set])
-      end
+    # --------------------------
+    # <state> switchport mode private-vlan host
+    def switchport_pvlan_host
+      config_get('interface', 'switchport_pvlan_host', name: @name)
     end
 
-    def switchport_mode_private_vlan_host
-      mode = config_get('interface',
-                        'switchport_mode_private_vlan_host',
-                        name: @name)
-      unless mode == default_switchport_mode_private_vlan_host
-        mode = IF_SWITCHPORT_MODE.key(mode)
-      end
-      mode
-    rescue IndexError
-      # Assume this is an interface that doesn't support switchport.
-      # Do not raise exception since the providers will prefetch this property
-      # regardless of interface type.
-      # TODO: this should probably be nil instead
-      return default_switchport_mode_private_vlan_host
+    def switchport_pvlan_host=(state)
+      pvlan_enable
+      config_set('interface', 'switchport_pvlan_host',
+                 name: @name, state: state ? '' : 'no')
     end
 
-    def switchport_mode_private_vlan_host=(mode_set)
-      fail ArgumentError unless IF_SWITCHPORT_MODE.keys.include? mode_set
-      Feature.private_vlan_enable
-      switchport_enable_and_mode_private_vlan_host(mode_set)
-    end
-
-    def default_switchport_mode_private_vlan_host
-      config_get_default('interface',
-                         'switchport_mode_private_vlan_host')
-    end
-
-    def switchport_mode_private_vlan_host_association
-      result = config_get('interface',
-                          'switchport_mode_private_vlan_host_association',
-                          name: @name)
-      unless result == default_switchport_mode_private_vlan_host_association
-        result = result[0].split(' ')
-      end
-      result
-    end
-
-    def switchport_mode_private_vlan_host_association=(vlans)
-      fail TypeError unless vlans.is_a?(Array) || vlans.empty?
-      switchport_enable unless switchport
-      Feature.private_vlan_enable
-      if vlans == default_switchport_mode_private_vlan_host_association
-        result = config_set('interface',
-                            'switchport_mode_private_vlan_host_association',
-                            name: @name, state: 'no', vlan_pr: '', vlan_sec: '')
-
-      else
-        result = config_set('interface',
-                            'switchport_mode_private_vlan_host_association',
-                            name: @name, state: '',
-                            vlan_pr: vlans[0], vlan_sec: vlans[1])
-
-      end
-      cli_error_check(result)
-    end
-
-    def default_switchport_mode_private_vlan_host_association
-      config_get_default('interface',
-                         'switchport_mode_private_vlan_host_association')
-    end
-
-    # This api is used by private vlan to prepare the input to the setter
-    # method. The input can be in the following formats for vlans:
-    # 10-12,14. Prepare_array api is transforming this input into a flat array.
-    # In the example above the returned array will be 10, 11, 12, 13. Prepare
-    # array is first splitting the input on ',' and the than expanding the vlan
-    # range element like 10-12 into a flat array. The final result will
-    # be a  flat array.
-    # This way we can later used the lib utility to check the delta from
-    # the input vlan value and the vlan configured to apply the right config.
-    def prepare_array(is_list)
-      new_list = []
-      is_list.each do |item|
-        if item.include?(',')
-          new_list.push(item.split(','))
-        else
-          new_list.push(item)
-        end
-      end
-      new_list.flatten!
-      new_list.sort!
-      new_list.each { |item| item.gsub!('-', '..') }
-      is_list_new = []
-      new_list.each do |elem|
-        if elem.include?('..')
-          elema = elem.split('..').map { |d| Integer(d) }
-          elema.sort!
-          tr = elema[0]..elema[1]
-          tr.to_a.each do |item|
-            is_list_new.push(item.to_s)
-          end
-        else
-          is_list_new.push(elem)
-        end
-      end
-      is_list_new
-    end
-
-    def configure_private_vlan_host_property(property, should_list_new,
-                                             is_list_new, pr_vlan)
-      delta_hash = Utils.delta_add_remove(should_list_new, is_list_new)
-      [:add, :remove].each do |action|
-        delta_hash[action].each do |vlans|
-          state = (action == :add) ? '' : 'no'
-          oper = (action == :add) ? 'add' : 'remove'
-          if property[/(host_promisc|mapping_trunk)/]
-
-            result = config_set('interface', PVLAN_PROPERTY[property],
-                                name: @name, state: state,
-                                vlan_pr: pr_vlan, vlans: vlans)
-            @match_found = true
-          end
-          if property[/allow_vlan/]
-            result = config_set('interface',
-                                PVLAN_PROPERTY[property],
-                                name: @name, state: '',
-                                oper: oper, vlans: vlans)
-          end
-          if property[/vlan_mapping/]
-            result = config_set('interface',
-                                PVLAN_PROPERTY[property],
-                                name: @name, state: state,
-                                vlans: vlans)
-          end
-          cli_error_check(result)
-        end
-      end
-    end
-
-    def configure_private_vlan_trunk_property(property, should_list_new,
-                                              is_list, pr_vlan)
-      case property
-      when :trunk_assoc
-        is_list.each do |vlans|
-          vlans = vlans.split(' ')
-          if vlans[0].eql? should_list_new[0]
-            config_set('interface',
-                       'switchport_private_vlan_association_trunk',
-                       name: @name, state: 'no',
-                       vlan_pr: pr_vlan, vlan: vlans[1])
-            break
-          else
-            next
-          end
-        end
-        result = config_set('interface', PVLAN_PROPERTY[property], name: @name,
-                            state: '', vlan_pr: should_list_new[0],
-                            vlan: should_list_new[1])
-      when :mapping_trunk
-        @match_found = false
-        is_list.each do |vlans|
-          vlans = vlans.split(' ')
-          interf_vlan_list_delta(:mapping_trunk, vlans,
-                                 should_list_new)
-          if @match_found
-            break
-          else
-            next
-          end
-        end
-        result = config_set('interface', PVLAN_PROPERTY[property], name: @name,
-                            state: '', vlan_pr: should_list_new[0],
-                            vlans: should_list_new[1])
-      end
-      cli_error_check(result)
+    def default_switchport_pvlan_host
+      config_get_default('interface', 'switchport_pvlan_host')
     end
 
     # --------------------------
-    # interf_vlan_list_delta is a helper function for the private_vlan_mapping
-    # property. It walks the delta hash and adds/removes each target private
-    # vlan.
-
-    def interf_vlan_list_delta(property, is_list, should_list)
-      pr_vlan = should_list[0]
-      if is_list[0].eql? should_list[0]
-        should_list = should_list[1].split(',')
-        is_list = is_list[1].split(',')
-
-        should_list_new = prepare_array(should_list)
-        is_list_new = prepare_array(is_list)
-        configure_private_vlan_host_property(property, should_list_new,
-                                             is_list_new, pr_vlan)
-      else
-        case property
-        when :mapping_trunk
-          return
-        end
-        # If primary vlan are different we can simply replacing the all
-        # config
-        if should_list == default_switchport_mode_private_vlan_host_promisc
-          result = config_set('interface',
-                              'switchport_mode_private_vlan_host_promiscous',
-                              name: @name, state: 'no',
-                              vlan_pr: '', vlans: '')
-
-        else
-          result = config_set('interface',
-                              'switchport_mode_private_vlan_host_promiscous',
-                              name: @name, state: '',
-                              vlan_pr: pr_vlan, vlans: should_list[1])
-
-        end
-        cli_error_check(result)
-      end
+    # <state> switchport mode private-vlan promiscuous
+    def switchport_pvlan_promiscuous
+      config_get('interface', 'switchport_pvlan_promiscuous', name: @name)
     end
 
-    def switchport_mode_private_vlan_host_promisc
-      result = config_get('interface',
-                          'switchport_mode_private_vlan_host_promiscous',
-                          name: @name)
-      unless result == default_switchport_mode_private_vlan_host_promisc
-        result = result[0].split(' ')
-      end
-      result
+    def switchport_pvlan_promiscuous=(state)
+      pvlan_enable
+      config_set('interface', 'switchport_pvlan_promiscuous',
+                 name: @name, state: state ? '' : 'no')
     end
 
-    def switchport_mode_private_vlan_host_promisc=(vlans)
-      fail TypeError unless vlans.is_a?(Array)
-      fail TypeError unless vlans.empty? || vlans.length == 2
-      switchport_enable unless switchport
-      Feature.private_vlan_enable
-      is_list = switchport_mode_private_vlan_host_promisc
-      interf_vlan_list_delta(:host_promisc, is_list, vlans)
+    def default_switchport_pvlan_promiscuous
+      config_get_default('interface', 'switchport_pvlan_promiscuous')
     end
 
-    def default_switchport_mode_private_vlan_host_promisc
-      config_get_default('interface',
-                         'switchport_mode_private_vlan_host_promiscous')
+    # --------------------------
+    # <state> switchport private-vlan host-association <pri> <sec>
+    # Note this is NOT a multiple, unlike trunk association.
+    def switchport_pvlan_host_association
+      config_get('interface', 'switchport_pvlan_host_association', name: @name)
     end
 
-    def switchport_mode_private_vlan_trunk_promiscuous
-      config_get('interface',
-                 'switchport_mode_private_vlan_trunk_promiscuous',
-                 name: @name)
-    rescue IndexError
-      # Assume this is an interface that doesn't support switchport.
-      # Do not raise exception since the providers will prefetch this property
-      # regardless of interface type.
-      # TODO: this should probably be nil instead
-      return default_switchport_mode_private_vlan_trunk_promiscuous
+    # Input: An array of primary and secondary vlans: ['44', '244']
+    def switchport_pvlan_host_association=(pri_and_sec)
+      pvlan_enable
+
+      state = pri_and_sec.empty? ? 'no' : ''
+      pri, sec = pri_and_sec
+      cli_error_check(
+        config_set('interface', 'switchport_pvlan_host_association',
+                   name: @name, state: state, pri: pri, sec: sec))
     end
 
-    def switchport_mode_private_vlan_trunk_promiscuous=(state)
-      Feature.private_vlan_enable
-      switchport_enable unless switchport
-      if state == default_switchport_mode_private_vlan_trunk_promiscuous
-        config_set('interface',
-                   'switchport_mode_private_vlan_trunk_promiscuous',
-                   name: @name, state: 'no')
-      else
-        config_set('interface',
-                   'switchport_mode_private_vlan_trunk_promiscuous',
-                   name: @name, state: '')
-      end
+    def default_switchport_pvlan_host_association
+      config_get_default('interface', 'switchport_pvlan_host_association')
     end
 
-    def default_switchport_mode_private_vlan_trunk_promiscuous
-      config_get_default('interface',
-                         'switchport_mode_private_vlan_trunk_promiscuous')
+    # --------------------------
+    # <state> switchport private-vlan mapping <primary> <vlan>
+    def switchport_pvlan_mapping
+      config_get('interface', 'switchport_pvlan_mapping', name: @name)
     end
 
-    def switchport_mode_private_vlan_trunk_secondary
-      config_get('interface',
-                 'switchport_mode_private_vlan_trunk_secondary',
-                 name: @name)
-    rescue IndexError
-      # Assume this is an interface that doesn't support switchport.
-      # Do not raise exception since the providers will prefetch this property
-      # regardless of interface type.
-      # TODO: this should probably be nil instead
-      return default_switchport_mode_private_vlan_trunk_secondary
+    # Input: An array of primary vlan and range of vlans: ['44', '3-4,6']
+    def switchport_pvlan_mapping=(primary_and_range)
+      pvlan_range_delta(primary_and_range, 'switchport_pvlan_mapping')
     end
 
-    def switchport_mode_private_vlan_trunk_secondary=(state)
-      Feature.private_vlan_enable
-      switchport_enable unless switchport
-      if state == default_switchport_mode_private_vlan_trunk_secondary
-        config_set('interface', 'switchport_mode_private_vlan_trunk_secondary',
-                   name: @name, state: 'no')
-      else
-        config_set('interface', 'switchport_mode_private_vlan_trunk_secondary',
-                   name: @name, state: '')
-      end
+    def default_switchport_pvlan_mapping
+      config_get_default('interface', 'switchport_pvlan_mapping')
     end
 
-    def default_switchport_mode_private_vlan_trunk_secondary
-      config_get_default('interface',
-                         'switchport_mode_private_vlan_trunk_secondary')
+    # --------------------------
+    # <state> switchport private-vlan mapping trunk <primary> <vlan>
+    def switchport_pvlan_mapping_trunk
+      config_get('interface', 'switchport_pvlan_mapping_trunk', name: @name)
     end
 
-    def switchport_private_vlan_trunk_allowed_vlan
-      result = config_get('interface',
-                          'switchport_private_vlan_trunk_allowed_vlan',
-                          name: @name)
+    # Input: An array of primary vlan and range of vlans: ['44', '3-4,6']
+    def switchport_pvlan_mapping_trunk=(primary_and_range)
+      pvlan_range_delta(primary_and_range, 'switchport_pvlan_mapping_trunk')
+    end
 
-      unless result == default_switchport_private_vlan_trunk_allowed_vlan
-        if result[0].eql? 'none'
-          result = default_switchport_private_vlan_trunk_allowed_vlan
-        else
-          result = result[0].split(',')
+    def default_switchport_pvlan_mapping_trunk
+      config_get_default('interface', 'switchport_pvlan_mapping_trunk')
+    end
+
+    # --------------------------
+    # pvlan_range_delta is a helper function for private-vlan mapping
+    # properties. It creates and walks a delta hash, then adds/removes
+    # each vlan from the range.
+    #
+    # Inputs:
+    # primary_and_range: An array of primary vlan and range of vlans
+    #              prop: The getter name to use with config_set
+    def pvlan_range_delta(primary_and_range, prop)
+      # Enable switchport mode and feature private-vlan
+      pvlan_enable
+      primary, should_range = primary_and_range
+
+      # primary changes require removing the entire command first
+      is_range = pvlan_remove_mapping_command?(prop, primary)
+
+      # convert ranges to individual elements
+      is = Utils.dash_range_to_elements(is_range)
+      should = Utils.dash_range_to_elements(should_range)
+
+      # create the delta hash and apply the changes
+      delta_hash = Utils.delta_add_remove(should, is)
+      Cisco::Logger.debug("xx_delta: #{@primary}: #{delta_hash}")
+      [:add, :remove].each do |action|
+        delta_hash[action].each do |vlan|
+          state = (action == :add) ? '' : 'no'
+          keys = { name: @name, state: state, primary: primary, vlan: vlan }
+          cli_error_check(config_set('interface', prop, keys))
         end
       end
-      result
     end
 
-    def switchport_private_vlan_trunk_allowed_vlan=(vlans)
-      fail TypeError unless vlans.is_a?(Array)
-      Feature.private_vlan_enable
-      switchport_enable unless switchport
-      if vlans == default_switchport_private_vlan_trunk_allowed_vlan
-        vlans = prepare_array(switchport_private_vlan_trunk_allowed_vlan)
-        # If there are no vlan presently configured, we can simply return
-        return if vlans == default_switchport_private_vlan_trunk_allowed_vlan
-        configure_private_vlan_host_property(:allow_vlan, [],
-                                             vlans, '')
-      else
-        vlans = prepare_array(vlans)
-        is_list = prepare_array(switchport_private_vlan_trunk_allowed_vlan)
-        configure_private_vlan_host_property(:allow_vlan, vlans,
-                                             is_list, '')
+    # --------------------------
+    # pvlan_remove_mapping_command?
+    # This is a helper to check if command needs to be removed entirely.
+    #
+    #           prop: getter property name
+    # should_primary: the new primary vlan value
+    #        Returns: the current vlan range
+    def pvlan_remove_mapping_command?(prop, should_primary)
+      is_primary, is_range = send(prop)
+
+      if (is_primary != should_primary) && !is_primary.nil?
+        cli_error_check(
+          config_set('interface', prop,
+                     name: @name, state: 'no', primary: '', vlan: ''))
+        is_range = []
+      end
+      is_range
+    end
+
+    # --------------------------
+    # <state> switchport private-vlan association trunk <pri> <sec>
+    # Supports multiple.
+    def switchport_pvlan_trunk_association
+      config_get('interface', 'switchport_pvlan_trunk_association', name: @name)
+    end
+
+    # Input: A nested array of primary and secondary vlans:
+    # [['44', '244'], ['99', '299']]
+    def switchport_pvlan_trunk_association=(should)
+      pvlan_enable
+
+      # Handle single-level arrays if found: [pri, sec] -> [[pri,sec]]
+      should = [should] if !should.empty? && (Utils.depth(should) == 1)
+
+      is = switchport_pvlan_trunk_association
+      pvlan_trunk_association_delta(is, should)
+    end
+
+    def pvlan_trunk_association_delta(is, should)
+      delta_hash = Utils.delta_add_remove(should, is)
+      Cisco::Logger.debug("pvlan_trunk_association_delta: #{delta_hash}")
+      [:remove, :add].each do |action|
+        delta_hash[action].each do |pri_and_sec|
+          state = (action == :add) ? '' : 'no'
+          pri, sec = pri_and_sec
+
+          # Cli does not like removals that specify the secondary
+          sec = '' if action[/remove/]
+          cli_error_check(
+            config_set('interface', 'switchport_pvlan_trunk_association',
+                       name: @name, state: state, pri: pri, sec: sec))
+        end
       end
     end
 
-    def default_switchport_private_vlan_trunk_allowed_vlan
-      config_get_default('interface',
-                         'switchport_private_vlan_trunk_allowed_vlan')
+    def default_switchport_pvlan_trunk_association
+      config_get_default('interface', 'switchport_pvlan_trunk_association')
     end
 
-    def switchport_private_vlan_trunk_native_vlan
-      config_get('interface',
-                 'switchport_private_vlan_trunk_native_vlan',
+    # --------------------------
+    # <state> switchport mode private-vlan trunk promiscuous
+    def switchport_pvlan_trunk_promiscuous
+      config_get('interface', 'switchport_pvlan_trunk_promiscuous', name: @name)
+    end
+
+    def switchport_pvlan_trunk_promiscuous=(state)
+      pvlan_enable
+      config_set('interface', 'switchport_pvlan_trunk_promiscuous',
+                 name: @name, state: state ? '' : 'no')
+    end
+
+    def default_switchport_pvlan_trunk_promiscuous
+      config_get_default('interface', 'switchport_pvlan_trunk_promiscuous')
+    end
+
+    # --------------------------
+    # <state> switchport mode private-vlan trunk secondary
+    def switchport_pvlan_trunk_secondary
+      config_get('interface', 'switchport_pvlan_trunk_secondary', name: @name)
+    end
+
+    def switchport_pvlan_trunk_secondary=(state)
+      pvlan_enable
+      config_set('interface', 'switchport_pvlan_trunk_secondary',
+                 name: @name, state: state ? '' : 'no')
+    end
+
+    def default_switchport_pvlan_trunk_secondary
+      config_get_default('interface', 'switchport_pvlan_trunk_secondary')
+    end
+
+    # --------------------------
+    # <state> switchport private-vlan trunk allowed vlan <range>
+    # Note that range is handled as a string because the entire range is
+    # replaced instead of individually adding or removing vlans from the range.
+    def switchport_pvlan_trunk_allowed_vlan
+      config_get('interface', 'switchport_pvlan_trunk_allowed_vlan',
                  name: @name)
     end
 
-    def switchport_private_vlan_trunk_native_vlan=(vlan)
-      Feature.private_vlan_enable
-      switchport_enable unless switchport
-      if vlan == default_switchport_private_vlan_trunk_native_vlan
-        config_set('interface',
-                   'switchport_private_vlan_trunk_native_vlan',
-                   name: @name, state: 'no', vlan: '')
+    def switchport_pvlan_trunk_allowed_vlan=(range)
+      pvlan_enable
 
-      else
-        config_set('interface',
-                   'switchport_private_vlan_trunk_native_vlan',
-                   name: @name, state: '', vlan: vlan)
+      range = Utils.normalize_range_array(range, :string) unless
+        range == default_switchport_pvlan_trunk_allowed_vlan
+
+      config_set('interface', 'switchport_pvlan_trunk_allowed_vlan',
+                 name: @name, range: range)
+    end
+
+    def default_switchport_pvlan_trunk_allowed_vlan
+      config_get_default('interface', 'switchport_pvlan_trunk_allowed_vlan')
+    end
+
+    # --------------------------
+    # <state> switchport trunk native vlan <vlan>
+    def switchport_pvlan_trunk_native_vlan
+      config_get('interface', 'switchport_pvlan_trunk_native_vlan', name: @name)
+    end
+
+    def switchport_pvlan_trunk_native_vlan=(vlan)
+      pvlan_enable
+      config_set('interface', 'switchport_pvlan_trunk_native_vlan',
+                 name: @name, vlan: vlan)
+    end
+
+    def default_switchport_pvlan_trunk_native_vlan
+      config_get_default('interface', 'switchport_pvlan_trunk_native_vlan')
+    end
+
+    # --------------------------
+    # This is an SVI property.
+    # <state> private-vlan mapping <range>  # ex. range = ['2-4,9']
+    def pvlan_mapping
+      range = config_get('interface', 'pvlan_mapping', name: @name)
+      range.empty? ? range : range.delete(' ')
+    end
+
+    def pvlan_mapping=(range)
+      feature_vlan_set
+      Feature.private_vlan_enable
+
+      is = Utils.dash_range_to_elements(pvlan_mapping)
+      should = Utils.dash_range_to_elements(range)
+      pvlan_mapping_delta(is, should)
+    end
+
+    def pvlan_mapping_delta(is, should)
+      delta_hash = Utils.delta_add_remove(should, is)
+      Cisco::Logger.debug("pvlan_mapping_delta: #{delta_hash}")
+      [:remove, :add].each do |action|
+        delta_hash[action].each do |vlan|
+          state = (action == :add) ? '' : 'no'
+          cli_error_check(
+            config_set('interface', 'pvlan_mapping',
+                       name: @name, state: state, vlan: vlan))
+        end
       end
     end
 
-    def default_switchport_private_vlan_trunk_native_vlan
-      config_get_default('interface',
-                         'switchport_private_vlan_trunk_native_vlan')
+    def default_pvlan_mapping
+      config_get_default('interface', 'pvlan_mapping')
     end
 
-    def switchport_private_vlan_association_trunk
-      config_get('interface',
-                 'switchport_private_vlan_association_trunk',
-                 name: @name)
-    end
-
-    def switchport_private_vlan_association_trunk=(vlans)
-      fail TypeError unless vlans.is_a?(Array) || vlans.empty?
-      Feature.private_vlan_enable
-      switchport_enable unless switchport
-      if vlans == default_switchport_private_vlan_association_trunk
-        config_set('interface', 'switchport_private_vlan_association_trunk',
-                   name: @name, state: 'no',
-                   vlan_pr: '', vlan: '')
-      else
-        is_list = switchport_private_vlan_association_trunk
-        configure_private_vlan_trunk_property(:trunk_assoc, vlans,
-                                              is_list, vlans[0])
-      end
-    end
-
-    def default_switchport_private_vlan_association_trunk
-      config_get_default('interface',
-                         'switchport_private_vlan_association_trunk')
-    end
-
-    def switchport_private_vlan_mapping_trunk
-      config_get('interface',
-                 'switchport_private_vlan_mapping_trunk',
-                 name: @name)
-    end
-
-    def switchport_private_vlan_mapping_trunk=(vlans)
-      fail TypeError unless vlans.is_a?(Array) || vlans.empty?
-      Feature.private_vlan_enable
-      switchport_enable unless switchport
-      if vlans == default_switchport_private_vlan_mapping_trunk
-        config_set('interface', 'switchport_private_vlan_mapping_trunk',
-                   name: @name, state: 'no',
-                   vlan_pr: '', vlans: '')
-      else
-        is_list = switchport_private_vlan_mapping_trunk
-        configure_private_vlan_trunk_property(:mapping_trunk, vlans,
-                                              is_list, vlans[0])
-      end
-    end
-
-    def default_switchport_private_vlan_mapping_trunk
-      config_get_default('interface',
-                         'switchport_private_vlan_mapping_trunk')
-    end
-
-    def private_vlan_mapping
-      match = config_get('interface',
-                         'private_vlan_mapping',
-                         name: @name)
-      match[0].delete!(' ') unless match == default_private_vlan_mapping
-      match
-    end
-
-    def private_vlan_mapping=(vlans)
-      fail TypeError unless vlans.is_a?(Array) || vlans.empty?
-      Feature.private_vlan_enable
-      feature_vlan_set(true)
-      if vlans == default_private_vlan_mapping
-        config_set('interface', 'private_vlan_mapping',
-                   name: @name, state: 'no', vlans: '')
-      else
-        is_list = private_vlan_mapping
-        new_is_list = prepare_array(is_list)
-        new_vlans = prepare_array(vlans)
-        configure_private_vlan_host_property(:vlan_mapping, new_vlans,
-                                             new_is_list, '')
-      end
-    end
-
-    def default_private_vlan_mapping
-      config_get_default('interface',
-                         'private_vlan_mapping')
-    end
-
+    # --------------------------
     # vlan_mapping & vlan_mapping_enable
     #  Hardware & Cli Dependencies:
     #   - F3 linecards only
@@ -1572,7 +1402,9 @@ module Cisco
       config_get('interface', 'feature_vlan')
     end
 
-    def feature_vlan_set(val)
+    def feature_vlan_set(val=true)
+      # 'feature interface-vlan'
+      # TBD: Replace this with Feature.interface_vlan_enable
       return if feature_vlan? == val
       config_set('interface', 'feature_vlan', state: val ? '' : 'no')
     end

--- a/lib/cisco_node_utils/interface_DEPRECATED.rb
+++ b/lib/cisco_node_utils/interface_DEPRECATED.rb
@@ -1,0 +1,512 @@
+# rubocop: disable Style/FileName
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+#
+#                        WARNING! WARNING! WARNING!
+#
+# This file contains deprecated methods that will be removed with version 2.0
+#
+###############################################################################
+
+require 'logger'
+
+# Cisco provider module
+module Cisco
+  PVLAN_PROPERTY = {
+    host_promisc:  'switchport_mode_private_vlan_host_promiscous',
+    allow_vlan:    'switchport_private_vlan_trunk_allowed_vlan',
+    trunk_assoc:   'switchport_private_vlan_association_trunk',
+    mapping_trunk: 'switchport_private_vlan_mapping_trunk',
+    vlan_mapping:  'private_vlan_mapping',
+  }
+
+  # Interface - node utility class for general interface config management
+  class InterfaceDeprecated < NodeUtil
+    def deprecation_warning(method, new_prop=nil)
+      if new_prop.nil?
+        new_prop = ''
+      else
+        new_prop = "The new property name is '#{new_prop}'"
+      end
+
+      warn "
+      #########################################################################
+       WARNING: Method '#{method.to_s.delete('=')}'
+       is deprecated and should not be used.
+       #{new_prop}
+      #########################################################################
+      "
+    end
+
+    def switchport_enable_and_mode_private_vlan_host(mode_set)
+      deprecation_warning(__method__)
+      switchport_enable unless switchport
+      if mode_set[/(host|promiscuous)/]
+        config_set('DEPRECATED', 'switchport_mode_private_vlan_host',
+                   name: @name, state: '', mode: IF_SWITCHPORT_MODE[mode_set])
+      else
+        config_set('DEPRECATED', 'switchport_mode_private_vlan_host',
+                   name: @name, state: 'no', mode: IF_SWITCHPORT_MODE[mode_set])
+      end
+    end
+
+    def switchport_mode_private_vlan_host
+      mode = config_get('DEPRECATED',
+                        'switchport_mode_private_vlan_host',
+                        name: @name)
+      unless mode == default_switchport_mode_private_vlan_host
+        mode = IF_SWITCHPORT_MODE.key(mode)
+      end
+      mode
+    rescue IndexError
+      # Assume this is an interface that doesn't support switchport.
+      # Do not raise exception since the providers will prefetch this property
+      # regardless of interface type.
+      # TODO: this should probably be nil instead
+      return default_switchport_mode_private_vlan_host
+    end
+
+    def switchport_mode_private_vlan_host=(mode_set)
+      deprecation_warning(__method__, 'switchport_pvlan_host')
+
+      fail ArgumentError unless IF_SWITCHPORT_MODE.keys.include? mode_set
+      Feature.private_vlan_enable
+      switchport_enable_and_mode_private_vlan_host(mode_set)
+    end
+
+    def default_switchport_mode_private_vlan_host
+      config_get_default('DEPRECATED',
+                         'switchport_mode_private_vlan_host')
+    end
+
+    def switchport_mode_private_vlan_host_association
+      result = config_get('DEPRECATED',
+                          'switchport_mode_private_vlan_host_association',
+                          name: @name)
+      unless result == default_switchport_mode_private_vlan_host_association
+        result = result[0].split(' ')
+      end
+      result
+    end
+
+    def switchport_mode_private_vlan_host_association=(vlans)
+      deprecation_warning(__method__, 'switchport_pvlan_host_association')
+      fail TypeError unless vlans.is_a?(Array) || vlans.empty?
+      switchport_enable unless switchport
+      Feature.private_vlan_enable
+      if vlans == default_switchport_mode_private_vlan_host_association
+        result = config_set('DEPRECATED',
+                            'switchport_mode_private_vlan_host_association',
+                            name: @name, state: 'no', vlan_pr: '', vlan_sec: '')
+
+      else
+        result = config_set('DEPRECATED',
+                            'switchport_mode_private_vlan_host_association',
+                            name: @name, state: '',
+                            vlan_pr: vlans[0], vlan_sec: vlans[1])
+
+      end
+      cli_error_check(result)
+    end
+
+    def default_switchport_mode_private_vlan_host_association
+      config_get_default('DEPRECATED',
+                         'switchport_mode_private_vlan_host_association')
+    end
+
+    # This api is used by private vlan to prepare the input to the setter
+    # method. The input can be in the following formats for vlans:
+    # 10-12,14. Prepare_array api is transforming this input into a flat array.
+    # In the example above the returned array will be 10, 11, 12, 13. Prepare
+    # array is first splitting the input on ',' and the than expanding the vlan
+    # range element like 10-12 into a flat array. The final result will
+    # be a  flat array.
+    # This way we can later used the lib utility to check the delta from
+    # the input vlan value and the vlan configured to apply the right config.
+    def prepare_array(is_list)
+      new_list = []
+      is_list.each do |item|
+        if item.include?(',')
+          new_list.push(item.split(','))
+        else
+          new_list.push(item)
+        end
+      end
+      new_list.flatten!
+      new_list.sort!
+      new_list.each { |item| item.gsub!('-', '..') }
+      is_list_new = []
+      new_list.each do |elem|
+        if elem.include?('..')
+          elema = elem.split('..').map { |d| Integer(d) }
+          elema.sort!
+          tr = elema[0]..elema[1]
+          tr.to_a.each do |item|
+            is_list_new.push(item.to_s)
+          end
+        else
+          is_list_new.push(elem)
+        end
+      end
+      is_list_new
+    end
+
+    def configure_private_vlan_host_property(property, should_list_new,
+                                             is_list_new, pr_vlan)
+      delta_hash = Utils.delta_add_remove(should_list_new, is_list_new)
+      [:add, :remove].each do |action|
+        delta_hash[action].each do |vlans|
+          state = (action == :add) ? '' : 'no'
+          oper = (action == :add) ? 'add' : 'remove'
+          if property[/(host_promisc|mapping_trunk)/]
+
+            result = config_set('DEPRECATED', PVLAN_PROPERTY[property],
+                                name: @name, state: state,
+                                vlan_pr: pr_vlan, vlans: vlans)
+            @match_found = true
+          end
+          if property[/allow_vlan/]
+            result = config_set('DEPRECATED',
+                                PVLAN_PROPERTY[property],
+                                name: @name, state: '',
+                                oper: oper, vlans: vlans)
+          end
+          if property[/vlan_mapping/]
+            result = config_set('DEPRECATED',
+                                PVLAN_PROPERTY[property],
+                                name: @name, state: state,
+                                vlans: vlans)
+          end
+          cli_error_check(result)
+        end
+      end
+    end
+
+    def configure_private_vlan_trunk_property(property, should_list_new,
+                                              is_list, pr_vlan)
+      case property
+      when :trunk_assoc
+        is_list.each do |vlans|
+          vlans = vlans.split(' ')
+          if vlans[0].eql? should_list_new[0]
+            config_set('DEPRECATED',
+                       'switchport_private_vlan_association_trunk',
+                       name: @name, state: 'no',
+                       vlan_pr: pr_vlan, vlan: vlans[1])
+            break
+          else
+            next
+          end
+        end
+        result = config_set('DEPRECATED', PVLAN_PROPERTY[property], name: @name,
+                            state: '', vlan_pr: should_list_new[0],
+                            vlan: should_list_new[1])
+      when :mapping_trunk
+        @match_found = false
+        is_list.each do |vlans|
+          vlans = vlans.split(' ')
+          interf_vlan_list_delta(:mapping_trunk, vlans,
+                                 should_list_new)
+          if @match_found
+            break
+          else
+            next
+          end
+        end
+        result = config_set('DEPRECATED', PVLAN_PROPERTY[property], name: @name,
+                            state: '', vlan_pr: should_list_new[0],
+                            vlans: should_list_new[1])
+      end
+      cli_error_check(result)
+    end
+
+    # --------------------------
+    # interf_vlan_list_delta is a helper function for the private_vlan_mapping
+    # property. It walks the delta hash and adds/removes each target private
+    # vlan.
+
+    def interf_vlan_list_delta(property, is_list, should_list)
+      pr_vlan = should_list[0]
+      if is_list[0].eql? should_list[0]
+        should_list = should_list[1].split(',')
+        is_list = is_list[1].split(',')
+
+        should_list_new = prepare_array(should_list)
+        is_list_new = prepare_array(is_list)
+        configure_private_vlan_host_property(property, should_list_new,
+                                             is_list_new, pr_vlan)
+      else
+        case property
+        when :mapping_trunk
+          return
+        end
+        # If primary vlan are different we can simply replacing the all
+        # config
+        if should_list == default_switchport_mode_private_vlan_host_promisc
+          result = config_set('DEPRECATED',
+                              'switchport_mode_private_vlan_host_promiscous',
+                              name: @name, state: 'no',
+                              vlan_pr: '', vlans: '')
+
+        else
+          result = config_set('DEPRECATED',
+                              'switchport_mode_private_vlan_host_promiscous',
+                              name: @name, state: '',
+                              vlan_pr: pr_vlan, vlans: should_list[1])
+
+        end
+        cli_error_check(result)
+      end
+    end
+
+    def switchport_mode_private_vlan_host_promisc
+      result = config_get('DEPRECATED',
+                          'switchport_mode_private_vlan_host_promiscous',
+                          name: @name)
+      unless result == default_switchport_mode_private_vlan_host_promisc
+        result = result[0].split(' ')
+      end
+      result
+    end
+
+    def switchport_mode_private_vlan_host_promisc=(vlans)
+      deprecation_warning(__method__, 'switchport_pvlan_promiscuous')
+      fail TypeError unless vlans.is_a?(Array)
+      fail TypeError unless vlans.empty? || vlans.length == 2
+      switchport_enable unless switchport
+      Feature.private_vlan_enable
+      is_list = switchport_mode_private_vlan_host_promisc
+      interf_vlan_list_delta(:host_promisc, is_list, vlans)
+    end
+
+    def default_switchport_mode_private_vlan_host_promisc
+      config_get_default('DEPRECATED',
+                         'switchport_mode_private_vlan_host_promiscous')
+    end
+
+    def switchport_mode_private_vlan_trunk_promiscuous
+      config_get('DEPRECATED',
+                 'switchport_mode_private_vlan_trunk_promiscuous',
+                 name: @name)
+    rescue IndexError
+      # Assume this is an interface that doesn't support switchport.
+      # Do not raise exception since the providers will prefetch this property
+      # regardless of interface type.
+      # TODO: this should probably be nil instead
+      return default_switchport_mode_private_vlan_trunk_promiscuous
+    end
+
+    def switchport_mode_private_vlan_trunk_promiscuous=(state)
+      deprecation_warning(__method__, 'switchport_pvlan_trunk_promiscuous')
+      Feature.private_vlan_enable
+      switchport_enable unless switchport
+      if state == default_switchport_mode_private_vlan_trunk_promiscuous
+        config_set('DEPRECATED',
+                   'switchport_mode_private_vlan_trunk_promiscuous',
+                   name: @name, state: 'no')
+      else
+        config_set('DEPRECATED',
+                   'switchport_mode_private_vlan_trunk_promiscuous',
+                   name: @name, state: '')
+      end
+    end
+
+    def default_switchport_mode_private_vlan_trunk_promiscuous
+      config_get_default('DEPRECATED',
+                         'switchport_mode_private_vlan_trunk_promiscuous')
+    end
+
+    def switchport_mode_private_vlan_trunk_secondary
+      config_get('DEPRECATED',
+                 'switchport_mode_private_vlan_trunk_secondary',
+                 name: @name)
+    rescue IndexError
+      # Assume this is an interface that doesn't support switchport.
+      # Do not raise exception since the providers will prefetch this property
+      # regardless of interface type.
+      # TODO: this should probably be nil instead
+      return default_switchport_mode_private_vlan_trunk_secondary
+    end
+
+    def switchport_mode_private_vlan_trunk_secondary=(state)
+      deprecation_warning(__method__, 'switchport_pvlan_trunk_secondary')
+      Feature.private_vlan_enable
+      switchport_enable unless switchport
+      if state == default_switchport_mode_private_vlan_trunk_secondary
+        config_set('DEPRECATED', 'switchport_mode_private_vlan_trunk_secondary',
+                   name: @name, state: 'no')
+      else
+        config_set('DEPRECATED', 'switchport_mode_private_vlan_trunk_secondary',
+                   name: @name, state: '')
+      end
+    end
+
+    def default_switchport_mode_private_vlan_trunk_secondary
+      config_get_default('DEPRECATED',
+                         'switchport_mode_private_vlan_trunk_secondary')
+    end
+
+    def switchport_private_vlan_trunk_allowed_vlan
+      result = config_get('DEPRECATED',
+                          'switchport_private_vlan_trunk_allowed_vlan',
+                          name: @name)
+
+      unless result == default_switchport_private_vlan_trunk_allowed_vlan
+        if result[0].eql? 'none'
+          result = default_switchport_private_vlan_trunk_allowed_vlan
+        else
+          result = result[0].split(',')
+        end
+      end
+      result
+    end
+
+    def switchport_private_vlan_trunk_allowed_vlan=(vlans)
+      deprecation_warning(__method__, 'switchport_pvlan_trunk_allowed_vlan')
+      fail TypeError unless vlans.is_a?(Array)
+      Feature.private_vlan_enable
+      switchport_enable unless switchport
+      if vlans == default_switchport_private_vlan_trunk_allowed_vlan
+        vlans = prepare_array(switchport_private_vlan_trunk_allowed_vlan)
+        # If there are no vlan presently configured, we can simply return
+        return if vlans == default_switchport_private_vlan_trunk_allowed_vlan
+        configure_private_vlan_host_property(:allow_vlan, [],
+                                             vlans, '')
+      else
+        vlans = prepare_array(vlans)
+        is_list = prepare_array(switchport_private_vlan_trunk_allowed_vlan)
+        configure_private_vlan_host_property(:allow_vlan, vlans,
+                                             is_list, '')
+      end
+    end
+
+    def default_switchport_private_vlan_trunk_allowed_vlan
+      config_get_default('DEPRECATED',
+                         'switchport_private_vlan_trunk_allowed_vlan')
+    end
+
+    def switchport_private_vlan_trunk_native_vlan
+      config_get('DEPRECATED',
+                 'switchport_private_vlan_trunk_native_vlan',
+                 name: @name)
+    end
+
+    def switchport_private_vlan_trunk_native_vlan=(vlan)
+      deprecation_warning(__method__, 'switchport_pvlan_trunk_native_vlan')
+      Feature.private_vlan_enable
+      switchport_enable unless switchport
+      if vlan == default_switchport_private_vlan_trunk_native_vlan
+        config_set('DEPRECATED',
+                   'switchport_private_vlan_trunk_native_vlan',
+                   name: @name, state: 'no', vlan: '')
+
+      else
+        config_set('DEPRECATED',
+                   'switchport_private_vlan_trunk_native_vlan',
+                   name: @name, state: '', vlan: vlan)
+      end
+    end
+
+    def default_switchport_private_vlan_trunk_native_vlan
+      config_get_default('DEPRECATED',
+                         'switchport_private_vlan_trunk_native_vlan')
+    end
+
+    def switchport_private_vlan_association_trunk
+      config_get('DEPRECATED',
+                 'switchport_private_vlan_association_trunk',
+                 name: @name)
+    end
+
+    def switchport_private_vlan_association_trunk=(vlans)
+      deprecation_warning(__method__, 'switchport_pvlan_trunk_association')
+      fail TypeError unless vlans.is_a?(Array) || vlans.empty?
+      Feature.private_vlan_enable
+      switchport_enable unless switchport
+      if vlans == default_switchport_private_vlan_association_trunk
+        config_set('DEPRECATED', 'switchport_private_vlan_association_trunk',
+                   name: @name, state: 'no',
+                   vlan_pr: '', vlan: '')
+      else
+        is_list = switchport_private_vlan_association_trunk
+        configure_private_vlan_trunk_property(:trunk_assoc, vlans,
+                                              is_list, vlans[0])
+      end
+    end
+
+    def default_switchport_private_vlan_association_trunk
+      config_get_default('DEPRECATED',
+                         'switchport_private_vlan_association_trunk')
+    end
+
+    def switchport_private_vlan_mapping_trunk
+      config_get('DEPRECATED',
+                 'switchport_private_vlan_mapping_trunk',
+                 name: @name)
+    end
+
+    def switchport_private_vlan_mapping_trunk=(vlans)
+      deprecation_warning(__method__, 'switchport_pvlan_mapping_trunk')
+      fail TypeError unless vlans.is_a?(Array) || vlans.empty?
+      Feature.private_vlan_enable
+      switchport_enable unless switchport
+      if vlans == default_switchport_private_vlan_mapping_trunk
+        config_set('DEPRECATED', 'switchport_private_vlan_mapping_trunk',
+                   name: @name, state: 'no',
+                   vlan_pr: '', vlans: '')
+      else
+        is_list = switchport_private_vlan_mapping_trunk
+        configure_private_vlan_trunk_property(:mapping_trunk, vlans,
+                                              is_list, vlans[0])
+      end
+    end
+
+    def default_switchport_private_vlan_mapping_trunk
+      config_get_default('DEPRECATED',
+                         'switchport_private_vlan_mapping_trunk')
+    end
+
+    def private_vlan_mapping
+      match = config_get('DEPRECATED',
+                         'private_vlan_mapping',
+                         name: @name)
+      match[0].delete!(' ') unless match == default_private_vlan_mapping
+      match
+    end
+
+    def private_vlan_mapping=(vlans)
+      deprecation_warning(__method__, 'pvlan_mapping')
+      fail TypeError unless vlans.is_a?(Array) || vlans.empty?
+      Feature.private_vlan_enable
+      feature_vlan_set(true)
+      if vlans == default_private_vlan_mapping
+        config_set('DEPRECATED', 'private_vlan_mapping',
+                   name: @name, state: 'no', vlans: '')
+      else
+        is_list = private_vlan_mapping
+        new_is_list = prepare_array(is_list)
+        new_vlans = prepare_array(vlans)
+        configure_private_vlan_host_property(:vlan_mapping, new_vlans,
+                                             new_is_list, '')
+      end
+    end
+
+    def default_private_vlan_mapping
+      config_get_default('DEPRECATED',
+                         'private_vlan_mapping')
+    end
+  end  # Class
+end    # Module

--- a/lib/cisco_node_utils/interface_DEPRECATED.rb
+++ b/lib/cisco_node_utils/interface_DEPRECATED.rb
@@ -17,7 +17,7 @@
 #
 #                        WARNING! WARNING! WARNING!
 #
-# This file contains deprecated methods that will be removed with version 2.0
+# This file contains deprecated methods that will be removed with version 2.0.0
 #
 ###############################################################################
 

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -197,7 +197,7 @@ class CiscoTestCase < TestCase
 
   def remove_all_svis
     Interface.interfaces(:vlan).each do |svi, obj|
-      next if svi == '1'
+      next if svi == 'vlan1'
       obj.destroy
     end
   end

--- a/tests/test_interface_private_vlan.rb
+++ b/tests/test_interface_private_vlan.rb
@@ -193,31 +193,6 @@ class TestInterfacePrivateVlan < CiscoTestCase
     assert_equal(default, i.switchport_pvlan_trunk_association)
   end
 
-  def test_pvlan_mapping
-    # This is an SVI property
-    svi = Interface.new('vlan13')
-    if validate_property_excluded?('interface', 'pvlan_mapping')
-      assert_raises(Cisco::UnsupportedError) do
-        svi.pvlan_mapping = ['10-11,4-7,8']
-      end
-      return
-    end
-
-    default = svi.default_pvlan_mapping
-    assert_equal(default, svi.pvlan_mapping)
-
-    # Input can be Array or String
-    svi.pvlan_mapping = ['10-11,4-7,8']
-    assert_equal('4-8,10-11', svi.pvlan_mapping)
-
-    # Change range
-    svi.pvlan_mapping = '11,4-6,8'
-    assert_equal('4-6,8,11', svi.pvlan_mapping)
-
-    svi.pvlan_mapping = default
-    assert_equal(default, svi.pvlan_mapping)
-  end
-
   def test_switchport_pvlan_mapping
     if validate_property_excluded?('interface', 'switchport_pvlan_mapping')
       assert_raises(Cisco::UnsupportedError) do

--- a/tests/test_interface_private_vlan.rb
+++ b/tests/test_interface_private_vlan.rb
@@ -18,18 +18,25 @@ require_relative '../lib/cisco_node_utils/vlan'
 
 include Cisco
 
-# TestInterfaceSwitchport
+# TestInterfacePrivateVlan
 # Parent class for specific types of switchport tests (below)
-class TestInterfaceSwitchport < CiscoTestCase
-  @@pre_clean_needed = true # rubocop:disable Style/ClassVars
-  attr_reader :interface
+class TestInterfacePrivateVlan < CiscoTestCase
+  # rubocop:disable Style/ClassVars
+  @@pre_clean_needed = true
+  attr_reader :i
+
+  def i
+    @@interface
+  end
 
   def setup
     super
-    @interface = Interface.new(interfaces[0])
-    cleanup if @@pre_clean_needed
-    @@pre_clean_needed = false # rubocop:disable Style/ClassVars
+    return unless @@pre_clean_needed
+    cleanup
+    @@interface = Interface.new(interfaces[0])
+    @@pre_clean_needed = false
   end
+  # rubocop:enable Style/ClassVars
 
   def teardown
     cleanup
@@ -37,687 +44,265 @@ class TestInterfaceSwitchport < CiscoTestCase
   end
 
   def cleanup
-    cleanup_pvlan_intfs
+    interface_cleanup_pvlan
     remove_all_vlans
     config_no_warn('no feature private-vlan', 'no feature vtp')
   end
 
-  def remove_svis
-    Interface.interfaces.each do |name, _i|
-      next unless name[/vlan/] || name.match(/^vlan1$/)
-      config("no interface #{name}")
-    end
-  end
-
-  def cleanup_pvlan_intfs
-    pvlan_intfs = Interface.interfaces(:private_vlan_any)
+  def interface_cleanup_pvlan
+    pvlan_intfs = Interface.interfaces(:pvlan_any)
     pvlan_intfs.keys.each { |name| interface_cleanup(name) }
   end
-end
 
-# TestSwitchport - general interface switchport tests.
-class TestSwitchport < TestInterfaceSwitchport
-  def test_switchport_private_host_mode
+  def test_switchport_pvlan_host
     if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
+                                   'switchport_pvlan_host')
       assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
-      end
-      return
-    end
-    switchport_modes = [
-      :host,
-      :promiscuous,
-    ]
-
-    switchport_modes.each do |start|
-      interface.switchport_mode_private_vlan_host = start
-      assert_equal(start, interface.switchport_mode_private_vlan_host,
-                   "Err: Switchport mode, #{start}, not as expected")
-    end
-  end
-
-  def test_switchport_private_trunk_promisc
-    if validate_property_excluded?(
-      'interface',
-      'switchport_mode_private_vlan_trunk_secondary')
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_trunk_promiscuous = true
-      end
-      return
-    end
-    interface.switchport_mode_private_vlan_trunk_promiscuous = true
-    assert(interface.switchport_mode_private_vlan_trunk_promiscuous,
-           'Err: Switchport mode, not as expected')
-  end
-
-  def test_switchport_private_trunk_secondary
-    if validate_property_excluded?(
-      'interface',
-      'switchport_mode_private_vlan_trunk_secondary')
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_trunk_secondary = true
-      end
-      return
-    end
-    interface.switchport_mode_private_vlan_trunk_secondary = true
-    assert(interface.switchport_mode_private_vlan_trunk_secondary,
-           'Err: Switchport mode, not as expected')
-  end
-
-  def test_no_switchport_private_host_mode
-    if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
-      end
-      return
-    end
-    switchport_modes = [
-      :host,
-      :promiscuous,
-    ]
-
-    switchport_modes.each do |start|
-      interface.switchport_mode_private_vlan_host = start
-      assert_equal(start, interface.switchport_mode_private_vlan_host,
-                   "Err: Switchport mode, #{start}, not as expected")
-      interface.switchport_mode_private_vlan_host = :disabled
-      assert_equal(:disabled, interface.switchport_mode_private_vlan_host,
-                   'Error: Switchport mode not disabled')
-    end
-  end
-
-  def test_no_switchport_private_trunk_mode
-    if validate_property_excluded?(
-      'interface',
-      'switchport_mode_private_vlan_trunk_secondary')
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_trunk_secondary = true
-      end
-      return
-    end
-    interface.switchport_mode_private_vlan_trunk_secondary = true
-    assert(interface.switchport_mode_private_vlan_trunk_secondary,
-           'Err: Switchport mode not as expected')
-    interface.switchport_mode_private_vlan_trunk_secondary = false
-    refute(interface.switchport_mode_private_vlan_trunk_secondary,
-           'Err: Switchport mode not disabled')
-  end
-
-  def test_switchport_private_host_association
-    if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
-      end
-      return
-    end
-    v1 = Vlan.new(10)
-    v1.private_vlan_type = 'primary'
-    v2 = Vlan.new(11)
-    v2.private_vlan_type = 'community'
-    v1.private_vlan_association = ['11']
-
-    interface.switchport_mode_private_vlan_host = :host
-    assert_equal(:host, interface.switchport_mode_private_vlan_host,
-                 'Err: Switchport mode not as expected')
-
-    input = %w(10 11)
-
-    interface.switchport_mode_private_vlan_host_association = input
-    assert_equal(input,
-                 interface.switchport_mode_private_vlan_host_association,
-                 'Err: switchport private host_association not configured')
-  end
-
-  def test_switchport_pvlan_host_assoc_change
-    if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
-      end
-      return
-    end
-    v1 = Vlan.new(10)
-    v1.private_vlan_type = 'primary'
-    v2 = Vlan.new(11)
-    v2.private_vlan_type = 'community'
-    v1.private_vlan_association = ['11']
-
-    interface.switchport_mode_private_vlan_host = :host
-    assert_equal(:host, interface.switchport_mode_private_vlan_host,
-                 'Error: Switchport mode not as expected')
-
-    input = %w(10 11)
-
-    interface.switchport_mode_private_vlan_host_association = input
-    assert_equal(input,
-                 interface.switchport_mode_private_vlan_host_association,
-                 'Err: switchport private host_association not configured')
-
-    v3 = Vlan.new(20)
-    v3.private_vlan_type = 'primary'
-
-    v4 = Vlan.new(21)
-    v4.private_vlan_type = 'community'
-    v3.private_vlan_association = ['21']
-
-    input = %w(20 21)
-    interface.switchport_mode_private_vlan_host_association = input
-    assert_equal(input,
-                 interface.switchport_mode_private_vlan_host_association,
-                 'Err: switchport private host_association not configured')
-
-    input = []
-    interface.switchport_mode_private_vlan_host_association = input
-    assert_equal(input,
-                 interface.switchport_mode_private_vlan_host_association,
-                 'Err: switchport private host_association not configured')
-  end
-
-  def test_switchport_no_pvlan_host_assoc
-    if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
-      end
-      return
-    end
-    v1 = Vlan.new(10)
-    v1.private_vlan_type = 'primary'
-    v2 = Vlan.new(11)
-    v2.private_vlan_type = 'community'
-    v1.private_vlan_association = ['11']
-
-    input = %w(10 11)
-    interface.switchport_mode_private_vlan_host = :host
-    assert_equal(:host, interface.switchport_mode_private_vlan_host,
-                 'Err: Switchport mode not as expected')
-    interface.switchport_mode_private_vlan_host_association = input
-    assert_equal(input,
-                 interface.switchport_mode_private_vlan_host_association,
-                 'Err: switchport private host_association not configured')
-    input = []
-    interface.switchport_mode_private_vlan_host_association = input
-    assert_equal(input,
-                 interface.switchport_mode_private_vlan_host_association,
-                 'Err: switchport private host_association not configured')
-  end
-
-  def test_switchport_pvlan_host_assoc_default
-    if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
-      end
-      return
-    end
-    val = interface.default_switchport_mode_private_vlan_host_association
-    assert_equal(val, interface.switchport_mode_private_vlan_host_association,
-                 'Err: host association failed')
-  end
-
-  def test_switchport_pvlan_host_assoc_bad_arg
-    if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
-      end
-      return
-    end
-    interface.switchport_mode_private_vlan_host = :host
-    assert_equal(:host, interface.switchport_mode_private_vlan_host,
-                 'Err: Switchport mode not as expected')
-
-    input = %w(10)
-    assert_raises(CliError) do
-      interface.switchport_mode_private_vlan_host_association = input
-    end
-
-    input = %w(10 ten)
-    assert_raises(CliError) do
-      interface.switchport_mode_private_vlan_host_association = input
-    end
-
-    input = %w(10,12)
-    assert_raises(CliError) do
-      interface.switchport_mode_private_vlan_host_association = input
-    end
-
-    input = %w(10 10)
-    assert_raises(RuntimeError,
-                  'host association did not raise RuntimeError') do
-      interface.switchport_mode_private_vlan_host_association = input
-    end
-  end
-
-  def test_switchport_pvlan_host_primisc_default
-    if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
-      end
-      return
-    end
-    val = interface.default_switchport_mode_private_vlan_host_promisc
-    assert_equal(val, interface.switchport_mode_private_vlan_host_promisc,
-                 'Err: promisc association failed')
-  end
-
-  def test_switchport_private_host_promisc
-    if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
-      end
-      return
-    end
-    v1 = Vlan.new(10)
-    v1.private_vlan_type = 'primary'
-    v2 = Vlan.new(11)
-    v2.private_vlan_type = 'community'
-    v1.private_vlan_association = ['11']
-
-    input = %w(10 11)
-    interface.switchport_mode_private_vlan_host = :promiscuous
-    assert_equal(:promiscuous,
-                 interface.switchport_mode_private_vlan_host,
-                 'Error: Switchport mode not as expected')
-    interface.switchport_mode_private_vlan_host_promisc = input
-    assert_equal(input,
-                 interface.switchport_mode_private_vlan_host_promisc,
-                 'Error: switchport private host promisc not configured')
-
-    v3 = Vlan.new(12)
-    v3.private_vlan_type = 'community'
-
-    v1.private_vlan_association = ['12']
-    input = %w(10 12)
-    interface.switchport_mode_private_vlan_host_promisc = input
-    assert_equal(input,
-                 interface.switchport_mode_private_vlan_host_promisc,
-                 'Error: switchport private host promisc not configured')
-
-    v4 = Vlan.new(12)
-    v4.private_vlan_type = 'community'
-
-    v5 = Vlan.new(13)
-    v5.private_vlan_type = 'community'
-
-    v6 = Vlan.new(18)
-    v6.private_vlan_type = 'community'
-
-    v7 = Vlan.new(30)
-    v7.private_vlan_type = 'community'
-
-    v1.private_vlan_association = ['12-13', '18', '30']
-    input = %w(10 12-13,18,30)
-    interface.switchport_mode_private_vlan_host_promisc = input
-    assert_equal(input,
-                 interface.switchport_mode_private_vlan_host_promisc,
-                 'Error: switchport private host promisc not configured')
-  end
-
-  def test_switchport_private_host_promisc_bad_arg
-    if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
+        i.switchport_pvlan_host = true
       end
       return
     end
 
-    input = %w(10)
-    interface.switchport_mode_private_vlan_host = :promiscuous
-    assert_equal(:promiscuous, interface.switchport_mode_private_vlan_host,
-                 'Error: Switchport mode not as expected')
+    assert_equal(i.default_switchport_pvlan_host,
+                 i.switchport_pvlan_host)
 
-    assert_raises(TypeError, 'private vlan host promisc raise typeError') do
-      interface.switchport_mode_private_vlan_host_promisc = input
-    end
+    i.switchport_pvlan_host = true
+    assert(i.switchport_pvlan_host)
 
-    input = %w(10,)
-    assert_raises(TypeError, 'private vlan host promisc raise typeError') do
-      interface.switchport_mode_private_vlan_host_promisc = input
-    end
-
-    input = %w(10 11 12)
-
-    assert_raises(TypeError, 'private vlan host promisc raise typeError') do
-      interface.switchport_mode_private_vlan_host_promisc = input
-    end
-
-    input = %w(10 ten)
-    assert_raises(CliError) do
-      interface.switchport_mode_private_vlan_host_promisc = input
-    end
-
-    input = %w(10 10)
-    assert_raises(CliError) do
-      interface.switchport_mode_private_vlan_host_promisc = input
-    end
-
-    input = %w(10 10)
-    assert_raises(RuntimeError,
-                  'promisc association did not raise RuntimeError') do
-      interface.switchport_mode_private_vlan_host_promisc = input
-    end
+    i.switchport_pvlan_host = false
+    refute(i.switchport_pvlan_host)
   end
 
-  def test_no_switchport_private_host_promisc
+  def test_switchport_pvlan_promiscuous
     if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-
+                                   'switchport_pvlan_promiscuous')
       assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
-      end
-      return
-    end
-    v1 = Vlan.new(10)
-    v1.private_vlan_type = 'primary'
-
-    v2 = Vlan.new(11)
-    v2.private_vlan_type = 'community'
-    v1.private_vlan_association = ['11']
-
-    input = %w(10 11)
-    interface.switchport_mode_private_vlan_host = :promiscuous
-    assert_equal(:promiscuous, interface.switchport_mode_private_vlan_host,
-                 'Error: Switchport mode not as expected')
-
-    interface.switchport_mode_private_vlan_host_promisc = input
-    assert_equal(input, interface.switchport_mode_private_vlan_host_promisc,
-                 'Error: switchport private host promisc not configured')
-    input = []
-    interface.switchport_mode_private_vlan_host_promisc = input
-    assert_equal(input, interface.switchport_mode_private_vlan_host_promisc,
-                 'Error: switchport private host promisc not configured')
-  end
-
-  def test_switchport_pvlan_trunk_allow_default
-    if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
-      end
-      return
-    end
-    val = interface.default_switchport_private_vlan_trunk_allowed_vlan
-    assert_equal(val, interface.switchport_private_vlan_trunk_allowed_vlan,
-                 'Err: trunk allowed vlan failed')
-  end
-
-  def test_switchport_pvlan_trunk_allow_bad_arg
-    if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
-      end
-      return
-    end
-    input = %w(ten)
-    assert_raises(CliError) do
-      interface.switchport_private_vlan_trunk_allowed_vlan = input
-    end
-
-    input = %w(5000)
-    assert_raises(CliError) do
-      interface.switchport_private_vlan_trunk_allowed_vlan = input
-    end
-  end
-
-  def test_switchport_pvlan_trunk_allow
-    if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
-      end
-      return
-    end
-    input = %w(10)
-    interface.switchport_private_vlan_trunk_allowed_vlan = input
-    assert_equal(input, interface.switchport_private_vlan_trunk_allowed_vlan,
-                 'Error: switchport private trunk allow vlan not configured')
-
-    input = %w(10-20)
-    result = %w(10-20)
-    interface.switchport_private_vlan_trunk_allowed_vlan = input
-    assert_equal(result, interface.switchport_private_vlan_trunk_allowed_vlan,
-                 'Error: switchport private trunk allow vlan not configured')
-
-    input = %w(10 13-14 40)
-    result = %w(10 13-14 40)
-    interface.switchport_private_vlan_trunk_allowed_vlan = input
-    assert_equal(result, interface.switchport_private_vlan_trunk_allowed_vlan,
-                 'Error: switchport private trunk allow vlan not configured')
-
-    input = []
-    interface.switchport_private_vlan_trunk_allowed_vlan = input
-    assert_equal(input, interface.switchport_private_vlan_trunk_allowed_vlan,
-                 'Error: switchport private trunk allow vlan not configured')
-  end
-
-  def test_switchport_pvlan_trunk_native_vlan_bad_arg
-    if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
-      end
-      return
-    end
-    input = 'ten'
-    assert_raises(CliError) do
-      interface.switchport_private_vlan_trunk_native_vlan = input
-    end
-
-    input = 5000
-    assert_raises(CliError) do
-      interface.switchport_private_vlan_trunk_native_vlan = input
-    end
-  end
-
-  def test_switchport_pvlan_trunk_native_default
-    if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
-      end
-      return
-    end
-    val = interface.default_switchport_private_vlan_trunk_native_vlan
-    assert_equal(val, interface.switchport_private_vlan_trunk_native_vlan,
-                 'Err: trunk native vlan failed')
-  end
-
-  def test_switchport_pvlan_trunk_native_vlan
-    if validate_property_excluded?('interface',
-                                   'switchport_mode_private_vlan_host')
-
-      assert_raises(Cisco::UnsupportedError) do
-        interface.switchport_mode_private_vlan_host = :host
+        i.switchport_pvlan_promiscuous = true
       end
       return
     end
 
-    input = 10
-    interface.switchport_private_vlan_trunk_native_vlan = input
+    assert_equal(i.default_switchport_pvlan_promiscuous,
+                 i.switchport_pvlan_promiscuous)
 
-    assert_equal(input, interface.switchport_private_vlan_trunk_native_vlan,
-                 'Error: switchport private trunk native vlan not configured')
-    input = 1
-    interface.switchport_private_vlan_trunk_native_vlan = input
-    assert_equal(input, interface.switchport_private_vlan_trunk_native_vlan,
-                 'Error: switchport private trunk native vlan not configured')
-    input = 40
-    interface.switchport_private_vlan_trunk_native_vlan = input
-    assert_equal(input, interface.switchport_private_vlan_trunk_native_vlan,
-                 'Error: switchport private trunk native vlan not configured')
+    i.switchport_pvlan_promiscuous = true
+    assert(i.switchport_pvlan_promiscuous)
 
-    input = 50
-    interface.switchport_private_vlan_trunk_native_vlan = input
-    assert_equal(input,
-                 interface.switchport_private_vlan_trunk_native_vlan,
-                 'Error: switchport private trunk native vlan not configured')
+    i.switchport_pvlan_promiscuous = false
+    refute(i.switchport_pvlan_promiscuous)
   end
 
-  def test_switchport_pvlan_association_trunk
+  def test_switchport_pvlan_trunk_promiscuous
     if validate_property_excluded?('interface',
-                                   'switchport_private_vlan_association_trunk')
-      assert_nil(interface.switchport_private_vlan_association_trunk)
+                                   'switchport_pvlan_trunk_promiscuous')
+      assert_raises(Cisco::UnsupportedError) do
+        i.switchport_pvlan_trunk_promiscuous = true
+      end
       return
     end
-    input = %w(10 12)
-    result = ['10 12']
-    interface.switchport_private_vlan_association_trunk = input
-    input = interface.switchport_private_vlan_association_trunk
-    refute((result & input).empty?,
-           'Err: wrong config for switchport private trunk association')
-    input = %w(20 30)
-    result = ['20 30']
-    interface.switchport_private_vlan_association_trunk = input
-    input = interface.switchport_private_vlan_association_trunk
-    refute((result & input).empty?,
-           'Err: wrong config for switchport private trunk association')
 
-    input = %w(10 13)
-    result = ['10 13']
-    interface.switchport_private_vlan_association_trunk = input
-    input = interface.switchport_private_vlan_association_trunk
-    refute((result & input).empty?,
-           'Err: wrong config for switchport private trunk association')
+    assert_equal(i.default_switchport_pvlan_trunk_promiscuous,
+                 i.switchport_pvlan_trunk_promiscuous)
 
-    input = []
-    interface.switchport_private_vlan_association_trunk = input
-    assert_equal(input, interface.switchport_private_vlan_association_trunk,
-                 'Err: wrong config for switchport private trunk association')
+    i.switchport_pvlan_trunk_promiscuous = true
+    assert(i.switchport_pvlan_trunk_promiscuous)
+
+    i.switchport_pvlan_trunk_promiscuous = false
+    refute(i.switchport_pvlan_trunk_promiscuous)
   end
 
-  def test_switchport_pvlan_trunk_assoc_vlan_bad_arg
+  def test_switchport_pvlan_trunk_secondary
     if validate_property_excluded?('interface',
-                                   'switchport_private_vlan_association_trunk')
-      assert_nil(interface.switchport_private_vlan_association_trunk)
+                                   'switchport_pvlan_trunk_secondary')
+      assert_raises(Cisco::UnsupportedError) do
+        i.switchport_pvlan_trunk_secondary = true
+      end
       return
     end
-    input = %w(10 10)
-    assert_raises(CliError) do
-      interface.switchport_private_vlan_association_trunk = input
-    end
 
-    input = %w(10 5000)
-    assert_raises(CliError) do
-      interface.switchport_private_vlan_association_trunk = input
-    end
+    assert_equal(i.default_switchport_pvlan_trunk_secondary,
+                 i.switchport_pvlan_trunk_secondary)
 
-    input = %w(10)
-    assert_raises(CliError) do
-      interface.switchport_private_vlan_association_trunk = input
-    end
+    i.switchport_pvlan_trunk_secondary = true
+    assert(i.switchport_pvlan_trunk_secondary)
 
-    input = '10'
-    assert_raises(TypeError,
-                  'private vlan trunk association raise typeError') do
-      interface.switchport_private_vlan_association_trunk = input
-    end
+    i.switchport_pvlan_trunk_secondary = false
+    refute(i.switchport_pvlan_trunk_secondary)
   end
 
-  def test_switchport_pvlan_trunk_assocciation_default
-    if validate_property_excluded?('interface',
-                                   'switchport_private_vlan_association_trunk')
-      assert_nil(interface.switchport_private_vlan_association_trunk)
-      return
-    end
-    val = interface.default_switchport_private_vlan_association_trunk
-    assert_equal(val, interface.switchport_private_vlan_association_trunk,
-                 'Err: association trunk failed')
+  # Helper to setup vlan association prerequisites
+  def vlan_associate(pri, sec)
+    Vlan.new(sec).private_vlan_type = 'community'
+    Vlan.new(pri).private_vlan_type = 'primary'
+    Vlan.new(pri).private_vlan_association = sec
   end
 
-  def test_switchport_pvlan_mapping_trunk_default
+  def test_switchport_pvlan_host_association
+    # Supports single instance of [pri, sec]
     if validate_property_excluded?('interface',
-                                   'switchport_private_vlan_mapping_trunk')
-
-      assert_nil(interface.switchport_private_vlan_mapping_trunk)
+                                   'switchport_pvlan_host_association')
+      assert_raises(Cisco::UnsupportedError) do
+        i.switchport_pvlan_host_association = %w(2 3)
+      end
       return
     end
-    val = interface.default_switchport_private_vlan_mapping_trunk
-    assert_equal(val, interface.switchport_private_vlan_mapping_trunk,
-                 'Err: mapping trunk failed')
+
+    default = i.default_switchport_pvlan_host_association
+    assert_equal(default, i.switchport_pvlan_host_association)
+
+    # Setup prerequisites
+    vlan_associate('2', '3')
+
+    i.switchport_pvlan_host_association = %w(2 3)
+    assert_equal(%w(2 3), i.switchport_pvlan_host_association)
+
+    i.switchport_pvlan_host_association = default
+    assert_equal(default, i.switchport_pvlan_host_association)
+  end
+
+  def test_switchport_pvlan_trunk_association
+    # Supports multiple instances of [[pri, sec], [pri2, sec2]]
+    if validate_property_excluded?('interface',
+                                   'switchport_pvlan_trunk_association')
+      assert_raises(Cisco::UnsupportedError) do
+        i.switchport_pvlan_trunk_association = %w(2 3)
+      end
+      return
+    end
+
+    default = i.default_switchport_pvlan_trunk_association
+    assert_equal(default, i.switchport_pvlan_trunk_association)
+
+    pairs = %w(2 3)
+    i.switchport_pvlan_trunk_association = pairs
+    assert_equal([pairs], i.switchport_pvlan_trunk_association)
+
+    # Add a second pairs
+    pairs = [%w(2 3), %w(4 5)]
+    i.switchport_pvlan_trunk_association = pairs
+    assert_equal(pairs, i.switchport_pvlan_trunk_association)
+
+    # New pair
+    pairs = [%w(6 7)]
+    i.switchport_pvlan_trunk_association = pairs
+    assert_equal(pairs, i.switchport_pvlan_trunk_association)
+
+    i.switchport_pvlan_trunk_association = default
+    assert_equal(default, i.switchport_pvlan_trunk_association)
+  end
+
+  def test_pvlan_mapping
+    # This is an SVI property
+    svi = Interface.new('vlan13')
+    if validate_property_excluded?('interface', 'pvlan_mapping')
+      assert_raises(Cisco::UnsupportedError) do
+        svi.pvlan_mapping = ['10-11,4-7,8']
+      end
+      return
+    end
+
+    default = svi.default_pvlan_mapping
+    assert_equal(default, svi.pvlan_mapping)
+
+    # Input can be Array or String
+    svi.pvlan_mapping = ['10-11,4-7,8']
+    assert_equal('4-8,10-11', svi.pvlan_mapping)
+
+    # Change range
+    svi.pvlan_mapping = '11,4-6,8'
+    assert_equal('4-6,8,11', svi.pvlan_mapping)
+
+    svi.pvlan_mapping = default
+    assert_equal(default, svi.pvlan_mapping)
+  end
+
+  def test_switchport_pvlan_mapping
+    if validate_property_excluded?('interface', 'switchport_pvlan_mapping')
+      assert_raises(Cisco::UnsupportedError) do
+        i.switchport_pvlan_mapping = ['2', '10-11,4-7,8']
+      end
+      return
+    end
+
+    default = i.default_switchport_pvlan_mapping
+    assert_equal(default, i.switchport_pvlan_mapping)
+
+    # Setup prerequisites
+    vlan_associate('2', '3')
+
+    i.switchport_pvlan_mapping = %w(2 3)
+    assert_equal(%w(2 3), i.switchport_pvlan_mapping)
+
+    i.switchport_pvlan_mapping = default
+    assert_equal(default, i.switchport_pvlan_mapping)
   end
 
   def test_switchport_pvlan_mapping_trunk
     if validate_property_excluded?('interface',
-                                   'switchport_private_vlan_mapping_trunk')
-      assert_nil(interface.switchport_private_vlan_mapping_trunk)
+                                   'switchport_pvlan_mapping_trunk')
+      assert_raises(Cisco::UnsupportedError) do
+        i.switchport_pvlan_mapping_trunk = ['2', '10-11,4-7,8']
+      end
       return
     end
-    input = %w(10 11)
-    result = '10 11'
-    interface.switchport_private_vlan_mapping_trunk = input
-    input = interface.switchport_private_vlan_mapping_trunk
-    assert_includes(input, result,
-                    'Err: wrong config for switchport private mapping trunk ')
 
-    input = %w(10 12)
-    result = '10 12'
-    interface.switchport_private_vlan_mapping_trunk = input
-    input = interface.switchport_private_vlan_mapping_trunk
-    assert_includes(input, result,
-                    'Err: wrong config for switchport private mapping trunk ')
+    default = i.default_switchport_pvlan_mapping_trunk
+    assert_equal(default, i.switchport_pvlan_mapping_trunk)
 
-    input = %w(20 21)
-    result = '20 21'
-    interface.switchport_private_vlan_mapping_trunk = input
-    input = interface.switchport_private_vlan_mapping_trunk
-    assert_includes(input, result,
-                    'Err: wrong config for switchport private mapping trunk ')
+    i.switchport_pvlan_mapping_trunk = ['2', '10-11,4-7,8']
+    assert_equal(['2', '4-8,10-11'], i.switchport_pvlan_mapping_trunk)
 
-    input = []
-    interface.switchport_private_vlan_mapping_trunk = input
-    assert_equal(input, interface.switchport_private_vlan_mapping_trunk)
+    # Same primary, but change range
+    i.switchport_pvlan_mapping_trunk = ['2', '11,4-6,8']
+    assert_equal(['2', '4-6,8,11'], i.switchport_pvlan_mapping_trunk)
+
+    # Change primary
+    i.switchport_pvlan_mapping_trunk = ['3', '11,4-6,8']
+    assert_equal(['3', '4-6,8,11'], i.switchport_pvlan_mapping_trunk)
+
+    i.switchport_pvlan_mapping_trunk = default
+    assert_equal(default, i.switchport_pvlan_mapping_trunk)
   end
 
-  def test_switchport_pvlan_mapping_trunk_bad_arg
+  def test_switchport_pvlan_trunk_allowed_vlan
     if validate_property_excluded?('interface',
-                                   'switchport_private_vlan_mapping_trunk')
-      assert_nil(interface.switchport_private_vlan_mapping_trunk)
+                                   'switchport_pvlan_trunk_allowed_vlan')
+      assert_raises(Cisco::UnsupportedError) do
+        i.switchport_pvlan_trunk_allowed_vlan = '8-9,4,2-3'
+      end
       return
     end
-    input = %w(10 10)
-    assert_raises(CliError) do
-      interface.switchport_private_vlan_mapping_trunk = input
+
+    default = i.default_switchport_pvlan_trunk_allowed_vlan
+    assert_equal(default, i.switchport_pvlan_trunk_allowed_vlan)
+
+    i.switchport_pvlan_trunk_allowed_vlan = '8-9,4,2-3'
+    assert_equal('2-4,8-9', i.switchport_pvlan_trunk_allowed_vlan)
+
+    # Change range
+    i.switchport_pvlan_trunk_allowed_vlan = '9-10,2'
+    assert_equal('2,9-10', i.switchport_pvlan_trunk_allowed_vlan)
+
+    i.switchport_pvlan_trunk_allowed_vlan = default
+    assert_equal(default, i.switchport_pvlan_trunk_allowed_vlan)
+  end
+
+  def test_switchport_pvlan_trunk_native_vlan
+    if validate_property_excluded?('interface',
+                                   'switchport_pvlan_trunk_native_vlan')
+      assert_raises(Cisco::UnsupportedError) do
+        i.switchport_pvlan_trunk_native_vlan = '2'
+      end
+      return
     end
 
-    input = %w(10 5000)
-    assert_raises(CliError) do
-      interface.switchport_private_vlan_mapping_trunk = input
-    end
+    default = i.default_switchport_pvlan_trunk_native_vlan
+    assert_equal(default, i.switchport_pvlan_trunk_native_vlan)
 
-    input = %w(10)
-    assert_raises(CliError) do
-      interface.switchport_private_vlan_mapping_trunk = input
-    end
+    i.switchport_pvlan_trunk_native_vlan = '2'
+    assert_equal('2', i.switchport_pvlan_trunk_native_vlan)
 
-    input = '10'
-    assert_raises(TypeError,
-                  'private vlan mapping trunk raise typeError') do
-      interface.switchport_private_vlan_mapping_trunk = input
-    end
-
-    input = %w(10 20-148)
-    assert_raises(RuntimeError,
-                  'mapping trunk did not raise RuntimeError') do
-      interface.switchport_private_vlan_mapping_trunk = input
-    end
+    i.switchport_pvlan_trunk_native_vlan = default
+    assert_equal(default, i.switchport_pvlan_trunk_native_vlan)
   end
 end

--- a/tests/test_interface_svi.rb
+++ b/tests/test_interface_svi.rb
@@ -67,53 +67,29 @@ class TestSvi < CiscoTestCase
     end
   end
 
-  def test_private_vlan_mapping
-    if validate_property_excluded?('interface',
-                                   'private_vlan_mapping')
-      assert_nil(svi.private_vlan_mapping)
+  def test_pvlan_mapping
+    # This is an SVI property
+    svi = Interface.new('vlan13')
+    if validate_property_excluded?('interface', 'pvlan_mapping')
+      assert_raises(Cisco::UnsupportedError) do
+        svi.pvlan_mapping = ['10-11,4-7,8']
+      end
       return
     end
-    input = %w(10-20 30)
-    result = ['10-20,30']
-    svi.private_vlan_mapping = input
-    assert_equal(result,
-                 svi.private_vlan_mapping,
-                 'Error: svi private mapping not configured')
 
-    input = %w(11-13)
-    result = %w(11-13)
-    svi.private_vlan_mapping = input
-    assert_equal(result,
-                 svi.private_vlan_mapping,
-                 'Error: svi private mapping not configured')
+    default = svi.default_pvlan_mapping
+    assert_equal(default, svi.pvlan_mapping)
 
-    input = []
-    result = []
-    svi.private_vlan_mapping = input
-    input = svi.private_vlan_mapping
-    assert_equal(input, result,
-                 'Err: wrong config for svi pvlan mapping')
-  end
+    # Input can be Array or String
+    svi.pvlan_mapping = ['10-11,4-7,8']
+    assert_equal('4-8,10-11', svi.pvlan_mapping)
 
-  def test_private_vlan_mapping_bad_args
-    if validate_property_excluded?('interface',
-                                   'private_vlan_mapping')
-      assert_nil(svi.private_vlan_mapping)
-      return
-    end
-    input = %w(10 20)
-    result = ['10,20']
-    svi.private_vlan_mapping = input
-    input = svi.private_vlan_mapping
-    assert_equal(result,
-                 svi.private_vlan_mapping,
-                 'Error: svi private mapping not configured')
+    # Change range
+    svi.pvlan_mapping = '11,4-6,8'
+    assert_equal('4-6,8,11', svi.pvlan_mapping)
 
-    input = %w(23)
-    assert_raises(RuntimeError,
-                  'svi pvlan mapping did not raise RuntimeError') do
-      svi.private_vlan_mapping = input
-    end
+    svi.pvlan_mapping = default
+    assert_equal(default, svi.pvlan_mapping)
   end
 
   def test_prop_nil_when_ethernet


### PR DESCRIPTION
- There were a few errors with the original implementation. As I worked through this I found that it made sense to rewrite many of the methods to use the new range conversion utilities, and with so many functional changes we decided to take the opportunity to shorten the property names. Since the original code was already released with 1.3.0 we decided to just deprecate them.
- Created `DEPRECATED.yaml` and `interface_DEPRECATED.rb` for the original code. The setters will raise a warning if used, which includes the name of the new property to use. I ran the original test_interface_private_vlan tests against the deprecated code and they still pass, but then updated the test file to use the new methods. This means that going forward the deprecated methods will not have any tests run, and any issues found will not be fixed.
- Related puppet fixes are in the works.
- Tested on n3-I4,n5,n6,n7,n8,n9-I2,n9-I3
