### PR TITLE
virtual_service and system_image yaml fix

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/show_version.yaml
+++ b/lib/cisco_node_utils/cmd_ref/show_version.yaml
@@ -13,8 +13,11 @@ board:
 
 boot_image:
   _exclude: [ios_xr]
-  nexus:
-    get_value: "kick_file_name"
+  get_value: "kick_file_name"
+  N5k: &sys_img_isan
+    get_value: "isan_file_name"
+  N6k: *sys_img_isan
+  N7k: *sys_img_isan
 
 cpu:
   nexus:

--- a/lib/cisco_node_utils/cmd_ref/show_version.yaml
+++ b/lib/cisco_node_utils/cmd_ref/show_version.yaml
@@ -14,10 +14,10 @@ board:
 boot_image:
   _exclude: [ios_xr]
   get_value: "kick_file_name"
-  N5k: &sys_img_isan
+  N5k: &boot_img_isan
     get_value: "isan_file_name"
-  N6k: *sys_img_isan
-  N7k: *sys_img_isan
+  N6k: *boot_img_isan
+  N7k: *boot_img_isan
 
 cpu:
   nexus:

--- a/lib/cisco_node_utils/cmd_ref/virtual_service.yaml
+++ b/lib/cisco_node_utils/cmd_ref/virtual_service.yaml
@@ -3,5 +3,6 @@
 services:
   _exclude: [ios_xr]
   multiple: true
+  get_data_format: nxapi_structured
   get_command: 'show virtual-service detail'
   get_context: ["TABLE_detail", "ROW_detail"]

--- a/tests/test_platform.rb
+++ b/tests/test_platform.rb
@@ -221,8 +221,12 @@ class TestPlatform < CiscoTestCase
   end
 
   def test_virtual_services
+    if validate_property_excluded?('virtual_service', 'services')
+      assert_nil(node.config_get('virtual_service', 'services'))
+      return
+    end
     # Only run this test if a virtual-service is installed
-    if @device.cmd('show virtual-service global')[/services installed : 0$/]
+    if config('show virtual-service global')[/services installed : 0$/]
       skip('This test requires a virtual-service to be installed')
     end
     # this would be beyond ugly to parse from ascii, utilize config_get

--- a/tests/test_platform.rb
+++ b/tests/test_platform.rb
@@ -221,6 +221,10 @@ class TestPlatform < CiscoTestCase
   end
 
   def test_virtual_services
+    # Only run this test if a virtual-service is installed
+    if @device.cmd('show virtual-service global')[/services installed : 0$/]
+      skip('This test requires a virtual-service to be installed')
+    end
     # this would be beyond ugly to parse from ascii, utilize config_get
     vir_arr = node.config_get('virtual_service', 'services')
     vir_arr = [vir_arr] if vir_arr.is_a? Hash


### PR DESCRIPTION
**Summary:**
This is essentially a double-commit of https://github.com/cisco/cisco-network-chef-cookbook/pull/30.  The only difference is that the `test_virtual_services` mini-test now fails IF a virtual-service is not installed.  We check and skip with a meaningful message if this is the case.

**Testing with a virtual-service installed:**

```
Run options: -v -e n9k -n test_virtual_services --seed 26658

# Running:


Node under test:
  - name  - dt-n9k5-1
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I4.1.bin

TestPlatform#test_virtual_services = 3.57 s = .

Finished in 3.574870s, 0.2797 runs/s, 0.2797 assertions/s.

1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```

**Testing without a virtual-service installed:**

```
rtp-ads-432:/nobackup/mwiebe/REPOS_NODE_UTILS/release131/cisco-network-node-utils> ruby tests/test_platform.rb -v -e n9k -n test_virtual_services
Run options: -v -e n9k -n test_virtual_services --seed 32346

# Running:


Node under test:
  - name  - dt-n9k5-1
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I4.1.bin

TestPlatform#test_virtual_services = 2.16 s = S

Finished in 2.161806s, 0.4626 runs/s, 0.0000 assertions/s.

  1) Skipped:
TestPlatform#test_virtual_services [tests/test_platform.rb:226]:
This test requires a virtual-service to be installed

1 runs, 0 assertions, 0 failures, 0 errors, 1 skips

```
