### PR TITLE
(WIP) Feature/ospf area

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/ospf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf.yaml
@@ -8,6 +8,21 @@ _template:
     - "router ospf <name>"
     - "(?)vrf <vrf>"
 
+area:
+  multiple: true
+  get_value: '/^area\s+(\S+)/'
+
+area_authentication:
+  get_value: '/^area <area> authentication (\S+)/'
+  set_value: '<state> area <area> authentication <auth_type>'
+  default_value: ~ 
+
+area_default_cost:
+  kind: int
+  get_value: '/^area <area> default-cost (\d+)/'
+  set_value: '<state> area <area> default-cost <cost>'
+  default_value: ~
+
 auto_cost:
   get_value: '/^auto-cost reference-bandwidth (\d+)\s*(\S+)?$/'
   set_value: "auto-cost reference-bandwidth <cost> <type>"
@@ -18,6 +33,16 @@ default_metric:
   get_value: '/^default-metric (\d+)?$/'
   set_value: "<state> default-metric <metric>"
   default_value: 0
+
+filter_list_in:
+  get_value: '/^area <area> filter-list route-map (\S+) in/'
+  set_value: '<state> area <area> filter-list route-map <route_map> in'
+  default_value: ~
+
+filter_list_out:
+  get_value: '/^area <area> filter-list route-map (\S+) out/'
+  set_value: '<state> area <area> filter-list route-map <route_map> out'
+  default_value: ~
 
 log_adjacency:
   auto_default: false

--- a/lib/cisco_node_utils/router_ospf_area.rb
+++ b/lib/cisco_node_utils/router_ospf_area.rb
@@ -1,0 +1,167 @@
+# Rohan Gandhi Korlepara, May 2016
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'node_util'
+require_relative 'router_ospf'
+require_relative 'router_ospf_vrf'
+
+module Cisco
+  # RouterOspfVrf - node utility class for per-VRF OSPF config management
+  class RouterOspfArea < NodeUtil
+    attr_reader :name, :parent
+
+    def initialize(router, vrf_name, area_id, instantiate=true)
+      fail TypeError if router.nil?
+      fail TypeError if vrf_name.nil?
+      fail TypeError if area_id.nil?
+      fail ArgumentError unless router.length > 0
+      fail ArgumentError unless vrf_name.length > 0
+      fail ArgumentError unless area_id.length > 0
+      @router = router
+      @vrf_name = vrf_name
+      @area_id = area_id
+      @parent = {}
+      if @name == 'default'
+        @get_args = @set_args = { name: @router, area: @area_id }
+      else
+        @get_args = @set_args = { name: @router, vrf: @vrf_name,
+            area: @area_id }
+      end
+
+      create if instantiate
+    end
+
+    def self.areas
+      hash_final = {}
+      hash_tmp = {}
+      RouterOspf.routers.each do |instance|
+        name = instance[0]
+        area_ids = config_get('ospf', 'area', name: name)
+        unless area_ids.nil?
+          area_ids.uniq.each do |area|
+            hash_tmp =
+              { name => { 'default' => { area => RouterOspfArea
+                                                 .new(name, 'default',
+                                                      area, false) } } }
+          end
+        end
+        vrf_ids = config_get('ospf', 'vrf', name: name)
+        unless vrf_ids.nil?
+          vrf_ids.each do |vrf|
+            area_ids = config_get('ospf', 'area', name: name, vrf: vrf)
+            next if area_ids.nil?
+            area_ids.uniq.each do |area|
+              hash_tmp =
+                { name => { vrf => { area => RouterOspfArea
+                                             .new(name, 'default',
+                                                  area, false) } } }
+            end
+          end
+        end
+        hash_final.merge!(hash_tmp)
+      end
+      hash_final
+    end
+
+    # Create one router ospf vrf instance
+    def create
+      @parent = RouterOspfVrf.new(@router, @vrf_name)
+    end
+
+    # Destroy one router ospf vrf instance
+    def destroy
+      self.authentication = ''
+      self.cost = ''
+      self.filter_list_in = ''
+      self.filter_list_out = ''
+    end
+
+    # Helper method to delete @set_args hash keys
+    def delete_set_args_keys(list)
+      list.each { |key| @set_args.delete(key) }
+    end
+
+    def authentication
+      auth = config_get('ospf', 'area_authentication', @get_args)
+      return auth if auth.nil?
+      (auth.eql? 'message-digest') ? 'md5' : 'simple'
+    end
+
+    def authentication=(val)
+      @set_args[:auth_type] = (val.eql? 'simple') ? '' : 'message-digest'
+      @set_args[:state] = (val.empty?) ? 'no' : ''
+      config_set('ospf', 'area_authentication', @set_args)
+      delete_set_args_keys([:auth_type, :state])
+    end
+
+    def default_authentication
+      config_get_default('ospf', 'area_authentication')
+    end
+
+    def cost
+      config_get('ospf', 'area_default_cost', @get_args)
+    end
+
+    def cost=(val)
+      @set_args[:state] = (val.to_s.empty?) ? 'no' : ''
+      @set_args[:cost] = (@set_args[:state] == 'no') ? '' : val.to_i
+      config_set('ospf', 'area_default_cost', @set_args)
+      delete_set_args_keys([:cost, :state])
+    end
+
+    def default_cost
+      config_get_default('ospf', 'area_default_cost')
+    end
+
+    def filter_list_in
+      config_get('ospf', 'filter_list_in', @get_args)
+    end
+
+    def filter_list_in=(val)
+      @set_args[:state] = (val.to_s.empty?) ? 'no' : ''
+      if @set_args[:state] == 'no'
+        @set_args[:route_map] = (filter_list_in.nil?) ? '' : filter_list_in
+      else
+        @set_args[:route_map] = val
+      end
+      config_set('ospf', 'filter_list_in', @set_args)
+      delete_set_args_keys([:route_map, :state])
+    end
+
+    def default_filter_list_in
+      config_get_default('ospf', 'filter_list_in')
+    end
+
+    def filter_list_out
+      config_get('ospf', 'filter_list_out', @get_args)
+    end
+
+    def filter_list_out=(val)
+      @set_args[:state] = (val.to_s.empty?) ? 'no' : ''
+      if @set_args[:state] == 'no'
+        @set_args[:route_map] = (filter_list_out.nil?) ? '' : filter_list_out
+      else
+        @set_args[:route_map] = val
+      end
+      config_set('ospf', 'filter_list_out', @set_args)
+      delete_set_args_keys([:route_map, :state])
+    end
+
+    def default_filter_list_out
+      config_get_default('ospf', 'filter_list_out')
+    end
+  end
+end

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -32,7 +32,7 @@ class TestRouterOspfArea < CiscoTestCase
   end
 
   def test_ospf_area_properties
-    ospf_area = RouterOspfArea.new('green','testvrf1','5.5.5.5')
+    ospf_area = RouterOspfArea.new('green', 'testvrf1', '5.5.5.5')
     # Check authentication property
     assert_equal(ospf_area.default_authentication, ospf_area.authentication,
                  'Error: Area Authentication is not initialized to default')
@@ -59,5 +59,4 @@ class TestRouterOspfArea < CiscoTestCase
                  'Error: Area filter_list_out has not been set to test_map_out')
     ospf_area.destroy
   end
-
 end

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -1,0 +1,63 @@
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/router_ospf_area'
+
+# TestRouterOspfArea - Minitest for RouterOspfArea node utility class
+class TestRouterOspfArea < CiscoTestCase
+  @skip_unless_supported = 'ospf'
+  @@pre_clean_needed = true # rubocop:disable Style/ClassVars
+
+  def setup
+    super
+    remove_all_ospfs if @@pre_clean_needed
+    @@pre_clean_needed = false # rubocop:disable Style/ClassVars
+  end
+
+  def teardown
+    remove_all_ospfs
+    super
+  end
+
+  def test_ospf_area_properties
+    ospf_area = RouterOspfArea.new('green','testvrf1','5.5.5.5')
+    # Check authentication property
+    assert_equal(ospf_area.default_authentication, ospf_area.authentication,
+                 'Error: Area Authentication is not initialized to default')
+    ospf_area.authentication = 'md5'
+    assert_equal('md5', ospf_area.authentication,
+                 'Error: Area Authentication is not md5')
+    # Check default-cost property
+    assert_equal(ospf_area.default_cost, ospf_area.cost,
+                 'Error: Area default-cost is not initialized to default')
+    ospf_area.cost = 10
+    assert_equal(10, ospf_area.cost,
+                 'Error: Area default-cost has not been set to 10')
+    # Check filter_list_in property
+    assert_equal(ospf_area.default_filter_list_in, ospf_area.filter_list_in,
+                 'Error: Area filter_list_in is not initialized to default')
+    ospf_area.filter_list_in = 'test_map_in'
+    assert_equal('test_map_in', ospf_area.filter_list_in,
+                 'Error: Area filter_list_in has not been set to test_map_in')
+    # Check filter_list_out property
+    assert_equal(ospf_area.default_filter_list_out, ospf_area.filter_list_out,
+                 'Error: Area filter_list_out is not initialized to default')
+    ospf_area.filter_list_out = 'test_map_out'
+    assert_equal('test_map_out', ospf_area.filter_list_out,
+                 'Error: Area filter_list_out has not been set to test_map_out')
+    ospf_area.destroy
+  end
+
+end


### PR DESCRIPTION
This is the node util class for feature ospf_area. The properties implemented are as below manifest

cisco_ospf_area { 'green vrf1 5.5.5.5':
  ensure           => present,
  authentication   => simple,         # Choices are simple, md5
  default_cost     => 555,            # Simple integer prop
  filter_list_in   => rtmap_name,     # Simple string prop
  filter_list_out  => rtmap_name,     # Simple string prop
}

This include a minitest for the above properties and checking if set or not.

This has been tested on n7k, n9k, n5k, n6k, n3k. This is not supported in ios platform
