### PR TITLE
Ospf_area with nssa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog
 #### Cisco Resources
 * Bidirectional Forwarding Detection
   * bfd (@saichint)
+* OSPF
+  * ospf_area (@saichint)
 
 ### Added
 

--- a/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
@@ -35,7 +35,7 @@ filter_list_out:
 
 range:
   multiple: true
-  get_value: '/^area <area> range (\S+)\s*(?:(not-advertise))?\s*(?:cost (\d+))?$/'
+  get_value: '/^area <area> range (.*)$/'
   set_value: '<state> area <area> range <ip> <not_advertise> <cost> <value>'
   default_value: []
 

--- a/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
@@ -1,0 +1,45 @@
+# ospf_area
+---
+_exclude: [ios_xr]
+
+_template:
+  get_command: "show running ospf | include area"
+  context:
+    - "router ospf <name>"
+    - "(?)vrf <vrf>"
+
+areas:
+  multiple: true
+  get_value: '/^area\s+(\S+)/'
+
+authentication:
+  get_value: '/^area <area> authentication ?(.*)$/'
+  set_value: '<state> area <area> authentication <auth>'
+  default_value: false
+
+default_cost:
+  kind: int
+  get_value: '/^area <area> default-cost (\d+)$/'
+  set_value: '<state> area <area> default-cost <cost>'
+  default_value: false
+
+filter_list_in:
+  get_value: '/^area <area> filter-list route-map (\S+) in$/'
+  set_value: '<state> area <area> filter-list route-map <route_map> in'
+  default_value: false
+
+filter_list_out:
+  get_value: '/^area <area> filter-list route-map (\S+) out$/'
+  set_value: '<state> area <area> filter-list route-map <route_map> out'
+  default_value: false
+
+range:
+  multiple: true
+  get_value: '/^area <area> range .+$/'
+  set_value: '<state> area <area> range <ip> <not_advertise> <cost>'
+  default_value: []
+
+stub:
+  get_value: '/^area <area> stub ?(.*)$/'
+  set_value: '<state> area <area> stub <stub>'
+  default_value: false

--- a/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
@@ -45,6 +45,13 @@ range:
   default_value: []
 
 stub:
-  get_value: '/^area <area> stub(?:\s+\S+)?$/'
-  set_value: '<state> area <area> stub <stub>'
+  kind: boolean
+  get_value: '/^area <area> stub/'
+  set_value: '<state> area <area> stub'
+  default_value: false
+
+stub_no_summary:
+  kind: boolean
+  get_value: '/^area <area> stub no-summary$/'
+  set_value: '<state> area <area> stub no-summary'
   default_value: false

--- a/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
@@ -13,6 +13,11 @@ areas:
   get_value: '/^area\s+(\S+)/'
 
 authentication:
+  # the config can be 'area <area> authentication' or
+  # 'area <area> authentication message-digest' or
+  # no authentication config at all so need to grab the
+  # optional match to get the whole config for checking
+  # the mode
   get_value: '/^area <area> authentication(?:\s+\S+)?$/'
   set_value: '<state> area <area> authentication <auth>'
   default_value: false

--- a/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
@@ -21,7 +21,7 @@ default_cost:
   kind: int
   get_value: '/^area <area> default-cost (\d+)$/'
   set_value: '<state> area <area> default-cost <cost>'
-  default_value: false
+  default_value: 1
 
 filter_list_in:
   get_value: '/^area <area> filter-list route-map (\S+) in$/'

--- a/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
@@ -3,7 +3,7 @@
 _exclude: [ios_xr]
 
 _template:
-  get_command: "show running ospf | include area"
+  get_command: "show running ospf | no-more"
   context:
     - "router ospf <name>"
     - "(?)vrf <vrf>"
@@ -13,7 +13,7 @@ areas:
   get_value: '/^area\s+(\S+)/'
 
 authentication:
-  get_value: '/^area <area> authentication ?(.*)$/'
+  get_value: '/^area <area> authentication(?:\s+\S+)?$/'
   set_value: '<state> area <area> authentication <auth>'
   default_value: false
 
@@ -40,6 +40,6 @@ range:
   default_value: []
 
 stub:
-  get_value: '/^area <area> stub ?(.*)$/'
+  get_value: '/^area <area> stub(?:\s+\S+)?$/'
   set_value: '<state> area <area> stub <stub>'
   default_value: false

--- a/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
@@ -60,7 +60,7 @@ nssa_no_summary:
   default_value: false
 
 nssa_route_map:
-  default_value: false
+  default_value: ''
 
 nssa_translate_type7:
   get_value: '/^area <area> nssa translate type7 (.*)$/'

--- a/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
@@ -38,6 +38,11 @@ filter_list_out:
   set_value: '<state> area <area> filter-list route-map <route_map> out'
   default_value: false
 
+nssa_translate_type7:
+  get_value: '/^area <area> nssa translate type7 (.*)$/'
+  set_value: '<state> area <area> nssa translate type7 <value>'
+  default_value: false
+
 range:
   multiple: true
   get_value: '/^area <area> range (.*)$/'

--- a/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
@@ -35,8 +35,8 @@ filter_list_out:
 
 range:
   multiple: true
-  get_value: '/^area <area> range .+$/'
-  set_value: '<state> area <area> range <ip> <not_advertise> <cost>'
+  get_value: '/^area <area> range (\S+)\s*(?:(not-advertise))?\s*(?:cost (\d+))?$/'
+  set_value: '<state> area <area> range <ip> <not_advertise> <cost> <value>'
   default_value: []
 
 stub:

--- a/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
@@ -38,6 +38,30 @@ filter_list_out:
   set_value: '<state> area <area> filter-list route-map <route_map> out'
   default_value: false
 
+nssa:
+  multiple: true
+  get_value: '/^area <area> nssa(.*)$/'
+  set_value: '<state> area <area> nssa <no_summary> <no_redistribution> <default_information_originate> <route_map> <rm>'
+
+nssa_def_info_originate:
+  kind: boolean
+  default_value: false
+
+nssa_enable:
+  kind: boolean
+  default_value: false
+
+nssa_no_redistribution:
+  kind: boolean
+  default_value: false
+
+nssa_no_summary:
+  kind: boolean
+  default_value: false
+
+nssa_route_map:
+  default_value: false
+
 nssa_translate_type7:
   get_value: '/^area <area> nssa translate type7 (.*)$/'
   set_value: '<state> area <area> nssa translate type7 <value>'

--- a/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
@@ -39,17 +39,19 @@ filter_list_out:
   default_value: false
 
 nssa:
+  kind: boolean
+  default_value: false
+
+nssa_default_originate:
+  kind: boolean
+  default_value: false
+
+nssa_destroy:
+  set_value: 'no area <area> nssa'
+
+nssa_get:
   multiple: true
   get_value: '/^area <area> nssa(.*)$/'
-  set_value: '<state> area <area> nssa <no_summary> <no_redistribution> <default_information_originate> <route_map> <rm>'
-
-nssa_def_info_originate:
-  kind: boolean
-  default_value: false
-
-nssa_enable:
-  kind: boolean
-  default_value: false
 
 nssa_no_redistribution:
   kind: boolean
@@ -61,6 +63,9 @@ nssa_no_summary:
 
 nssa_route_map:
   default_value: ''
+
+nssa_set:
+  set_value: '<state> area <area> nssa <no_summary> <no_redistribution> <default_information_originate> <route_map> <rm>'
 
 nssa_translate_type7:
   get_value: '/^area <area> nssa translate type7 (.*)$/'

--- a/lib/cisco_node_utils/router_ospf_area.rb
+++ b/lib/cisco_node_utils/router_ospf_area.rb
@@ -92,6 +92,7 @@ module Cisco
        :default_cost,
        :filter_list_in,
        :filter_list_out,
+       :nssa_translate_type7,
        :range,
        :stub,
       ].each do |prop|
@@ -181,6 +182,31 @@ module Cisco
 
     def default_filter_list_out
       config_get_default('ospf_area', 'filter_list_out')
+    end
+
+    # CLI can be the following or none
+    # area 1.1.1.1 nssa translate type7 always
+    # area 1.1.1.1 nssa translate type7 always supress-fa
+    # area 1.1.1.1 nssa translate type7 never
+    # area 1.1.1.1 nssa translate type7 supress-fa
+    def nssa_translate_type7
+      str = config_get('ospf_area', 'nssa_translate_type7', @get_args)
+      str = 'always_supress_fa' if str == 'always supress-fa'
+      str = 'supress_fa' if str == 'supress-fa'
+      str
+    end
+
+    def nssa_translate_type7=(val)
+      state = val ? '' : 'no'
+      value = val ? val : ''
+      value = 'always supress-fa' if val.to_s == 'always_supress_fa'
+      value = 'supress-fa' if val.to_s == 'supress_fa'
+      set_args_keys(state: state, value: value)
+      config_set('ospf_area', 'nssa_translate_type7', @set_args)
+    end
+
+    def default_nssa_translate_type7
+      config_get_default('ospf_area', 'nssa_translate_type7')
     end
 
     # range can take multiple values for the same vrf

--- a/lib/cisco_node_utils/router_ospf_area.rb
+++ b/lib/cisco_node_utils/router_ospf_area.rb
@@ -136,8 +136,8 @@ module Cisco
     end
 
     def default_cost=(val)
-      state = val ? '' : 'no'
-      cost = val ? val : ''
+      state = val == default_default_cost ? 'no' : ''
+      cost = val == default_default_cost ? '' : val
       set_args_keys(state: state, cost: cost)
       config_set('ospf_area', 'default_cost', @set_args)
     end
@@ -185,11 +185,7 @@ module Cisco
         llist = []
         params = line.split
         llist[0] = params[0]
-        if line.include?('not-advertise')
-          llist[1] = true
-        else
-          llist[1] = false
-        end
+        line.include?('not-advertise') ? llist[1] = true : llist[1] = false
         if line.include?('cost')
           llist[2] = params[params.index('cost') + 1]
         else
@@ -215,18 +211,9 @@ module Cisco
         config_set('ospf_area', 'range', @set_args)
       end
       set_list.each do |ip, not_advertise, cval|
-        if not_advertise
-          na = 'not-advertise'
-        else
-          na = ''
-        end
-        if cval
-          cost = 'cost'
-          value = cval
-        else
-          cost = ''
-          value = ''
-        end
+        na = not_advertise ? 'not-advertise' : ''
+        cost = cval ? 'cost' : ''
+        value = cval ? cval : ''
         set_args_keys(state: '', ip: ip, not_advertise: na,
                       cost: cost, value: value)
         config_set('ospf_area', 'range', @set_args)
@@ -244,11 +231,13 @@ module Cisco
     end
 
     def stub=(val)
-      # we need to reset stub property first
-      state = 'no'
-      stu = ''
-      set_args_keys(state: state, stub: stu)
-      config_set('ospf_area', 'stub', @set_args)
+      if stub
+        # we need to reset stub property first
+        state = 'no'
+        stu = ''
+        set_args_keys(state: state, stub: stu)
+        config_set('ospf_area', 'stub', @set_args)
+      end
       return unless val # go further only if the val is not false
       state = ''
       stu = (val == 'no_summary') ? 'no-summary' : ''

--- a/lib/cisco_node_utils/router_ospf_area.rb
+++ b/lib/cisco_node_utils/router_ospf_area.rb
@@ -128,7 +128,7 @@ module Cisco
 
     def authentication=(val)
       state = val ? '' : 'no'
-      auth = (val == 'md5') ? 'message-digest' : ''
+      auth = (val.to_s == 'md5') ? 'message-digest' : ''
       set_args_keys(state: state, auth: auth)
       config_set('ospf_area', 'authentication', @set_args)
     end
@@ -277,7 +277,7 @@ module Cisco
       end
       return unless val # stop if the val is false
       state = ''
-      stu = (val == 'no_summary') ? 'no-summary' : ''
+      stu = (val.to_s == 'no_summary') ? 'no-summary' : ''
       set_args_keys(state: state, stub: stu)
       config_set('ospf_area', 'stub', @set_args)
     end

--- a/lib/cisco_node_utils/router_ospf_area.rb
+++ b/lib/cisco_node_utils/router_ospf_area.rb
@@ -296,12 +296,11 @@ module Cisco
       else
         @set_args[:default_information_originate] = ''
       end
-      if route_map
-        @set_args[:route_map] = 'route-map'
-        @set_args[:rm] = route_map
-      else
+      @set_args[:rm] = route_map
+      if route_map == default_nssa_route_map
         @set_args[:route_map] = ''
-        @set_args[:rm] = ''
+      else
+        @set_args[:route_map] = 'route-map'
       end
       config_set('ospf_area', 'nssa', @set_args)
     end

--- a/lib/cisco_node_utils/router_ospf_area.rb
+++ b/lib/cisco_node_utils/router_ospf_area.rb
@@ -115,6 +115,11 @@ module Cisco
       set_args_keys_default
     end
 
+    def ==(other)
+      (ospf_router == other.ospf_router) &&
+        (vrf_name == other.vrf_name) && (area_id == other.area_id)
+    end
+
     ########################################################
     #                      PROPERTIES                      #
     ########################################################

--- a/lib/cisco_node_utils/router_ospf_area.rb
+++ b/lib/cisco_node_utils/router_ospf_area.rb
@@ -1,0 +1,198 @@
+#
+# NXAPI implementation of Router OSPF Area class
+#
+# June 2016, Sai Chintalapudi
+#
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'node_util'
+require_relative 'ipaddr'
+require_relative 'router_ospf'
+require_relative 'router_ospf_vrf'
+
+module Cisco
+  # node_utils class for ospf_area
+  class RouterOspfArea < NodeUtil
+    attr_reader :router, :vrf, :area_id
+
+    def initialize(ospf_router, vrf_name, area_id, instantiate=true)
+      fail TypeError unless ospf_router.is_a?(String)
+      fail TypeError unless vrf_name.is_a?(String)
+      fail TypeError unless area_id.is_a?(String)
+      fail ArgumentError unless ospf_router.length > 0
+      fail ArgumentError unless vrf_name.length > 0
+      fail ArgumentError unless area_id.length > 0
+
+      # check the area_id is a proper ipv4 address
+      fail ArgumentError if (begin
+                               IPAddr.new(area_id)
+                             rescue
+                               nil
+                             end).nil?
+      fail ArgumentError unless IPAddr.new(area_id).ipv4?
+
+      @router = ospf_router
+      @vrf = vrf_name
+      @area_id = area_id
+
+      set_args_keys_default
+      create if instantiate
+    end
+
+    def self.areas
+      hash_final = {}
+      RouterOspf.routers.each do |instance|
+        name = instance[0]
+        area_ids = config_get('ospf_area', 'area', name: name)
+        unless area_ids.nil?
+          area_ids.uniq.each do |area|
+            hash_tmp[name]['default'][area] =
+              RouterOspfArea.new(name, vrf, area, false)
+          end
+        end
+        vrf_ids = config_get('ospf', 'vrf', name: name)
+        unless vrf_ids.nil?
+          vrf_ids.each do |vrf|
+            area_ids = config_get('ospf_area', 'area', name: name, vrf: vrf)
+            next if area_ids.nil?
+            area_ids.uniq.each do |area|
+              hash_tmp[name][vrf][area] =
+                RouterOspfArea.new(name, vrf, area, false)
+            end
+          end
+        end
+        hash_final.merge!(hash_tmp)
+      end
+      hash_final
+    end
+
+    # Helper method to delete @set_args hash keys
+    def set_args_keys_default
+      @set_args = { name: @router }
+      @set_args[:vrf] = @vrf unless @vrf == 'default'
+      @set_args[:area] = @area_id
+      @get_args = @set_args
+    end
+
+    # rubocop:disable Style/AccessorMethodName
+    def set_args_keys(hash={})
+      set_args_keys_default
+      @set_args = @get_args.merge!(hash) unless hash.empty?
+    end
+
+    def create
+      # create RouterOspfVrf only
+      # area_id is used at each config cli, not as a context
+      RouterOspfVrf.new(@router, @vrf)
+    end
+
+    def destroy
+      return unless Feature.ospf_enabled?
+      [:authentication,
+       :default_cost,
+       :filter_list_in,
+       :filter_list_out,
+       :range,
+       :stub,
+      ].each do |prop|
+        send("#{prop}=", send("default_#{prop}"))
+      end
+      set_args_keys_default
+    end
+
+    ########################################################
+    #                      PROPERTIES                      #
+    ########################################################
+
+    def authentication
+      auth = config_get('ospf_area', 'authentication', @get_args)
+      return auth unless auth
+      (auth == 'message-digest') ? 'md5' : 'clear_text'
+    end
+
+    def authentication=(val)
+      state = val ? '' : 'no'
+      auth = (val == 'md5') ? 'message-digest' : ''
+      set_args_keys(state: state, auth: auth)
+      config_set('ospf_area', 'authentication', @set_args)
+    end
+
+    def default_authentication
+      config_get_default('ospf_area', 'authentication')
+    end
+
+    def default_cost
+      config_get('ospf_area', 'default_cost', @get_args)
+    end
+
+    def default_cost=(val)
+      state = val ? '' : 'no'
+      cost = val ? val : ''
+      set_args_keys(state: state, cost: cost)
+      config_set('ospf_area', 'default_cost', @set_args)
+    end
+
+    def default_default_cost
+      config_get_default('ospf_area', 'default_cost')
+    end
+
+    def filter_list_in
+      config_get('ospf_area', 'filter_list_in', @get_args)
+    end
+
+    def filter_list_in=(val)
+      state = val ? '' : 'no'
+      rm = val ? val : ''
+      set_args_keys(state: state, route_map: rm)
+      config_set('ospf_area', 'filter_list_in', @set_args)
+    end
+
+    def default_filter_list_in
+      config_get_default('ospf_area', 'filter_list_in')
+    end
+
+    def filter_list_out
+      config_get('ospf_area', 'filter_list_out', @get_args)
+    end
+
+    def filter_list_out=(val)
+      state = val ? '' : 'no'
+      rm = val ? val : ''
+      set_args_keys(state: state, route_map: rm)
+      config_set('ospf_area', 'filter_list_out', @set_args)
+    end
+
+    def default_filter_list_out
+      config_get_default('ospf_area', 'filter_list_out')
+    end
+
+    def stub
+      stu = config_get('ospf_area', 'stub', @get_args)
+      return stu unless stu
+      (stu == 'no-summary') ? 'no_summary' : 'summary'
+    end
+
+    def stub=(val)
+      state = val ? '' : 'no'
+      stu = (val == 'no_summary') ? 'no-summary' : ''
+      set_args_keys(state: state, stub: stu)
+      config_set('ospf_area', 'stub', @set_args)
+    end
+
+    def default_stub
+      config_get_default('ospf_area', 'stub')
+    end
+  end # class
+end # module

--- a/lib/cisco_node_utils/router_ospf_area.rb
+++ b/lib/cisco_node_utils/router_ospf_area.rb
@@ -180,20 +180,20 @@ module Cisco
 
     def range
       list = []
-      get_list = config_get('ospf_area', 'range', @get_args)
-      get_list.each do |array|
+      ranges = config_get('ospf_area', 'range', @get_args)
+      ranges.each do |line|
         llist = []
-        llist[0] = array[0]
-        llist[1] = llist[2] = ''
-        if array.length == 2
-          if array[1] == 'not-advertise'
-            llist[1] = true
-          else
-            llist[2] = array[1]
-          end
-        elsif array.length == 3
+        params = line.split
+        llist[0] = params[0]
+        if line.include?('not-advertise')
           llist[1] = true
-          llist[2] = array[2]
+        else
+          llist[1] = false
+        end
+        if line.include?('cost')
+          llist[2] = params[params.index('cost') + 1]
+        else
+          llist[2] = false
         end
         list << llist
       end
@@ -201,6 +201,12 @@ module Cisco
     end
 
     def range=(set_list)
+      ip_list = []
+      set_list.each do |ip, _not_advertise, _cval|
+        ip_list << ip
+      end
+      fail ArgumentError, 'Duplicate ip values for range' unless
+        ip_list.size == ip_list.uniq.size
       cur_list = range
       # reset the current ranges first
       cur_list.each do |ip, _not_advertise, _cval|

--- a/lib/cisco_node_utils/router_ospf_area.rb
+++ b/lib/cisco_node_utils/router_ospf_area.rb
@@ -82,9 +82,8 @@ module Cisco
 
     # Helper method to delete @set_args hash keys
     def set_args_keys_default
-      @set_args = { name: @router }
+      @set_args = { name: @router, area: @area_id }
       @set_args[:vrf] = @vrf unless @vrf == 'default'
-      @set_args[:area] = @area_id
       @get_args = @set_args
     end
 

--- a/lib/cisco_node_utils/router_ospf_area.rb
+++ b/lib/cisco_node_utils/router_ospf_area.rb
@@ -178,6 +178,59 @@ module Cisco
       config_get_default('ospf_area', 'filter_list_out')
     end
 
+    def range
+      list = []
+      get_list = config_get('ospf_area', 'range', @get_args)
+      get_list.each do |array|
+        llist = []
+        llist[0] = array[0]
+        llist[1] = llist[2] = ''
+        if array.length == 2
+          if array[1] == 'not-advertise'
+            llist[1] = true
+          else
+            llist[2] = array[1]
+          end
+        elsif array.length == 3
+          llist[1] = true
+          llist[2] = array[2]
+        end
+        list << llist
+      end
+      list
+    end
+
+    def range=(set_list)
+      cur_list = range
+      # reset the current ranges first
+      cur_list.each do |ip, _not_advertise, _cval|
+        set_args_keys(state: 'no', ip: ip, not_advertise: '',
+                      cost: '', value: '')
+        config_set('ospf_area', 'range', @set_args)
+      end
+      set_list.each do |ip, not_advertise, cval|
+        if not_advertise
+          na = 'not-advertise'
+        else
+          na = ''
+        end
+        if cval
+          cost = 'cost'
+          value = cval
+        else
+          cost = ''
+          value = ''
+        end
+        set_args_keys(state: '', ip: ip, not_advertise: na,
+                      cost: cost, value: value)
+        config_set('ospf_area', 'range', @set_args)
+      end
+    end
+
+    def default_range
+      config_get_default('ospf_area', 'range')
+    end
+
     def stub
       stu = config_get('ospf_area', 'stub', @get_args)
       return stu unless stu

--- a/lib/cisco_node_utils/router_ospf_area.rb
+++ b/lib/cisco_node_utils/router_ospf_area.rb
@@ -192,6 +192,7 @@ module Cisco
     # the above command can be appended with no-summary and/or
     # no-redistribution and/or default-information-originate.
     # route-map <map> can be appended with default-information-originate
+    # Basically, every property this CLI configures is optional
     def nssa
       hash = {}
       output = config_get('ospf_area', 'nssa', @get_args)

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -29,7 +29,7 @@ class TestRouterOspfArea < CiscoTestCase
   end
 
   def teardown
-    # remove_all_ospfs
+    remove_all_ospfs
     super
   end
 
@@ -125,10 +125,25 @@ class TestRouterOspfArea < CiscoTestCase
     ad = create_routerospfarea_default
     assert_equal(ad.default_range, ad.range)
     ranges = [['10.3.0.0/16', true, '23'], ['10.3.0.0/32', true, false],
-              ['10.3.0.1/32', false, false], ['10.3.3.0/24', false, 450]]
+              ['10.3.0.1/32', false, false], ['10.3.3.0/24', false, '450']]
+    ad.range = ranges
+    assert_equal(ranges, ad.range)
+    ranges = [['10.3.0.0/16', true, '23'], ['10.3.3.0/24', false, '450']]
     ad.range = ranges
     assert_equal(ranges, ad.range)
     ad.range = ad.default_range
     assert_equal(ad.default_range, ad.range)
+    av = create_routerospfarea_vrf
+    assert_equal(av.default_range, av.range)
+    ranges = [['10.3.0.0/16', false, '8000'], ['10.3.0.0/32', true, false],
+              ['10.3.0.1/32', false, false], ['10.3.3.0/24', true, '10212']]
+    av.range = ranges
+    assert_equal(ranges, av.range)
+    ranges = [['10.3.0.0/16', false, '4989'], ['10.3.1.1/32', false, false],
+              ['10.3.3.0/24', true, '76376']]
+    av.range = ranges
+    assert_equal(ranges, av.range)
+    av.range = av.default_range
+    assert_equal(av.default_range, av.range)
   end
 end

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -1,0 +1,123 @@
+# Copyright (c) 2016 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/router_ospf'
+require_relative '../lib/cisco_node_utils/router_ospf_vrf'
+require_relative '../lib/cisco_node_utils/router_ospf_area'
+
+# TestRouterOspfArea - Minitest for RouterOspfArea node utility class
+class TestRouterOspfArea < CiscoTestCase
+  @skip_unless_supported = 'ospf_area'
+  @@pre_clean_needed = true # rubocop:disable Style/ClassVars
+
+  def setup
+    super
+    remove_all_ospfs if @@pre_clean_needed
+    @@pre_clean_needed = false # rubocop:disable Style/ClassVars
+  end
+
+  def teardown
+    remove_all_ospfs
+    super
+  end
+
+  def create_routerospfarea_default(router='Wolfpack', name='default',
+                                    area_id='1.1.1.1')
+    RouterOspfArea.new(router, name, area_id)
+  end
+
+  def create_routerospfarea_vrf(router='Wolfpack', name='blue',
+                                area_id='1.1.1.1')
+    RouterOspfArea.new(router, name, area_id)
+  end
+
+  def test_authentication
+    ad = create_routerospfarea_default
+    assert_equal(ad.default_authentication, ad.authentication)
+    ad.authentication = 'md5'
+    assert_equal('md5', ad.authentication)
+    ad.authentication = 'clear_text'
+    assert_equal('clear_text', ad.authentication)
+    ad.authentication = ad.default_authentication
+    assert_equal(ad.default_authentication, ad.authentication)
+    av = create_routerospfarea_vrf
+    assert_equal(av.default_authentication, av.authentication)
+    av.authentication = 'md5'
+    assert_equal('md5', av.authentication)
+    av.authentication = 'clear_text'
+    assert_equal('clear_text', av.authentication)
+    av.authentication = av.default_authentication
+    assert_equal(av.default_authentication, av.authentication)
+  end
+
+  def test_default_cost
+    ad = create_routerospfarea_default
+    assert_equal(ad.default_default_cost, ad.default_cost)
+    ad.default_cost = 2000
+    assert_equal(2000, ad.default_cost)
+    ad.default_cost = ad.default_default_cost
+    assert_equal(ad.default_default_cost, ad.default_cost)
+    av = create_routerospfarea_vrf
+    assert_equal(av.default_default_cost, av.default_cost)
+    av.default_cost = 10_000
+    assert_equal(10_000, av.default_cost)
+    av.default_cost = av.default_default_cost
+    assert_equal(av.default_default_cost, av.default_cost)
+  end
+
+  def test_filter_list
+    ad = create_routerospfarea_default
+    assert_equal(ad.default_filter_list_in, ad.filter_list_in)
+    assert_equal(ad.default_filter_list_out, ad.filter_list_out)
+    ad.filter_list_in = 'abc'
+    assert_equal('abc', ad.filter_list_in)
+    ad.filter_list_out = 'efg'
+    assert_equal('efg', ad.filter_list_out)
+    ad.filter_list_in = ad.default_filter_list_in
+    assert_equal(ad.default_filter_list_in, ad.filter_list_in)
+    ad.filter_list_out = ad.default_filter_list_out
+    assert_equal(ad.default_filter_list_out, ad.filter_list_out)
+    av = create_routerospfarea_vrf
+    assert_equal(av.default_filter_list_in, av.filter_list_in)
+    assert_equal(av.default_filter_list_out, av.filter_list_out)
+    av.filter_list_in = 'uvw'
+    assert_equal('uvw', av.filter_list_in)
+    av.filter_list_out = 'xyz'
+    assert_equal('xyz', av.filter_list_out)
+    av.filter_list_in = av.default_filter_list_in
+    assert_equal(av.default_filter_list_in, av.filter_list_in)
+    av.filter_list_out = av.default_filter_list_out
+    assert_equal(av.default_filter_list_out, av.filter_list_out)
+  end
+
+  def test_stub
+    ad = create_routerospfarea_default
+    assert_equal(ad.default_stub, ad.stub)
+    ad.stub = 'no_summary'
+    assert_equal('no_summary', ad.stub)
+    ad.stub = 'summary'
+    assert_equal('summary', ad.stub)
+    ad.stub = ad.default_stub
+    assert_equal(ad.default_stub, ad.stub)
+    av = create_routerospfarea_vrf
+    assert_equal(av.default_stub, av.stub)
+    av.stub = 'no_summary'
+    assert_equal('no_summary', av.stub)
+    av.stub = 'summary'
+    assert_equal('summary', av.stub)
+    av.stub = av.default_stub
+    assert_equal(av.default_stub, av.stub)
+  end
+end

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -189,6 +189,232 @@ class TestRouterOspfArea < CiscoTestCase
     assert_equal(av.default_range, av.range)
   end
 
+  def test_nssa
+    ad = create_routerospfarea_default
+    assert_equal(ad.default_nssa_enable, ad.nssa_enable)
+    ad.nssa_set(true, ad.default_nssa_def_info_originate,
+                ad.default_nssa_no_redistribution,
+                ad.default_nssa_no_summary,
+                ad.default_nssa_route_map)
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
+    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
+    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+
+    ad.nssa_set(ad.default_nssa_enable,
+                ad.default_nssa_def_info_originate,
+                ad.default_nssa_no_redistribution,
+                ad.default_nssa_no_summary,
+                ad.default_nssa_route_map)
+    assert_equal(ad.default_nssa_enable, ad.nssa_enable)
+    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
+    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
+    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+
+    av = create_routerospfarea_vrf
+    assert_equal(av.default_nssa_enable, av.nssa_enable)
+    av.nssa_set(true, av.default_nssa_def_info_originate,
+                av.default_nssa_no_redistribution,
+                av.default_nssa_no_summary,
+                av.default_nssa_route_map)
+    assert_equal(true, av.nssa_enable)
+    assert_equal(av.default_nssa_def_info_originate, av.nssa_def_info_originate)
+    assert_equal(av.default_nssa_no_redistribution, av.nssa_no_redistribution)
+    assert_equal(av.default_nssa_no_summary, av.nssa_no_summary)
+    assert_equal(av.default_nssa_route_map, av.nssa_route_map)
+
+    av.nssa_set(av.default_nssa_enable,
+                av.default_nssa_def_info_originate,
+                av.default_nssa_no_redistribution,
+                av.default_nssa_no_summary,
+                av.default_nssa_route_map)
+    assert_equal(av.default_nssa_enable, av.nssa_enable)
+    assert_equal(av.default_nssa_def_info_originate, av.nssa_def_info_originate)
+    assert_equal(av.default_nssa_no_redistribution, av.nssa_no_redistribution)
+    assert_equal(av.default_nssa_no_summary, av.nssa_no_summary)
+    assert_equal(av.default_nssa_route_map, av.nssa_route_map)
+  end
+
+  def test_nssa_default_vrf_others
+    ad = create_routerospfarea_default
+    ad.nssa_set(true, true,
+                ad.default_nssa_no_redistribution,
+                ad.default_nssa_no_summary,
+                ad.default_nssa_route_map)
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
+    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+
+    ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
+                ad.default_nssa_no_summary, 'aaa')
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
+    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
+    assert_equal('aaa', ad.nssa_route_map)
+
+    ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
+                true, ad.default_nssa_route_map)
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
+    assert_equal(true, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+
+    ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
+                true, 'aaa')
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
+    assert_equal(true, ad.nssa_no_summary)
+    assert_equal('aaa', ad.nssa_route_map)
+
+    ad.nssa_set(true, true, true,
+                ad.default_nssa_no_summary,
+                ad.default_nssa_route_map)
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(true, ad.nssa_no_redistribution)
+    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+
+    ad.nssa_set(true, true, true,
+                ad.default_nssa_no_summary,
+                'aaa')
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(true, ad.nssa_no_redistribution)
+    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
+    assert_equal('aaa', ad.nssa_route_map)
+
+    ad.nssa_set(true, true, true, true, 'aaa')
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(true, ad.nssa_no_redistribution)
+    assert_equal(true, ad.nssa_no_summary)
+    assert_equal('aaa', ad.nssa_route_map)
+
+    ad.nssa_set(true, ad.default_nssa_def_info_originate,
+                true, true,
+                ad.default_nssa_route_map)
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
+    assert_equal(true, ad.nssa_no_redistribution)
+    assert_equal(true, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+
+    ad.nssa_set(true, ad.default_nssa_def_info_originate,
+                true, ad.default_nssa_no_summary,
+                ad.default_nssa_route_map)
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
+    assert_equal(true, ad.nssa_no_redistribution)
+    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+
+    ad.nssa_set(true, ad.default_nssa_def_info_originate,
+                ad.default_nssa_no_redistribution, true,
+                ad.default_nssa_route_map)
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
+    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
+    assert_equal(true, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+  end
+
+  def test_nssa_non_default_vrf_others
+    ad = create_routerospfarea_vrf
+    ad.nssa_set(true, true,
+                ad.default_nssa_no_redistribution,
+                ad.default_nssa_no_summary,
+                ad.default_nssa_route_map)
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
+    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+
+    ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
+                ad.default_nssa_no_summary, 'aaa')
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
+    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
+    assert_equal('aaa', ad.nssa_route_map)
+
+    ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
+                true, ad.default_nssa_route_map)
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
+    assert_equal(true, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+
+    ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
+                true, 'aaa')
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
+    assert_equal(true, ad.nssa_no_summary)
+    assert_equal('aaa', ad.nssa_route_map)
+
+    ad.nssa_set(true, true, true,
+                ad.default_nssa_no_summary,
+                ad.default_nssa_route_map)
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(true, ad.nssa_no_redistribution)
+    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+
+    ad.nssa_set(true, true, true,
+                ad.default_nssa_no_summary,
+                'aaa')
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(true, ad.nssa_no_redistribution)
+    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
+    assert_equal('aaa', ad.nssa_route_map)
+
+    ad.nssa_set(true, true, true, true, 'aaa')
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(true, ad.nssa_no_redistribution)
+    assert_equal(true, ad.nssa_no_summary)
+    assert_equal('aaa', ad.nssa_route_map)
+
+    ad.nssa_set(true, ad.default_nssa_def_info_originate,
+                true, true,
+                ad.default_nssa_route_map)
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
+    assert_equal(true, ad.nssa_no_redistribution)
+    assert_equal(true, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+
+    ad.nssa_set(true, ad.default_nssa_def_info_originate,
+                true, ad.default_nssa_no_summary,
+                ad.default_nssa_route_map)
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
+    assert_equal(true, ad.nssa_no_redistribution)
+    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+
+    ad.nssa_set(true, ad.default_nssa_def_info_originate,
+                ad.default_nssa_no_redistribution, true,
+                ad.default_nssa_route_map)
+    assert_equal(true, ad.nssa_enable)
+    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
+    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
+    assert_equal(true, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+  end
+
   def test_nssa_translate_type7
     ad = create_routerospfarea_default
     assert_equal(ad.default_nssa_translate_type7, ad.nssa_translate_type7)
@@ -235,6 +461,10 @@ class TestRouterOspfArea < CiscoTestCase
               ['10.3.0.0/32', 'not_advertise'],
               ['10.3.0.1/32'],
               ['10.3.3.0/24', '450']]
+    ad.nssa_set(true, ad.default_nssa_def_info_originate,
+                ad.default_nssa_no_redistribution,
+                ad.default_nssa_no_summary,
+                ad.default_nssa_route_map)
     ad.nssa_translate_type7 = 'never'
     ad.range = ranges
     ad.stub = true

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -189,6 +189,29 @@ class TestRouterOspfArea < CiscoTestCase
     assert_equal(av.default_range, av.range)
   end
 
+  def test_nssa_translate_type7
+    ad = create_routerospfarea_default
+    assert_equal(ad.default_nssa_translate_type7, ad.nssa_translate_type7)
+    ad.nssa_translate_type7 = 'never'
+    assert_equal('never', ad.nssa_translate_type7)
+    ad.nssa_translate_type7 = 'supress_fa'
+    assert_equal('supress_fa', ad.nssa_translate_type7)
+    ad.nssa_translate_type7 = 'always_supress_fa'
+    assert_equal('always_supress_fa', ad.nssa_translate_type7)
+    ad.nssa_translate_type7 = ad.default_nssa_translate_type7
+    assert_equal(ad.default_nssa_translate_type7, ad.nssa_translate_type7)
+    av = create_routerospfarea_vrf
+    assert_equal(av.default_nssa_translate_type7, av.nssa_translate_type7)
+    av.nssa_translate_type7 = 'never'
+    assert_equal('never', av.nssa_translate_type7)
+    av.nssa_translate_type7 = 'supress_fa'
+    assert_equal('supress_fa', av.nssa_translate_type7)
+    av.nssa_translate_type7 = 'always_supress_fa'
+    assert_equal('always_supress_fa', av.nssa_translate_type7)
+    av.nssa_translate_type7 = av.default_nssa_translate_type7
+    assert_equal(av.default_nssa_translate_type7, av.nssa_translate_type7)
+  end
+
   def test_destroy
     ad = create_routerospfarea_default
     # destroy without changing any properties
@@ -198,6 +221,7 @@ class TestRouterOspfArea < CiscoTestCase
      :filter_list_in,
      :filter_list_out,
      :range,
+     :nssa_translate_type7,
      :stub,
      :stub_no_summary,
     ].each do |prop|
@@ -211,6 +235,7 @@ class TestRouterOspfArea < CiscoTestCase
               ['10.3.0.0/32', 'not_advertise'],
               ['10.3.0.1/32'],
               ['10.3.3.0/24', '450']]
+    ad.nssa_translate_type7 = 'never'
     ad.range = ranges
     ad.stub = true
     ad.stub_no_summary = true
@@ -221,6 +246,7 @@ class TestRouterOspfArea < CiscoTestCase
      :filter_list_in,
      :filter_list_out,
      :range,
+     :nssa_translate_type7,
      :stub,
      :stub_no_summary,
     ].each do |prop|

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -57,7 +57,7 @@ class TestRouterOspfArea < CiscoTestCase
     # unless the entire ospf router is removed. The default value of
     # default_cost is 1 and so this is just a cosmetic issue but
     # need to skip the below test as the size will be wrong.
-    # platform as the size will be wrong.
+    # platform as the size will be wrong. bug ID: CSCva04066
     assert_equal(1, RouterOspfArea.areas['Wolfpack'].size) unless
       /N8/ =~ node.product_id
     ad.destroy

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -423,6 +423,8 @@ class TestRouterOspfArea < CiscoTestCase
     assert_equal('supress_fa', ad.nssa_translate_type7)
     ad.nssa_translate_type7 = 'always_supress_fa'
     assert_equal('always_supress_fa', ad.nssa_translate_type7)
+    ad.nssa_translate_type7 = 'always'
+    assert_equal('always', ad.nssa_translate_type7)
     ad.nssa_translate_type7 = ad.default_nssa_translate_type7
     assert_equal(ad.default_nssa_translate_type7, ad.nssa_translate_type7)
     av = create_routerospfarea_vrf
@@ -433,6 +435,8 @@ class TestRouterOspfArea < CiscoTestCase
     assert_equal('supress_fa', av.nssa_translate_type7)
     av.nssa_translate_type7 = 'always_supress_fa'
     assert_equal('always_supress_fa', av.nssa_translate_type7)
+    av.nssa_translate_type7 = 'always'
+    assert_equal('always', av.nssa_translate_type7)
     av.nssa_translate_type7 = av.default_nssa_translate_type7
     assert_equal(av.default_nssa_translate_type7, av.nssa_translate_type7)
   end
@@ -460,10 +464,7 @@ class TestRouterOspfArea < CiscoTestCase
               ['10.3.0.0/32', 'not_advertise'],
               ['10.3.0.1/32'],
               ['10.3.3.0/24', '450']]
-    ad.nssa_set(true, ad.default_nssa_def_info_originate,
-                ad.default_nssa_no_redistribution,
-                ad.default_nssa_no_summary,
-                ad.default_nssa_route_map)
+    ad.nssa_set(true, true, true, true, 'aaa')
     ad.nssa_translate_type7 = 'never'
     ad.range = ranges
     ad.stub = true
@@ -475,6 +476,11 @@ class TestRouterOspfArea < CiscoTestCase
      :filter_list_in,
      :filter_list_out,
      :range,
+     :nssa_def_info_originate,
+     :nssa_enable,
+     :nssa_no_redistribution,
+     :nssa_no_summary,
+     :nssa_route_map,
      :nssa_translate_type7,
      :stub,
      :stub_no_summary,

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -52,7 +52,7 @@ class TestRouterOspfArea < CiscoTestCase
     av.stub = true
     assert_equal(2, RouterOspfArea.areas['Wolfpack'].size)
     av.destroy
-    # on n8k (only) , we cannot remove "area <area> default-cost 1",
+    # on n8k (only), we cannot remove "area <area> default-cost 1",
     # unless the entire ospf router is removed. The default value of
     # default_cost is 1 and so this is just a cosmetic issue but
     # need to skip the below test as the size will be wrong.
@@ -238,12 +238,17 @@ class TestRouterOspfArea < CiscoTestCase
 
   def test_nssa_default_vrf_others
     ad = create_routerospfarea_default
+    # on n8k (only), we cannot configure
+    # "area <area> nssa default-information-originate",
+    # properly if we reset it first. It is only configuring nssa
+    # but not the other parameters. bug ID: CSCva11482
     ad.nssa_set(true, true,
                 ad.default_nssa_no_redistribution,
                 ad.default_nssa_no_summary,
                 ad.default_nssa_route_map)
     assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(true, ad.nssa_def_info_originate) unless
+      /N8/ =~ node.product_id
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
     assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
@@ -251,10 +256,12 @@ class TestRouterOspfArea < CiscoTestCase
     ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
                 ad.default_nssa_no_summary, 'aaa')
     assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(true, ad.nssa_def_info_originate) unless
+      /N8/ =~ node.product_id
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
-    assert_equal('aaa', ad.nssa_route_map)
+    assert_equal('aaa', ad.nssa_route_map) unless
+      /N8/ =~ node.product_id
 
     ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
                 true, ad.default_nssa_route_map)
@@ -327,12 +334,17 @@ class TestRouterOspfArea < CiscoTestCase
 
   def test_nssa_non_default_vrf_others
     ad = create_routerospfarea_vrf
+    # on n8k (only), we cannot configure
+    # "area <area> nssa default-information-originate",
+    # properly if we reset it first. It is only configuring nssa
+    # but not the other parameters. bug ID: CSCva11482
     ad.nssa_set(true, true,
                 ad.default_nssa_no_redistribution,
                 ad.default_nssa_no_summary,
                 ad.default_nssa_route_map)
     assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(true, ad.nssa_def_info_originate) unless
+      /N8/ =~ node.product_id
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
     assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
@@ -340,10 +352,12 @@ class TestRouterOspfArea < CiscoTestCase
     ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
                 ad.default_nssa_no_summary, 'aaa')
     assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate)
+    assert_equal(true, ad.nssa_def_info_originate) unless
+      /N8/ =~ node.product_id
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
-    assert_equal('aaa', ad.nssa_route_map)
+    assert_equal('aaa', ad.nssa_route_map) unless
+      /N8/ =~ node.product_id
 
     ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
                 true, ad.default_nssa_route_map)
@@ -450,6 +464,11 @@ class TestRouterOspfArea < CiscoTestCase
      :filter_list_in,
      :filter_list_out,
      :range,
+     :nssa_def_info_originate,
+     :nssa_enable,
+     :nssa_no_redistribution,
+     :nssa_no_summary,
+     :nssa_route_map,
      :nssa_translate_type7,
      :stub,
      :stub_no_summary,

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -124,23 +124,29 @@ class TestRouterOspfArea < CiscoTestCase
   def test_range
     ad = create_routerospfarea_default
     assert_equal(ad.default_range, ad.range)
-    ranges = [['10.3.0.0/16', true, '23'], ['10.3.0.0/32', true, false],
-              ['10.3.0.1/32', false, false], ['10.3.3.0/24', false, '450']]
+    ranges = [['10.3.0.0/16', 'not_advertise', '23'],
+              ['10.3.0.0/32', 'not_advertise'],
+              ['10.3.0.1/32'],
+              ['10.3.3.0/24', '450']]
     ad.range = ranges
     assert_equal(ranges, ad.range)
-    ranges = [['10.3.0.0/16', true, '23'], ['10.3.3.0/24', false, '450']]
+    ranges = [['10.3.0.0/16', 'not_advertise', '23'],
+              ['10.3.3.0/24', '450']]
     ad.range = ranges
     assert_equal(ranges, ad.range)
     ad.range = ad.default_range
     assert_equal(ad.default_range, ad.range)
     av = create_routerospfarea_vrf
     assert_equal(av.default_range, av.range)
-    ranges = [['10.3.0.0/16', false, '8000'], ['10.3.0.0/32', true, false],
-              ['10.3.0.1/32', false, false], ['10.3.3.0/24', true, '10212']]
+    ranges = [['10.3.0.0/16', '8000'],
+              ['10.3.0.0/32', 'not_advertise'],
+              ['10.3.0.1/32'],
+              ['10.3.3.0/24', 'not_advertise', '10212']]
     av.range = ranges
     assert_equal(ranges, av.range)
-    ranges = [['10.3.0.0/16', false, '4989'], ['10.3.1.1/32', false, false],
-              ['10.3.3.0/24', true, '76376']]
+    ranges = [['10.3.0.0/16', '4989'],
+              ['10.3.1.1/32'],
+              ['10.3.3.0/24', 'not_advertise', '76376']]
     av.range = ranges
     assert_equal(ranges, av.range)
     av.range = av.default_range
@@ -149,15 +155,28 @@ class TestRouterOspfArea < CiscoTestCase
 
   def test_destroy
     ad = create_routerospfarea_default
+    # destroy without changing any properties
+    ad.destroy
+    [:authentication,
+     :default_cost,
+     :filter_list_in,
+     :filter_list_out,
+     :range,
+     :stub,
+    ].each do |prop|
+      assert_equal(ad.send("default_#{prop}"), ad.send("#{prop}"))
+    end
     ad.authentication = 'md5'
     ad.default_cost = 2000
     ad.filter_list_in = 'abc'
     ad.filter_list_out = 'efg'
-    ranges = [['10.3.0.0/16', true, '23'], ['10.3.0.0/32', true, false],
-              ['10.3.0.1/32', false, false], ['10.3.3.0/24', false, '450']]
+    ranges = [['10.3.0.0/16', 'not_advertise', '23'],
+              ['10.3.0.0/32', 'not_advertise'],
+              ['10.3.0.1/32'],
+              ['10.3.3.0/24', '450']]
     ad.range = ranges
     ad.stub = 'no_summary'
-    # destroy
+    # destroy after changing properties
     ad.destroy
     [:authentication,
      :default_cost,

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -29,7 +29,7 @@ class TestRouterOspfArea < CiscoTestCase
   end
 
   def teardown
-    remove_all_ospfs
+    # remove_all_ospfs
     super
   end
 
@@ -119,5 +119,16 @@ class TestRouterOspfArea < CiscoTestCase
     assert_equal('summary', av.stub)
     av.stub = av.default_stub
     assert_equal(av.default_stub, av.stub)
+  end
+
+  def test_range
+    ad = create_routerospfarea_default
+    assert_equal(ad.default_range, ad.range)
+    ranges = [['10.3.0.0/16', true, '23'], ['10.3.0.0/32', true, false],
+              ['10.3.0.1/32', false, false], ['10.3.3.0/24', false, 450]]
+    ad.range = ranges
+    assert_equal(ranges, ad.range)
+    ad.range = ad.default_range
+    assert_equal(ad.default_range, ad.range)
   end
 end

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -189,243 +189,171 @@ class TestRouterOspfArea < CiscoTestCase
   end
 
   def test_nssa
+    hash = {}
     ad = create_routerospfarea_default
-    assert_equal(ad.default_nssa_enable, ad.nssa_enable)
-    ad.nssa_set(true, ad.default_nssa_def_info_originate,
-                ad.default_nssa_no_redistribution,
-                ad.default_nssa_no_summary,
-                ad.default_nssa_route_map)
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
+    assert_equal(ad.default_nssa, ad.nssa)
+    hash[:nssa] = true
+    hash[:no_summary] = ''
+    hash[:no_redistribution] = ''
+    hash[:default_information_originate] = ''
+    hash[:route_map] = ''
+    hash[:rm] = ''
+    ad.nssa_set(hash)
+    assert_equal(true, ad.nssa)
+    assert_equal(ad.default_nssa_default_originate, ad.nssa_default_originate)
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
     assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
 
-    ad.nssa_set(ad.default_nssa_enable,
-                ad.default_nssa_def_info_originate,
-                ad.default_nssa_no_redistribution,
-                ad.default_nssa_no_summary,
-                ad.default_nssa_route_map)
-    assert_equal(ad.default_nssa_enable, ad.nssa_enable)
-    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
+    hash = {}
+    ad.nssa_set(hash)
+    assert_equal(ad.default_nssa, ad.nssa)
+    assert_equal(ad.default_nssa_default_originate, ad.nssa_default_originate)
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
     assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
 
     av = create_routerospfarea_vrf
-    assert_equal(av.default_nssa_enable, av.nssa_enable)
-    av.nssa_set(true, av.default_nssa_def_info_originate,
-                av.default_nssa_no_redistribution,
-                av.default_nssa_no_summary,
-                av.default_nssa_route_map)
-    assert_equal(true, av.nssa_enable)
-    assert_equal(av.default_nssa_def_info_originate, av.nssa_def_info_originate)
+    assert_equal(av.default_nssa, av.nssa)
+    hash[:nssa] = true
+    hash[:no_summary] = ''
+    hash[:no_redistribution] = ''
+    hash[:default_information_originate] = ''
+    hash[:route_map] = ''
+    hash[:rm] = ''
+    av.nssa_set(hash)
+    assert_equal(true, av.nssa)
+    assert_equal(av.default_nssa_default_originate, av.nssa_default_originate)
     assert_equal(av.default_nssa_no_redistribution, av.nssa_no_redistribution)
     assert_equal(av.default_nssa_no_summary, av.nssa_no_summary)
     assert_equal(av.default_nssa_route_map, av.nssa_route_map)
 
-    av.nssa_set(av.default_nssa_enable,
-                av.default_nssa_def_info_originate,
-                av.default_nssa_no_redistribution,
-                av.default_nssa_no_summary,
-                av.default_nssa_route_map)
-    assert_equal(av.default_nssa_enable, av.nssa_enable)
-    assert_equal(av.default_nssa_def_info_originate, av.nssa_def_info_originate)
+    hash = {}
+    av.nssa_set(hash)
+    assert_equal(av.default_nssa, av.nssa)
+    assert_equal(av.default_nssa_default_originate, av.nssa_default_originate)
     assert_equal(av.default_nssa_no_redistribution, av.nssa_no_redistribution)
     assert_equal(av.default_nssa_no_summary, av.nssa_no_summary)
     assert_equal(av.default_nssa_route_map, av.nssa_route_map)
   end
 
-  def test_nssa_default_vrf_others
-    ad = create_routerospfarea_default
+  def nssa_helper(ad)
+    hash = {}
+    hash[:nssa] = true
+    hash[:no_summary] = ''
+    hash[:no_redistribution] = ''
+    hash[:route_map] = ''
+    hash[:rm] = ''
+    hash[:default_information_originate] = 'default-information-originate'
+    ad.nssa_set(hash)
+    assert_equal(true, ad.nssa)
+    assert(ad.nssa_default_originate)
+    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
+    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+
     # on n8k (only), we cannot configure
     # "area <area> nssa default-information-originate",
     # properly if we reset it first. It is only configuring nssa
     # but not the other parameters. bug ID: CSCva11482
-    ad.nssa_set(true, true,
-                ad.default_nssa_no_redistribution,
-                ad.default_nssa_no_summary,
-                ad.default_nssa_route_map)
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate) unless
-      /N8/ =~ node.product_id
+    hash[:route_map] = 'route-map'
+    hash[:rm] = 'aaa'
+    ad.nssa_set(hash)
+    assert_equal(true, ad.nssa)
+    if node.product_id[/N8/]
+      refute(ad.nssa_default_originate)
+    else
+      assert(ad.nssa_default_originate)
+    end
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
-    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+    if node.product_id[/N8/]
+      refute_equal('aaa', ad.nssa_route_map)
+    else
+      assert_equal('aaa', ad.nssa_route_map)
+    end
 
-    ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
-                ad.default_nssa_no_summary, 'aaa')
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate) unless
-      /N8/ =~ node.product_id
-    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
-    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
-    assert_equal('aaa', ad.nssa_route_map) unless
-      /N8/ =~ node.product_id
-
-    ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
-                true, ad.default_nssa_route_map)
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate)
+    hash[:no_summary] = 'no-summary'
+    hash[:route_map] = ''
+    hash[:rm] = ''
+    ad.nssa_set(hash)
+    assert_equal(true, ad.nssa)
+    assert_equal(true, ad.nssa_default_originate)
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
     assert_equal(true, ad.nssa_no_summary)
     assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
 
-    ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
-                true, 'aaa')
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate)
+    hash[:route_map] = 'route-map'
+    hash[:rm] = 'aaa'
+    ad.nssa_set(hash)
+    assert_equal(true, ad.nssa)
+    assert_equal(true, ad.nssa_default_originate)
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
-    assert_equal(true, ad.nssa_no_summary)
-    assert_equal('aaa', ad.nssa_route_map)
-
-    ad.nssa_set(true, true, true,
-                ad.default_nssa_no_summary,
-                ad.default_nssa_route_map)
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate)
-    assert_equal(true, ad.nssa_no_redistribution)
-    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
-    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
-
-    ad.nssa_set(true, true, true,
-                ad.default_nssa_no_summary,
-                'aaa')
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate)
-    assert_equal(true, ad.nssa_no_redistribution)
-    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
-    assert_equal('aaa', ad.nssa_route_map)
-
-    ad.nssa_set(true, true, true, true, 'aaa')
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate)
-    assert_equal(true, ad.nssa_no_redistribution)
     assert_equal(true, ad.nssa_no_summary)
     assert_equal('aaa', ad.nssa_route_map)
 
-    ad.nssa_set(true, ad.default_nssa_def_info_originate,
-                true, true,
-                ad.default_nssa_route_map)
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
-    assert_equal(true, ad.nssa_no_redistribution)
-    assert_equal(true, ad.nssa_no_summary)
-    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
-
-    ad.nssa_set(true, ad.default_nssa_def_info_originate,
-                true, ad.default_nssa_no_summary,
-                ad.default_nssa_route_map)
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
+    hash[:no_redistribution] = 'no-redistribution'
+    hash[:route_map] = ''
+    hash[:rm] = ''
+    hash[:no_summary] = ''
+    ad.nssa_set(hash)
+    assert_equal(true, ad.nssa)
+    assert_equal(true, ad.nssa_default_originate)
     assert_equal(true, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
     assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
 
-    ad.nssa_set(true, ad.default_nssa_def_info_originate,
-                ad.default_nssa_no_redistribution, true,
-                ad.default_nssa_route_map)
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
+    hash[:route_map] = 'route-map'
+    hash[:rm] = 'aaa'
+    ad.nssa_set(hash)
+    assert_equal(true, ad.nssa)
+    assert_equal(true, ad.nssa_default_originate)
+    assert_equal(true, ad.nssa_no_redistribution)
+    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
+    assert_equal('aaa', ad.nssa_route_map)
+
+    hash[:no_summary] = 'no-summary'
+    ad.nssa_set(hash)
+    assert_equal(true, ad.nssa)
+    assert_equal(true, ad.nssa_default_originate)
+    assert_equal(true, ad.nssa_no_redistribution)
+    assert_equal(true, ad.nssa_no_summary)
+    assert_equal('aaa', ad.nssa_route_map)
+
+    hash[:route_map] = ''
+    hash[:rm] = ''
+    hash[:default_information_originate] = ''
+    ad.nssa_set(hash)
+    assert_equal(true, ad.nssa)
+    assert_equal(ad.default_nssa_default_originate, ad.nssa_default_originate)
+    assert_equal(true, ad.nssa_no_redistribution)
+    assert_equal(true, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+
+    hash[:no_summary] = ''
+    ad.nssa_set(hash)
+    assert_equal(true, ad.nssa)
+    assert_equal(ad.default_nssa_default_originate, ad.nssa_default_originate)
+    assert_equal(true, ad.nssa_no_redistribution)
+    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
+    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+
+    hash[:no_summary] = 'no-summary'
+    hash[:no_redistribution] = ''
+    ad.nssa_set(hash)
+    assert_equal(true, ad.nssa)
+    assert_equal(ad.default_nssa_default_originate, ad.nssa_default_originate)
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
     assert_equal(true, ad.nssa_no_summary)
     assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
   end
 
   def test_nssa_non_default_vrf_others
-    ad = create_routerospfarea_vrf
-    # on n8k (only), we cannot configure
-    # "area <area> nssa default-information-originate",
-    # properly if we reset it first. It is only configuring nssa
-    # but not the other parameters. bug ID: CSCva11482
-    ad.nssa_set(true, true,
-                ad.default_nssa_no_redistribution,
-                ad.default_nssa_no_summary,
-                ad.default_nssa_route_map)
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate) unless
-      /N8/ =~ node.product_id
-    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
-    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
-    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+    nssa_helper(create_routerospfarea_vrf)
+  end
 
-    ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
-                ad.default_nssa_no_summary, 'aaa')
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate) unless
-      /N8/ =~ node.product_id
-    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
-    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
-    assert_equal('aaa', ad.nssa_route_map) unless
-      /N8/ =~ node.product_id
-
-    ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
-                true, ad.default_nssa_route_map)
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate)
-    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
-    assert_equal(true, ad.nssa_no_summary)
-    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
-
-    ad.nssa_set(true, true, ad.default_nssa_no_redistribution,
-                true, 'aaa')
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate)
-    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
-    assert_equal(true, ad.nssa_no_summary)
-    assert_equal('aaa', ad.nssa_route_map)
-
-    ad.nssa_set(true, true, true,
-                ad.default_nssa_no_summary,
-                ad.default_nssa_route_map)
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate)
-    assert_equal(true, ad.nssa_no_redistribution)
-    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
-    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
-
-    ad.nssa_set(true, true, true,
-                ad.default_nssa_no_summary,
-                'aaa')
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate)
-    assert_equal(true, ad.nssa_no_redistribution)
-    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
-    assert_equal('aaa', ad.nssa_route_map)
-
-    ad.nssa_set(true, true, true, true, 'aaa')
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(true, ad.nssa_def_info_originate)
-    assert_equal(true, ad.nssa_no_redistribution)
-    assert_equal(true, ad.nssa_no_summary)
-    assert_equal('aaa', ad.nssa_route_map)
-
-    ad.nssa_set(true, ad.default_nssa_def_info_originate,
-                true, true,
-                ad.default_nssa_route_map)
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
-    assert_equal(true, ad.nssa_no_redistribution)
-    assert_equal(true, ad.nssa_no_summary)
-    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
-
-    ad.nssa_set(true, ad.default_nssa_def_info_originate,
-                true, ad.default_nssa_no_summary,
-                ad.default_nssa_route_map)
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
-    assert_equal(true, ad.nssa_no_redistribution)
-    assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
-    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
-
-    ad.nssa_set(true, ad.default_nssa_def_info_originate,
-                ad.default_nssa_no_redistribution, true,
-                ad.default_nssa_route_map)
-    assert_equal(true, ad.nssa_enable)
-    assert_equal(ad.default_nssa_def_info_originate, ad.nssa_def_info_originate)
-    assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
-    assert_equal(true, ad.nssa_no_summary)
-    assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
+  def test_nssa_default_vrf_others
+    nssa_helper(create_routerospfarea_default)
   end
 
   def test_nssa_translate_type7
@@ -464,8 +392,8 @@ class TestRouterOspfArea < CiscoTestCase
      :filter_list_in,
      :filter_list_out,
      :range,
-     :nssa_def_info_originate,
-     :nssa_enable,
+     :nssa,
+     :nssa_default_originate,
      :nssa_no_redistribution,
      :nssa_no_summary,
      :nssa_route_map,
@@ -483,7 +411,15 @@ class TestRouterOspfArea < CiscoTestCase
               ['10.3.0.0/32', 'not_advertise'],
               ['10.3.0.1/32'],
               ['10.3.3.0/24', '450']]
-    ad.nssa_set(true, true, true, true, 'aaa')
+    hash = {}
+    hash[:nssa] = true
+    hash[:default_information_originate] = 'default-information-originate'
+    hash[:no_summary] = 'no-summary'
+    hash[:no_redistribution] = 'no-redistribution'
+    hash[:route_map] = 'route-map'
+    hash[:rm] = 'aaa'
+    ad.nssa_set(hash)
+
     ad.nssa_translate_type7 = 'never'
     ad.range = ranges
     ad.stub = true
@@ -495,8 +431,8 @@ class TestRouterOspfArea < CiscoTestCase
      :filter_list_in,
      :filter_list_out,
      :range,
-     :nssa_def_info_originate,
-     :nssa_enable,
+     :nssa,
+     :nssa_default_originate,
      :nssa_no_redistribution,
      :nssa_no_summary,
      :nssa_route_map,

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -146,4 +146,27 @@ class TestRouterOspfArea < CiscoTestCase
     av.range = av.default_range
     assert_equal(av.default_range, av.range)
   end
+
+  def test_destroy
+    ad = create_routerospfarea_default
+    ad.authentication = 'md5'
+    ad.default_cost = 2000
+    ad.filter_list_in = 'abc'
+    ad.filter_list_out = 'efg'
+    ranges = [['10.3.0.0/16', true, '23'], ['10.3.0.0/32', true, false],
+              ['10.3.0.1/32', false, false], ['10.3.3.0/24', false, '450']]
+    ad.range = ranges
+    ad.stub = 'no_summary'
+    # destroy
+    ad.destroy
+    [:authentication,
+     :default_cost,
+     :filter_list_in,
+     :filter_list_out,
+     :range,
+     :stub,
+    ].each do |prop|
+      assert_equal(ad.send("default_#{prop}"), ad.send("#{prop}"))
+    end
+  end
 end


### PR DESCRIPTION
This PR is for router_ospf_area provider which includes nssa properties.
All tests pass on on platforms except on n8k.
On n8k, commands like "area <area> nssa default-information-originate" and "area <area> nssa default-information-originate route-map <route-map>" are not getting configured properly after we reset nssa and due to this the relevant tests failed. Bug is filed on nxos platform and skipping these tests only on n8k.
