### PR TITLE
private_vlan refactor for vlan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Changelog
 ## [v1.3.1]
 
 ### Changed
+* Deprecated `vlan` private-vlan properties and replaced with new methods. New file `vlan_DEPRECATED.rb` has been created to store the deprecated methods. The old -> new properties are:
+
+| Old Name | New Name(s) |
+|:---|:---:|
+| `private_vlan_association`                      | `pvlan_association`
+| `private_vlan_type`                             | `pvlan_type`
+
 * Deprecated `interface` private-vlan properties and replaced with new methods. New files `interface_DEPRECATED.rb` and `DEPRECATED.yaml` have been created to store the deprecated methods. The old -> new properties are:
 
 | Old Name | New Name(s) |

--- a/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
+++ b/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
@@ -1,0 +1,115 @@
+# DEPRECATED
+#
+###############################################################################
+# WARNING. DO NOT USE ANY OF THE YAML TAGS IN THIS FILE.
+# These yaml tags are deprecated and will be removed in future releases.
+###############################################################################
+---
+_template:
+  context: ["interface <name>"]
+  nexus:
+    get_command: "show running interface all"
+
+private_vlan_any:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'pvlan_any'
+  multiple:
+  get_value: '/switchport private-vlan/'
+
+private_vlan_association:
+  # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'pvlan_association'
+  _exclude: [N8k]
+  multiple: true
+  get_command: "show vlan private-vlan"
+  get_value: '/^<id>\s+(\d+)/'
+  set_context: ['vlan <vlan>']
+  set_value: "<state> private-vlan association <vlans> ; end"
+  default_value: []
+
+private_vlan_mapping:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'pvlan_mapping'
+  _exclude: [ios_xr, N8k]
+  multiple: true
+  get_value: '/^private-vlan mapping (.*)$/'
+  set_value: "<state> private-vlan mapping <vlans>"
+  default_value: []
+
+private_vlan_type:
+  # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'pvlan_type'
+  _exclude: [N8k]
+  kind: string
+  get_command: 'show vlan private-vlan type'
+  get_value: '/^<id>\s+(\S+)/'
+  set_context: ['vlan <vlan>']
+  set_value: "<state> private-vlan <type> ; end"
+  default_value: ""
+
+switchport_mode_private_vlan_host:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_host'
+  _exclude: [ios_xr, N8k]
+  get_value: '/^switchport mode private-vlan (.*)$/'
+  set_value: "<state> switchport mode private-vlan <mode>"
+  default_value: :disabled
+
+switchport_mode_private_vlan_host_association:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_host_association'
+  _exclude: [ios_xr, N8k]
+  multiple: true
+  get_value: '/^switchport private-vlan host-association (.*)$/'
+  set_value: "<state> switchport private-vlan host-association <vlan_pr> <vlan_sec>"
+  default_value: []
+
+switchport_mode_private_vlan_host_promiscous:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_promiscuous'
+  _exclude: [ios_xr, N8k]
+  multiple: true
+  get_value: '/^switchport private-vlan mapping (\d+.*)$/'
+  set_value: "<state> switchport private-vlan mapping <vlan_pr> <vlans>"
+  default_value: []
+
+switchport_mode_private_vlan_trunk_promiscuous:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_trunk_promiscuous'
+  _exclude: [ios_xr, N3k, N8k]
+  kind: boolean
+  get_value: '/^switchport mode private-vlan trunk promiscuous$/'
+  default_value: false
+
+switchport_mode_private_vlan_trunk_secondary:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_trunk_secondary'
+  _exclude: [ios_xr, N3k, N8k]
+  kind: boolean
+  get_value: '/^switchport mode private-vlan trunk secondary$/'
+  set_value: "<state> switchport mode private-vlan trunk secondary"
+  default_value: false
+
+switchport_private_vlan_association_trunk:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_trunk_association'
+  _exclude: [ios_xr, N3k, N8k]
+  multiple: true
+  #get_value: '/^switchport private-vlan association trunk (.*) (.*)$/'
+  get_value: '/^switchport private-vlan association trunk (.*)$/'
+  set_value: "<state> switchport private-vlan association trunk <vlan_pr> <vlan>"
+  default_value: []
+
+switchport_private_vlan_mapping_trunk:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_mapping_trunk'
+  _exclude: [ios_xr, N3k, N8k]
+  multiple: true
+  get_value: '/^switchport private-vlan mapping trunk (.*)$/'
+  set_value: "<state> switchport private-vlan mapping trunk <vlan_pr> <vlans>"
+  default_value: []
+
+switchport_private_vlan_trunk_allowed_vlan:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_trunk_allowed_vlan'
+  _exclude: [ios_xr, N8k]
+  multiple: true
+  get_value: '/^switchport private-vlan trunk allowed vlan (.*)$/'
+  set_value: "<state> switchport private-vlan trunk allowed vlan <oper> <vlans>"
+  default_value: []
+
+switchport_private_vlan_trunk_native_vlan:
+  # DEPRECATED (REMOVING AT 2.0.0). USE 'switchport_pvlan_trunk_native_vlan'
+  _exclude: [ios_xr, N8k]
+  kind: int
+  get_value: '/^switchport private-vlan trunk native vlan (.*)$/'
+  set_value: "<state> switchport private-vlan trunk native vlan <vlan>"
+  default_value: 1

--- a/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
+++ b/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
@@ -20,6 +20,7 @@ private_vlan_association:
   _exclude: [N8k]
   multiple: true
   get_command: "show vlan private-vlan"
+  get_context: ~
   get_value: '/^<id>\s+(\d+)/'
   set_context: ['vlan <vlan>']
   set_value: "<state> private-vlan association <vlans> ; end"
@@ -38,6 +39,7 @@ private_vlan_type:
   _exclude: [N8k]
   kind: string
   get_command: 'show vlan private-vlan type'
+  get_context: ~
   get_value: '/^<id>\s+(\S+)/'
   set_context: ['vlan <vlan>']
   set_value: "<state> private-vlan <type> ; end"

--- a/lib/cisco_node_utils/cmd_ref/vlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vlan.yaml
@@ -64,7 +64,7 @@ name:
   set_context: ["vlan %d"]
   set_value: "%s name %s ; end"
 
-private_vlan_association:
+pvlan_association:
   _exclude: [N8k]
   multiple: true
   get_command: "show vlan private-vlan"
@@ -73,7 +73,7 @@ private_vlan_association:
   set_value: "<state> private-vlan association <vlans> ; end"
   default_value: []
 
-private_vlan_type:
+pvlan_type:
   _exclude: [N8k]
   kind: string
   get_command: 'show vlan private-vlan type'

--- a/lib/cisco_node_utils/vlan_DEPRECATED.rb
+++ b/lib/cisco_node_utils/vlan_DEPRECATED.rb
@@ -1,0 +1,104 @@
+# rubocop: disable Style/FileName
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+#
+#                        WARNING! WARNING! WARNING!
+#
+# This file contains deprecated methods that will be removed with version 2.0.0
+#
+###############################################################################
+module Cisco
+  # Vlan - node utility class for VLAN configuration management
+  class VlanDeprecated < NodeUtil
+    def deprecation_warning(method, new_prop=nil)
+      if new_prop.nil?
+        new_prop = ''
+      else
+        new_prop = "The new property name is '#{new_prop}'"
+      end
+
+      warn "
+      #########################################################################
+       WARNING: Method '#{method.to_s.delete('=')}'
+       is deprecated and should not be used.
+       #{new_prop}
+      #########################################################################
+      "
+    end
+
+    def private_vlan_type
+      return nil unless Feature.private_vlan_enabled?
+      config_get('DEPRECATED', 'private_vlan_type', id: @vlan_id)
+    end
+
+    def private_vlan_type=(type)
+      deprecation_warning(__method__, 'pvlan_type')
+      Feature.private_vlan_enable
+      fail TypeError unless type && type.is_a?(String)
+
+      if type == default_private_vlan_type
+        return if private_vlan_type.empty?
+        set_args_keys(state: 'no', type: private_vlan_type)
+        ignore_msg = 'Warning: Private-VLAN CLI removed'
+      else
+        set_args_keys(state: '', type: type)
+        ignore_msg = 'Warning: Private-VLAN CLI entered'
+      end
+      result = config_set('DEPRECATED', 'private_vlan_type', @set_args)
+      cli_error_check(result, ignore_msg)
+    end
+
+    def default_private_vlan_type
+      config_get_default('DEPRECATED', 'private_vlan_type')
+    end
+
+    def private_vlan_association
+      return nil unless Feature.private_vlan_enabled?
+      range = config_get('DEPRECATED', 'private_vlan_association', id: @vlan_id)
+      Utils.normalize_range_array(range)
+    end
+
+    def private_vlan_association=(range)
+      deprecation_warning(__method__, 'pvlan_association')
+      Feature.private_vlan_enable
+      is = Utils.dash_range_to_elements(private_vlan_association)
+      should = Utils.dash_range_to_elements(range)
+      association_delta(is, should)
+    end
+
+    def default_private_vlan_association
+      config_get_default('DEPRECATED', 'private_vlan_association')
+    end
+
+    # --------------------------
+    # association_delta is a helper function for the private_vlan_association
+    # property. It walks the delta hash and adds/removes each target private
+    # vlan.
+    def association_delta(is, should)
+      delta_hash = Utils.delta_add_remove(should, is)
+      Cisco::Logger.debug("association_delta: #{@vlan_id}: #{delta_hash}")
+      [:add, :remove].each do |action|
+        delta_hash[action].each do |vlans|
+          state = (action == :add) ? '' : 'no'
+          set_args_keys(state: state, vlans: vlans)
+          result = config_set('DEPRECATED',
+                              'private_vlan_association', @set_args)
+          cli_error_check(result)
+        end
+      end
+    end
+  end # Class
+end # Module

--- a/tests/test_vlan.rb
+++ b/tests/test_vlan.rb
@@ -349,13 +349,13 @@ class TestVlan < CiscoTestCase
 
   def test_mode_with_pvlan
     v = Vlan.new(1000)
-    if validate_property_excluded?('vlan', 'private_vlan_type') ||
+    if validate_property_excluded?('vlan', 'pvlan_type') ||
        validate_property_excluded?('vlan', 'mode')
-      features = 'private_vlan_type and/or vlan mode'
+      features = 'pvlan_type and/or vlan mode'
       skip("Skip test: Features #{features} are not supported on this device")
     end
     result = 'CE'
-    v.private_vlan_type = 'primary'
+    v.pvlan_type = 'primary'
     assert_equal(result, v.mode)
   end
 end

--- a/tests/test_vlan_private.rb
+++ b/tests/test_vlan_private.rb
@@ -45,357 +45,357 @@ class TestVlan < CiscoTestCase
     cleanup
   end
 
-  def test_private_type_default
+  def test_pvlan_type_default
     config_no_warn('no feature vtp')
     config_no_warn('feature private-vlan')
     v1 = Vlan.new(100)
     pv_type = ''
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
     else
-      assert_equal(pv_type, v1.private_vlan_type)
+      assert_equal(pv_type, v1.pvlan_type)
     end
   end
 
-  def test_private_association_default
+  def test_pvlan_association_default
     config_no_warn('no feature vtp')
     config_no_warn('feature private-vlan')
     v1 = Vlan.new(100)
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       return
     else
       result = []
-      assert_equal(result, v1.private_vlan_association)
+      assert_equal(result, v1.pvlan_association)
     end
   end
 
-  def test_private_vlan_type_primary
+  def test_pvlan_type_primary
     v1 = Vlan.new(100)
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
     end
   end
 
-  def test_no_private_vlan_type_primary
+  def test_no_pvlan_type_primary
     v1 = Vlan.new(200)
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       pv_type = ''
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
     end
   end
 
-  def test_multi_private_vlan_type_primary
+  def test_multi_pvlan_type_primary
     v1 = Vlan.new(100)
     v2 = Vlan.new(101)
     v3 = Vlan.new(200)
     v4 = Vlan.new(201)
     v5 = Vlan.new(203)
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      v2.private_vlan_type = pv_type
-      v3.private_vlan_type = pv_type
-      v4.private_vlan_type = pv_type
-      v5.private_vlan_type = pv_type
+      v1.pvlan_type = pv_type
+      v2.pvlan_type = pv_type
+      v3.pvlan_type = pv_type
+      v4.pvlan_type = pv_type
+      v5.pvlan_type = pv_type
 
-      assert_equal(pv_type, v1.private_vlan_type)
-      assert_equal(pv_type, v2.private_vlan_type)
-      assert_equal(pv_type, v3.private_vlan_type)
-      assert_equal(pv_type, v4.private_vlan_type)
-      assert_equal(pv_type, v5.private_vlan_type)
+      assert_equal(pv_type, v1.pvlan_type)
+      assert_equal(pv_type, v2.pvlan_type)
+      assert_equal(pv_type, v3.pvlan_type)
+      assert_equal(pv_type, v4.pvlan_type)
+      assert_equal(pv_type, v5.pvlan_type)
     end
   end
 
-  def test_private_vlan_type_isolated
+  def test_pvlan_type_isolated
     v1 = Vlan.new(100)
     pv_type = 'isolated'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
     end
   end
 
-  def test_private_vlan_type_community
+  def test_pvlan_type_community
     v1 = Vlan.new(100)
     pv_type = 'community'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
     end
   end
 
-  def test_private_vlan_type_isolated_primary
+  def test_pvlan_type_isolated_primary
     v1 = Vlan.new(100)
     pv_type = 'isolated'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       v2 = Vlan.new(200)
       pv_type = 'primary'
-      v2.private_vlan_type = pv_type
-      assert_equal(pv_type, v2.private_vlan_type)
+      v2.pvlan_type = pv_type
+      assert_equal(pv_type, v2.pvlan_type)
     end
   end
 
-  def test_private_vlan_type_isolated_community_primary
+  def test_pvlan_type_isolated_community_primary
     v1 = Vlan.new(100)
     pv_type = 'isolated'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       v2 = Vlan.new(200)
       pv_type = 'primary'
-      v2.private_vlan_type = pv_type
-      assert_equal(pv_type, v2.private_vlan_type)
+      v2.pvlan_type = pv_type
+      assert_equal(pv_type, v2.pvlan_type)
       v3 = Vlan.new(300)
       pv_type = 'community'
-      v3.private_vlan_type = pv_type
-      assert_equal(pv_type, v3.private_vlan_type)
+      v3.pvlan_type = pv_type
+      assert_equal(pv_type, v3.pvlan_type)
     end
   end
 
-  def test_private_vlan_type_change_isolated_to_primary
+  def test_pvlan_type_change_isolated_to_primary
     v1 = Vlan.new(100)
     pv_type = 'isolated'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       pv_type = 'primary'
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
     end
   end
 
-  def test_private_vlan_type_change_isolated_to_community
+  def test_pvlan_type_change_isolated_to_community
     v1 = Vlan.new(100)
     pv_type = 'isolated'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       pv_type = 'community'
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
     end
   end
 
-  def test_private_vlan_type_change_community_to_isolated
+  def test_pvlan_type_change_community_to_isolated
     v1 = Vlan.new(100)
     pv_type = 'community'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       pv_type = 'isolated'
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
     end
   end
 
-  def test_private_vlan_type_change_community_to_primary
+  def test_pvlan_type_change_community_to_primary
     v1 = Vlan.new(100)
     pv_type = 'community'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       pv_type = 'primary'
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
     end
   end
 
-  def test_private_vlan_type_change_primary_to_isolated
+  def test_pvlan_type_change_primary_to_isolated
     v1 = Vlan.new(100)
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       pv_type = 'isolated'
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
     end
   end
 
-  def test_private_vlan_type_change_primary_to_community
+  def test_pvlan_type_change_primary_to_community
     v1 = Vlan.new(100)
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       pv_type = 'community'
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
     end
   end
 
-  def test_private_vlan_isolate_association
+  def test_pvlan_isolate_association
     vlan_list = %w(100 101)
     result = ['101']
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       pv_type = 'isolated'
-      v2.private_vlan_type = pv_type
-      assert_equal(pv_type, v2.private_vlan_type)
+      v2.pvlan_type = pv_type
+      assert_equal(pv_type, v2.pvlan_type)
 
-      v1.private_vlan_association = ['101']
+      v1.pvlan_association = ['101']
 
-      assert_equal(result, v1.private_vlan_association)
+      assert_equal(result, v1.pvlan_association)
     end
   end
 
-  def test_private_vlan_community_association
+  def test_pvlan_community_association
     vlan_list = %w(100 101)
     result = ['101']
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       pv_type = 'community'
-      v2.private_vlan_type = pv_type
-      assert_equal(pv_type, v2.private_vlan_type)
+      v2.pvlan_type = pv_type
+      assert_equal(pv_type, v2.pvlan_type)
 
-      v1.private_vlan_association = ['101']
+      v1.pvlan_association = ['101']
 
-      assert_equal(result, v1.private_vlan_association)
+      assert_equal(result, v1.pvlan_association)
     end
   end
 
-  def test_private_vlan_association_failure
+  def test_pvlan_association_failure
     vlan_list = %w(100 101 200)
     result = %w(101 200)
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     v3 = Vlan.new(vlan_list[2])
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       pv_type = 'isolated'
-      v2.private_vlan_type = pv_type
-      assert_equal(pv_type, v2.private_vlan_type)
+      v2.pvlan_type = pv_type
+      assert_equal(pv_type, v2.pvlan_type)
       pv_type = 'community'
-      v3.private_vlan_type = pv_type
-      assert_equal(pv_type, v3.private_vlan_type)
+      v3.pvlan_type = pv_type
+      assert_equal(pv_type, v3.pvlan_type)
 
-      v1.private_vlan_association = %w(101 200)
+      v1.pvlan_association = %w(101 200)
 
-      assert_equal(result, v1.private_vlan_association)
+      assert_equal(result, v1.pvlan_association)
 
       pv_type = 'isolated'
       assert_raises(RuntimeError, 'vlan misconf did not raise RuntimeError') do
-        v3.private_vlan_type = pv_type
+        v3.pvlan_type = pv_type
       end
 
-      assert_equal(result, v1.private_vlan_association)
+      assert_equal(result, v1.pvlan_association)
 
     end
   end
 
-  def test_private_vlan_association_operational_and_not_operational
+  def test_pvlan_association_operational_and_not_operational
     vlan_list = %w(100 101 200)
     result = %w(101 200)
 
@@ -403,109 +403,109 @@ class TestVlan < CiscoTestCase
     v2 = Vlan.new(vlan_list[1])
 
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
 
       pv_type = 'isolated'
-      v2.private_vlan_type = pv_type
-      assert_equal(pv_type, v2.private_vlan_type)
+      v2.pvlan_type = pv_type
+      assert_equal(pv_type, v2.pvlan_type)
 
-      v1.private_vlan_association = %w(101 200)
+      v1.pvlan_association = %w(101 200)
 
-      assert_equal(result, v1.private_vlan_association)
+      assert_equal(result, v1.pvlan_association)
     end
   end
 
-  def test_private_vlan_association_vlan_not_configured
+  def test_pvlan_association_vlan_not_configured
     vlan_list = %w(100 101 200)
     result = %w(101 200)
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       pv_type = 'isolated'
-      v2.private_vlan_type = pv_type
-      assert_equal(pv_type, v2.private_vlan_type)
+      v2.pvlan_type = pv_type
+      assert_equal(pv_type, v2.pvlan_type)
 
-      v1.private_vlan_association = %w(101 200)
-      assert_equal(result, v1.private_vlan_association)
+      v1.pvlan_association = %w(101 200)
+      assert_equal(result, v1.pvlan_association)
     end
   end
 
-  def test_private_vlan_association_add_vlan
+  def test_pvlan_association_add_vlan
     vlan_list = %w(100 101)
     result = ['101']
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       pv_type = 'isolated'
-      v2.private_vlan_type = pv_type
-      assert_equal(pv_type, v2.private_vlan_type)
+      v2.pvlan_type = pv_type
+      assert_equal(pv_type, v2.pvlan_type)
 
-      v1.private_vlan_association = ['101']
-      assert_equal(result, v1.private_vlan_association)
+      v1.pvlan_association = ['101']
+      assert_equal(result, v1.pvlan_association)
     end
   end
 
-  def test_private_vlan_association_remove_vlan
+  def test_pvlan_association_remove_vlan
     vlan_list = %w(100 101 200)
     result = %w(101 200)
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     v3 = Vlan.new(vlan_list[2])
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       pv_type = 'isolated'
-      v2.private_vlan_type = pv_type
-      assert_equal(pv_type, v2.private_vlan_type)
+      v2.pvlan_type = pv_type
+      assert_equal(pv_type, v2.pvlan_type)
 
       pv_type = 'community'
-      v3.private_vlan_type = pv_type
-      assert_equal(pv_type, v3.private_vlan_type)
+      v3.pvlan_type = pv_type
+      assert_equal(pv_type, v3.pvlan_type)
 
-      v1.private_vlan_association = %w(101 200)
-      assert_equal(result, v1.private_vlan_association)
+      v1.pvlan_association = %w(101 200)
+      assert_equal(result, v1.pvlan_association)
 
-      # v1.private_vlan_association_remove_vlans = '101'
+      # v1.pvlan_association_remove_vlans = '101'
       # result = '200'
       # assert_equal(result, vlan_list(v1))
 
     end
   end
 
-  def test_no_private_vlan_association
+  def test_no_pvlan_association
     vlan_list = %w(100 101 200)
     result = %w(101 200)
     v1 = Vlan.new(vlan_list[0])
@@ -513,35 +513,35 @@ class TestVlan < CiscoTestCase
     v3 = Vlan.new(vlan_list[2])
 
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
 
       pv_type = 'isolated'
-      v2.private_vlan_type = pv_type
-      assert_equal(pv_type, v2.private_vlan_type)
+      v2.pvlan_type = pv_type
+      assert_equal(pv_type, v2.pvlan_type)
 
       pv_type = 'community'
-      v3.private_vlan_type = pv_type
-      assert_equal(pv_type, v3.private_vlan_type)
+      v3.pvlan_type = pv_type
+      assert_equal(pv_type, v3.pvlan_type)
 
-      v1.private_vlan_association = %w(101 200)
-      assert_equal(result, v1.private_vlan_association)
+      v1.pvlan_association = %w(101 200)
+      assert_equal(result, v1.pvlan_association)
 
-      v1.private_vlan_association = ['200']
+      v1.pvlan_association = ['200']
       result = ['200']
-      assert_equal(result, v1.private_vlan_association)
+      assert_equal(result, v1.pvlan_association)
 
     end
   end
 
-  def test_no_private_vlan_association_all
+  def test_no_pvlan_association_all
     vlan_list = %w(100 101 200)
     result = %w(101 200)
     v1 = Vlan.new(vlan_list[0])
@@ -549,70 +549,70 @@ class TestVlan < CiscoTestCase
     v3 = Vlan.new(vlan_list[2])
 
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
 
       pv_type = 'isolated'
-      v2.private_vlan_type = pv_type
-      assert_equal(pv_type, v2.private_vlan_type)
+      v2.pvlan_type = pv_type
+      assert_equal(pv_type, v2.pvlan_type)
 
       pv_type = 'community'
-      v3.private_vlan_type = pv_type
-      assert_equal(pv_type, v3.private_vlan_type)
+      v3.pvlan_type = pv_type
+      assert_equal(pv_type, v3.pvlan_type)
 
-      v1.private_vlan_association = %w(101 200)
-      assert_equal(result, v1.private_vlan_association)
-      v1.private_vlan_association = []
+      v1.pvlan_association = %w(101 200)
+      assert_equal(result, v1.pvlan_association)
+      v1.pvlan_association = []
       result = []
-      assert_equal(result, v1.private_vlan_association)
+      assert_equal(result, v1.pvlan_association)
 
     end
   end
 
-  def test_private_vlan_isolate_community_association
+  def test_pvlan_isolate_community_association
     vlan_list = %w(100 101 200)
     result = %w(101 200)
     v1 = Vlan.new(vlan_list[0])
     v2 = Vlan.new(vlan_list[1])
     v3 = Vlan.new(vlan_list[2])
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
       assert_raises(Cisco::UnsupportedError) do
-        v1.private_vlan_type = pv_type
+        v1.pvlan_type = pv_type
       end
       return
     else
-      v1.private_vlan_type = pv_type
-      assert_equal(pv_type, v1.private_vlan_type)
+      v1.pvlan_type = pv_type
+      assert_equal(pv_type, v1.pvlan_type)
       pv_type = 'isolated'
-      v2.private_vlan_type = pv_type
-      assert_equal(pv_type, v2.private_vlan_type)
+      v2.pvlan_type = pv_type
+      assert_equal(pv_type, v2.pvlan_type)
       pv_type = 'community'
-      v3.private_vlan_type = pv_type
-      assert_equal(pv_type, v3.private_vlan_type)
+      v3.pvlan_type = pv_type
+      assert_equal(pv_type, v3.pvlan_type)
 
-      v1.private_vlan_association = %w(101 200)
+      v1.pvlan_association = %w(101 200)
 
-      assert_equal(result, v1.private_vlan_association)
+      assert_equal(result, v1.pvlan_association)
     end
   end
 
-  def test_private_vlan_multi_isolate_community_association
+  def test_pvlan_multi_isolate_community_association
     vlan_list = %w(100 101 102 104 105 200 201 202)
     v1 = Vlan.new(vlan_list[0])
 
     pv_type = 'primary'
-    if validate_property_excluded?('vlan', 'private_vlan_type')
-      assert_nil(v1.private_vlan_type)
-      assert_raises(Cisco::UnsupportedError) { v1.private_vlan_type = pv_type }
+    if validate_property_excluded?('vlan', 'pvlan_type')
+      assert_nil(v1.pvlan_type)
+      assert_raises(Cisco::UnsupportedError) { v1.pvlan_type = pv_type }
       return
     end
 
@@ -623,39 +623,39 @@ class TestVlan < CiscoTestCase
     v6 = Vlan.new(vlan_list[5])
     v7 = Vlan.new(vlan_list[6])
 
-    v1.private_vlan_type = pv_type
-    assert_equal(pv_type, v1.private_vlan_type)
+    v1.pvlan_type = pv_type
+    assert_equal(pv_type, v1.pvlan_type)
 
     pv_type = 'isolated'
-    v2.private_vlan_type = pv_type
-    assert_equal(pv_type, v2.private_vlan_type)
+    v2.pvlan_type = pv_type
+    assert_equal(pv_type, v2.pvlan_type)
 
     pv_type = 'isolated'
-    v3.private_vlan_type = pv_type
-    assert_equal(pv_type, v3.private_vlan_type)
+    v3.pvlan_type = pv_type
+    assert_equal(pv_type, v3.pvlan_type)
 
     pv_type = 'community'
-    v4.private_vlan_type = pv_type
-    assert_equal(pv_type, v4.private_vlan_type)
+    v4.pvlan_type = pv_type
+    assert_equal(pv_type, v4.pvlan_type)
 
     pv_type = 'community'
-    v5.private_vlan_type = pv_type
-    assert_equal(pv_type, v5.private_vlan_type)
+    v5.pvlan_type = pv_type
+    assert_equal(pv_type, v5.pvlan_type)
 
     pv_type = 'community'
-    v6.private_vlan_type = pv_type
-    assert_equal(pv_type, v6.private_vlan_type)
+    v6.pvlan_type = pv_type
+    assert_equal(pv_type, v6.pvlan_type)
 
     pv_type = 'primary'
-    v7.private_vlan_type = pv_type
-    assert_equal(pv_type, v7.private_vlan_type)
+    v7.pvlan_type = pv_type
+    assert_equal(pv_type, v7.pvlan_type)
 
-    v1.private_vlan_association = %w(101 104 105 200 202)
+    v1.pvlan_association = %w(101 104 105 200 202)
     result = %w(101 104-105 200 202)
-    assert_equal(result, v1.private_vlan_association)
+    assert_equal(result, v1.pvlan_association)
 
-    v1.private_vlan_association = %w(101 103 104-105 108)
+    v1.pvlan_association = %w(101 103 104-105 108)
     result = %w(101 103-105 108)
-    assert_equal(result, v1.private_vlan_association)
+    assert_equal(result, v1.pvlan_association)
   end
 end


### PR DESCRIPTION
This PR is for refactoring private_vlan association and private_vlan_type to pvlan_association and pvlan_type. 

Created a new file vlan_DEPRECATED.yaml for the original code.
Changed DEPRECATED>yaml to include the 2 properties which are refactored.

ALl minitests passed.
