### PR TITLE
Condense vlan configuration and fix teardown error

### DIFF
--- a/tests/test_interface_private_vlan.rb
+++ b/tests/test_interface_private_vlan.rb
@@ -322,13 +322,9 @@ class TestInterfacePrivateVlan < CiscoTestCase
     i.switchport_pvlan_trunk_allowed_vlan = default
     assert_equal(default, i.switchport_pvlan_trunk_allowed_vlan)
 
-    vlans = '500-528,530,532,534,587,590-593'
-    all_vlans = '500-528,530,532,534,587,590-593,597-598'
-    config("interface #{i.name}",
-           "switchport private-vlan trunk allowed vlan #{vlans}",
-           'switchport private-vlan trunk allowed vlan add 597',
-           'switchport private-vlan trunk allowed vlan add 598')
-    assert_equal(all_vlans, i.switchport_pvlan_trunk_allowed_vlan)
+    vlans = '500-528,530,532,534,587,590-593,597-598,600,602,604'
+    i.switchport_pvlan_trunk_allowed_vlan = vlans
+    assert_equal(vlans, i.switchport_pvlan_trunk_allowed_vlan)
   end
 
   def test_switchport_pvlan_trunk_native_vlan

--- a/tests/test_interface_switchport.rb
+++ b/tests/test_interface_switchport.rb
@@ -282,13 +282,9 @@ class TestSwitchport < TestInterfaceSwitchport
 
       # Some images have behavior where 'vlan add' is separate line
       # This behavior is triggered for vlan ranges that exceed character limit
-      vlans = '500-528,530,532,534,587,590-593'
-      all_vlans = vlans + ',597-598'
-      config("interface #{interface.name}",
-             "switchport trunk allowed vlan #{vlans}",
-             'switchport trunk allowed vlan add 597',
-             'switchport trunk allowed vlan add 598')
-      assert_equal(all_vlans, interface.switchport_trunk_allowed_vlan)
+      vlans = '500-528,530,532,534,587,590-593,597-598,600,602,604'
+      interface.switchport_trunk_allowed_vlan = vlans
+      assert_equal(vlans, interface.switchport_trunk_allowed_vlan)
     end
   end
 
@@ -368,7 +364,7 @@ class TestInterfaceSwitchportSvi < TestInterfaceSwitchport
   end
 
   def teardown
-    svi.destroy unless platform == :ios_xr
+    svi.destroy unless platform == :ios_xr || svi.nil?
     super
   end
 


### PR DESCRIPTION
### Condense testing code

The multiple `config` lines were unnecessary as the behavior could be applied in one line.
### Fix error when node is missing interfaces

``` bash
  2) Skipped:
TestInterfaceSwitchportSvi#test_sw_autostate_trunk:
No suitable interfaces found on 10.122.84.157 for this test

Error:
TestInterfaceSwitchportSvi#test_sw_autostate_trunk:
NoMethodError: undefined method `destroy' for nil:NilClass
    tests/test_interface_switchport.rb:367:in `teardown'
```
