### PR TITLE
Bfd global

### DIFF
--- a/lib/cisco_node_utils/bfd_global.rb
+++ b/lib/cisco_node_utils/bfd_global.rb
@@ -56,14 +56,11 @@ module Cisco
       self.fabricpath_slow_timer = default_fabricpath_slow_timer if
       fabricpath_slow_timer
       self.startup_timer = default_startup_timer if startup_timer
-      config_set('bfd_global', 'interval', state: 'no',
-                 intv: 50, mrx: 50, mult: 3)
-      config_set('bfd_global', 'ipv4_interval', state: 'no',
-                 intv: 50, mrx: 50, mult: 3) if ipv4_interval
-      config_set('bfd_global', 'ipv6_interval', state: 'no',
-                 intv: 50, mrx: 50, mult: 3) if ipv6_interval
-      config_set('bfd_global', 'fabricpath_interval', state: 'no',
-                 intv: 50, mrx: 50, mult: 3) if fabricpath_interval
+      self.interval = default_interval
+      self.ipv4_interval = default_ipv4_interval if ipv4_interval
+      self.ipv6_interval = default_ipv6_interval if ipv6_interval
+      self.fabricpath_interval = default_fabricpath_interval if
+      fabricpath_interval
       @name = nil
       set_args_keys_default
     end
@@ -254,212 +251,73 @@ module Cisco
       config_get_default('bfd_global', 'fabricpath_interval')
     end
 
-    def default_min_rx
-      config_get_default('bfd_global', 'min_rx')
-    end
-
-    def default_ipv4_min_rx
-      config_get_default('bfd_global', 'ipv4_min_rx')
-    end
-
-    def default_ipv6_min_rx
-      config_get_default('bfd_global', 'ipv6_min_rx')
-    end
-
-    def default_fabricpath_min_rx
-      config_get_default('bfd_global', 'fabricpath_min_rx')
-    end
-
-    def default_multiplier
-      config_get_default('bfd_global', 'multiplier')
-    end
-
-    def default_ipv4_multiplier
-      config_get_default('bfd_global', 'ipv4_multiplier')
-    end
-
-    def default_ipv6_multiplier
-      config_get_default('bfd_global', 'ipv6_multiplier')
-    end
-
-    def default_fabricpath_multiplier
-      config_get_default('bfd_global', 'fabricpath_multiplier')
-    end
-
-    def interval_get
-      config_get('bfd_global', 'interval_param', @get_args).map(&:to_i)
-    end
-
-    def ipv4_interval_get
-      config_get('bfd_global', 'ipv4_interval_param', @get_args).map(&:to_i)
-    end
-
-    def ipv6_interval_get
-      config_get('bfd_global', 'ipv6_interval_param', @get_args).map(&:to_i)
-    end
-
-    def fabricpath_interval_get
-      config_get('bfd_global',
-                 'fabricpath_interval_param', @get_args).map(&:to_i)
-    end
-
+    # interval is an array of interval, min_rx and multiplier
     def interval
-      interval_get[0]
+      config_get('bfd_global', 'interval', @get_args)
     end
 
+    # ipv4_interval is an array of ipv4_interval, ipv4_min_rx and
+    # ipv4_multiplier
     def ipv4_interval
-      ipv4_interval_get[0]
+      config_get('bfd_global', 'ipv4_interval', @get_args)
     end
 
+    # ipv6_interval is an array of ipv6_interval, ipv6_min_rx and
+    # ipv6_multiplier
     def ipv6_interval
-      ipv6_interval_get[0]
+      config_get('bfd_global', 'ipv6_interval', @get_args)
     end
 
+    # fabricpath_interval is an array of fabricpath_interval,
+    # fabricpath_min_rx and fabricpath_multiplier
     def fabricpath_interval
-      fabricpath_interval_get[0]
+      config_get('bfd_global', 'fabricpath_interval', @get_args)
     end
 
-    def min_rx
-      interval_get[1]
-    end
-
-    def ipv4_min_rx
-      ipv4_interval_get[1]
-    end
-
-    def ipv6_min_rx
-      ipv6_interval_get[1]
-    end
-
-    def fabricpath_min_rx
-      fabricpath_interval_get[1]
-    end
-
-    def multiplier
-      interval_get[2]
-    end
-
-    def ipv4_multiplier
-      ipv4_interval_get[2]
-    end
-
-    def ipv6_multiplier
-      ipv6_interval_get[2]
-    end
-
-    def fabricpath_multiplier
-      fabricpath_interval_get[2]
-    end
-
-    def interval=(val)
-      @set_args[:intv] = val
-    end
-
-    def ipv4_interval=(val)
-      @set_args[:intv] = val
-    end
-
-    def ipv6_interval=(val)
-      @set_args[:intv] = val
-    end
-
-    def fabricpath_interval=(val)
-      @set_args[:intv] = val
-    end
-
-    def min_rx=(val)
-      @set_args[:mrx] = val
-    end
-
-    def ipv4_min_rx=(val)
-      @set_args[:mrx] = val
-    end
-
-    def ipv6_min_rx=(val)
-      @set_args[:mrx] = val
-    end
-
-    def fabricpath_min_rx=(val)
-      @set_args[:mrx] = val
-    end
-
-    def multiplier=(val)
-      @set_args[:mult] = val
-    end
-
-    def ipv4_multiplier=(val)
-      @set_args[:mult] = val
-    end
-
-    def ipv6_multiplier=(val)
-      @set_args[:mult] = val
-    end
-
-    def fabricpath_multiplier=(val)
-      @set_args[:mult] = val
-    end
-
-    def interval_set(attrs)
-      set_args_keys(attrs)
-      [:interval,
-       :min_rx,
-       :multiplier,
-      ].each do |p|
-        send(p.to_s + '=', attrs[p])
-      end
-      @set_args[:state] = 'no' if
-        @set_args[:intv] == default_interval &&
-        @set_args[:mrx] == default_min_rx &&
-        @set_args[:mult] == default_multiplier
-      config_set('bfd_global', 'interval_param', @set_args)
+    # interval is an array of interval, min_rx and multiplier
+    # ex: ['100', '100', '25']
+    def interval=(arr)
+      @set_args[:state] = 'no' if arr == default_interval
+      @set_args[:intv] = arr[0]
+      @set_args[:mrx] = arr[1]
+      @set_args[:mult] = arr[2]
+      config_set('bfd_global', 'interval', @set_args)
       set_args_keys_default
     end
 
-    def ipv4_interval_set(attrs)
-      set_args_keys(attrs)
-      [:ipv4_interval,
-       :ipv4_min_rx,
-       :ipv4_multiplier,
-      ].each do |p|
-        send(p.to_s + '=', attrs[p])
-      end
-      @set_args[:state] = 'no' if
-        @set_args[:intv] == default_ipv4_interval &&
-        @set_args[:mrx] == default_ipv4_min_rx &&
-        @set_args[:mult] == default_ipv4_multiplier
-      config_set('bfd_global', 'ipv4_interval_param', @set_args)
+    # ipv4_interval is an array of ipv4_interval, ipv4_min_rx and
+    # ipv4_multiplier
+    # ex: ['100', '100', '25']
+    def ipv4_interval=(arr)
+      @set_args[:state] = 'no' if arr == default_ipv4_interval
+      @set_args[:intv] = arr[0]
+      @set_args[:mrx] = arr[1]
+      @set_args[:mult] = arr[2]
+      config_set('bfd_global', 'ipv4_interval', @set_args)
       set_args_keys_default
     end
 
-    def ipv6_interval_set(attrs)
-      set_args_keys(attrs)
-      [:ipv6_interval,
-       :ipv6_min_rx,
-       :ipv6_multiplier,
-      ].each do |p|
-        send(p.to_s + '=', attrs[p])
-      end
-      @set_args[:state] = 'no' if
-        @set_args[:intv] == default_ipv6_interval &&
-        @set_args[:mrx] == default_ipv6_min_rx &&
-        @set_args[:mult] == default_ipv6_multiplier
-      config_set('bfd_global', 'ipv6_interval_param', @set_args)
+    # ipv6_interval is an array of ipv6_interval, ipv6_min_rx and
+    # ipv6_multiplier
+    # ex: ['100', '100', '25']
+    def ipv6_interval=(arr)
+      @set_args[:state] = 'no' if arr == default_ipv6_interval
+      @set_args[:intv] = arr[0]
+      @set_args[:mrx] = arr[1]
+      @set_args[:mult] = arr[2]
+      config_set('bfd_global', 'ipv6_interval', @set_args)
       set_args_keys_default
     end
 
-    def fabricpath_interval_set(attrs)
-      set_args_keys(attrs)
-      [:fabricpath_interval,
-       :fabricpath_min_rx,
-       :fabricpath_multiplier,
-      ].each do |p|
-        send(p.to_s + '=', attrs[p])
-      end
-      @set_args[:state] = 'no' if
-        @set_args[:intv] == default_fabricpath_interval &&
-        @set_args[:mrx] == default_fabricpath_min_rx &&
-        @set_args[:mult] == default_fabricpath_multiplier
-      config_set('bfd_global', 'fabricpath_interval_param', @set_args)
+    # fabricpath_interval is an array of fabricpath_interval,
+    # fabricpath_min_rx and fabricpath_multiplier
+    # ex: ['100', '100', '25']
+    def fabricpath_interval=(arr)
+      @set_args[:state] = 'no' if arr == default_fabricpath_interval
+      @set_args[:intv] = arr[0]
+      @set_args[:mrx] = arr[1]
+      @set_args[:mult] = arr[2]
+      config_set('bfd_global', 'fabricpath_interval', @set_args)
       set_args_keys_default
     end
   end # class

--- a/lib/cisco_node_utils/bfd_global.rb
+++ b/lib/cisco_node_utils/bfd_global.rb
@@ -33,24 +33,24 @@ module Cisco
     # Reset everything back to default
     def destroy
       return unless Feature.bfd_enabled?
-      self.interval = default_interval if interval
-      self.echo_interface = default_echo_interface
-      self.echo_rx_interval = default_echo_rx_interval if echo_rx_interval
-      self.ipv4_echo_rx_interval = default_ipv4_echo_rx_interval if
-        ipv4_echo_rx_interval
-      self.ipv6_echo_rx_interval = default_ipv6_echo_rx_interval if
-        ipv6_echo_rx_interval
-      self.fabricpath_vlan = default_fabricpath_vlan if fabricpath_vlan
-      self.slow_timer = default_slow_timer
-      self.ipv4_slow_timer = default_ipv4_slow_timer if ipv4_slow_timer
-      self.ipv6_slow_timer = default_ipv6_slow_timer if ipv6_slow_timer
-      self.fabricpath_slow_timer = default_fabricpath_slow_timer if
-        fabricpath_slow_timer
-      self.startup_timer = default_startup_timer if startup_timer
-      self.ipv4_interval = default_ipv4_interval if ipv4_interval
-      self.ipv6_interval = default_ipv6_interval if ipv6_interval
-      self.fabricpath_interval = default_fabricpath_interval if
-        fabricpath_interval
+      [:interval,
+       :ipv4_interval,
+       :ipv6_interval,
+       :fabricpath_interval,
+       :echo_interface,
+       :echo_rx_interval,
+       :ipv4_echo_rx_interval,
+       :ipv6_echo_rx_interval,
+       :fabricpath_vlan,
+       :slow_timer,
+       :ipv4_slow_timer,
+       :ipv6_slow_timer,
+       :fabricpath_slow_timer,
+       :startup_timer,
+      ].each do |prop|
+        send("#{prop}=", send("default_#{prop}")) if
+          send prop
+      end
       set_args_keys_default
     end
 
@@ -258,7 +258,8 @@ module Cisco
     # ex: ['100', '100', '25']
     # CLI: bfd interval 100 min_rx 100 multiplier 25
     def interval=(arr)
-      set_args_keys(intv: arr[0], mrx: arr[1], mult: arr[2],
+      interval, min_rx, multiplier = arr
+      set_args_keys(interval: interval, min_rx: min_rx, multiplier: multiplier,
                     state: arr == default_interval ? 'no' : '')
       config_set('bfd_global', 'interval', @set_args)
     end
@@ -268,7 +269,8 @@ module Cisco
     # ex: ['100', '100', '25']
     # CLI: bfd ipv4 interval 100 min_rx 100 multiplier 25
     def ipv4_interval=(arr)
-      set_args_keys(intv: arr[0], mrx: arr[1], mult: arr[2],
+      interval, min_rx, multiplier = arr
+      set_args_keys(interval: interval, min_rx: min_rx, multiplier: multiplier,
                     state: arr == default_ipv4_interval ? 'no' : '')
       config_set('bfd_global', 'ipv4_interval', @set_args)
     end
@@ -278,7 +280,8 @@ module Cisco
     # ex: ['100', '100', '25']
     # CLI: bfd ipv6 interval 100 min_rx 100 multiplier 25
     def ipv6_interval=(arr)
-      set_args_keys(intv: arr[0], mrx: arr[1], mult: arr[2],
+      interval, min_rx, multiplier = arr
+      set_args_keys(interval: interval, min_rx: min_rx, multiplier: multiplier,
                     state: arr == default_ipv6_interval ? 'no' : '')
       config_set('bfd_global', 'ipv6_interval', @set_args)
     end
@@ -288,7 +291,8 @@ module Cisco
     # ex: ['100', '100', '25']
     # CLI: bfd fabricpath interval 100 min_rx 100 multiplier 25
     def fabricpath_interval=(arr)
-      set_args_keys(intv: arr[0], mrx: arr[1], mult: arr[2],
+      interval, min_rx, multiplier = arr
+      set_args_keys(interval: interval, min_rx: min_rx, multiplier: multiplier,
                     state: arr == default_fabricpath_interval ? 'no' : '')
       config_set('bfd_global', 'fabricpath_interval', @set_args)
     end

--- a/lib/cisco_node_utils/bfd_global.rb
+++ b/lib/cisco_node_utils/bfd_global.rb
@@ -49,6 +49,8 @@ module Cisco
       self.echo_rx_interval = default_echo_rx_interval if echo_rx_interval
       self.ipv4_echo_rx_interval = default_ipv4_echo_rx_interval if
       ipv4_echo_rx_interval
+      self.ipv6_echo_rx_interval = default_ipv6_echo_rx_interval if
+      ipv6_echo_rx_interval
       self.fabricpath_vlan = default_fabricpath_vlan if fabricpath_vlan
       self.slow_timer = default_slow_timer if slow_timer
       self.ipv4_slow_timer = default_ipv4_slow_timer if ipv4_slow_timer

--- a/lib/cisco_node_utils/bfd_global.rb
+++ b/lib/cisco_node_utils/bfd_global.rb
@@ -33,6 +33,7 @@ module Cisco
     # Reset everything back to default
     def destroy
       return unless Feature.bfd_enabled?
+      self.interval = default_interval if interval
       self.echo_interface = default_echo_interface
       self.echo_rx_interval = default_echo_rx_interval if echo_rx_interval
       self.ipv4_echo_rx_interval = default_ipv4_echo_rx_interval if
@@ -50,7 +51,6 @@ module Cisco
       self.ipv6_interval = default_ipv6_interval if ipv6_interval
       self.fabricpath_interval = default_fabricpath_interval if
         fabricpath_interval
-      self.interval = default_interval
       set_args_keys_default
     end
 

--- a/lib/cisco_node_utils/bfd_global.rb
+++ b/lib/cisco_node_utils/bfd_global.rb
@@ -228,30 +228,35 @@ module Cisco
     end
 
     # interval is an array of interval, min_rx and multiplier
+    # CLI: bfd interval 100 min_rx 100 multiplier 25
     def interval
       config_get('bfd_global', 'interval', @get_args)
     end
 
     # ipv4_interval is an array of ipv4_interval, ipv4_min_rx and
     # ipv4_multiplier
+    # CLI: bfd ipv4 interval 100 min_rx 100 multiplier 25
     def ipv4_interval
       config_get('bfd_global', 'ipv4_interval', @get_args)
     end
 
     # ipv6_interval is an array of ipv6_interval, ipv6_min_rx and
     # ipv6_multiplier
+    # CLI: bfd ipv6 interval 100 min_rx 100 multiplier 25
     def ipv6_interval
       config_get('bfd_global', 'ipv6_interval', @get_args)
     end
 
     # fabricpath_interval is an array of fabricpath_interval,
     # fabricpath_min_rx and fabricpath_multiplier
+    # CLI: bfd fabricpath interval 100 min_rx 100 multiplier 25
     def fabricpath_interval
       config_get('bfd_global', 'fabricpath_interval', @get_args)
     end
 
     # interval is an array of interval, min_rx and multiplier
     # ex: ['100', '100', '25']
+    # CLI: bfd interval 100 min_rx 100 multiplier 25
     def interval=(arr)
       set_args_keys(intv: arr[0], mrx: arr[1], mult: arr[2],
                     state: arr == default_interval ? 'no' : '')
@@ -261,6 +266,7 @@ module Cisco
     # ipv4_interval is an array of ipv4_interval, ipv4_min_rx and
     # ipv4_multiplier
     # ex: ['100', '100', '25']
+    # CLI: bfd ipv4 interval 100 min_rx 100 multiplier 25
     def ipv4_interval=(arr)
       set_args_keys(intv: arr[0], mrx: arr[1], mult: arr[2],
                     state: arr == default_ipv4_interval ? 'no' : '')
@@ -270,6 +276,7 @@ module Cisco
     # ipv6_interval is an array of ipv6_interval, ipv6_min_rx and
     # ipv6_multiplier
     # ex: ['100', '100', '25']
+    # CLI: bfd ipv6 interval 100 min_rx 100 multiplier 25
     def ipv6_interval=(arr)
       set_args_keys(intv: arr[0], mrx: arr[1], mult: arr[2],
                     state: arr == default_ipv6_interval ? 'no' : '')
@@ -279,6 +286,7 @@ module Cisco
     # fabricpath_interval is an array of fabricpath_interval,
     # fabricpath_min_rx and fabricpath_multiplier
     # ex: ['100', '100', '25']
+    # CLI: bfd fabricpath interval 100 min_rx 100 multiplier 25
     def fabricpath_interval=(arr)
       set_args_keys(intv: arr[0], mrx: arr[1], mult: arr[2],
                     state: arr == default_fabricpath_interval ? 'no' : '')

--- a/lib/cisco_node_utils/bfd_global.rb
+++ b/lib/cisco_node_utils/bfd_global.rb
@@ -24,53 +24,39 @@ module Cisco
   class BfdGlobal < NodeUtil
     attr_reader :name
 
-    def initialize(name, instantiate=true)
-      fail ArgumentError unless name.to_s == 'default'
-      @name = name.downcase
+    def initialize(instantiate=true)
       set_args_keys_default
 
       Feature.bfd_enable if instantiate
     end
 
-    def to_s
-      "bfd_global #{name}"
-    end
-
-    def self.globals
-      hash = {}
-      hash['default'] = BfdGlobal.new('default', false) if
-        Feature.bfd_enabled?
-      hash
-    end
-
     # Reset everything back to default
     def destroy
+      return unless Feature.bfd_enabled?
       self.echo_interface = default_echo_interface
       self.echo_rx_interval = default_echo_rx_interval if echo_rx_interval
       self.ipv4_echo_rx_interval = default_ipv4_echo_rx_interval if
-      ipv4_echo_rx_interval
+        ipv4_echo_rx_interval
       self.ipv6_echo_rx_interval = default_ipv6_echo_rx_interval if
-      ipv6_echo_rx_interval
+        ipv6_echo_rx_interval
       self.fabricpath_vlan = default_fabricpath_vlan if fabricpath_vlan
-      self.slow_timer = default_slow_timer if slow_timer
+      self.slow_timer = default_slow_timer
       self.ipv4_slow_timer = default_ipv4_slow_timer if ipv4_slow_timer
       self.ipv6_slow_timer = default_ipv6_slow_timer if ipv6_slow_timer
       self.fabricpath_slow_timer = default_fabricpath_slow_timer if
-      fabricpath_slow_timer
+        fabricpath_slow_timer
       self.startup_timer = default_startup_timer if startup_timer
-      self.interval = default_interval
       self.ipv4_interval = default_ipv4_interval if ipv4_interval
       self.ipv6_interval = default_ipv6_interval if ipv6_interval
       self.fabricpath_interval = default_fabricpath_interval if
-      fabricpath_interval
-      @name = nil
+        fabricpath_interval
+      self.interval = default_interval
       set_args_keys_default
     end
 
     # Helper method to delete @set_args hash keys
     def set_args_keys_default
-      keys = { name: @name }
-      keys[:state] = ''
+      keys = { state: '' }
       @get_args = @set_args = keys
     end
 
@@ -89,15 +75,10 @@ module Cisco
     end
 
     def echo_interface=(val)
-      if val
-        @set_args[:intf] = val
-      else
-        @set_args[:state] = 'no'
-        @set_args[:intf] = echo_interface
-      end
+      set_args_keys(intf:  val ? val : echo_interface,
+                    state: val ? '' : 'no')
       config_set('bfd_global', 'echo_interface', @set_args) if
-      @set_args[:intf]
-      set_args_keys_default
+        @set_args[:intf]
     end
 
     def default_echo_interface
@@ -109,10 +90,9 @@ module Cisco
     end
 
     def echo_rx_interval=(val)
-      @set_args[:state] = 'no' if val == default_echo_rx_interval
-      @set_args[:rxi] = val
+      set_args_keys(rxi:   val,
+                    state: val == default_echo_rx_interval ? 'no' : '')
       config_set('bfd_global', 'echo_rx_interval', @set_args)
-      set_args_keys_default
     end
 
     def default_echo_rx_interval
@@ -124,10 +104,9 @@ module Cisco
     end
 
     def ipv4_echo_rx_interval=(val)
-      @set_args[:state] = 'no' if val == default_ipv4_echo_rx_interval
-      @set_args[:rxi] = val
+      set_args_keys(rxi:   val,
+                    state: val == default_ipv4_echo_rx_interval ? 'no' : '')
       config_set('bfd_global', 'ipv4_echo_rx_interval', @set_args)
-      set_args_keys_default
     end
 
     def default_ipv4_echo_rx_interval
@@ -139,10 +118,9 @@ module Cisco
     end
 
     def ipv6_echo_rx_interval=(val)
-      @set_args[:state] = 'no' if val == default_ipv6_echo_rx_interval
-      @set_args[:rxi] = val
+      set_args_keys(rxi:   val,
+                    state: val == default_ipv6_echo_rx_interval ? 'no' : '')
       config_set('bfd_global', 'ipv6_echo_rx_interval', @set_args)
-      set_args_keys_default
     end
 
     def default_ipv6_echo_rx_interval
@@ -154,10 +132,9 @@ module Cisco
     end
 
     def slow_timer=(val)
-      @set_args[:state] = 'no' if val == default_slow_timer
-      @set_args[:timer] = val
+      set_args_keys(timer: val,
+                    state: val == default_slow_timer ? 'no' : '')
       config_set('bfd_global', 'slow_timer', @set_args)
-      set_args_keys_default
     end
 
     def default_slow_timer
@@ -169,10 +146,9 @@ module Cisco
     end
 
     def ipv4_slow_timer=(val)
-      @set_args[:state] = 'no' if val == default_ipv4_slow_timer
-      @set_args[:timer] = val
+      set_args_keys(timer: val,
+                    state: val == default_ipv4_slow_timer ? 'no' : '')
       config_set('bfd_global', 'ipv4_slow_timer', @set_args)
-      set_args_keys_default
     end
 
     def default_ipv4_slow_timer
@@ -184,10 +160,9 @@ module Cisco
     end
 
     def ipv6_slow_timer=(val)
-      @set_args[:state] = 'no' if val == default_ipv6_slow_timer
-      @set_args[:timer] = val
+      set_args_keys(timer: val,
+                    state: val == default_ipv6_slow_timer ? 'no' : '')
       config_set('bfd_global', 'ipv6_slow_timer', @set_args)
-      set_args_keys_default
     end
 
     def default_ipv6_slow_timer
@@ -199,10 +174,9 @@ module Cisco
     end
 
     def fabricpath_slow_timer=(val)
-      @set_args[:state] = 'no' if val == default_fabricpath_slow_timer
-      @set_args[:timer] = val
+      set_args_keys(timer: val,
+                    state: val == default_fabricpath_slow_timer ? 'no' : '')
       config_set('bfd_global', 'fabricpath_slow_timer', @set_args)
-      set_args_keys_default
     end
 
     def default_fabricpath_slow_timer
@@ -214,9 +188,9 @@ module Cisco
     end
 
     def startup_timer=(val)
-      @set_args[:timer] = val
+      set_args_keys(timer: val,
+                    state: val == default_startup_timer ? 'no' : '')
       config_set('bfd_global', 'startup_timer', @set_args)
-      set_args_keys_default
     end
 
     def default_startup_timer
@@ -228,9 +202,9 @@ module Cisco
     end
 
     def fabricpath_vlan=(val)
-      @set_args[:vlan] = val
+      set_args_keys(vlan:  val,
+                    state: val == default_fabricpath_vlan ? 'no' : '')
       config_set('bfd_global', 'fabricpath_vlan', @set_args)
-      set_args_keys_default
     end
 
     def default_fabricpath_vlan
@@ -279,48 +253,36 @@ module Cisco
     # interval is an array of interval, min_rx and multiplier
     # ex: ['100', '100', '25']
     def interval=(arr)
-      @set_args[:state] = 'no' if arr == default_interval
-      @set_args[:intv] = arr[0]
-      @set_args[:mrx] = arr[1]
-      @set_args[:mult] = arr[2]
+      set_args_keys(intv: arr[0], mrx: arr[1], mult: arr[2],
+                    state: arr == default_interval ? 'no' : '')
       config_set('bfd_global', 'interval', @set_args)
-      set_args_keys_default
     end
 
     # ipv4_interval is an array of ipv4_interval, ipv4_min_rx and
     # ipv4_multiplier
     # ex: ['100', '100', '25']
     def ipv4_interval=(arr)
-      @set_args[:state] = 'no' if arr == default_ipv4_interval
-      @set_args[:intv] = arr[0]
-      @set_args[:mrx] = arr[1]
-      @set_args[:mult] = arr[2]
+      set_args_keys(intv: arr[0], mrx: arr[1], mult: arr[2],
+                    state: arr == default_ipv4_interval ? 'no' : '')
       config_set('bfd_global', 'ipv4_interval', @set_args)
-      set_args_keys_default
     end
 
     # ipv6_interval is an array of ipv6_interval, ipv6_min_rx and
     # ipv6_multiplier
     # ex: ['100', '100', '25']
     def ipv6_interval=(arr)
-      @set_args[:state] = 'no' if arr == default_ipv6_interval
-      @set_args[:intv] = arr[0]
-      @set_args[:mrx] = arr[1]
-      @set_args[:mult] = arr[2]
+      set_args_keys(intv: arr[0], mrx: arr[1], mult: arr[2],
+                    state: arr == default_ipv6_interval ? 'no' : '')
       config_set('bfd_global', 'ipv6_interval', @set_args)
-      set_args_keys_default
     end
 
     # fabricpath_interval is an array of fabricpath_interval,
     # fabricpath_min_rx and fabricpath_multiplier
     # ex: ['100', '100', '25']
     def fabricpath_interval=(arr)
-      @set_args[:state] = 'no' if arr == default_fabricpath_interval
-      @set_args[:intv] = arr[0]
-      @set_args[:mrx] = arr[1]
-      @set_args[:mult] = arr[2]
+      set_args_keys(intv: arr[0], mrx: arr[1], mult: arr[2],
+                    state: arr == default_fabricpath_interval ? 'no' : '')
       config_set('bfd_global', 'fabricpath_interval', @set_args)
-      set_args_keys_default
     end
   end # class
 end # module

--- a/lib/cisco_node_utils/cmd_ref/bfd_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bfd_global.yaml
@@ -7,9 +7,9 @@ _template:
   context: ~
 
 echo_interface:
-  kind: int
-  get_value: '/^bfd echo-interface loopback(\d+)$/'
-  set_value: '<state> bfd echo-interface loopback <intf>'
+  kind: string
+  get_value: '/^bfd echo-interface (.*)$/'
+  set_value: '<state> bfd echo-interface <intf>'
   default_value: false
 
 echo_rx_interval:
@@ -45,6 +45,7 @@ fabricpath_vlan:
   default_value: 1
 
 interval:
+  _exclude: [N8k, N9k] # TBD: bug on n8k, n9k this is not working now
   get_value: '/^bfd interval (\d+) min_rx (\d+) multiplier (\d+)$/'
   set_value: '<state> bfd interval <intv> min_rx <mrx> multiplier <mult>'
   N3k: &interval_250

--- a/lib/cisco_node_utils/cmd_ref/bfd_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bfd_global.yaml
@@ -6,18 +6,6 @@ _template:
   get_command: "show running-config bfd all"
   context: ~
 
-common_echo_rx_interval:
-  get_value: '/^bfd <protocol>echo-rx-interval (\d+)$/'
-  set_value: '<state> bfd <protocol> echo-rx-interval <rxi>'
-
-common_interval:
-  get_value: '/^bfd <protocol>interval (\d+) min_rx (\d+) multiplier (\d+)$/'
-  set_value: '<state> bfd <protocol> interval <intv> min_rx <mrx> multiplier <mult>'
-
-common_slow_timer:
-  get_value: '/^bfd <protocol>slow-timer (\d+)$/'
-  set_value: '<state> bfd <protocol> slow-timer <timer>'
-
 echo_interface:
   kind: int
   get_value: '/^bfd echo-interface loopback(\d+)$/'
@@ -27,12 +15,40 @@ echo_interface:
 echo_rx_interval:
   _exclude: [N5k, N6k]
   kind: int
+  get_value: '/^bfd echo-rx-interval (\d+)$/'
+  set_value: '<state> bfd echo-rx-interval <rxi>'
   N3k: &rx_interval_250
     default_value: 250
   N7k: &rx_interval_50
     default_value: 50
   N8k: *rx_interval_50
   N9k: *rx_interval_50
+
+fabricpath_interval:
+  _exclude: [N3k, N8k, N9k]
+  kind: int
+  default_value: 50
+
+fabricpath_interval_param:
+  get_value: '/^bfd fabricpath interval (\d+) min_rx (\d+) multiplier (\d+)$/'
+  set_value: '<state> bfd fabricpath interval <intv> min_rx <mrx> multiplier <mult>'
+
+fabricpath_min_rx:
+  _exclude: [N3k, N8k, N9k]
+  kind: int
+  default_value: 50
+
+fabricpath_multiplier:
+  _exclude: [N3k, N8k, N9k]
+  kind: int
+  default_value: 3
+
+fabricpath_slow_timer:
+  _exclude: [N3k, N8k, N9k]
+  kind: int
+  get_value: '/^bfd fabricpath slow-timer (\d+)$/'
+  set_value: '<state> bfd fabricpath slow-timer <timer>'
+  default_value: 2000
 
 fabricpath_vlan:
   _exclude: [N3k, N8k, N9k]
@@ -52,6 +68,105 @@ interval:
   N8k: *interval_50
   N9k: *interval_50
 
+interval_param:
+  get_value: '/^bfd interval (\d+) min_rx (\d+) multiplier (\d+)$/'
+  set_value: '<state> bfd interval <intv> min_rx <mrx> multiplier <mult>'
+
+ipv4_echo_rx_interval:
+  _exclude: [N5k, N6k]
+  kind: int
+  get_value: '/^bfd ipv4 echo-rx-interval (\d+)$/'
+  set_value: '<state> bfd ipv4 echo-rx-interval <rxi>'
+  N3k: &ipv4_rx_interval_250
+    default_value: 250
+  N7k: &ipv4_rx_interval_50
+    default_value: 50
+  N8k: *ipv4_rx_interval_50
+  N9k: *ipv4_rx_interval_50
+
+ipv4_interval:
+  _exclude: [N5k, N6k]
+  kind: int
+  N3k: &ipv4_interval_250
+    default_value: 250
+  N7k: &ipv4_interval_50
+    default_value: 50
+  N8k: *ipv4_interval_50
+  N9k: *ipv4_interval_50
+
+ipv4_interval_param:
+  get_value: '/^bfd ipv4 interval (\d+) min_rx (\d+) multiplier (\d+)$/'
+  set_value: '<state> bfd ipv4 interval <intv> min_rx <mrx> multiplier <mult>'
+
+ipv4_min_rx:
+  _exclude: [N5k, N6k]
+  kind: int
+  N3k: &ipv4_min_rx_250
+    default_value: 250
+  N7k: &ipv4_min_rx_50
+    default_value: 50
+  N8k: *ipv4_min_rx_50
+  N9k: *ipv4_min_rx_50
+
+ipv4_multiplier:
+  _exclude: [N5k, N6k]
+  kind: int
+  default_value: 3
+
+ipv4_slow_timer:
+  kind: int
+  get_value: '/^bfd ipv4 slow-timer (\d+)$/'
+  set_value: '<state> bfd ipv4 slow-timer <timer>'
+  default_value: 2000
+
+ipv6_echo_rx_interval:
+  _exclude: [N5k, N6k]
+  kind: int
+  get_value: '/^bfd ipv6 echo-rx-interval (\d+)$/'
+  set_value: '<state> bfd ipv6 echo-rx-interval <rxi>'
+  N3k: &ipv6_rx_interval_250
+    default_value: 250
+  N7k: &ipv6_rx_interval_50
+    default_value: 50
+  N8k: *ipv6_rx_interval_50
+  N9k: *ipv6_rx_interval_50
+
+ipv6_interval:
+  _exclude: [N5k, N6k]
+  kind: int
+  N3k: &ipv6_interval_250
+    default_value: 250
+  N7k: &ipv6_interval_50
+    default_value: 50
+  N8k: *ipv6_interval_50
+  N9k: *ipv6_interval_50
+
+ipv6_interval_param:
+  get_value: '/^bfd ipv6 interval (\d+) min_rx (\d+) multiplier (\d+)$/'
+  set_value: '<state> bfd ipv6 interval <intv> min_rx <mrx> multiplier <mult>'
+
+ipv6_min_rx:
+  _exclude: [N5k, N6k]
+  kind: int
+  N3k: &ipv6_min_rx_250
+    default_value: 250
+  N7k: &ipv6_min_rx_50
+    default_value: 50
+  N8k: *ipv6_min_rx_50
+  N9k: *ipv6_min_rx_50
+
+ipv6_multiplier:
+  _exclude: [N5k, N6k]
+  kind: int
+  default_value: 3
+
+ipv6_slow_timer:
+  _exclude: [N5k, N6k]
+  kind: int
+  get_value: '/^bfd ipv6 slow-timer (\d+)$/'
+  set_value: '<state> bfd ipv6 slow-timer <timer>'
+  default_value: 2000
+
 min_rx:
   kind: int
   N3k: &min_rx_250
@@ -69,6 +184,8 @@ multiplier:
 
 slow_timer:
   kind: int
+  get_value: '/^bfd slow-timer (\d+)$/'
+  set_value: '<state> bfd slow-timer <timer>'
   default_value: 2000
 
 startup_timer:
@@ -77,15 +194,3 @@ startup_timer:
   get_value: '/^bfd startup-timer (\d+)$/'
   set_value: '<state> bfd startup-timer <timer>'
   default_value: 5
-
-type:
-  kind: string
-  N3k: &ip
-    default_only: 'ip'
-  N5k: &fabric
-    default_only: 'fabric'
-  N6k: *fabric
-  N7k: &ip_fabric
-    default_only: 'ip_fabric'
-  N8k: *ip
-  N9k: *ip

--- a/lib/cisco_node_utils/cmd_ref/bfd_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bfd_global.yaml
@@ -26,22 +26,9 @@ echo_rx_interval:
 
 fabricpath_interval:
   _exclude: [N3k, N8k, N9k]
-  kind: int
-  default_value: 50
-
-fabricpath_interval_param:
   get_value: '/^bfd fabricpath interval (\d+) min_rx (\d+) multiplier (\d+)$/'
   set_value: '<state> bfd fabricpath interval <intv> min_rx <mrx> multiplier <mult>'
-
-fabricpath_min_rx:
-  _exclude: [N3k, N8k, N9k]
-  kind: int
-  default_value: 50
-
-fabricpath_multiplier:
-  _exclude: [N3k, N8k, N9k]
-  kind: int
-  default_value: 3
+  default_value: ['50', '50', '3']
 
 fabricpath_slow_timer:
   _exclude: [N3k, N8k, N9k]
@@ -58,19 +45,16 @@ fabricpath_vlan:
   default_value: 1
 
 interval:
-  kind: int
+  get_value: '/^bfd interval (\d+) min_rx (\d+) multiplier (\d+)$/'
+  set_value: '<state> bfd interval <intv> min_rx <mrx> multiplier <mult>'
   N3k: &interval_250
-    default_value: 250
+    default_value: ['250', '250', '3']
   N5k: &interval_50
-    default_value: 50
+    default_value: ['50', '50', '3']
   N6k: *interval_50
   N7k: *interval_50
   N8k: *interval_50
   N9k: *interval_50
-
-interval_param:
-  get_value: '/^bfd interval (\d+) min_rx (\d+) multiplier (\d+)$/'
-  set_value: '<state> bfd interval <intv> min_rx <mrx> multiplier <mult>'
 
 ipv4_echo_rx_interval:
   _exclude: [N5k, N6k]
@@ -86,34 +70,17 @@ ipv4_echo_rx_interval:
 
 ipv4_interval:
   _exclude: [N5k, N6k]
-  kind: int
+  get_value: '/^bfd ipv4 interval (\d+) min_rx (\d+) multiplier (\d+)$/'
+  set_value: '<state> bfd ipv4 interval <intv> min_rx <mrx> multiplier <mult>'
   N3k: &ipv4_interval_250
-    default_value: 250
+    default_value: ['250', '250', '3']
   N7k: &ipv4_interval_50
-    default_value: 50
+    default_value: ['50', '50', '3']
   N8k: *ipv4_interval_50
   N9k: *ipv4_interval_50
 
-ipv4_interval_param:
-  get_value: '/^bfd ipv4 interval (\d+) min_rx (\d+) multiplier (\d+)$/'
-  set_value: '<state> bfd ipv4 interval <intv> min_rx <mrx> multiplier <mult>'
-
-ipv4_min_rx:
-  _exclude: [N5k, N6k]
-  kind: int
-  N3k: &ipv4_min_rx_250
-    default_value: 250
-  N7k: &ipv4_min_rx_50
-    default_value: 50
-  N8k: *ipv4_min_rx_50
-  N9k: *ipv4_min_rx_50
-
-ipv4_multiplier:
-  _exclude: [N5k, N6k]
-  kind: int
-  default_value: 3
-
 ipv4_slow_timer:
+  _exclude: [N5k, N6k]
   kind: int
   get_value: '/^bfd ipv4 slow-timer (\d+)$/'
   set_value: '<state> bfd ipv4 slow-timer <timer>'
@@ -133,32 +100,14 @@ ipv6_echo_rx_interval:
 
 ipv6_interval:
   _exclude: [N5k, N6k]
-  kind: int
-  N3k: &ipv6_interval_250
-    default_value: 250
-  N7k: &ipv6_interval_50
-    default_value: 50
-  N8k: *ipv6_interval_50
-  N9k: *ipv6_interval_50
-
-ipv6_interval_param:
   get_value: '/^bfd ipv6 interval (\d+) min_rx (\d+) multiplier (\d+)$/'
   set_value: '<state> bfd ipv6 interval <intv> min_rx <mrx> multiplier <mult>'
-
-ipv6_min_rx:
-  _exclude: [N5k, N6k]
-  kind: int
-  N3k: &ipv6_min_rx_250
-    default_value: 250
-  N7k: &ipv6_min_rx_50
-    default_value: 50
-  N8k: *ipv6_min_rx_50
-  N9k: *ipv6_min_rx_50
-
-ipv6_multiplier:
-  _exclude: [N5k, N6k]
-  kind: int
-  default_value: 3
+  N3k: &ipv6_interval_250
+    default_value: ['250', '250', '3']
+  N7k: &ipv6_interval_50
+    default_value: ['50', '50', '3']
+  N8k: *ipv6_interval_50
+  N9k: *ipv6_interval_50
 
 ipv6_slow_timer:
   _exclude: [N5k, N6k]
@@ -166,21 +115,6 @@ ipv6_slow_timer:
   get_value: '/^bfd ipv6 slow-timer (\d+)$/'
   set_value: '<state> bfd ipv6 slow-timer <timer>'
   default_value: 2000
-
-min_rx:
-  kind: int
-  N3k: &min_rx_250
-    default_value: 250
-  N5k: &min_rx_50
-    default_value: 50
-  N6k: *min_rx_50
-  N7k: *min_rx_50
-  N8k: *min_rx_50
-  N9k: *min_rx_50
-
-multiplier:
-  kind: int
-  default_value: 3
 
 slow_timer:
   kind: int

--- a/lib/cisco_node_utils/cmd_ref/bfd_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bfd_global.yaml
@@ -17,17 +17,15 @@ echo_rx_interval:
   kind: int
   get_value: '/^bfd echo-rx-interval (\d+)$/'
   set_value: '<state> bfd echo-rx-interval <rxi>'
-  N3k: &rx_interval_250
+  N3k:
     default_value: 250
-  N7k: &rx_interval_50
+  else:
     default_value: 50
-  N8k: *rx_interval_50
-  N9k: *rx_interval_50
 
 fabricpath_interval:
   _exclude: [N3k, N8k, N9k]
   get_value: '/^bfd fabricpath interval (\d+) min_rx (\d+) multiplier (\d+)$/'
-  set_value: '<state> bfd fabricpath interval <intv> min_rx <mrx> multiplier <mult>'
+  set_value: '<state> bfd fabricpath interval <interval> min_rx <min_rx> multiplier <multiplier>'
   default_value: ['50', '50', '3']
 
 fabricpath_slow_timer:
@@ -47,38 +45,30 @@ fabricpath_vlan:
 interval:
   _exclude: [N8k, N9k] # TBD: bug on n8k, n9k this is not working now
   get_value: '/^bfd interval (\d+) min_rx (\d+) multiplier (\d+)$/'
-  set_value: '<state> bfd interval <intv> min_rx <mrx> multiplier <mult>'
-  N3k: &interval_250
+  set_value: '<state> bfd interval <interval> min_rx <min_rx> multiplier <multiplier>'
+  N3k:
     default_value: ['250', '250', '3']
-  N5k: &interval_50
+  else:
     default_value: ['50', '50', '3']
-  N6k: *interval_50
-  N7k: *interval_50
-  N8k: *interval_50
-  N9k: *interval_50
 
 ipv4_echo_rx_interval:
   _exclude: [N5k, N6k]
   kind: int
   get_value: '/^bfd ipv4 echo-rx-interval (\d+)$/'
   set_value: '<state> bfd ipv4 echo-rx-interval <rxi>'
-  N3k: &ipv4_rx_interval_250
+  N3k:
     default_value: 250
-  N7k: &ipv4_rx_interval_50
+  else:
     default_value: 50
-  N8k: *ipv4_rx_interval_50
-  N9k: *ipv4_rx_interval_50
 
 ipv4_interval:
   _exclude: [N5k, N6k]
   get_value: '/^bfd ipv4 interval (\d+) min_rx (\d+) multiplier (\d+)$/'
-  set_value: '<state> bfd ipv4 interval <intv> min_rx <mrx> multiplier <mult>'
-  N3k: &ipv4_interval_250
+  set_value: '<state> bfd ipv4 interval <interval> min_rx <min_rx> multiplier <multiplier>'
+  N3k:
     default_value: ['250', '250', '3']
-  N7k: &ipv4_interval_50
+  else:
     default_value: ['50', '50', '3']
-  N8k: *ipv4_interval_50
-  N9k: *ipv4_interval_50
 
 ipv4_slow_timer:
   _exclude: [N5k, N6k]
@@ -92,23 +82,19 @@ ipv6_echo_rx_interval:
   kind: int
   get_value: '/^bfd ipv6 echo-rx-interval (\d+)$/'
   set_value: '<state> bfd ipv6 echo-rx-interval <rxi>'
-  N3k: &ipv6_rx_interval_250
+  N3k:
     default_value: 250
-  N7k: &ipv6_rx_interval_50
+  else:
     default_value: 50
-  N8k: *ipv6_rx_interval_50
-  N9k: *ipv6_rx_interval_50
 
 ipv6_interval:
   _exclude: [N5k, N6k]
   get_value: '/^bfd ipv6 interval (\d+) min_rx (\d+) multiplier (\d+)$/'
-  set_value: '<state> bfd ipv6 interval <intv> min_rx <mrx> multiplier <mult>'
-  N3k: &ipv6_interval_250
+  set_value: '<state> bfd ipv6 interval <interval> min_rx <min_rx> multiplier <multiplier>'
+  N3k:
     default_value: ['250', '250', '3']
-  N7k: &ipv6_interval_50
+  else:
     default_value: ['50', '50', '3']
-  N8k: *ipv6_interval_50
-  N9k: *ipv6_interval_50
 
 ipv6_slow_timer:
   _exclude: [N5k, N6k]

--- a/tests/test_bfd_global.rb
+++ b/tests/test_bfd_global.rb
@@ -181,116 +181,67 @@ class TestBfdGlobal < CiscoTestCase
     assert_equal(bg.default_fabricpath_slow_timer, bg.fabricpath_slow_timer)
   end
 
-  def interval_params_helper(props)
+  def test_interval
     bg = BfdGlobal.new('default')
-    test_hash = {
-      interval:   bg.default_interval,
-      min_rx:     bg.default_min_rx,
-      multiplier: bg.default_multiplier,
-    }.merge!(props)
-    bg.interval_set(test_hash)
-    bg
+    arr = %w(100 100 25)
+    if validate_property_excluded?('bfd_global', 'interval')
+      assert_nil(bg.interval)
+      assert_raises(Cisco::UnsupportedError) do
+        bg.interval = arr
+      end
+      return
+    end
+    bg.interval = arr
+    assert_equal(arr, bg.interval)
+    bg.interval = bg.default_interval
+    assert_equal(bg.interval, bg.default_interval)
   end
 
-  def test_interval_params
-    bg = interval_params_helper(interval:   100,
-                                min_rx:     100,
-                                multiplier: 25)
-    assert_equal(100, bg.interval)
-    assert_equal(100, bg.min_rx)
-    assert_equal(25, bg.multiplier)
-    bg = interval_params_helper(interval:   bg.default_interval,
-                                min_rx:     bg.default_min_rx,
-                                multiplier: bg.default_multiplier)
-    assert_equal(bg.default_interval, bg.interval)
-    assert_equal(bg.default_min_rx, bg.min_rx)
-    assert_equal(bg.default_multiplier, bg.multiplier)
-  end
-
-  def ipv4_interval_params_helper(props)
+  def test_ipv4_interval
     bg = BfdGlobal.new('default')
-    skip('Test not supported on this platform') if
-    validate_property_excluded?('bfd_global', 'ipv4_interval')
-    test_hash = {
-      ipv4_interval:   bg.default_ipv4_interval,
-      ipv4_min_rx:     bg.default_ipv4_min_rx,
-      ipv4_multiplier: bg.default_ipv4_multiplier,
-    }.merge!(props)
-    bg.ipv4_interval_set(test_hash)
-    bg
+    arr = %w(200 200 50)
+    if validate_property_excluded?('bfd_global', 'ipv4_interval')
+      assert_nil(bg.ipv4_interval)
+      assert_raises(Cisco::UnsupportedError) do
+        bg.ipv4_interval = arr
+      end
+      return
+    end
+    bg.ipv4_interval = arr
+    assert_equal(arr, bg.ipv4_interval)
+    bg.ipv4_interval = bg.default_ipv4_interval
+    assert_equal(bg.ipv4_interval, bg.default_ipv4_interval)
   end
 
-  def test_ipv4_interval_params
-    bg = ipv4_interval_params_helper(ipv4_interval:   200,
-                                     ipv4_min_rx:     200,
-                                     ipv4_multiplier: 50)
-    assert_equal(200, bg.ipv4_interval)
-    assert_equal(200, bg.ipv4_min_rx)
-    assert_equal(50, bg.ipv4_multiplier)
-    bg = ipv4_interval_params_helper(
-      ipv4_interval:   bg.default_ipv4_interval,
-      ipv4_min_rx:     bg.default_ipv4_min_rx,
-      ipv4_multiplier: bg.default_ipv4_multiplier)
-    assert_equal(bg.default_ipv4_interval, bg.ipv4_interval)
-    assert_equal(bg.default_ipv4_min_rx, bg.ipv4_min_rx)
-    assert_equal(bg.default_ipv4_multiplier, bg.ipv4_multiplier)
-  end
-
-  def ipv6_interval_params_helper(props)
+  def test_ipv6_interval
     bg = BfdGlobal.new('default')
-    skip('Test not supported on this platform') if
-    validate_property_excluded?('bfd_global', 'ipv6_interval')
-    test_hash = {
-      ipv6_interval:   bg.default_ipv6_interval,
-      ipv6_min_rx:     bg.default_ipv6_min_rx,
-      ipv6_multiplier: bg.default_ipv6_multiplier,
-    }.merge!(props)
-    bg.ipv6_interval_set(test_hash)
-    bg
+    arr = %w(500 500 30)
+    if validate_property_excluded?('bfd_global', 'ipv6_interval')
+      assert_nil(bg.ipv6_interval)
+      assert_raises(Cisco::UnsupportedError) do
+        bg.ipv6_interval = arr
+      end
+      return
+    end
+    bg.ipv6_interval = arr
+    assert_equal(arr, bg.ipv6_interval)
+    bg.ipv6_interval = bg.default_ipv6_interval
+    assert_equal(bg.ipv6_interval, bg.default_ipv6_interval)
   end
 
-  def test_ipv6_interval_params
-    bg = ipv6_interval_params_helper(ipv6_interval:   500,
-                                     ipv6_min_rx:     500,
-                                     ipv6_multiplier: 30)
-    assert_equal(500, bg.ipv6_interval)
-    assert_equal(500, bg.ipv6_min_rx)
-    assert_equal(30, bg.ipv6_multiplier)
-    bg = ipv6_interval_params_helper(
-      ipv6_interval:   bg.default_ipv6_interval,
-      ipv6_min_rx:     bg.default_ipv6_min_rx,
-      ipv6_multiplier: bg.default_ipv6_multiplier)
-    assert_equal(bg.default_ipv6_interval, bg.ipv6_interval)
-    assert_equal(bg.default_ipv6_min_rx, bg.ipv6_min_rx)
-    assert_equal(bg.default_ipv6_multiplier, bg.ipv6_multiplier)
-  end
-
-  def fabricpath_interval_params_helper(props)
+  def test_fabricpath_interval
     bg = BfdGlobal.new('default')
-    skip('Test not supported on this platform') if
-    validate_property_excluded?('bfd_global', 'fabricpath_interval')
-    test_hash = {
-      fabricpath_interval:   bg.default_fabricpath_interval,
-      fabricpath_min_rx:     bg.default_fabricpath_min_rx,
-      fabricpath_multiplier: bg.default_fabricpath_multiplier,
-    }.merge!(props)
-    bg.fabricpath_interval_set(test_hash)
-    bg
-  end
-
-  def test_fabricpath_interval_params
-    bg = fabricpath_interval_params_helper(fabricpath_interval:   750,
-                                           fabricpath_min_rx:     350,
-                                           fabricpath_multiplier: 45)
-    assert_equal(750, bg.fabricpath_interval)
-    assert_equal(350, bg.fabricpath_min_rx)
-    assert_equal(45, bg.fabricpath_multiplier)
-    bg = fabricpath_interval_params_helper(
-      fabricpath_interval:   bg.default_fabricpath_interval,
-      fabricpath_min_rx:     bg.default_fabricpath_min_rx,
-      fabricpath_multiplier: bg.default_fabricpath_multiplier)
-    assert_equal(bg.default_fabricpath_interval, bg.fabricpath_interval)
-    assert_equal(bg.default_fabricpath_min_rx, bg.fabricpath_min_rx)
-    assert_equal(bg.default_fabricpath_multiplier, bg.fabricpath_multiplier)
+    arr = %w(750 350 45)
+    if validate_property_excluded?('bfd_global', 'fabricpath_interval')
+      assert_nil(bg.fabricpath_interval)
+      assert_raises(Cisco::UnsupportedError) do
+        bg.fabricpath_interval = arr
+      end
+      return
+    end
+    bg.fabricpath_interval = arr
+    assert_equal(arr, bg.fabricpath_interval)
+    bg.fabricpath_interval = bg.default_fabricpath_interval
+    assert_equal(bg.fabricpath_interval, bg.default_fabricpath_interval)
   end
 end

--- a/tests/test_bfd_global.rb
+++ b/tests/test_bfd_global.rb
@@ -39,31 +39,24 @@ class TestBfdGlobal < CiscoTestCase
 
     # destroy
     bg.destroy
-    assert_equal(bg.interval, bg.default_interval) if bg.interval
-    assert_equal(bg.echo_interface, bg.default_echo_interface)
-    assert_equal(bg.echo_rx_interval, bg.default_echo_rx_interval) if
-      bg.echo_rx_interval
-    assert_equal(bg.ipv4_echo_rx_interval, bg.default_ipv4_echo_rx_interval) if
-      bg.ipv4_echo_rx_interval
-    assert_equal(bg.ipv6_echo_rx_interval, bg.default_ipv6_echo_rx_interval) if
-      bg.ipv6_echo_rx_interval
-    assert_equal(bg.fabricpath_vlan, bg.default_fabricpath_vlan) if
-      bg.fabricpath_vlan
-    assert_equal(bg.slow_timer, bg.default_slow_timer)
-    assert_equal(bg.ipv4_slow_timer, bg.default_ipv4_slow_timer) if
-      bg.ipv4_slow_timer
-    assert_equal(bg.ipv6_slow_timer, bg.default_ipv6_slow_timer) if
-      bg.ipv6_slow_timer
-    assert_equal(bg.fabricpath_slow_timer, bg.default_fabricpath_slow_timer) if
-      bg.fabricpath_slow_timer
-    assert_equal(bg.startup_timer, bg.default_startup_timer) if
-      bg.startup_timer
-    assert_equal(bg.ipv4_interval, bg.default_ipv4_interval) if
-      bg.ipv4_interval
-    assert_equal(bg.ipv6_interval, bg.default_ipv6_interval) if
-      bg.ipv6_interval
-    assert_equal(bg.fabricpath_interval, bg.default_fabricpath_interval) if
-      bg.fabricpath_interval
+    [:interval,
+     :ipv4_interval,
+     :ipv6_interval,
+     :fabricpath_interval,
+     :echo_interface,
+     :echo_rx_interval,
+     :ipv4_echo_rx_interval,
+     :ipv6_echo_rx_interval,
+     :fabricpath_vlan,
+     :slow_timer,
+     :ipv4_slow_timer,
+     :ipv6_slow_timer,
+     :fabricpath_slow_timer,
+     :startup_timer,
+    ].each do |prop|
+      assert_equal(bg.send("default_#{prop}"), bg.send("#{prop}")) if
+        bg.send("#{prop}")
+    end
   end
 
   def test_echo_interface
@@ -119,7 +112,7 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
-    assert_equal(bg.echo_rx_interval, bg.echo_rx_interval)
+    assert_equal(bg.default_echo_rx_interval, bg.echo_rx_interval)
     bg.echo_rx_interval = 300
     assert_equal(300, bg.echo_rx_interval)
     bg.echo_rx_interval = bg.default_echo_rx_interval
@@ -225,11 +218,11 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
-    assert_equal(bg.interval, bg.default_interval)
+    assert_equal(bg.default_interval, bg.interval)
     bg.interval = arr
     assert_equal(arr, bg.interval)
     bg.interval = bg.default_interval
-    assert_equal(bg.interval, bg.default_interval)
+    assert_equal(bg.default_interval, bg.interval)
   end
 
   def test_ipv4_interval
@@ -242,11 +235,11 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
-    assert_equal(bg.ipv4_interval, bg.default_ipv4_interval)
+    assert_equal(bg.default_ipv4_interval, bg.ipv4_interval)
     bg.ipv4_interval = arr
     assert_equal(arr, bg.ipv4_interval)
     bg.ipv4_interval = bg.default_ipv4_interval
-    assert_equal(bg.ipv4_interval, bg.default_ipv4_interval)
+    assert_equal(bg.default_ipv4_interval, bg.ipv4_interval)
   end
 
   def test_ipv6_interval
@@ -259,11 +252,11 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
-    assert_equal(bg.ipv6_interval, bg.default_ipv6_interval)
+    assert_equal(bg.default_ipv6_interval, bg.ipv6_interval)
     bg.ipv6_interval = arr
     assert_equal(arr, bg.ipv6_interval)
     bg.ipv6_interval = bg.default_ipv6_interval
-    assert_equal(bg.ipv6_interval, bg.default_ipv6_interval)
+    assert_equal(bg.default_ipv6_interval, bg.ipv6_interval)
   end
 
   def test_fabricpath_interval
@@ -276,10 +269,10 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
-    assert_equal(bg.fabricpath_interval, bg.default_fabricpath_interval)
+    assert_equal(bg.default_fabricpath_interval, bg.fabricpath_interval)
     bg.fabricpath_interval = arr
     assert_equal(arr, bg.fabricpath_interval)
     bg.fabricpath_interval = bg.default_fabricpath_interval
-    assert_equal(bg.fabricpath_interval, bg.default_fabricpath_interval)
+    assert_equal(bg.default_fabricpath_interval, bg.fabricpath_interval)
   end
 end

--- a/tests/test_bfd_global.rb
+++ b/tests/test_bfd_global.rb
@@ -34,17 +34,40 @@ class TestBfdGlobal < CiscoTestCase
 
   def test_create_destroy
     # create
-    bg = BfdGlobal.new('default')
-    assert_equal('default', bg.name)
-    refute_empty(BfdGlobal.globals)
+    bg = BfdGlobal.new
+    assert_equal(true, Feature.bfd_enabled?)
 
     # destroy
     bg.destroy
-    assert_nil(bg.name)
+    assert_equal(bg.echo_interface, bg.default_echo_interface)
+    assert_equal(bg.echo_rx_interval, bg.default_echo_rx_interval) if
+      bg.echo_rx_interval
+    assert_equal(bg.ipv4_echo_rx_interval, bg.default_ipv4_echo_rx_interval) if
+      bg.ipv4_echo_rx_interval
+    assert_equal(bg.ipv6_echo_rx_interval, bg.default_ipv6_echo_rx_interval) if
+      bg.ipv6_echo_rx_interval
+    assert_equal(bg.fabricpath_vlan, bg.default_fabricpath_vlan) if
+      bg.fabricpath_vlan
+    assert_equal(bg.slow_timer, bg.default_slow_timer)
+    assert_equal(bg.ipv4_slow_timer, bg.default_ipv4_slow_timer) if
+      bg.ipv4_slow_timer
+    assert_equal(bg.ipv6_slow_timer, bg.default_ipv6_slow_timer) if
+      bg.ipv6_slow_timer
+    assert_equal(bg.fabricpath_slow_timer, bg.default_fabricpath_slow_timer) if
+      bg.fabricpath_slow_timer
+    assert_equal(bg.startup_timer, bg.default_startup_timer) if
+      bg.startup_timer
+    assert_equal(bg.interval, bg.default_interval)
+    assert_equal(bg.ipv4_interval, bg.default_ipv4_interval) if
+      bg.ipv4_interval
+    assert_equal(bg.ipv6_interval, bg.default_ipv6_interval) if
+      bg.ipv6_interval
+    assert_equal(bg.fabricpath_interval, bg.default_fabricpath_interval) if
+      bg.fabricpath_interval
   end
 
   def test_echo_interface
-    bg = BfdGlobal.new('default')
+    bg = BfdGlobal.new
     config 'interface loopback 10'
     bg.echo_interface = 10
     assert_equal(10, bg.echo_interface)
@@ -54,7 +77,7 @@ class TestBfdGlobal < CiscoTestCase
   end
 
   def test_fabricpath_vlan
-    bg = BfdGlobal.new('default')
+    bg = BfdGlobal.new
     if validate_property_excluded?('bfd_global', 'fabricpath_vlan')
       assert_nil(bg.fabricpath_vlan)
       assert_raises(Cisco::UnsupportedError) do
@@ -69,7 +92,7 @@ class TestBfdGlobal < CiscoTestCase
   end
 
   def test_startup_timer
-    bg = BfdGlobal.new('default')
+    bg = BfdGlobal.new
     if validate_property_excluded?('bfd_global', 'startup_timer')
       assert_nil(bg.startup_timer)
       assert_raises(Cisco::UnsupportedError) do
@@ -84,7 +107,7 @@ class TestBfdGlobal < CiscoTestCase
   end
 
   def test_echo_rx_interval
-    bg = BfdGlobal.new('default')
+    bg = BfdGlobal.new
     if validate_property_excluded?('bfd_global', 'echo_rx_interval')
       assert_nil(bg.echo_rx_interval)
       assert_raises(Cisco::UnsupportedError) do
@@ -99,7 +122,7 @@ class TestBfdGlobal < CiscoTestCase
   end
 
   def test_ipv4_echo_rx_interval
-    bg = BfdGlobal.new('default')
+    bg = BfdGlobal.new
     if validate_property_excluded?('bfd_global', 'ipv4_echo_rx_interval')
       assert_nil(bg.ipv4_echo_rx_interval)
       assert_raises(Cisco::UnsupportedError) do
@@ -114,7 +137,7 @@ class TestBfdGlobal < CiscoTestCase
   end
 
   def test_ipv6_echo_rx_interval
-    bg = BfdGlobal.new('default')
+    bg = BfdGlobal.new
     if validate_property_excluded?('bfd_global', 'ipv6_echo_rx_interval')
       assert_nil(bg.ipv6_echo_rx_interval)
       assert_raises(Cisco::UnsupportedError) do
@@ -129,7 +152,7 @@ class TestBfdGlobal < CiscoTestCase
   end
 
   def test_slow_timer
-    bg = BfdGlobal.new('default')
+    bg = BfdGlobal.new
     bg.slow_timer = 5000
     assert_equal(5000, bg.slow_timer)
     bg.slow_timer = bg.default_slow_timer
@@ -137,7 +160,7 @@ class TestBfdGlobal < CiscoTestCase
   end
 
   def test_ipv4_slow_timer
-    bg = BfdGlobal.new('default')
+    bg = BfdGlobal.new
     if validate_property_excluded?('bfd_global', 'ipv4_slow_timer')
       assert_nil(bg.ipv4_slow_timer)
       assert_raises(Cisco::UnsupportedError) do
@@ -152,7 +175,7 @@ class TestBfdGlobal < CiscoTestCase
   end
 
   def test_ipv6_slow_timer
-    bg = BfdGlobal.new('default')
+    bg = BfdGlobal.new
     if validate_property_excluded?('bfd_global', 'ipv6_slow_timer')
       assert_nil(bg.ipv6_slow_timer)
       assert_raises(Cisco::UnsupportedError) do
@@ -167,7 +190,7 @@ class TestBfdGlobal < CiscoTestCase
   end
 
   def test_fabricpath_slow_timer
-    bg = BfdGlobal.new('default')
+    bg = BfdGlobal.new
     if validate_property_excluded?('bfd_global', 'fabricpath_slow_timer')
       assert_nil(bg.fabricpath_slow_timer)
       assert_raises(Cisco::UnsupportedError) do
@@ -182,7 +205,7 @@ class TestBfdGlobal < CiscoTestCase
   end
 
   def test_interval
-    bg = BfdGlobal.new('default')
+    bg = BfdGlobal.new
     arr = %w(100 100 25)
     if validate_property_excluded?('bfd_global', 'interval')
       assert_nil(bg.interval)
@@ -198,7 +221,7 @@ class TestBfdGlobal < CiscoTestCase
   end
 
   def test_ipv4_interval
-    bg = BfdGlobal.new('default')
+    bg = BfdGlobal.new
     arr = %w(200 200 50)
     if validate_property_excluded?('bfd_global', 'ipv4_interval')
       assert_nil(bg.ipv4_interval)
@@ -214,7 +237,7 @@ class TestBfdGlobal < CiscoTestCase
   end
 
   def test_ipv6_interval
-    bg = BfdGlobal.new('default')
+    bg = BfdGlobal.new
     arr = %w(500 500 30)
     if validate_property_excluded?('bfd_global', 'ipv6_interval')
       assert_nil(bg.ipv6_interval)
@@ -230,7 +253,7 @@ class TestBfdGlobal < CiscoTestCase
   end
 
   def test_fabricpath_interval
-    bg = BfdGlobal.new('default')
+    bg = BfdGlobal.new
     arr = %w(750 350 45)
     if validate_property_excluded?('bfd_global', 'fabricpath_interval')
       assert_nil(bg.fabricpath_interval)

--- a/tests/test_bfd_global.rb
+++ b/tests/test_bfd_global.rb
@@ -85,19 +85,45 @@ class TestBfdGlobal < CiscoTestCase
 
   def test_echo_rx_interval
     bg = BfdGlobal.new('default')
-    # cannot use validate_property_excluded? for common properties
-    # which differ only in protocol so skip it
-    skip('Test not supported on this platform') if bg.type == 'fabric'
+    if validate_property_excluded?('bfd_global', 'echo_rx_interval')
+      assert_nil(bg.echo_rx_interval)
+      assert_raises(Cisco::UnsupportedError) do
+        bg.echo_rx_interval = 300
+      end
+      return
+    end
     bg.echo_rx_interval = 300
     assert_equal(300, bg.echo_rx_interval)
     bg.echo_rx_interval = bg.default_echo_rx_interval
     assert_equal(bg.default_echo_rx_interval, bg.echo_rx_interval)
+  end
+
+  def test_ipv4_echo_rx_interval
+    bg = BfdGlobal.new('default')
+    if validate_property_excluded?('bfd_global', 'ipv4_echo_rx_interval')
+      assert_nil(bg.ipv4_echo_rx_interval)
+      assert_raises(Cisco::UnsupportedError) do
+        bg.ipv4_echo_rx_interval = 100
+      end
+      return
+    end
     bg.ipv4_echo_rx_interval = 100
     assert_equal(100, bg.ipv4_echo_rx_interval)
     bg.ipv4_echo_rx_interval = bg.default_ipv4_echo_rx_interval
     assert_equal(bg.default_ipv4_echo_rx_interval, bg.ipv4_echo_rx_interval)
-    bg.ipv6_echo_rx_interval = 200
-    assert_equal(200, bg.ipv6_echo_rx_interval)
+  end
+
+  def test_ipv6_echo_rx_interval
+    bg = BfdGlobal.new('default')
+    if validate_property_excluded?('bfd_global', 'ipv6_echo_rx_interval')
+      assert_nil(bg.ipv6_echo_rx_interval)
+      assert_raises(Cisco::UnsupportedError) do
+        bg.ipv6_echo_rx_interval = 100
+      end
+      return
+    end
+    bg.ipv6_echo_rx_interval = 100
+    assert_equal(100, bg.ipv6_echo_rx_interval)
     bg.ipv6_echo_rx_interval = bg.default_ipv6_echo_rx_interval
     assert_equal(bg.default_ipv6_echo_rx_interval, bg.ipv6_echo_rx_interval)
   end
@@ -112,9 +138,13 @@ class TestBfdGlobal < CiscoTestCase
 
   def test_ipv4_slow_timer
     bg = BfdGlobal.new('default')
-    # cannot use validate_property_excluded? for common properties
-    # which differ only in protocol so skip it
-    skip('Test not supported on this platform') if bg.type == 'fabric'
+    if validate_property_excluded?('bfd_global', 'ipv4_slow_timer')
+      assert_nil(bg.ipv4_slow_timer)
+      assert_raises(Cisco::UnsupportedError) do
+        bg.ipv4_slow_timer = 10_000
+      end
+      return
+    end
     bg.ipv4_slow_timer = 10_000
     assert_equal(10_000, bg.ipv4_slow_timer)
     bg.ipv4_slow_timer = bg.default_ipv4_slow_timer
@@ -123,9 +153,13 @@ class TestBfdGlobal < CiscoTestCase
 
   def test_ipv6_slow_timer
     bg = BfdGlobal.new('default')
-    # cannot use validate_property_excluded? for common properties
-    # which differ only in protocol so skip it
-    skip('Test not supported on this platform') if bg.type == 'fabric'
+    if validate_property_excluded?('bfd_global', 'ipv6_slow_timer')
+      assert_nil(bg.ipv6_slow_timer)
+      assert_raises(Cisco::UnsupportedError) do
+        bg.ipv6_slow_timer = 25_000
+      end
+      return
+    end
     bg.ipv6_slow_timer = 25_000
     assert_equal(25_000, bg.ipv6_slow_timer)
     bg.ipv6_slow_timer = bg.default_ipv6_slow_timer
@@ -134,9 +168,13 @@ class TestBfdGlobal < CiscoTestCase
 
   def test_fabricpath_slow_timer
     bg = BfdGlobal.new('default')
-    # cannot use validate_property_excluded? for common properties
-    # which differ only in protocol so skip it
-    skip('Test not supported on this platform') if bg.type == 'ip'
+    if validate_property_excluded?('bfd_global', 'fabricpath_slow_timer')
+      assert_nil(bg.fabricpath_slow_timer)
+      assert_raises(Cisco::UnsupportedError) do
+        bg.fabricpath_slow_timer = 15_000
+      end
+      return
+    end
     bg.fabricpath_slow_timer = 15_000
     assert_equal(15_000, bg.fabricpath_slow_timer)
     bg.fabricpath_slow_timer = bg.default_fabricpath_slow_timer
@@ -145,15 +183,12 @@ class TestBfdGlobal < CiscoTestCase
 
   def interval_params_helper(props)
     bg = BfdGlobal.new('default')
-    # this skip is due to bug on the nxos platform, it will be
-    # removed after it is fixed
-    skip('Test not supported on this platform') if bg.type == 'ip'
     test_hash = {
       interval:   bg.default_interval,
       min_rx:     bg.default_min_rx,
       multiplier: bg.default_multiplier,
     }.merge!(props)
-    bg.interval_params_set(test_hash, '')
+    bg.interval_set(test_hash)
     bg
   end
 
@@ -174,15 +209,14 @@ class TestBfdGlobal < CiscoTestCase
 
   def ipv4_interval_params_helper(props)
     bg = BfdGlobal.new('default')
-    # cannot use validate_property_excluded? for common properties
-    # which differ only in protocol so skip it
-    skip('Test not supported on this platform') if bg.type == 'fabric'
+    skip('Test not supported on this platform') if
+    validate_property_excluded?('bfd_global', 'ipv4_interval')
     test_hash = {
       ipv4_interval:   bg.default_ipv4_interval,
       ipv4_min_rx:     bg.default_ipv4_min_rx,
       ipv4_multiplier: bg.default_ipv4_multiplier,
     }.merge!(props)
-    bg.interval_params_set(test_hash, 'ipv4')
+    bg.ipv4_interval_set(test_hash)
     bg
   end
 
@@ -204,15 +238,14 @@ class TestBfdGlobal < CiscoTestCase
 
   def ipv6_interval_params_helper(props)
     bg = BfdGlobal.new('default')
-    # cannot use validate_property_excluded? for common properties
-    # which differ only in protocol so skip it
-    skip('Test not supported on this platform') if bg.type == 'fabric'
+    skip('Test not supported on this platform') if
+    validate_property_excluded?('bfd_global', 'ipv6_interval')
     test_hash = {
       ipv6_interval:   bg.default_ipv6_interval,
       ipv6_min_rx:     bg.default_ipv6_min_rx,
       ipv6_multiplier: bg.default_ipv6_multiplier,
     }.merge!(props)
-    bg.interval_params_set(test_hash, 'ipv6')
+    bg.ipv6_interval_set(test_hash)
     bg
   end
 
@@ -234,15 +267,14 @@ class TestBfdGlobal < CiscoTestCase
 
   def fabricpath_interval_params_helper(props)
     bg = BfdGlobal.new('default')
-    # cannot use validate_property_excluded? for common properties
-    # which differ only in protocol so skip it
-    skip('Test not supported on this platform') if bg.type == 'ip'
+    skip('Test not supported on this platform') if
+    validate_property_excluded?('bfd_global', 'fabricpath_interval')
     test_hash = {
       fabricpath_interval:   bg.default_fabricpath_interval,
       fabricpath_min_rx:     bg.default_fabricpath_min_rx,
       fabricpath_multiplier: bg.default_fabricpath_multiplier,
     }.merge!(props)
-    bg.interval_params_set(test_hash, 'fabricpath')
+    bg.fabricpath_interval_set(test_hash)
     bg
   end
 

--- a/tests/test_bfd_global.rb
+++ b/tests/test_bfd_global.rb
@@ -39,6 +39,7 @@ class TestBfdGlobal < CiscoTestCase
 
     # destroy
     bg.destroy
+    assert_equal(bg.interval, bg.default_interval) if bg.interval
     assert_equal(bg.echo_interface, bg.default_echo_interface)
     assert_equal(bg.echo_rx_interval, bg.default_echo_rx_interval) if
       bg.echo_rx_interval
@@ -57,7 +58,6 @@ class TestBfdGlobal < CiscoTestCase
       bg.fabricpath_slow_timer
     assert_equal(bg.startup_timer, bg.default_startup_timer) if
       bg.startup_timer
-    assert_equal(bg.interval, bg.default_interval)
     assert_equal(bg.ipv4_interval, bg.default_ipv4_interval) if
       bg.ipv4_interval
     assert_equal(bg.ipv6_interval, bg.default_ipv6_interval) if
@@ -69,10 +69,12 @@ class TestBfdGlobal < CiscoTestCase
   def test_echo_interface
     bg = BfdGlobal.new
     config 'interface loopback 10'
-    bg.echo_interface = 10
-    assert_equal(10, bg.echo_interface)
-    bg.echo_interface = bg.default_echo_interface
-    assert_equal(bg.default_echo_interface, bg.echo_interface)
+    default = bg.default_echo_interface
+    assert_equal(default, bg.echo_interface)
+    bg.echo_interface = 'loopback10'
+    assert_equal('loopback10', bg.echo_interface)
+    bg.echo_interface = default
+    assert_equal(default, bg.echo_interface)
     config 'no interface loopback 10'
   end
 
@@ -85,6 +87,7 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
+    assert_equal(bg.default_fabricpath_vlan, bg.fabricpath_vlan)
     bg.fabricpath_vlan = 100
     assert_equal(100, bg.fabricpath_vlan)
     bg.fabricpath_vlan = bg.default_fabricpath_vlan
@@ -100,6 +103,7 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
+    assert_equal(bg.default_startup_timer, bg.startup_timer)
     bg.startup_timer = 25
     assert_equal(25, bg.startup_timer)
     bg.startup_timer = bg.default_startup_timer
@@ -115,6 +119,7 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
+    assert_equal(bg.echo_rx_interval, bg.echo_rx_interval)
     bg.echo_rx_interval = 300
     assert_equal(300, bg.echo_rx_interval)
     bg.echo_rx_interval = bg.default_echo_rx_interval
@@ -130,6 +135,7 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
+    assert_equal(bg.default_ipv4_echo_rx_interval, bg.ipv4_echo_rx_interval)
     bg.ipv4_echo_rx_interval = 100
     assert_equal(100, bg.ipv4_echo_rx_interval)
     bg.ipv4_echo_rx_interval = bg.default_ipv4_echo_rx_interval
@@ -145,6 +151,7 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
+    assert_equal(bg.default_ipv6_echo_rx_interval, bg.ipv6_echo_rx_interval)
     bg.ipv6_echo_rx_interval = 100
     assert_equal(100, bg.ipv6_echo_rx_interval)
     bg.ipv6_echo_rx_interval = bg.default_ipv6_echo_rx_interval
@@ -153,6 +160,7 @@ class TestBfdGlobal < CiscoTestCase
 
   def test_slow_timer
     bg = BfdGlobal.new
+    assert_equal(bg.default_slow_timer, bg.slow_timer)
     bg.slow_timer = 5000
     assert_equal(5000, bg.slow_timer)
     bg.slow_timer = bg.default_slow_timer
@@ -168,6 +176,7 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
+    assert_equal(bg.default_ipv4_slow_timer, bg.ipv4_slow_timer)
     bg.ipv4_slow_timer = 10_000
     assert_equal(10_000, bg.ipv4_slow_timer)
     bg.ipv4_slow_timer = bg.default_ipv4_slow_timer
@@ -183,6 +192,7 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
+    assert_equal(bg.default_ipv6_slow_timer, bg.ipv6_slow_timer)
     bg.ipv6_slow_timer = 25_000
     assert_equal(25_000, bg.ipv6_slow_timer)
     bg.ipv6_slow_timer = bg.default_ipv6_slow_timer
@@ -198,6 +208,7 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
+    assert_equal(bg.default_fabricpath_slow_timer, bg.fabricpath_slow_timer)
     bg.fabricpath_slow_timer = 15_000
     assert_equal(15_000, bg.fabricpath_slow_timer)
     bg.fabricpath_slow_timer = bg.default_fabricpath_slow_timer
@@ -214,6 +225,7 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
+    assert_equal(bg.interval, bg.default_interval)
     bg.interval = arr
     assert_equal(arr, bg.interval)
     bg.interval = bg.default_interval
@@ -230,6 +242,7 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
+    assert_equal(bg.ipv4_interval, bg.default_ipv4_interval)
     bg.ipv4_interval = arr
     assert_equal(arr, bg.ipv4_interval)
     bg.ipv4_interval = bg.default_ipv4_interval
@@ -246,6 +259,7 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
+    assert_equal(bg.ipv6_interval, bg.default_ipv6_interval)
     bg.ipv6_interval = arr
     assert_equal(arr, bg.ipv6_interval)
     bg.ipv6_interval = bg.default_ipv6_interval
@@ -262,6 +276,7 @@ class TestBfdGlobal < CiscoTestCase
       end
       return
     end
+    assert_equal(bg.fabricpath_interval, bg.default_fabricpath_interval)
     bg.fabricpath_interval = arr
     assert_equal(arr, bg.fabricpath_interval)
     bg.fabricpath_interval = bg.default_fabricpath_interval


### PR DESCRIPTION
This PR is for the remaining properties of the bfd global provider. 
All tests pass on all nexus platforms.
The 'interval' property is excluded on n8k and n9k due to platform bugs. They will be included once the bugs are resolved.
