### PR TITLE
YANG JSON support for gRPC client

### DIFF
--- a/lib/cisco_node_utils/client.rb
+++ b/lib/cisco_node_utils/client.rb
@@ -22,7 +22,7 @@ end
 require_relative 'client/client'
 
 # Try to load known extensions
-extensions = ['client/nxapi',
+extensions = [#'client/nxapi',
               'client/grpc',
              ]
 extensions.each do |ext|

--- a/lib/cisco_node_utils/client.rb
+++ b/lib/cisco_node_utils/client.rb
@@ -22,7 +22,7 @@ end
 require_relative 'client/client'
 
 # Try to load known extensions
-extensions = [#'client/nxapi',
+extensions = ['client/nxapi',
               'client/grpc',
              ]
 extensions.each do |ext|

--- a/lib/cisco_node_utils/client/client.rb
+++ b/lib/cisco_node_utils/client/client.rb
@@ -167,9 +167,11 @@ class Cisco::Client
   # @param data_format one of Cisco::DATA_FORMATS. Default is :cli
   # @param context [String, Array<String>] Context for the configuration
   # @param values [String, Array<String>] Actual configuration to set
+  # @param kwargs data-format-specific args
   def set(data_format: :cli,
           context:     nil,
-          values:      nil)
+          values:      nil,
+          **_kwargs)
     # subclasses will generally want to call Client.munge_to_array()
     # on context and/or values before calling super()
     fail Cisco::RequestNotSupported unless self.supports?(data_format)
@@ -210,36 +212,6 @@ class Cisco::Client
       unless context.nil? || context.empty?
     Cisco::Logger.debug("  to get value:     #{value}") \
       unless value.nil?
-    # to be implemented by subclasses
-  end
-
-  # Retrieve JSON YANG config from the device for the specified path.
-  # @param yang_path [String] The node path from which to retrieve configuration
-  def get_yang(_yang_path)
-    fail Cisco::RequestNotSupported
-    # to be implemented by subclasses
-  end
-
-  # Merge the specified JSON YANG config with the running config
-  # on the device.
-  # @param yang [String] The desired YANG configuration
-  def merge_yang(_yang)
-    fail Cisco::RequestNotSupported
-    # to be implemented by subclasses
-  end
-
-  # Replace the running config on the device with the specified
-  # JSON YANG config.
-  # @param yang [String] The desired YANG configuration
-  def replace_yang(_yang)
-    fail Cisco::RequestNotSupported
-    # to be implemented by subclasses
-  end
-
-  # Delete the specified JSON YANG config from the device.
-  # @param yang [String] The YANG configuration to delete.
-  def delete_yang(_yang)
-    fail Cisco::RequestNotSupported
     # to be implemented by subclasses
   end
 

--- a/lib/cisco_node_utils/client/client.rb
+++ b/lib/cisco_node_utils/client/client.rb
@@ -213,6 +213,36 @@ class Cisco::Client
     # to be implemented by subclasses
   end
 
+  # Retrieve JSON YANG config from the device for the specified path.
+  # @param yang_path [String] The node path from which to retrieve configuration
+  def get_yang(_yang_path)
+    fail Cisco::RequestNotSupported
+    # to be implemented by subclasses
+  end
+
+  # Merge the specified JSON YANG config with the running config
+  # on the device.
+  # @param yang [String] The desired YANG configuration
+  def merge_yang(_yang)
+    fail Cisco::RequestNotSupported
+    # to be implemented by subclasses
+  end
+
+  # Replace the running config on the device with the specified
+  # JSON YANG config.
+  # @param yang [String] The desired YANG configuration
+  def replace_yang(_yang)
+    fail Cisco::RequestNotSupported
+    # to be implemented by subclasses
+  end
+
+  # Delete the specified JSON YANG config from the device.
+  # @param yang [String] The YANG configuration to delete.
+  def delete_yang(_yang)
+    fail Cisco::RequestNotSupported
+    # to be implemented by subclasses
+  end
+
   private
 
   # Set the list of data formats supported by this client.

--- a/lib/cisco_node_utils/client/grpc/client.rb
+++ b/lib/cisco_node_utils/client/grpc/client.rb
@@ -37,7 +37,7 @@ class Cisco::Client::GRPC < Cisco::Client
     kwargs[:host] ||= '127.0.0.1'
     kwargs[:port] ||= 57_400
     # rubocop:disable Style/HashSyntax
-    super(data_formats: [:cli],
+    super(data_formats: [:cli, :yang_json],
           platform:     :ios_xr,
           **kwargs)
     # rubocop:enable Style/HashSyntax
@@ -85,36 +85,46 @@ class Cisco::Client::GRPC < Cisco::Client
   # @param data_format one of Cisco::DATA_FORMATS. Default is :cli
   # @param context [Array<String>] Zero or more configuration commands used
   #                to enter the desired CLI sub-mode
-  # @param values [Array<String>] One or more commands to enter within the
-  #   CLI sub-mode.
+  # @param values [Array<String>] One or more commands to execute /
+  #                               config strings to send
+  # @param kwargs data-format-specific args
   def set(data_format: :cli,
           context:     nil,
-          values:      nil)
+          values:      nil,
+          **kwargs)
     context = munge_to_array(context)
     values = munge_to_array(values)
     super
-    # IOS XR lets us concatenate submode commands together.
-    # This makes it possible to guarantee we are in the correct context:
-    #   context: ['foo', 'bar'], values: ['baz', 'bat']
-    #   ---> values: ['foo bar baz', 'foo bar bat']
-    # However, there's a special case for 'no' commands:
-    #   context: ['foo', 'bar'], values: ['no baz']
-    #   ---> values: ['no foo bar baz'] ---- the 'no' goes at the start
-    context = context.join(' ')
-    unless context.empty?
-      values.map! do |cmd|
-        match = cmd[/^\s*no\s+(.*)/, 1]
-        if match
-          cmd = "no #{context} #{match}"
-        else
-          cmd = "#{context} #{cmd}"
-        end
-        cmd
+    if data_format == :yang_json
+      mode = kwargs[:mode] || :merge_config
+      fail ArgumentError unless YANG_SET_MODE.include? mode
+      values.each do |yang|
+        yang_req(@config, mode.to_s, ConfigArgs.new(yangjson: yang))
       end
+    else
+      # IOS XR lets us concatenate submode commands together.
+      # This makes it possible to guarantee we are in the correct context:
+      #   context: ['foo', 'bar'], values: ['baz', 'bat']
+      #   ---> values: ['foo bar baz', 'foo bar bat']
+      # However, there's a special case for 'no' commands:
+      #   context: ['foo', 'bar'], values: ['no baz']
+      #   ---> values: ['no foo bar baz'] ---- the 'no' goes at the start
+      context = context.join(' ')
+      unless context.empty?
+        values.map! do |cmd|
+          match = cmd[/^\s*no\s+(.*)/, 1]
+          if match
+            cmd = "no #{context} #{match}"
+          else
+            cmd = "#{context} #{cmd}"
+          end
+          cmd
+        end
+      end
+      # CliConfigArgs wants a newline-separated string of commands
+      args = CliConfigArgs.new(cli: values.join("\n"))
+      req(@config, 'cli_config', args)
     end
-    # CliConfigArgs wants a newline-separated string of commands
-    args = CliConfigArgs.new(cli: values.join("\n"))
-    req(@config, 'cli_config', args)
   end
 
   def get(data_format: :cli,
@@ -123,9 +133,14 @@ class Cisco::Client::GRPC < Cisco::Client
           value:       nil)
     super
     fail ArgumentError if command.nil?
-    args = ShowCmdArgs.new(cli: command)
-    output = req(@exec, 'show_cmd_text_output', args)
-    self.class.filter_cli(cli_output: output, context: context, value: value)
+
+    if data_format == :yang_json
+      yang_req(@config, 'get_config', ConfigGetArgs.new(yangpathjson: command))
+    else
+      args = ShowCmdArgs.new(cli: command)
+      output = req(@exec, 'show_cmd_text_output', args)
+      self.class.filter_cli(cli_output: output, context: context, value: value)
+    end
   end
 
   def req(stub, type, args)
@@ -168,36 +183,6 @@ class Cisco::Client::GRPC < Cisco::Client
     else
       raise Cisco::ClientError, e.details
     end
-  end
-
-  # Retrieve JSON YANG config from the device for the specified path.
-  # @param yang [String] The node path from which to retrieve configuration
-  def get_yang(yang_path)
-    fail ArgumentError if yang_path.nil?
-    yang_req(@config, 'get_config', ConfigGetArgs.new(yangpathjson: yang_path))
-  end
-
-  # Merge the specified JSON YANG config with the running config
-  # on the device.
-  # @param yang [String] The desired YANG configuration
-  def merge_yang(yang)
-    fail ArgumentError if yang.nil?
-    yang_req(@config, 'merge_config', ConfigArgs.new(yangjson: yang))
-  end
-
-  # Replace the running config on the device with the specified
-  # JSON YANG config.
-  # @param yang [String] The desired YANG configuration
-  def replace_yang(yang)
-    fail ArgumentError if yang.nil?
-    yang_req(@config, 'replace_config', ConfigArgs.new(yangjson: yang))
-  end
-
-  # Delete the specified JSON YANG config from the device.
-  # @param yang [String] The YANG configuration to delete.
-  def delete_yang(yang)
-    fail ArgumentError if yang.nil?
-    yang_req(@config, 'delete_config', ConfigArgs.new(yangjson: yang))
   end
 
   # Send a YANG request via gRPC

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -105,9 +105,11 @@ class Cisco::Client::NXAPI < Cisco::Client
   #   used to enter the desired CLI sub-mode
   # @param values [String, Array<String>] One or more commands
   #   to enter within the CLI sub-mode.
+  # @param kwargs data-format-specific args
   def set(data_format: :cli,
           context: nil,
-          values: nil)
+          values: nil,
+          **_kwargs)
     # we don't currently support nxapi_structured for configuration
     fail Cisco::RequestNotSupported if data_format == :nxapi_structured
     context = munge_to_array(context)

--- a/lib/cisco_node_utils/constants.rb
+++ b/lib/cisco_node_utils/constants.rb
@@ -28,6 +28,13 @@ module Cisco
     :cli,
     # Structured data format specific to NX-API
     :nxapi_structured,
-    # TODO: :yang,
+    # YANG JSON
+    :yang_json,
+  ]
+
+  YANG_SET_MODE = [
+    :merge_config,
+    :replace_config,
+    :delete_config,
   ]
 end

--- a/lib/cisco_node_utils/exceptions.rb
+++ b/lib/cisco_node_utils/exceptions.rb
@@ -88,6 +88,35 @@ module Cisco
     end
   end
 
+  # Extension of RequestFailed class specifically for YANG errors
+  class YangError < RequestFailed
+    def initialize(message=nil,
+                   error: nil,
+                   rejected_input:   nil,
+                   successful_input: [],
+                   **kwargs)
+      unless message
+        if rejected_input.is_a?(Array)
+          if rejected_input.length > 1
+            message = "The following configs were rejected:\n"
+            message += "  #{rejected_input.join("\n  ")}\n"
+          else
+            message = "The config '#{rejected_input.first}' was rejected "
+          end
+        else
+          message = "The config '#{rejected_input}' was rejected "
+        end
+
+        message += "with error:\n#{error}"
+      end
+      super(message,
+            :error => error,
+            :rejected_input => rejected_input,
+            :successful_input => successful_input,
+            **kwargs)
+    end
+  end
+
   # RequestNotSupported means we made a request that was validly
   # constructed but includes options that are unsupported.
   #

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -206,6 +206,28 @@ module Cisco
       @client.get(**kwargs)
     end
 
+    # Merge the specified JSON YANG config with the running config on
+    # the device.
+    def merge_yang(yang)
+      @client.merge_yang(yang)
+    end
+
+    # Replace the running config on the device with the specified
+    # JSON YANG config.
+    def replace_yang(yang)
+      @client.replace_yang(yang)
+    end
+
+    # Delete the specified JSON YANG config from the device.
+    def delete_yang(yang)
+      @client.delete_yang(yang)
+    end
+
+    # Retrieve JSON YANG config from the device for the specified path.
+    def get_yang(yang_path)
+      @client.get_yang(yang_path)
+    end
+
     # @return [String] such as "Cisco Nexus Operating System (NX-OS) Software"
     def os
       o = config_get('show_version', 'header')

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -209,23 +209,24 @@ module Cisco
     # Merge the specified JSON YANG config with the running config on
     # the device.
     def merge_yang(yang)
-      @client.merge_yang(yang)
+      @client.set(data_format: :yang_json, values: [yang], mode: :merge_config)
     end
 
     # Replace the running config on the device with the specified
     # JSON YANG config.
     def replace_yang(yang)
-      @client.replace_yang(yang)
+      @client.set(data_format: :yang_json, values: [yang],
+                  mode: :replace_config)
     end
 
     # Delete the specified JSON YANG config from the device.
     def delete_yang(yang)
-      @client.delete_yang(yang)
+      @client.set(data_format: :yang_json, values: [yang], mode: :delete_config)
     end
 
     # Retrieve JSON YANG config from the device for the specified path.
     def get_yang(yang_path)
-      @client.get_yang(yang_path)
+      @client.get(data_format: :yang_json, command: yang_path)
     end
 
     # @return [String] such as "Cisco Nexus Operating System (NX-OS) Software"

--- a/lib/cisco_node_utils/yang.rb
+++ b/lib/cisco_node_utils/yang.rb
@@ -49,7 +49,6 @@ module Cisco
       !needs_something?(:replace, should_hash, is_hash)
     end
 
-
     # usage:
     #   needs_something?(op, should, run)
     #

--- a/lib/cisco_node_utils/yang.rb
+++ b/lib/cisco_node_utils/yang.rb
@@ -1,0 +1,156 @@
+# June 2016, Charles Burkett
+#
+# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'json'
+
+module Cisco
+  # class Cisco::Yang
+  # Utility class mainly containing methods to compare YANG configurations
+  # in order to determine if the running config is in-sync with the
+  # desired config.
+  class Yang
+    # Is the specified yang string empty?
+    def self.empty?(yang)
+      !yang || yang.empty?
+    end
+
+    # Given a current and target YANG configuration, returns true if
+    # the configurations are in-sync, relative to a "merge_config" action
+    def self.insync_for_merge(target, current)
+      target_hash = self.empty?(target) ? {} : JSON.parse(target)
+      current_hash = self.empty?(current) ? {} : JSON.parse(current)
+
+      !needs_something?(:merge, target_hash, current_hash)
+    end
+
+    # Given a current and target YANG configuration, returns true if
+    # the configuration are in-sync, relative to a "replace_config" action
+    def self.insync_for_replace(target, current)
+      target_hash = self.empty?(target) ? {} : JSON.parse(target)
+      current_hash = self.empty?(current) ? {} : JSON.parse(current)
+
+      !needs_something?(:replace, target_hash, current_hash)
+    end
+
+    # usage:
+    #   needs_something?(op, target, run)
+    #
+    #   op     - symbol - If value is not :replace, it's assumed to be :merge.
+    #                     Indicates to the function whether to check for a
+    #                     possible merge vs. replace
+    #
+    #   target - JSON   - JSON tree representing target configuration
+    #
+    #   run    - JSON   - JSON tree representing target configuration
+    #
+    #
+    # Needs merge will determine if target and run differ
+    # sufficiently to necessitate running the merge command.
+    #
+    # The logic here amounts to determining if target is a subtree
+    # of run, with a tiny bit of domain trickiness surrounding
+    # elements that are arrays that contain a single nil element
+    # that is required for "creating" certain configuration elements.
+    #
+    # There are ultimately 3 different types of elements in a json
+    # tree.  Hashes, Arrays, and leaves.  While hashes and array values
+    # are organized with an order, the logic here ignores the order.
+    # In fact, it specifically attempts to match assuming order
+    # doesn't matter.  This is largely to allow users some freedom
+    # in specifying the config in the manifest.  The gRPC interface
+    # doesn't seem to care about order.  If that changes, then so
+    # should this code.
+    #
+    # Arrays and Hashes are compared by iterating over every element
+    # in target, and ensuring it is within run.
+    #
+    # Leaves are directly compared for equality, excepting the
+    # condition that the target leaf is in fact an array with one
+    # element that is nil.
+    #
+    # Needs replace will determine if target and run differ
+    # sufficiently to necessitate running the replace command.
+    #
+    # The logic is the same as merge, except when comparing
+    # hashes, if the run hash table has elements that are not
+    # in target, we ultimately indicate that replace is needed
+    def self.needs_something?(op, target, run)
+      !hash_equiv?(op, target, run)
+    end
+
+    def self.nil_array(elt)
+      elt.nil? || (elt.is_a?(Array) && elt.length == 1 && elt[0].nil?)
+    end
+
+    def self.sub_elt(op, target, run)
+      if target.is_a?(Hash) && run.is_a?(Hash)
+        return self.hash_equiv?(op, target, run)
+      elsif target.is_a?(Array) && run.is_a?(Array)
+        return self.array_equiv?(op, target, run)
+      else
+        return !(target != run && !nil_array(target))
+      end
+    end
+
+    def self.array_equiv?(op, target, run)
+      n = target.length
+      loop = lambda do|i|
+        if i == n
+          if op == :replace
+            run.length == target.length
+          else
+            true
+          end
+        else
+          target_elt = target[i]
+          run_elt = run.find do |elt|
+            sub_elt(op, target_elt, elt)
+          end
+          if run_elt.nil? && !nil_array(target_elt)
+            target_elt.nil?
+          else
+            loop.call(i + 1)
+          end
+        end
+      end
+      loop.call(0)
+    end
+
+    def self.hash_equiv?(op, target, run)
+      keys = target.keys
+      n = keys.length
+      loop = lambda do|i|
+        if i == n
+          if op == :replace
+            run.keys.length == target.keys.length
+          else
+            true
+          end
+        else
+          k = keys[i]
+          run_v = run[k]
+          target_v = target[k]
+          if run_v.nil? && !nil_array(target_v)
+            false
+          else
+            sub_elt(op, target_v, run_v) && loop.call(i + 1)
+          end
+        end
+      end
+      loop.call(0)
+    end
+  end # Yang
+end # Cisco

--- a/lib/cisco_node_utils/yang.rb
+++ b/lib/cisco_node_utils/yang.rb
@@ -29,7 +29,7 @@ module Cisco
 
     # Given a current and target YANG configuration, returns true if
     # the configurations are in-sync, relative to a "merge_config" action
-    def self.insync_for_merge(target, current)
+    def self.insync_for_merge?(target, current)
       target_hash = self.empty?(target) ? {} : JSON.parse(target)
       current_hash = self.empty?(current) ? {} : JSON.parse(current)
 
@@ -38,7 +38,7 @@ module Cisco
 
     # Given a current and target YANG configuration, returns true if
     # the configuration are in-sync, relative to a "replace_config" action
-    def self.insync_for_replace(target, current)
+    def self.insync_for_replace?(target, current)
       target_hash = self.empty?(target) ? {} : JSON.parse(target)
       current_hash = self.empty?(current) ? {} : JSON.parse(current)
 

--- a/tests/test_yang.rb
+++ b/tests/test_yang.rb
@@ -312,12 +312,12 @@ class TestYang < CiscoTestCase
 
     # ensure that new leaves are merged with old.
     assert(Yang.insync_for_merge?(BLUE_VRF_PROPERTIES2,
-                                 node.get_yang(PATH_VRFS)), 'Expected in-sync')
+                                  node.get_yang(PATH_VRFS)), 'Expected in-sync')
 
     # update description and vpn-id
     node.merge_yang(BLUE_VRF_PROPERTIES3)
     assert(Yang.insync_for_merge?(BLUE_VRF_PROPERTIES3,
-                                 node.get_yang(PATH_VRFS)), 'Expected in-sync')
+                                  node.get_yang(PATH_VRFS)), 'Expected in-sync')
   end
 
   def test_replace_leaves
@@ -328,13 +328,13 @@ class TestYang < CiscoTestCase
 
     # ensure that new properties are replaced by old.
     assert(Yang.insync_for_replace?(BLUE_VRF_PROPERTIES1,
-                                   node.get_yang(PATH_VRFS)),
+                                    node.get_yang(PATH_VRFS)),
            'Expected in-sync')
 
     # replace description and vpn-id
     node.replace_yang(BLUE_VRF_PROPERTIES3)
     assert(Yang.insync_for_replace?(BLUE_VRF_PROPERTIES3,
-                                   node.get_yang(PATH_VRFS)),
+                                    node.get_yang(PATH_VRFS)),
            'Expected in-sync')
   end
 

--- a/tests/test_yang.rb
+++ b/tests/test_yang.rb
@@ -1,0 +1,357 @@
+#!/usr/bin/env ruby
+# Yang Unit Tests
+#
+# Charles Burkett, May, 2016
+#
+# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/yang'
+
+# TestYang - Minitest for Yang class
+class TestYang < CiscoTestCase
+  BLUE_VRF = '{"Cisco-IOS-XR-infra-rsi-cfg:vrfs":{
+      "vrf":[
+         {
+            "vrf-name":"BLUE",
+            "description":"Generic external traffic",
+            "create":[
+               null
+            ]
+         }
+      ]
+    }}'
+
+  RED_VRF = '{"Cisco-IOS-XR-infra-rsi-cfg:vrfs":{
+      "vrf":[
+         {
+            "vrf-name":"RED",
+            "create":[
+               null
+            ]
+         }
+      ]
+    }}'
+
+  GREEN_VRF = '{"Cisco-IOS-XR-infra-rsi-cfg:vrfs":{
+      "vrf":[
+         {
+            "vrf-name":"GREEN",
+            "create": [null]
+         }
+      ]
+    }}'
+
+  BLUE_GREEN_VRF = '{"Cisco-IOS-XR-infra-rsi-cfg:vrfs":{
+      "vrf":[
+         {
+            "vrf-name":"BLUE",
+            "create":[null],
+            "description":"Generic external traffic"
+         },
+         {
+            "vrf-name":"GREEN",
+            "create":[null]
+         }
+      ]
+  }}'
+
+  BLUE_VRF_NO_PROPERTIES = '{"Cisco-IOS-XR-infra-rsi-cfg:vrfs":{
+      "vrf":[
+         {
+            "vrf-name":"BLUE",
+            "create":[
+               null
+            ]
+         }
+      ]
+    }}'
+
+  BLUE_VRF_PROPERTIES1 = '{"Cisco-IOS-XR-infra-rsi-cfg:vrfs":{
+      "vrf":[
+         {
+            "vrf-name":"BLUE",
+            "create":[
+               null
+            ],
+            "vpn-id":{
+              "vpn-oui":0,
+              "vpn-index":0
+              }
+         }
+      ]
+    }}'
+
+  BLUE_VRF_PROPERTIES2 = '{"Cisco-IOS-XR-infra-rsi-cfg:vrfs":{
+      "vrf":[
+         {
+            "vrf-name":"BLUE",
+            "description":"Generic external traffic",
+            "create":[
+               null
+            ],
+            "vpn-id":{
+              "vpn-oui":0,
+              "vpn-index":0
+              }
+         }
+      ]
+    }}'
+
+  BLUE_VRF_PROPERTIES3 = '{"Cisco-IOS-XR-infra-rsi-cfg:vrfs":{
+      "vrf":[
+         {
+            "vrf-name":"BLUE",
+            "description":"Generic ext traffic",
+            "create":[
+               null
+            ],
+            "vpn-id":{
+              "vpn-oui":8,
+              "vpn-index":9
+              }
+         }
+      ]
+    }}'
+
+  NO_VRFS = '{"Cisco-IOS-XR-infra-rsi-cfg:vrfs": [null]}'
+  PATH_VRFS = '{"Cisco-IOS-XR-infra-rsi-cfg:vrfs": [null]}'
+
+  def setup
+    super
+    clear_vrfs
+  end
+
+  def teardown
+    super
+    clear_vrfs
+  end
+
+  def clear_vrfs
+    current_vrfs = node.get_yang(PATH_VRFS)
+
+    # remove all vrfs
+    node.delete_yang(PATH_VRFS) unless Yang.empty?(current_vrfs)
+  end
+
+  def test_delete_vrfs
+    node.merge_yang(BLUE_VRF)  # ensure at least one VRF is there
+    assert(node.get_yang(PATH_VRFS).match('BLUE'), 'Did not find the BLUE vrf')
+
+    clear_vrfs
+    assert_equal('', node.get_yang(PATH_VRFS),
+                 'There are still vrfs configured')
+  end
+
+  def test_add_vrf
+    node.merge_yang(BLUE_VRF)  # create a single VRF
+    assert(node.get_yang(PATH_VRFS).match('BLUE'), 'Did not find the BLUE vrf')
+
+    node.replace_yang(GREEN_VRF) # create a single VRF
+    assert(node.get_yang(PATH_VRFS).match('GREEN'),
+           'Did not find the BLUE vrf')
+    refute(node.get_yang(PATH_VRFS).match('BLUE'),
+           'Found the BLUE vrf')
+  end
+
+  def test_errors
+    # Note: Originally, we were checking for YangErrors and ClientErrors,
+    # but the type of error raised seemed to change from one XR image to the
+    # next, so now we check for the more general CiscoError in these tests.
+
+    # === test get_yang ===========
+
+    # Request is not wellformed
+    assert_raises(Cisco::CiscoError) { node.get_yang('aabbcc') }
+
+    # parse error: object key and value must be separated by a colon
+    assert_raises(Cisco::CiscoError) { node.get_yang('{"aabbcc"}') }
+
+    # unknown-namespace
+    assert_raises(Cisco::CiscoError) { node.get_yang('{"aabbcc": "foo"}') }
+
+    # unknown-element
+    assert_raises(Cisco::CiscoError) do
+      node.get_yang('{"Cisco-IOS-XR-infra-rsi-cfg:aabbcc": "foo"}')
+    end
+
+    # parse error: premature EOF
+    assert_raises(Cisco::CiscoError) { node.get_yang('{') }
+
+    # parse error: invalid object key (must be a string)
+    assert_raises(Cisco::CiscoError) { node.get_yang('{: "foo"}') }
+
+    # === test merge_yang ===========
+
+    # Request is not wellformed
+    assert_raises(Cisco::CiscoError) { node.merge_yang('aabbcc') }
+
+    # unknown-element
+    assert_raises(Cisco::CiscoError) do
+      node.merge_yang('{"Cisco-IOS-XR-infra-rsi-cfg:aabbcc": "foo"}')
+    end
+
+    # bad-element
+    assert_raises(Cisco::CiscoError) do
+      node.merge_yang('{"Cisco-IOS-XR-infra-rsi-cfg:vrfs": "foo"}')
+    end
+
+    # missing-element
+    assert_raises(Cisco::CiscoError) do
+      node.merge_yang('{"Cisco-IOS-XR-infra-rsi-cfg:vrfs": {"vrf":[{}]}}')
+    end
+
+    # === test replace_yang ===========
+
+    # unknown-namespace
+    assert_raises(Cisco::CiscoError) do
+      node.replace_yang('{"Cisco-IOS-XR-infra-rsi-cfg:aabbcc": "foo"}')
+    end
+
+    # for some reason replace_yang does not have the same error checking
+    # that merge_yang does, so this just fails quietly
+    node.replace_yang('{"Cisco-IOS-XR-infra-rsi-cfg:vrfs": }')
+  end
+
+  def test_merge_diff
+    # ensure we think that a merge is needed (in-sinc = false)
+    refute(Yang.insync_for_merge(BLUE_VRF, node.get_yang(PATH_VRFS)),
+           'Expected not in-sync')
+
+    node.merge_yang(BLUE_VRF) # create the blue VRF
+
+    # ensure we think that a merge is NOT needed (in-sinc = true)
+    assert(Yang.insync_for_merge(BLUE_VRF, node.get_yang(PATH_VRFS)),
+           'Expected in-sync')
+
+    # ensure we think that the merge is needed (in-sinc = false)
+    refute(Yang.insync_for_merge(RED_VRF, node.get_yang(PATH_VRFS)),
+           'Expected not in-sync')
+
+    node.merge_yang(RED_VRF) # create the red VRF
+
+    # ensure we think that a merge is NOT needed (in-sinc = true)
+    assert(Yang.insync_for_merge(RED_VRF, node.get_yang(PATH_VRFS)),
+           'Expected in-sync')
+
+    node.merge_yang(GREEN_VRF) # create green VRF
+    # ensure we think that a merge is NOT needed (in-sinc = true)
+    assert(Yang.insync_for_merge(GREEN_VRF, node.get_yang(PATH_VRFS)),
+           'Expected in-sync')
+  end
+
+  def test_replace_diff
+    # ensure we think that a merge is needed (in-sinc = false)
+    refute(Yang.insync_for_replace(BLUE_VRF, node.get_yang(PATH_VRFS)),
+           'Expected not in-sync')
+
+    node.replace_yang(BLUE_VRF) # create the blue VRF
+    # ensure we think that a replace is NOT needed (in-sinc = true)
+    assert(Yang.insync_for_replace(BLUE_VRF, node.get_yang(PATH_VRFS)),
+           'Expected in-sync')
+
+    node.replace_yang(RED_VRF) # create the red VRF
+    # ensure we think that a replace is NOT needed (in-sinc = true)
+    assert(Yang.insync_for_replace(RED_VRF, node.get_yang(PATH_VRFS)),
+           'Expected in-sync')
+
+    node.replace_yang(GREEN_VRF) # create green VRF
+    # ensure we think that a replace is NOT needed (in-sinc = true)
+    assert(Yang.insync_for_replace(GREEN_VRF, node.get_yang(PATH_VRFS)),
+           'Expected in-sync')
+
+    node.merge_yang(BLUE_VRF)
+
+    # ensure we think that a replace is NOT needed (in-sinc = true)
+    assert(Yang.insync_for_replace(BLUE_GREEN_VRF, node.get_yang(PATH_VRFS)),
+           'Expected in sync')
+    # ensure we think that a replace is needed (in-sinc = true)
+    refute(Yang.insync_for_replace(BLUE_VRF, node.get_yang(PATH_VRFS)),
+           'Expected not in sync')
+    refute(Yang.insync_for_replace(GREEN_VRF, node.get_yang(PATH_VRFS)),
+           'Expected not in sync')
+
+    node.replace_yang(BLUE_VRF)
+    # ensure we think that a replace is NOT needed (in-sinc = true)
+    assert(Yang.insync_for_replace(BLUE_VRF, node.get_yang(PATH_VRFS)),
+           'Expected in-sync')
+    # ensure we think that a replace is needed (in-sinc = true)
+    refute(Yang.insync_for_replace(GREEN_VRF, node.get_yang(PATH_VRFS)),
+           'Expected not in-sync')
+    refute(Yang.insync_for_replace(BLUE_GREEN_VRF, node.get_yang(PATH_VRFS)),
+           'Expected not in-sync')
+  end
+
+  def test_merge_leaves
+    node.merge_yang(BLUE_VRF) # create blue vrf with description
+
+    # merge blue vrf with vpn id to blue vrf with description
+    node.merge_yang(BLUE_VRF_PROPERTIES1)
+
+    # ensure that new leaves are merged with old.
+    assert(Yang.insync_for_merge(BLUE_VRF_PROPERTIES2,
+                                 node.get_yang(PATH_VRFS)), 'Expected in-sync')
+
+    # update description and vpn-id
+    node.merge_yang(BLUE_VRF_PROPERTIES3)
+    assert(Yang.insync_for_merge(BLUE_VRF_PROPERTIES3,
+                                 node.get_yang(PATH_VRFS)), 'Expected in-sync')
+  end
+
+  def test_replace_leaves
+    node.replace_yang(BLUE_VRF) # create blue vrf with description
+
+    # replace blue vrf (description) by blue vrf (vpn-id)
+    node.replace_yang(BLUE_VRF_PROPERTIES1)
+
+    # ensure that new properties are replaced by old.
+    assert(Yang.insync_for_replace(BLUE_VRF_PROPERTIES1,
+                                   node.get_yang(PATH_VRFS)),
+           'Expected in-sync')
+
+    # replace description and vpn-id
+    node.replace_yang(BLUE_VRF_PROPERTIES3)
+    assert(Yang.insync_for_replace(BLUE_VRF_PROPERTIES3,
+                                   node.get_yang(PATH_VRFS)),
+           'Expected in-sync')
+  end
+
+  def test_merge
+    node.merge_yang(BLUE_VRF)   # create blue vrf
+    node.merge_yang(GREEN_VRF)  # create green vrf
+
+    yang = node.get_yang(PATH_VRFS)
+
+    assert_yang_equal(BLUE_GREEN_VRF, yang)
+  end
+
+  def test_replace
+    node.merge_yang(BLUE_VRF)     # create blue vrf
+    node.replace_yang(GREEN_VRF)  # create green vrf
+
+    yang = node.get_yang(PATH_VRFS)
+
+    assert_yang_equal(GREEN_VRF, yang)
+  end
+
+  def assert_yang_equal(expected, actual)
+    equal = Yang.insync_for_replace(expected, actual) &&
+            Yang.insync_for_replace(actual, expected)
+    assert(equal,
+           "Expected: '#{expected}',\n"\
+           "Actual: '#{actual}',\n",
+          )
+  end
+end

--- a/tests/test_yang.rb
+++ b/tests/test_yang.rb
@@ -129,6 +129,15 @@ class TestYang < CiscoTestCase
   NO_VRFS = '{"Cisco-IOS-XR-infra-rsi-cfg:vrfs": [null]}'
   PATH_VRFS = '{"Cisco-IOS-XR-infra-rsi-cfg:vrfs": [null]}'
 
+  def self.runnable_methods
+    return [:all_skipped] unless platform == :ios_xr
+    super
+  end
+
+  def all_skipped
+    skip 'Node under test does not appear to use the gRPC client'
+  end
+
   def setup
     super
     clear_vrfs
@@ -140,6 +149,7 @@ class TestYang < CiscoTestCase
   end
 
   def clear_vrfs
+    return unless platform == :ios_xr
     current_vrfs = node.get_yang(PATH_VRFS)
 
     # remove all vrfs

--- a/tests/test_yang.rb
+++ b/tests/test_yang.rb
@@ -237,70 +237,70 @@ class TestYang < CiscoTestCase
 
   def test_merge_diff
     # ensure we think that a merge is needed (in-sinc = false)
-    refute(Yang.insync_for_merge(BLUE_VRF, node.get_yang(PATH_VRFS)),
+    refute(Yang.insync_for_merge?(BLUE_VRF, node.get_yang(PATH_VRFS)),
            'Expected not in-sync')
 
     node.merge_yang(BLUE_VRF) # create the blue VRF
 
     # ensure we think that a merge is NOT needed (in-sinc = true)
-    assert(Yang.insync_for_merge(BLUE_VRF, node.get_yang(PATH_VRFS)),
+    assert(Yang.insync_for_merge?(BLUE_VRF, node.get_yang(PATH_VRFS)),
            'Expected in-sync')
 
     # ensure we think that the merge is needed (in-sinc = false)
-    refute(Yang.insync_for_merge(RED_VRF, node.get_yang(PATH_VRFS)),
+    refute(Yang.insync_for_merge?(RED_VRF, node.get_yang(PATH_VRFS)),
            'Expected not in-sync')
 
     node.merge_yang(RED_VRF) # create the red VRF
 
     # ensure we think that a merge is NOT needed (in-sinc = true)
-    assert(Yang.insync_for_merge(RED_VRF, node.get_yang(PATH_VRFS)),
+    assert(Yang.insync_for_merge?(RED_VRF, node.get_yang(PATH_VRFS)),
            'Expected in-sync')
 
     node.merge_yang(GREEN_VRF) # create green VRF
     # ensure we think that a merge is NOT needed (in-sinc = true)
-    assert(Yang.insync_for_merge(GREEN_VRF, node.get_yang(PATH_VRFS)),
+    assert(Yang.insync_for_merge?(GREEN_VRF, node.get_yang(PATH_VRFS)),
            'Expected in-sync')
   end
 
   def test_replace_diff
     # ensure we think that a merge is needed (in-sinc = false)
-    refute(Yang.insync_for_replace(BLUE_VRF, node.get_yang(PATH_VRFS)),
+    refute(Yang.insync_for_replace?(BLUE_VRF, node.get_yang(PATH_VRFS)),
            'Expected not in-sync')
 
     node.replace_yang(BLUE_VRF) # create the blue VRF
     # ensure we think that a replace is NOT needed (in-sinc = true)
-    assert(Yang.insync_for_replace(BLUE_VRF, node.get_yang(PATH_VRFS)),
+    assert(Yang.insync_for_replace?(BLUE_VRF, node.get_yang(PATH_VRFS)),
            'Expected in-sync')
 
     node.replace_yang(RED_VRF) # create the red VRF
     # ensure we think that a replace is NOT needed (in-sinc = true)
-    assert(Yang.insync_for_replace(RED_VRF, node.get_yang(PATH_VRFS)),
+    assert(Yang.insync_for_replace?(RED_VRF, node.get_yang(PATH_VRFS)),
            'Expected in-sync')
 
     node.replace_yang(GREEN_VRF) # create green VRF
     # ensure we think that a replace is NOT needed (in-sinc = true)
-    assert(Yang.insync_for_replace(GREEN_VRF, node.get_yang(PATH_VRFS)),
+    assert(Yang.insync_for_replace?(GREEN_VRF, node.get_yang(PATH_VRFS)),
            'Expected in-sync')
 
     node.merge_yang(BLUE_VRF)
 
     # ensure we think that a replace is NOT needed (in-sinc = true)
-    assert(Yang.insync_for_replace(BLUE_GREEN_VRF, node.get_yang(PATH_VRFS)),
+    assert(Yang.insync_for_replace?(BLUE_GREEN_VRF, node.get_yang(PATH_VRFS)),
            'Expected in sync')
     # ensure we think that a replace is needed (in-sinc = true)
-    refute(Yang.insync_for_replace(BLUE_VRF, node.get_yang(PATH_VRFS)),
+    refute(Yang.insync_for_replace?(BLUE_VRF, node.get_yang(PATH_VRFS)),
            'Expected not in sync')
-    refute(Yang.insync_for_replace(GREEN_VRF, node.get_yang(PATH_VRFS)),
+    refute(Yang.insync_for_replace?(GREEN_VRF, node.get_yang(PATH_VRFS)),
            'Expected not in sync')
 
     node.replace_yang(BLUE_VRF)
     # ensure we think that a replace is NOT needed (in-sinc = true)
-    assert(Yang.insync_for_replace(BLUE_VRF, node.get_yang(PATH_VRFS)),
+    assert(Yang.insync_for_replace?(BLUE_VRF, node.get_yang(PATH_VRFS)),
            'Expected in-sync')
     # ensure we think that a replace is needed (in-sinc = true)
-    refute(Yang.insync_for_replace(GREEN_VRF, node.get_yang(PATH_VRFS)),
+    refute(Yang.insync_for_replace?(GREEN_VRF, node.get_yang(PATH_VRFS)),
            'Expected not in-sync')
-    refute(Yang.insync_for_replace(BLUE_GREEN_VRF, node.get_yang(PATH_VRFS)),
+    refute(Yang.insync_for_replace?(BLUE_GREEN_VRF, node.get_yang(PATH_VRFS)),
            'Expected not in-sync')
   end
 
@@ -311,12 +311,12 @@ class TestYang < CiscoTestCase
     node.merge_yang(BLUE_VRF_PROPERTIES1)
 
     # ensure that new leaves are merged with old.
-    assert(Yang.insync_for_merge(BLUE_VRF_PROPERTIES2,
+    assert(Yang.insync_for_merge?(BLUE_VRF_PROPERTIES2,
                                  node.get_yang(PATH_VRFS)), 'Expected in-sync')
 
     # update description and vpn-id
     node.merge_yang(BLUE_VRF_PROPERTIES3)
-    assert(Yang.insync_for_merge(BLUE_VRF_PROPERTIES3,
+    assert(Yang.insync_for_merge?(BLUE_VRF_PROPERTIES3,
                                  node.get_yang(PATH_VRFS)), 'Expected in-sync')
   end
 
@@ -327,13 +327,13 @@ class TestYang < CiscoTestCase
     node.replace_yang(BLUE_VRF_PROPERTIES1)
 
     # ensure that new properties are replaced by old.
-    assert(Yang.insync_for_replace(BLUE_VRF_PROPERTIES1,
+    assert(Yang.insync_for_replace?(BLUE_VRF_PROPERTIES1,
                                    node.get_yang(PATH_VRFS)),
            'Expected in-sync')
 
     # replace description and vpn-id
     node.replace_yang(BLUE_VRF_PROPERTIES3)
-    assert(Yang.insync_for_replace(BLUE_VRF_PROPERTIES3,
+    assert(Yang.insync_for_replace?(BLUE_VRF_PROPERTIES3,
                                    node.get_yang(PATH_VRFS)),
            'Expected in-sync')
   end
@@ -357,8 +357,8 @@ class TestYang < CiscoTestCase
   end
 
   def assert_yang_equal(expected, actual)
-    equal = Yang.insync_for_replace(expected, actual) &&
-            Yang.insync_for_replace(actual, expected)
+    equal = Yang.insync_for_replace?(expected, actual) &&
+            Yang.insync_for_replace?(actual, expected)
     assert(equal,
            "Expected: '#{expected}',\n"\
            "Actual: '#{actual}',\n",

--- a/tests/test_yang.rb
+++ b/tests/test_yang.rb
@@ -171,7 +171,7 @@ class TestYang < CiscoTestCase
 
     node.replace_yang(GREEN_VRF) # create a single VRF
     assert(node.get_yang(PATH_VRFS).match('GREEN'),
-           'Did not find the BLUE vrf')
+           'Did not find the GREEN vrf')
     refute(node.get_yang(PATH_VRFS).match('BLUE'),
            'Found the BLUE vrf')
   end


### PR DESCRIPTION
This PR adds support for getting/setting config in YANG JSON format over gRPC.
### Tested Platforms
- xrv9k
- n9kv

I ran the full set of minitests on n9kv and there were many failures/errors, but none of them seemed to be due to my changes, and the errors were reported properly (indicating the changes to the error handling code still work properly on nexus).
