### PR TITLE
Pim.pims fix for feature disabled

### DIFF
--- a/lib/cisco_node_utils/pim.rb
+++ b/lib/cisco_node_utils/pim.rb
@@ -45,6 +45,7 @@ module Cisco
     def self.pims
       afis = %w(ipv4) # TBD: No support for ipv6 at this time
       hash_final = {}
+      return hash_final unless Feature.pim_enabled?
       afis.each do |afi|
         hash_final[afi] = {}
         default_vrf = 'default'

--- a/lib/cisco_node_utils/pim_group_list.rb
+++ b/lib/cisco_node_utils/pim_group_list.rb
@@ -42,6 +42,7 @@ module Cisco
     def self.group_lists
       afis = %w(ipv4) # TBD ipv6
       hash = {}
+      return hash unless Feature.pim_enabled?
       afis.each do |afi|
         hash[afi] = {}
         default_vrf = 'default'

--- a/lib/cisco_node_utils/pim_rp_address.rb
+++ b/lib/cisco_node_utils/pim_rp_address.rb
@@ -39,6 +39,7 @@ module Cisco
     def self.rp_addresses
       afis = %w(ipv4) # TBD ipv6
       hash = {}
+      return hash unless Feature.pim_enabled?
       afis.each do |afi|
         hash[afi] = {}
         default_vrf = 'default'


### PR DESCRIPTION
- The global nature of the pim resource means that an object will be created for each vrf regardless of state; however, this meant that objects were getting created even when feature pim was disabled, causing puppet agent/resource to to raise an error whenever the getter was called.
- Tested on n7
