### PR TITLE
Added IOS XR support for snmp_user

### DIFF
--- a/lib/.rubocop.yml
+++ b/lib/.rubocop.yml
@@ -12,7 +12,7 @@ Metrics/MethodLength:
   Max: 50
 
 Metrics/ParameterLists:
-  Max: 9
+  Max: 10
 
 Metrics/PerceivedComplexity:
   Max: 24

--- a/lib/cisco_node_utils/cmd_ref/snmp_user.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_user.yaml
@@ -1,49 +1,67 @@
 # snmp_user
 ---
-_exclude: [ios_xr]
-
 _template:
   multiple: true
 
 auth_password:
-  get_command: "show run snmp all"
-  get_value: '/snmp-server user (\S+) \S+ auth \S+ (\S+)/'
+  get_value: '/snmp-server user (\S+) \S+ \S+ auth \S+ \S+ (\S+)/'
+  ios_xr:
+    get_command: "show running-config snmp-server"
+  nexus:
+    get_command: "show run snmp all"
   default_value: ""
 
 # The getter format will not have group info if engine id is configured.
 auth_password_with_engine_id:
-  get_command: "show run snmp all"
-  get_value: '/snmp-server user (\S+) auth \S+ (\S+) .*engineID (\S+)/'
+  _exclude: [ios_xr]
+  nexus:
+    get_command: "show run snmp all"
+    get_value: '/snmp-server user (\S+) auth \S+ (\S+) .*engineID (\S+)/'
   default_value: ""
 
 auth_protocol:
   default_value: "md5"
+  ios_xr:
+    get_command: "show running-config snmp-server"
+    get_value: '/snmp-server user (\S+) \S+ \S+ auth (\S+)'
   N9k:
     # TODO: is this really N9K-specific?
     get_value: "auth"
 
 engine_id:
+  _exclude: [ios_xr]
   default_value: ""
 
 group:
   default_value: "network-operator"
+  ios_xr:
+    get_command: "show running-config snmp-server"
+    get_value: '/snmp-server user (\S+) (\S+)'
   N9k:
     # TODO: is this really N9K-specific?
     get_value: "group"
 
 priv_password:
-  get_command: "show run snmp all"
-  get_value: '/snmp-server user (\S+) \S+ auth \S+ \S+ priv.*(0x\S+)/'
+  ios_xr:
+    get_command: "show running-config snmp-server"
+    get_value: '/snmp-server user (\S+).*priv.*encrypted (\S+)/'
+  nexus:
+    get_command: "show run snmp all"
+    get_value: '/snmp-server user (\S+) \S+ auth \S+ \S+ priv.*(0x\S+)/'
   default_value: ""
 
 # The getter format will not have group info if engine id is configured.
 priv_password_with_engine_id:
-  get_command: "show run snmp all"
-  get_value: '/snmp-server user (\S+) auth \S+ \S+ priv .*(0x\S+) .*engineID (\S+)/'
+  _exclude: [ios_xr]
+  nexus:
+    get_command: "show run snmp all"
+    get_value: '/snmp-server user (\S+) auth \S+ \S+ priv .*(0x\S+) .*engineID (\S+)/'
   default_value: ""
 
 priv_protocol:
   default_value: "des"
+  ios_xr:
+    get_value: '/snmp-server user (\S+).*priv (3des|aes 128|aes 192|aes 256|des56)/'
   N9k:
     # TODO: is this really N9K-specific?
     get_value: "priv"
@@ -52,6 +70,17 @@ priv_protocol:
 # [no] snmp-server user <user> [group] [auth {md5|sha} <passwd1> \
 #       [priv [aes-128] <passwd2>] [localizedkey] [engineID <id>]]
 user:
-  get_command: "show run snmp all | i 'snmp-server user'"
-  get_value: '/^snmp.server user (.*)$/'
-  set_value: "%s snmp-server user %s %s %s %s %s %s"
+  get_value: '/^snmp-server user (.*)$/'
+  ios_xr:
+    get_command: "show running-config snmp-server"
+    set_value: "<state> snmp-server user <name> <group> <version> <auth> <priv>"
+  nexus:
+    get_command: "show run snmp all | i 'snmp-server user'"
+    set_value: "<state> snmp-server user <name> <group> <version> <auth> <priv> <localizedKey> <engineId>"
+
+version:
+  _exclude: [nexus]
+  get_command: "show running-config snmp-server"
+  get_value: '/snmp-server user (\S+) \S+ (\S+)/'
+  default_value: ""
+

--- a/lib/cisco_node_utils/cmd_ref/snmp_user.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_user.yaml
@@ -72,7 +72,7 @@ user:
     set_value: "<state> snmp-server user <name> <group> <version> <auth> <priv>"
   nexus:
     get_command: "show run snmp all | i 'snmp-server user'"
-    set_value: "<state> snmp-server user <name> <group> <version> <auth> <priv> <localizedKey> <engineId>"
+    set_value: "<state> snmp-server user <name> <group> <auth> <priv> <localizedKey> <engineId>"
 
 version:
   _exclude: [nexus]

--- a/lib/cisco_node_utils/cmd_ref/snmp_user.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_user.yaml
@@ -2,27 +2,28 @@
 ---
 _template:
   multiple: true
-
-auth_password:
-  get_value: '/snmp-server user (\S+) \S+ \S+ auth \S+ \S+ (\S+)/'
   ios_xr:
     get_command: "show running-config snmp-server"
   nexus:
     get_command: "show run snmp all"
+
+auth_password:
+  ios_xr:
+    get_value: '/snmp-server user (\S+) \S+ \S+ auth \S+ \S+ (\S+)/'
+  nexus:
+    get_value: '/snmp-server user (\S+) \S+ auth \S+ (\S+)/'
   default_value: ""
 
 # The getter format will not have group info if engine id is configured.
 auth_password_with_engine_id:
   _exclude: [ios_xr]
   nexus:
-    get_command: "show run snmp all"
     get_value: '/snmp-server user (\S+) auth \S+ (\S+) .*engineID (\S+)/'
   default_value: ""
 
 auth_protocol:
   default_value: "md5"
   ios_xr:
-    get_command: "show running-config snmp-server"
     get_value: '/snmp-server user (\S+) \S+ \S+ auth (\S+)'
   N9k:
     # TODO: is this really N9K-specific?
@@ -35,7 +36,6 @@ engine_id:
 group:
   default_value: "network-operator"
   ios_xr:
-    get_command: "show running-config snmp-server"
     get_value: '/snmp-server user (\S+) (\S+)'
   N9k:
     # TODO: is this really N9K-specific?
@@ -43,10 +43,8 @@ group:
 
 priv_password:
   ios_xr:
-    get_command: "show running-config snmp-server"
     get_value: '/snmp-server user (\S+).*priv.*encrypted (\S+)/'
   nexus:
-    get_command: "show run snmp all"
     get_value: '/snmp-server user (\S+) \S+ auth \S+ \S+ priv.*(0x\S+)/'
   default_value: ""
 
@@ -54,7 +52,6 @@ priv_password:
 priv_password_with_engine_id:
   _exclude: [ios_xr]
   nexus:
-    get_command: "show run snmp all"
     get_value: '/snmp-server user (\S+) auth \S+ \S+ priv .*(0x\S+) .*engineID (\S+)/'
   default_value: ""
 
@@ -72,7 +69,6 @@ priv_protocol:
 user:
   get_value: '/^snmp-server user (.*)$/'
   ios_xr:
-    get_command: "show running-config snmp-server"
     set_value: "<state> snmp-server user <name> <group> <version> <auth> <priv>"
   nexus:
     get_command: "show run snmp all | i 'snmp-server user'"
@@ -80,7 +76,6 @@ user:
 
 version:
   _exclude: [nexus]
-  get_command: "show running-config snmp-server"
   get_value: '/snmp-server user (\S+) \S+ (\S+)/'
   default_value: ""
 

--- a/lib/cisco_node_utils/snmpuser.rb
+++ b/lib/cisco_node_utils/snmpuser.rb
@@ -18,9 +18,10 @@ module Cisco
   # SnmpUser - node utility class for SNMP user configuration management
   class SnmpUser < NodeUtil
     def initialize(name, groups, authproto, authpass, privproto,
-                   privpass, localizedkey, engineid, instantiate=true)
+                   privpass, localizedkey, engineid, instantiate=true,
+                   version=nil)
       initialize_validator(name, groups, authproto, authpass, privproto,
-                           privpass, engineid, instantiate)
+                           privpass, engineid, version, instantiate)
       @name = name
       @engine_id = engineid
 
@@ -32,6 +33,7 @@ module Cisco
       privprotostr = _priv_sym_to_str(privproto)
 
       return unless instantiate
+
       # Config string syntax:
       # [no] snmp-server user <user> [group] ...
       #      [auth {md5|sha} <passwd1>
@@ -40,18 +42,28 @@ module Cisco
       # Assume if multiple groups, apply all config to each
       groups = [''] if groups.empty?
       groups.each do |group|
-        config_set('snmp_user', 'user', '',
-                   name,
-                   group,
-                   authpass.empty? ? '' : "auth #{authprotostr} #{authpass}",
-                   privpass.empty? ? '' : "priv #{privprotostr} #{privpass}",
-                   localizedkey ? 'localizedkey' : '',
-                   engineid.empty? ? '' : "engineID #{engineid}")
+        if platform == :ios_xr
+          authstr = "auth #{authprotostr} encrypted #{authpass}"
+          privstr = "priv #{privprotostr} encrypted #{privpass}"
+        else
+          authstr = "auth #{authprotostr} #{authpass}"
+          privstr = "priv #{privprotostr} #{privpass}"
+        end
+
+        config_set('snmp_user', 'user',
+                   state:        '',
+                   name:         name,
+                   group:        group,
+                   version:      version.to_s,
+                   auth:         authpass.empty? ? '' : authstr,
+                   priv:         privpass.empty? ? '' : privstr,
+                   localizedKey: localizedkey ? 'localizedkey' : '',
+                   engineId:     engineid.empty? ? '' : "engineID #{engineid}")
       end
     end
 
     def initialize_validator(name, groups, authproto, authpass, privproto,
-                             privpass, engineid, instantiate)
+                             privpass, engineid, version, instantiate)
       fail TypeError unless name.is_a?(String) &&
                             groups.is_a?(Array) &&
                             authproto.is_a?(Symbol) &&
@@ -60,6 +72,15 @@ module Cisco
                             privpass.is_a?(String) &&
                             engineid.is_a?(String)
       fail ArgumentError if name.empty?
+
+      if platform == :ios_xr && instantiate
+        fail TypeError \
+          unless version.is_a?(Symbol) && [:v1, :v2c, :v3].include?(version)
+
+        fail TypeError \
+          if groups.length > 1
+      end
+
       # empty password but protocol provided = bad
       # non-empty password and no protocol provided = bad
       if authpass.empty?
@@ -68,9 +89,12 @@ module Cisco
         fail ArgumentError unless [:sha, :md5].include?(authproto)
       end
       if privpass.empty?
-        fail ArgumentError if [:des, :aes128].include?(privproto) && instantiate
+        fail ArgumentError \
+          if [:des, :aes128, :aes192, :aes256].include?(privproto) &&
+             instantiate
       else
-        fail ArgumentError unless [:des, :aes128].include?(privproto)
+        fail ArgumentError \
+          unless [:des, :aes128, :aes192, :aes256].include?(privproto)
       end
     end
 
@@ -107,7 +131,8 @@ module Cisco
         users_hash[index] = SnmpUser.new(name, groups_arr.flatten, auth,
                                          '', priv, '', false,
                                          engineid,
-                                         false)
+                                         false,
+                                         nil)
       end
       users_hash
     end
@@ -123,10 +148,30 @@ module Cisco
       unless priv_password.nil? || priv_password.empty?
         priv_str = "priv #{_priv_sym_to_str(priv_protocol)} #{priv_password}"
       end
-      config_set('snmp_user', 'user', 'no',
-                 @name, '', auth_str, priv_str, local_str,
-                 @engine_id.empty? ? '' : "engineID #{@engine_id}")
-      SnmpUser.users.delete(@name + ' ' + @engine_id)
+
+      if platform == :ios_xr
+        groups.each do |group|
+          config_set('snmp_user', 'user',
+                     state:   'no',
+                     name:    @name,
+                     group:   group,
+                     version: version.to_s,
+                     auth:    '',
+                     priv:    '')
+        end
+      else
+        engineidstr = @engine_id.empty? ? '' : "engineID #{@engine_id}"
+        config_set('snmp_user', 'user',
+                   state:        'no',
+                   name:         @name,
+                   group:        '',
+                   auth:         auth_str,
+                   priv:         priv_str,
+                   localizedKey: local_str,
+                   engineId:     engineidstr)
+      end
+
+      SnmpUser.users.delete(@name + ' ' + @engine_id) if platform != :ios_xr
     end
 
     attr_reader :name
@@ -203,6 +248,21 @@ module Cisco
       config_get_default('snmp_user', 'priv_password')
     end
 
+    def self.version(name)
+      users = config_get('snmp_user', 'version')
+      unless users.nil? || users.empty?
+        users.each_entry { |user| return user[1] if user[0] == name }
+      end
+    end
+
+    def version
+      SnmpUser.version(@name)
+    end
+
+    def self.default_version
+      config_get_default('snmp_user', 'version')
+    end
+
     attr_reader :engine_id
 
     def self.default_engine_id
@@ -232,11 +292,19 @@ module Cisco
         # In this case passed in password is clear text while the running
         # config is hashed value. We need to hash the passed in clear text.
 
+        group = platform == :ios_xr ? 'network-operator' : ''
+        authstr = "auth #{_auth_sym_to_str(auth_protocol)} #{input_pw}"
+        engineidstr = @engine_id.empty? ? '' : "engineID #{@engine_id}"
         # Create dummy user
-        config_set('snmp_user', 'user', '', 'dummy_user', '',
-                   "auth #{_auth_sym_to_str(auth_protocol)} #{input_pw}",
-                   '', '',
-                   @engine_id.empty? ? '' : "engineID #{@engine_id}")
+        config_set('snmp_user', 'user',
+                   state:        '',
+                   name:         'dummy_user',
+                   group:        group,
+                   version:      'v3',
+                   auth:         authstr,
+                   priv:         '',
+                   localizedKey: '',
+                   engineId:     engineidstr)
 
         # Retrieve password hashes
         hashed_pw = SnmpUser.auth_password('dummy_user', @engine_id)
@@ -246,11 +314,18 @@ module Cisco
                + @@node.get(command: 'show run snmp all')
         end
 
+        authstr = "auth #{_auth_sym_to_str(auth_protocol)} #{hashed_pw}"
+        engineidstr = @engine_id.empty? ? '' : "engineID #{@engine_id}"
         # Delete dummy user
-        config_set('snmp_user', 'user', 'no', 'dummy_user', '',
-                   "auth #{_auth_sym_to_str(auth_protocol)} #{hashed_pw}",
-                   '', 'localizedkey',
-                   @engine_id.empty? ? '' : "engineID #{@engine_id}")
+        config_set('snmp_user', 'user',
+                   state:        'no',
+                   name:         'dummy_user',
+                   group:        group,
+                   version:      'v3',
+                   auth:         authstr,
+                   priv:         '',
+                   localizedKey: 'localizedkey',
+                   engineId:     engineidstr)
       end
       hashed_pw == current_pw
     end
@@ -278,12 +353,19 @@ module Cisco
         # In this case passed in password is clear text while the running
         # config is hashed value. We need to hash the passed in clear text.
 
+        group = platform == :ios_xr ? 'network-operator' : ''
+        authstr = "auth #{_auth_sym_to_str(auth_protocol)} #{input_pw}"
+        privstr = "priv #{_priv_sym_to_str(priv_protocol)} #{input_pw}"
+        engineidstr = @engine_id.empty? ? '' : "engineID #{@engine_id}"
         # Create dummy user
-        config_set('snmp_user', 'user', '', 'dummy_user', '',
-                   "auth #{_auth_sym_to_str(auth_protocol)} #{input_pw}",
-                   "priv #{_priv_sym_to_str(priv_protocol)} #{input_pw}",
-                   '',
-                   @engine_id.empty? ? '' : "engineID #{@engine_id}")
+        config_set('snmp_user', 'user',
+                   state:        '',
+                   name:         'dummy_user',
+                   group:        group,
+                   auth:         authstr,
+                   priv:         privstr,
+                   localizedKey: '',
+                   engineId:     engineidstr)
 
         # Retrieve password hashes
         dummyau = SnmpUser.auth_password('dummy_user', @engine_id)
@@ -294,12 +376,19 @@ module Cisco
                + @@node.get(command: 'show run snmp all')
         end
 
+        group = platform == :ios_xr ? 'network-operator' : ''
+        authstr = "auth #{_auth_sym_to_str(auth_protocol)} #{dummyau}"
+        privstr = "priv #{_priv_sym_to_str(priv_protocol)} #{hashed_pw}"
+        engineidstr = @engine_id.empty? ? '' : "engineID #{@engine_id}"
         # Delete dummy user
-        config_set('snmp_user', 'user', 'no', 'dummy_user', '',
-                   "auth #{_auth_sym_to_str(auth_protocol)} #{dummyau}",
-                   "priv #{_priv_sym_to_str(priv_protocol)} #{hashed_pw}",
-                   'localizedkey',
-                   @engine_id.empty? ? '' : "engineID #{@engine_id}")
+        config_set('snmp_user', 'user',
+                   state:        'no',
+                   name:         'dummy_user',
+                   group:        group,
+                   auth:         authstr,
+                   priv:         privstr,
+                   localizedKey: 'localizedkey',
+                   engineId:     engineidstr)
       end
       hashed_pw == current_pw
     end
@@ -320,7 +409,13 @@ module Cisco
       # privproto always comes after priv_index if priv exists
       pri = priv_index.nil? ? '' : lparams[priv_index + 1]
       # for the empty priv protocol default
-      pri = 'des' unless pri.empty? || pri == 'aes-128'
+      if platform == :ios_xr
+        if pri == 'aes'
+          pri = "#{lparams[priv_index + 1]} #{lparams[priv_index + 2]}"
+        end
+      else
+        pri = 'des' unless pri.empty? || pri == 'aes-128'
+      end
       auth = _auth_str_to_sym(aut)
       priv = _priv_str_to_sym(pri)
       user_var[:name] = name
@@ -361,9 +456,15 @@ module Cisco
     def _priv_sym_to_str(sym)
       case sym
       when :des
-        return '' # no protocol specified defaults to DES
+        return 'des56'
+      when :'3des'
+        return '3des'
       when :aes128
-        return 'aes-128'
+        if platform == :ios_xr
+          return 'aes 128'
+        else
+          return 'aes-128'
+        end
       else
         return ''
       end
@@ -390,13 +491,30 @@ module Cisco
     end
 
     def self._priv_str_to_sym(str)
-      case str
-      when /des/i
-        return :des
-      when /aes/i
-        return :aes128
+      if platform == :ios_xr
+        case str
+        when /3des/i
+          return :'3des'
+        when /des/i
+          return :des
+        when /aes 128/i
+          return :aes128
+        when /aes 192/i
+          return :aes192
+        when /aes 256/i
+          return :aes256
+        else
+          return :none
+        end
       else
-        return :none
+        case str
+        when /des/i
+          return :des
+        when /aes/i
+          return :aes128
+        else
+          return :none
+        end
       end
     end
   end

--- a/lib/cisco_node_utils/snmpuser.rb
+++ b/lib/cisco_node_utils/snmpuser.rb
@@ -75,7 +75,7 @@ module Cisco
 
       if platform == :ios_xr && instantiate
         fail TypeError \
-          unless version.is_a?(Symbol) && [:v1, :v2c, :v3].include?(version)
+          unless [:v1, :v2c, :v3].include?(version)
 
         fail TypeError \
           if groups.length > 1
@@ -169,9 +169,8 @@ module Cisco
                    priv:         priv_str,
                    localizedKey: local_str,
                    engineId:     engineidstr)
+        SnmpUser.users.delete(@name + ' ' + @engine_id)
       end
-
-      SnmpUser.users.delete(@name + ' ' + @engine_id) if platform != :ios_xr
     end
 
     attr_reader :name

--- a/tests/.rubocop.yml
+++ b/tests/.rubocop.yml
@@ -13,3 +13,6 @@ Metrics/MethodLength:
 
 Metrics/PerceivedComplexity:
   Max: 17
+
+Metrics/LineLength:
+  Max: 120

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -100,7 +100,7 @@ class CiscoTestCase < TestCase
 
   def config_and_warn_on_match(warn_match, *args)
     if node.client.platform == :ios_xr
-      result = super(warn_match, *args, 'commit best-effort')
+      result = super(warn_match, *args, 'commit')
     else
       result = super
     end

--- a/tests/test_snmp_notification_receiver.rb
+++ b/tests/test_snmp_notification_receiver.rb
@@ -58,13 +58,13 @@ class TestSnmpNotifRcvr < CiscoTestCase
                                           username:         'ab',
                                           port:             '45',
                                           vrf:              'red',
-                                          source_interface: interfaces[0].downcase) # rubocop:disable Metrics/LineLength
+                                          source_interface: interfaces[0].downcase)
 
     assert_includes(Cisco::SnmpNotificationReceiver.receivers, id)
     assert_equal(receiver, Cisco::SnmpNotificationReceiver.receivers[id])
 
     assert_equal(interfaces[0].downcase,
-                 Cisco::SnmpNotificationReceiver.receivers[id].source_interface) # rubocop:disable Metrics/LineLength
+                 Cisco::SnmpNotificationReceiver.receivers[id].source_interface)
     assert_equal('45', Cisco::SnmpNotificationReceiver.receivers[id].port)
     assert_equal('informs', Cisco::SnmpNotificationReceiver.receivers[id].type)
     assert_equal('ab', Cisco::SnmpNotificationReceiver.receivers[id].username)
@@ -89,7 +89,7 @@ class TestSnmpNotifRcvr < CiscoTestCase
                                           username:         'ab',
                                           port:             '45',
                                           vrf:              'red',
-                                          source_interface: interfaces[0].downcase) # rubocop:disable Metrics/LineLength
+                                          source_interface: interfaces[0].downcase)
 
     assert_includes(Cisco::SnmpNotificationReceiver.receivers, id)
     assert_equal(receiver, Cisco::SnmpNotificationReceiver.receivers[id])
@@ -123,7 +123,7 @@ class TestSnmpNotifRcvr < CiscoTestCase
                                           username:         'ab',
                                           port:             '45',
                                           vrf:              'red',
-                                          source_interface: interfaces[0].downcase) # rubocop:disable Metrics/LineLength
+                                          source_interface: interfaces[0].downcase)
 
     receiver2 = \
       Cisco::SnmpNotificationReceiver.new(id2,
@@ -134,13 +134,13 @@ class TestSnmpNotifRcvr < CiscoTestCase
                                           username:         'cd',
                                           port:             '46',
                                           vrf:              'red',
-                                          source_interface: interfaces[1].downcase) # rubocop:disable Metrics/LineLength
+                                          source_interface: interfaces[1].downcase)
 
     assert_includes(Cisco::SnmpNotificationReceiver.receivers, id)
     assert_equal(receiver, Cisco::SnmpNotificationReceiver.receivers[id])
 
     assert_equal(interfaces[0].downcase,
-                 Cisco::SnmpNotificationReceiver.receivers[id].source_interface) if platform == :nexus # rubocop:disable Metrics/LineLength
+                 Cisco::SnmpNotificationReceiver.receivers[id].source_interface) if platform == :nexus
     assert_equal('45', Cisco::SnmpNotificationReceiver.receivers[id].port)
     assert_equal('informs', Cisco::SnmpNotificationReceiver.receivers[id].type)
     assert_equal('ab', Cisco::SnmpNotificationReceiver.receivers[id].username)
@@ -152,7 +152,7 @@ class TestSnmpNotifRcvr < CiscoTestCase
     assert_equal(receiver2, Cisco::SnmpNotificationReceiver.receivers[id2])
 
     assert_equal(interfaces[1].downcase,
-                 Cisco::SnmpNotificationReceiver.receivers[id2].source_interface) # rubocop:disable Metrics/LineLength
+                 Cisco::SnmpNotificationReceiver.receivers[id2].source_interface)
     assert_equal('46', Cisco::SnmpNotificationReceiver.receivers[id2].port)
     assert_equal('traps', Cisco::SnmpNotificationReceiver.receivers[id2].type)
     assert_equal('cd', Cisco::SnmpNotificationReceiver.receivers[id2].username)

--- a/tests/test_snmpcommunity.rb
+++ b/tests/test_snmpcommunity.rb
@@ -312,7 +312,7 @@ class TestSnmpCommunity < CiscoTestCase
     if platform != :ios_xr
       line = assert_show_match(
         pattern: /snmp-server community\s#{name}\suse-acl\s\S+/)
-      acl = line.to_s.gsub(/snmp-server community\s#{name}\suse-acl\s/, '').strip # rubocop:disable Metrics/LineLength
+      acl = line.to_s.gsub(/snmp-server community\s#{name}\suse-acl\s/, '').strip
       assert_equal(snmpcommunity.acl, acl)
     else
       line = assert_show_match(

--- a/tests/test_snmpuser.rb
+++ b/tests/test_snmpuser.rb
@@ -92,7 +92,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_create_invalid_cli
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     args_list = [
       ['Cleartext password with localized key',
@@ -115,7 +115,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_engine_id_valid_and_none
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     create_user('tester', 'auth sha XXWWPass0wrf engineID 22:22:22:22:23:22')
     create_user('tester2')
@@ -162,7 +162,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_noauth_nopriv_multi
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     name = 'userv3test3'
     groups = ['network-admin', 'vdc-admin']
@@ -212,9 +212,8 @@ class TestSnmpUser < CiscoTestCase
     assert_nil(SnmpUser.users[name])
   end
 
-
   def test_auth_pw_equal_invalid_param
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     name = 'testV3PwEqualInvalid2'
     auth_pw = 'TeSt297534'
@@ -225,7 +224,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_priv_pw_equal_invalid_param
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     name = 'testV3PwEqualInvalid'
     auth_pw = 'XXWWPass0wrf'
@@ -238,7 +237,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_pw_equal_priv_invalid_param
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     name = 'testV3PwEqualInvalid'
     auth_pw = 'XXWWPass0wrf'
@@ -251,7 +250,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_pw_not_equal
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     name = 'testV3PwEqual'
     auth_pw = 'xxwwpass0r!f'
@@ -263,7 +262,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_pw_equal
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     name = 'testV3PwEqual'
     auth_pw = 'XXWWPass0wrf'
@@ -274,7 +273,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_priv_pw_equal_empty
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     name = 'testV3PwEmpty'
     create_user(name, 'network-admin')
@@ -286,7 +285,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_pw_equal_localizedkey
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     name = 'testV3PwEqual'
     auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
@@ -300,7 +299,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_priv_pw_equal_localizedkey
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     name = 'testV3PwEqual'
     auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
@@ -316,7 +315,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_priv_des_pw_equal
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     name = 'testV3PwEqual'
     auth_pw = 'XXWWPass0wrf'
@@ -330,7 +329,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_md5_nopriv
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
+
     name = 'userv3test5'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -343,7 +343,7 @@ class TestSnmpUser < CiscoTestCase
 
     assert_show_match(
       pattern: /#{user_pat(name)} auth md5 \S+ localizedkey/,
-      command: 'show run snmp all | in #{name} | no-more')
+      command: "show run snmp all | in #{name} | no-more")
     snmpuser.destroy
   end
 
@@ -377,7 +377,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_sha_nopriv
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
+
     name = 'userv3testsha'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -396,7 +397,8 @@ class TestSnmpUser < CiscoTestCase
   # If the auth pw is in hex and localized key param in constructor is false,
   # then the pw got localized by the device again.
   def test_auth_sha_nopriv_pw_localized_false
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
+
     name = 'userv3testauthsha3'
     groups = ['network-admin']
     auth_pw = '0xFe6cf9aea159c2c38e0a79ec23ed3cbb'
@@ -441,7 +443,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_md5_priv_des
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
+
     name = 'userv3test6'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -488,7 +491,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_md5_priv_aes128
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
+
     name = 'userv3test7'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -535,7 +539,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_sha_priv_des
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
+
     name = 'userv3test8'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -582,7 +587,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_sha_priv_aes128
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     name = 'userv3test9'
     groups = ['network-admin']
@@ -630,7 +635,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_create_destroy_with_engine_id
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
+
     name = 'test_with_engine_id'
     auth_pw = 'XXWWPass0wrf'
     priv_pw = 'XXWWPass0wrf'
@@ -669,7 +675,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_authpassword_with_engineid
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
+
     name = 'test_authpassword'
     auth_pw = '0x123456'
     engine_id = '128:12:12:12:12'
@@ -701,7 +708,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_privpassword_with_engineid
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     name = 'test_privpassword2'
     priv_password = '0x123456'
@@ -720,7 +727,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_password_equal_with_engineid
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     name = 'test_authpass_equal'
     auth_pass = 'XXWWPass0wrf'
@@ -736,7 +743,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_priv_password_equal_with_engineid
-    return if platform == :ios_xr
+    skip if platform == :ios_xr
 
     name = 'test_privpass_equal'
     priv_pass = 'XXWWPass0wrf'

--- a/tests/test_snmpuser.rb
+++ b/tests/test_snmpuser.rb
@@ -59,11 +59,11 @@ class TestSnmpUser < CiscoTestCase
     assert_empty(delta, 'Users not deleted after test!')
   end
 
-  def user_pat(name, group='network-admin')
-    group ? /snmp-server user #{name} #{group}/ : /snmp-server user #{name}/
+  def user_pat(name, group='network-admin', version='')
+    group ? /snmp-server user #{name} #{group} #{version}/ : /snmp-server user #{name}/
   end
 
-  ## test cases starts here
+  # test cases starts here
 
   def test_collection_not_empty
     create_user('tester')
@@ -75,15 +75,15 @@ class TestSnmpUser < CiscoTestCase
     args_list = [
       ['Empty name',
        ['', ['network-admin'],
-        :none, '', :none, '', false, ''],
+        :none, '', :none, '', false, '', true, :v3],
       ],
       ['Auth password but no authproto',
        ['userv3testUnknownAuth', ['network-admin'],
-        :none, 'test12345', :none, '', false, ''],
+        :none, 'test12345', :none, '', false, '', true, :v3],
       ],
       ['Priv password but no privproto',
        ['userv3testUnknownPriv', ['network-admin'],
-        :sha, 'test12345', :none, 'test12345', false, ''],
+        :sha, 'test12345', :none, 'test12345', false, '', true, :v3],
       ],
     ]
     args_list.each do |msg, args|
@@ -92,6 +92,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_create_invalid_cli
+    return if platform == :ios_xr
+
     args_list = [
       ['Cleartext password with localized key',
        ['userv3testauthsha1', ['network-admin'],
@@ -113,6 +115,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_engine_id_valid_and_none
+    return if platform == :ios_xr
+
     create_user('tester', 'auth sha XXWWPass0wrf engineID 22:22:22:22:23:22')
     create_user('tester2')
 
@@ -143,13 +147,23 @@ class TestSnmpUser < CiscoTestCase
                             :none, '',
                             :none, '',
                             false,
-                            '')
-    assert_show_match(pattern: user_pat(name),
-                      command: 'show run snmp all | no-more')
+                            '',
+                            true,
+                            :v1)
+
+    if platform == :ios_xr
+      assert_show_match(pattern: user_pat(name),
+                        command: 'show running-config snmp-server')
+    else
+      assert_show_match(pattern: user_pat(name),
+                        command: 'show run snmp all | no-more')
+    end
     snmpuser.destroy
   end
 
   def test_noauth_nopriv_multi
+    return if platform == :ios_xr
+
     name = 'userv3test3'
     groups = ['network-admin', 'vdc-admin']
     snmpuser = SnmpUser.new(name,
@@ -157,7 +171,9 @@ class TestSnmpUser < CiscoTestCase
                             :none, '',
                             :none, '',
                             false,
-                            '')
+                            '',
+                            true,
+                            :v1)
     s = @device.cmd('show run snmp all | no-more')
     groups.each do |group|
       assert_match(user_pat(name, group), s)
@@ -168,7 +184,13 @@ class TestSnmpUser < CiscoTestCase
   def test_destroy
     name = 'userv3testdestroy'
     group = 'network-operator'
-    create_user(name, group)
+    version = 'v3'
+
+    if platform == :ios_xr
+      create_user(name, "#{group} #{version}")
+    else
+      create_user(name, group)
+    end
 
     # get user
     snmpuser = SnmpUser.users[name]
@@ -179,12 +201,21 @@ class TestSnmpUser < CiscoTestCase
     # check user got removed.
     sleep(5)
     node.cache_flush
-    refute_show_match(command: 'show run snmp all | no-more',
+
+    if platform == :ios_xr
+      cmd = 'show running-config snmp-server'
+    else
+      cmd = 'show run snmp all | no-more'
+    end
+    refute_show_match(command: cmd,
                       pattern: user_pat(name, group))
     assert_nil(SnmpUser.users[name])
   end
 
+
   def test_auth_pw_equal_invalid_param
+    return if platform == :ios_xr
+
     name = 'testV3PwEqualInvalid2'
     auth_pw = 'TeSt297534'
     create_user(name, "network-admin auth md5 #{auth_pw}")
@@ -194,6 +225,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_priv_pw_equal_invalid_param
+    return if platform == :ios_xr
+
     name = 'testV3PwEqualInvalid'
     auth_pw = 'XXWWPass0wrf'
     create_user(name, "network-admin auth md5 #{auth_pw} priv #{auth_pw}")
@@ -205,6 +238,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_pw_equal_priv_invalid_param
+    return if platform == :ios_xr
+
     name = 'testV3PwEqualInvalid'
     auth_pw = 'XXWWPass0wrf'
     create_user(name, "network-operator auth md5 #{auth_pw} priv #{auth_pw}")
@@ -216,6 +251,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_pw_not_equal
+    return if platform == :ios_xr
+
     name = 'testV3PwEqual'
     auth_pw = 'xxwwpass0r!f'
     create_user(name, "network-admin auth md5 #{auth_pw}")
@@ -226,6 +263,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_pw_equal
+    return if platform == :ios_xr
+
     name = 'testV3PwEqual'
     auth_pw = 'XXWWPass0wrf'
     create_user(name, "network-admin auth md5 #{auth_pw}")
@@ -235,6 +274,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_priv_pw_equal_empty
+    return if platform == :ios_xr
+
     name = 'testV3PwEmpty'
     create_user(name, 'network-admin')
     # nil and "" are treated interchangeably
@@ -245,6 +286,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_pw_equal_localizedkey
+    return if platform == :ios_xr
+
     name = 'testV3PwEqual'
     auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
     create_user(name, "network-admin auth md5 #{auth_pw} localizedkey")
@@ -257,6 +300,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_priv_pw_equal_localizedkey
+    return if platform == :ios_xr
+
     name = 'testV3PwEqual'
     auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
     priv_pw = '0x29916eac22d90362598abef1b9045018'
@@ -271,6 +316,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_priv_des_pw_equal
+    return if platform == :ios_xr
+
     name = 'testV3PwEqual'
     auth_pw = 'XXWWPass0wrf'
     priv_pw = 'WWXXPaas0wrf'
@@ -283,6 +330,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_md5_nopriv
+    return if platform == :ios_xr
     name = 'userv3test5'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -292,31 +340,44 @@ class TestSnmpUser < CiscoTestCase
                             :none, '',
                             false, # clear text
                             '')
+
     assert_show_match(
       pattern: /#{user_pat(name)} auth md5 \S+ localizedkey/,
-      command: "show run snmp all | in #{name} | no-more")
+      command: 'show run snmp all | in #{name} | no-more')
     snmpuser.destroy
   end
 
   def test_auth_md5_nopriv_pw_localized
     name = 'userv3testauth'
     groups = ['network-admin']
-    auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
+    auth_pw = platform == :ios_xr ? '152A333B331A2A373B63223015' : '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
     snmpuser = SnmpUser.new(name,
                             groups,
                             :md5, auth_pw,
                             :none, '',
                             true, # localized
-                            '')
+                            '',
+                            true,
+                            :v3)
     assert_equal(snmpuser.name, name)
     assert_empty(snmpuser.engine_id)
+
+    if platform == :ios_xr
+      pat = "#{user_pat(name, groups[0], 'v3')} auth md5 encrypted 152A333B331A2A373B63223015"
+      cmd = 'show running-config snmp-server'
+    else
+      pat = "#{user_pat(name)} auth md5 #{auth_pw} localizedkey"
+      cmd = 'show run snmp all | in #{name} | no-more'
+    end
+
     assert_show_match(
-      pattern: /#{user_pat(name)} auth md5 #{auth_pw} localizedkey/,
-      command: "show run snmp all | in #{name} | no-more")
+      pattern: /#{pat}/,
+      command: cmd)
     snmpuser.destroy
   end
 
   def test_auth_sha_nopriv
+    return if platform == :ios_xr
     name = 'userv3testsha'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -335,6 +396,7 @@ class TestSnmpUser < CiscoTestCase
   # If the auth pw is in hex and localized key param in constructor is false,
   # then the pw got localized by the device again.
   def test_auth_sha_nopriv_pw_localized_false
+    return if platform == :ios_xr
     name = 'userv3testauthsha3'
     groups = ['network-admin']
     auth_pw = '0xFe6cf9aea159c2c38e0a79ec23ed3cbb'
@@ -354,20 +416,32 @@ class TestSnmpUser < CiscoTestCase
   def test_auth_sha_nopriv_pw_localized
     name = 'userv3testauthsha4'
     groups = ['network-admin']
-    auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
+    auth_pw = platform == :ios_xr ? '152A333B331A2A373B63223015' : '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
     snmpuser = SnmpUser.new(name,
                             groups,
                             :sha, auth_pw,
                             :none, '',
                             true, # localized
-                            '')
+                            '',
+                            true,
+                            :v3)
+
+    if platform == :ios_xr
+      pat = "#{user_pat(name, groups[0], 'v3')} auth sha encrypted 152A333B331A2A373B63223015"
+      cmd = 'show running-config snmp-server'
+    else
+      pat = "#{user_pat(name)} auth sha #{auth_pw} localizedkey"
+      cmd = 'show run snmp all | in #{name} | no-more'
+    end
+
     assert_show_match(
-      pattern: /#{user_pat(name)} auth sha #{auth_pw} localizedkey/,
-      command: "show run snmp all | in #{name} | no-more")
+      pattern: /#{pat}/,
+      command: cmd)
     snmpuser.destroy
   end
 
   def test_auth_md5_priv_des
+    return if platform == :ios_xr
     name = 'userv3test6'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -387,23 +461,34 @@ class TestSnmpUser < CiscoTestCase
   def test_auth_md5_priv_des_pw_localized
     name = 'userv3testauth'
     groups = ['network-admin']
-    auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
-    priv_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
+    auth_pw = platform == :ios_xr ? '0307530A080824414B' : '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
+    priv_pw = platform == :ios_xr ? '12491D42475E5A' : '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
     snmpuser = SnmpUser.new(name,
                             groups,
                             :md5, auth_pw,
                             :des, priv_pw,
                             true, # localized
-                            '')
-    # rubocop:disable Metrics/LineLength
+                            '',
+                            true,
+                            :v3)
+
+    if platform == :ios_xr
+      pat = "#{user_pat(name, groups[0], 'v3')} auth md5 encrypted #{auth_pw} priv des56 encrypted #{priv_pw}"
+      cmd = 'show running-config snmp-server'
+    else
+      pat = "#{user_pat(name)} auth md5 #{auth_pw} priv #{priv_pw} localizedkey"
+      cmd = 'show run snmp all | in #{name} | no-more'
+    end
+
     assert_show_match(
-      pattern: /#{user_pat(name)} auth md5 #{auth_pw} priv #{priv_pw} localizedkey/,
-      command: "show run snmp all | in #{name} | no-more")
-    # rubocop:enable Metrics/LineLength
+      pattern: /#{pat}/,
+      command: cmd)
+
     snmpuser.destroy
   end
 
   def test_auth_md5_priv_aes128
+    return if platform == :ios_xr
     name = 'userv3test7'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -423,23 +508,34 @@ class TestSnmpUser < CiscoTestCase
   def test_auth_md5_priv_aes128_pw_localized
     name = 'userv3testauth'
     groups = ['network-admin']
-    auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
-    priv_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
+    auth_pw = platform == :ios_xr ? '0307530A080824414B' : '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
+    priv_pw = platform == :ios_xr ? '12491D42475E5A' : '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
     snmpuser = SnmpUser.new(name,
                             groups,
                             :md5, auth_pw,
                             :aes128, priv_pw,
                             true, # localized
-                            '')
-    # rubocop:disable Metrics/LineLength
+                            '',
+                            true,
+                            :v3)
+
+    if platform == :ios_xr
+      pat = "#{user_pat(name, groups[0], 'v3')} auth md5 encrypted #{auth_pw} priv aes 128 encrypted #{priv_pw}"
+      cmd = 'show running-config snmp-server'
+    else
+      pat = "#{user_pat(name)} auth md5 #{auth_pw} priv aes-128 #{priv_pw} localizedkey"
+      cmd = 'show run snmp all | in #{name} | no-more'
+    end
+
     assert_show_match(
-      pattern: /#{user_pat(name)} auth md5 #{auth_pw} priv aes-128 #{priv_pw} localizedkey/,
-      command: "show run snmp all | in #{name} | no-more")
-    # rubocop:enable Metrics/LineLength
+      pattern: /#{pat}/,
+      command: cmd)
+
     snmpuser.destroy
   end
 
   def test_auth_sha_priv_des
+    return if platform == :ios_xr
     name = 'userv3test8'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -459,23 +555,35 @@ class TestSnmpUser < CiscoTestCase
   def test_auth_md5_priv_sha_pw_localized
     name = 'userv3testauth'
     groups = ['network-admin']
-    auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
-    priv_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
+    auth_pw = platform == :ios_xr ? '0307530A080824414B' : '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
+    priv_pw = platform == :ios_xr ? '12491D42475E5A' : '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
     snmpuser = SnmpUser.new(name,
                             groups,
                             :sha, auth_pw,
                             :des, priv_pw,
                             true, # localized
-                            '')
-    # rubocop:disable Metrics/LineLength
+                            '',
+                            true,
+                            :v3)
+
+    if platform == :ios_xr
+      pat = "#{user_pat(name, groups[0], 'v3')} auth sha encrypted #{auth_pw} priv des56 encrypted #{priv_pw}"
+      cmd = 'show running-config snmp-server'
+    else
+      pat = "#{user_pat(name)} auth sha #{auth_pw} priv #{priv_pw} localizedkey"
+      cmd = 'show run snmp all | in #{name} | no-more'
+    end
+
     assert_show_match(
-      pattern: /#{user_pat(name)} auth sha #{auth_pw} priv #{priv_pw} localizedkey/,
-      command: "show run snmp all | in #{name} | no-more")
-    # rubocop:enable Metrics/LineLength
+      pattern: /#{pat}/,
+      command: cmd)
+
     snmpuser.destroy
   end
 
   def test_auth_sha_priv_aes128
+    return if platform == :ios_xr
+
     name = 'userv3test9'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -495,34 +603,45 @@ class TestSnmpUser < CiscoTestCase
   def test_auth_sha_priv_aes128_pw_localized
     name = 'userv3testauth'
     groups = ['network-admin']
-    auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
-    priv_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
+    auth_pw = platform == :ios_xr ? '0307530A080824414B' : '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
+    priv_pw = platform == :ios_xr ? '12491D42475E5A' : '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
     snmpuser = SnmpUser.new(name,
                             groups,
                             :sha, auth_pw,
                             :aes128, priv_pw,
                             true, # localized
-                            '')
-    # rubocop:disable Metrics/LineLength
+                            '',
+                            true,
+                            :v3)
+
+    if platform == :ios_xr
+      pat = "#{user_pat(name, groups[0], 'v3')} auth sha encrypted #{auth_pw} priv aes 128 encrypted #{priv_pw}"
+      cmd = 'show running-config snmp-server'
+    else
+      pat = "#{user_pat(name)} auth sha #{auth_pw} priv aes-128 #{priv_pw} localizedkey"
+      cmd = 'show run snmp all | in #{name} | no-more'
+    end
+
     assert_show_match(
-      pattern: /#{user_pat(name)} auth sha #{auth_pw} priv aes-128 #{priv_pw} localizedkey/,
-      command: "show run snmp all | in #{name} | no-more")
-    # rubocop:enable Metrics/LineLength
+      pattern: /#{pat}/,
+      command: cmd)
+
     snmpuser.destroy
   end
 
   def test_create_destroy_with_engine_id
+    return if platform == :ios_xr
     name = 'test_with_engine_id'
     auth_pw = 'XXWWPass0wrf'
     priv_pw = 'XXWWPass0wrf'
     engine_id = '128:12:12:12:12'
     snmpuser = SnmpUser.new(name, [''], :md5, auth_pw, :des, priv_pw,
                             false, engine_id)
-    # rubocop:disable Metrics/LineLength
+
     assert_show_match(
       pattern: /snmp-server user #{name} auth \S+ \S+ priv .*\S+ localizedkey engineID #{engine_id}/,
       command: "show run snmp all | in #{name} | no-more")
-    # rubocop:enable Metrics/LineLength
+
     user = SnmpUser.users["#{name} #{engine_id}"]
     refute_nil(user)
     assert_equal(snmpuser.name, user.name)
@@ -530,18 +649,19 @@ class TestSnmpUser < CiscoTestCase
     assert_equal(snmpuser.engine_id, engine_id)
     assert_equal(snmpuser.engine_id, user.engine_id)
     snmpuser.destroy
-    # rubocop:disable Metrics/LineLength
+
     refute_show_match(
       pattern: /snmp-server user #{name} auth \S+ \S+ priv .*\S+ localizedkey engineID #{engine_id}/,
       command: "show run snmp all | in #{name} | no-more")
-    # rubocop:enable Metrics/LineLength
+
     assert_nil(SnmpUser.users["#{name} #{engine_id}"])
   end
 
   def test_authpassword
     name = 'test_authpassword'
-    auth_pw = '0x123456'
-    snmpuser = SnmpUser.new(name, [''], :md5, auth_pw, :none, '', true, '')
+    auth_pw = platform == :ios_xr ? '0307530A080824414B' : '0x123456'
+    group = platform == :ios_xr ? 'network-operator' : ''
+    snmpuser = SnmpUser.new(name, [group], :md5, auth_pw, :none, '', true, '', true, :v3)
 
     pw = snmpuser.auth_password
     assert_equal(auth_pw, pw)
@@ -549,6 +669,7 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_authpassword_with_engineid
+    return if platform == :ios_xr
     name = 'test_authpassword'
     auth_pw = '0x123456'
     engine_id = '128:12:12:12:12'
@@ -562,22 +683,26 @@ class TestSnmpUser < CiscoTestCase
 
   def test_privpassword
     name = 'test_privpassword'
-    priv_password = '0x123456'
-    snmpuser = SnmpUser.new(name, [''], :md5, priv_password,
-                            :des, priv_password, true, '')
+    priv_password = platform == :ios_xr ? '12491D42475E5A' : '0x123456'
+    group = platform == :ios_xr ? 'network-operator' : ''
+
+    snmpuser = SnmpUser.new(name, [group], :md5, priv_password,
+                            :des, priv_password, true, '', true, :v3)
 
     pw = snmpuser.priv_password
     assert_equal(priv_password, pw)
     snmpuser.destroy
 
-    snmpuser = SnmpUser.new(name, [''], :md5, priv_password,
-                            :aes128, priv_password, true, '')
+    snmpuser = SnmpUser.new(name, [group], :md5, priv_password,
+                            :aes128, priv_password, true, '', true, :v3)
     pw = snmpuser.priv_password
     assert_equal(priv_password, pw)
     snmpuser.destroy
   end
 
   def test_privpassword_with_engineid
+    return if platform == :ios_xr
+
     name = 'test_privpassword2'
     priv_password = '0x123456'
     engine_id = '128:12:12:12:12'
@@ -595,6 +720,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_auth_password_equal_with_engineid
+    return if platform == :ios_xr
+
     name = 'test_authpass_equal'
     auth_pass = 'XXWWPass0wrf'
     engine_id = '128:12:12:12:12'
@@ -609,6 +736,8 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def test_priv_password_equal_with_engineid
+    return if platform == :ios_xr
+
     name = 'test_privpass_equal'
     priv_pass = 'XXWWPass0wrf'
     engine_id = '128:12:12:12:12'

--- a/tests/test_snmpuser.rb
+++ b/tests/test_snmpuser.rb
@@ -60,7 +60,15 @@ class TestSnmpUser < CiscoTestCase
   end
 
   def user_pat(name, group='network-admin', version='')
-    group ? /snmp-server user #{name} #{group} #{version}/ : /snmp-server user #{name}/
+    if group
+      if !version.empty?
+        /snmp-server user #{name} #{group} #{version}/
+      else
+        /snmp-server user #{name} #{group}/
+      end
+    else
+      /snmp-server user #{name}/
+    end
   end
 
   # test cases starts here

--- a/tests/test_snmpuser.rb
+++ b/tests/test_snmpuser.rb
@@ -375,7 +375,7 @@ class TestSnmpUser < CiscoTestCase
       cmd = 'show running-config snmp-server'
     else
       pat = "#{user_pat(name)} auth md5 #{auth_pw} localizedkey"
-      cmd = 'show run snmp all | in #{name} | no-more'
+      cmd = "show run snmp all | in #{name} | no-more"
     end
 
     assert_show_match(
@@ -441,7 +441,7 @@ class TestSnmpUser < CiscoTestCase
       cmd = 'show running-config snmp-server'
     else
       pat = "#{user_pat(name)} auth sha #{auth_pw} localizedkey"
-      cmd = 'show run snmp all | in #{name} | no-more'
+      cmd = "show run snmp all | in #{name} | no-more"
     end
 
     assert_show_match(
@@ -488,7 +488,7 @@ class TestSnmpUser < CiscoTestCase
       cmd = 'show running-config snmp-server'
     else
       pat = "#{user_pat(name)} auth md5 #{auth_pw} priv #{priv_pw} localizedkey"
-      cmd = 'show run snmp all | in #{name} | no-more'
+      cmd = "show run snmp all | in #{name} | no-more"
     end
 
     assert_show_match(
@@ -536,7 +536,7 @@ class TestSnmpUser < CiscoTestCase
       cmd = 'show running-config snmp-server'
     else
       pat = "#{user_pat(name)} auth md5 #{auth_pw} priv aes-128 #{priv_pw} localizedkey"
-      cmd = 'show run snmp all | in #{name} | no-more'
+      cmd = "show run snmp all | in #{name} | no-more"
     end
 
     assert_show_match(
@@ -584,7 +584,7 @@ class TestSnmpUser < CiscoTestCase
       cmd = 'show running-config snmp-server'
     else
       pat = "#{user_pat(name)} auth sha #{auth_pw} priv #{priv_pw} localizedkey"
-      cmd = 'show run snmp all | in #{name} | no-more'
+      cmd = "show run snmp all | in #{name} | no-more"
     end
 
     assert_show_match(
@@ -632,7 +632,7 @@ class TestSnmpUser < CiscoTestCase
       cmd = 'show running-config snmp-server'
     else
       pat = "#{user_pat(name)} auth sha #{auth_pw} priv aes-128 #{priv_pw} localizedkey"
-      cmd = 'show run snmp all | in #{name} | no-more'
+      cmd = "show run snmp all | in #{name} | no-more"
     end
 
     assert_show_match(


### PR DESCRIPTION
This adds support to IOS XR for snmp_user.
This provider does not support providing unencrypted passwords due to the way salting works on this platform. As such, the minitests that test for equivalency between unencrypted and encrypted passwords have been skipped.

Needs https://github.com/cisco/cisco-network-puppet-module/pull/353/files

```
TestSnmpUser#test_snmpuser_create_destroy_with_engine_id = 7.25 s = .
TestSnmpUser#test_snmpuser_privpassword = 22.61 s = .
TestSnmpUser#test_snmpuser_create_invalid_args = 5.53 s = .
TestSnmpUser#test_snmpuser_auth_password_equal_localizedkey = 5.83 s = .
TestSnmpUser#test_create_1_group_auth_sha_nopriv_pw_localized_localizedkey_false = 5.59 s = .
TestSnmpUser#test_snmpuser_auth_priv_des_password_equal = 5.41 s = .
TestSnmpUser#test_snmpuser_create_with_single_group_auth_sha_nopriv = 5.20 s = .
TestSnmpUser#test_snmpuser_authpassword_with_engineid = 5.08 s = .
TestSnmpUser#test_snmpuser_auth_priv_password_equal_localizedkey = 4.88 s = .
TestSnmpUser#test_snmpuser_create_invalid_cli = 5.29 s = .
TestSnmpUser#test_snmpuser_create_with_single_group_noauth_nopriv = 16.65 s = .
TestSnmpUser#test_snmpuser_create_with_single_group_auth_sha_priv_aes128_pw_localized = 17.27 s = .
TestSnmpUser#test_snmpuser_create_with_single_group_auth_md5_priv_sha_pw_localized = 17.58 s = .
TestSnmpUser#test_snmpuser_create_with_single_group_auth_md5_priv_aes128_pw_localized = 18.79 s = .
TestSnmpUser#test_snmpuser_default_priv_protocol = 4.96 s = .
TestSnmpUser#test_snmpuser_create_with_single_group_auth_md5_nopriv = 4.76 s = .
TestSnmpUser#test_snmpuser_auth_password_not_equal = 5.16 s = .
TestSnmpUser#test_snmpuser_auth_priv_password_equal_empty = 6.43 s = .
TestSnmpUser#test_snmpuser_create_with_single_group_auth_md5_nopriv_pw_localized = 18.55 s = .
TestSnmpUser#test_snmpuser_create_with_single_group_auth_md5_priv_des = 5.00 s = .
TestSnmpUser#test_snmpuser_create_with_multi_group_noauth_nopriv = 5.22 s = .
TestSnmpUser#test_snmpuser_default_priv_password = 5.86 s = .
TestSnmpUser#test_snmpuser_default_auth_protocol = 5.16 s = .
TestSnmpUser#test_snmpuser_create_with_single_group_auth_md5_priv_aes128 = 5.80 s = .
TestSnmpUser#test_snmpuser_privpassword_with_engineid = 5.23 s = .
TestSnmpUser#test_snmpuser_priv_password_equal_with_engineid = 5.11 s = .
TestSnmpUser#test_snmpuser_auth_password_equal = 5.90 s = .
TestSnmpUser#test_snmpuser_authpassword = 15.89 s = .
TestSnmpUser#test_snmpuser_auth_password_equal_invalid_param = 6.36 s = .
TestSnmpUser#test_snmpuser_auth_priv_password_equal_invalid_param = 5.74 s = .
TestSnmpUser#test_snmpuser_auth_password_equal_with_engineid = 5.59 s = .
TestSnmpUser#test_engine_id_valid_and_none = 5.67 s = .
TestSnmpUser#test_snmpuser_auth_password_equal_priv_invalid_param = 5.99 s = .
TestSnmpUser#test_snmpuser_collection_not_empty = 18.44 s = .
TestSnmpUser#test_snmpuser_default_auth_password = 5.49 s = .
TestSnmpUser#test_snmpuser_create_with_single_group_auth_sha_priv_des = 5.38 s = .
TestSnmpUser#test_snmpuser_create_with_single_group_auth_sha_nopriv_pw_localized = 17.66 s = .
TestSnmpUser#test_snmpuser_create_with_single_group_auth_sha_priv_aes128 = 5.78 s = .
TestSnmpUser#test_snmpuser_create_with_single_group_auth_md5_priv_des_pw_localized = 18.19 s = .
TestSnmpUser#test_snmpuser_default_groups = 5.73 s = .
TestSnmpUser#test_snmpuser_destroy = 25.15 s = .

Finished in 380.284039s, 0.1078 runs/s, 0.3313 assertions/s.

41 runs, 126 assertions, 0 failures, 0 errors, 0 skips
```
