### PR TITLE
ospf_area with nssa changes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf_area.yaml
@@ -65,7 +65,7 @@ nssa_route_map:
   default_value: ''
 
 nssa_set:
-  set_value: '<state> area <area> nssa <no_summary> <no_redistribution> <default_information_originate> <route_map> <rm>'
+  set_value: '<state> area <area> nssa <nssa_no_summary> <nssa_no_redistribution> <nssa_default_originate> <nssa_route_map>'
 
 nssa_translate_type7:
   get_value: '/^area <area> nssa translate type7 (.*)$/'

--- a/lib/cisco_node_utils/router_ospf_area.rb
+++ b/lib/cisco_node_utils/router_ospf_area.rb
@@ -120,7 +120,7 @@ module Cisco
     def authentication
       auth = config_get('ospf_area', 'authentication', @get_args)
       return default_authentication unless auth
-      auth.include?('message-digest') ? 'md5' : 'clear_text'
+      auth.include?('message-digest') ? 'md5' : 'cleartext'
     end
 
     def authentication=(val)
@@ -264,9 +264,19 @@ module Cisco
       config_set('ospf_area', 'nssa_destroy', @set_args) if nssa
       return if hash.empty?
 
-      # Process each nssa property
       @set_args[:state] = ''
+      @set_args[:nssa_no_summary] = ''
+      @set_args[:nssa_no_redistribution] = ''
+      @set_args[:nssa_default_originate] = ''
+      @set_args[:nssa_route_map] = ''
+      # Process each nssa property
       hash.keys.each do |k|
+        hash[k] = 'default-information-originate' if
+          k == :nssa_default_originate
+        hash[k] = 'no-summary' if k == :nssa_no_summary
+        hash[k] = 'no-redistribution' if k == :nssa_no_redistribution
+        hash[k] = "route-map #{hash[:nssa_route_map]}" if
+          k == :nssa_route_map
         @set_args[k] = hash[k]
       end
       config_set('ospf_area', 'nssa_set', @set_args)

--- a/lib/cisco_node_utils/router_ospf_area.rb
+++ b/lib/cisco_node_utils/router_ospf_area.rb
@@ -27,13 +27,15 @@ module Cisco
   class RouterOspfArea < NodeUtil
     attr_reader :router, :vrf, :area_id
 
-    def initialize(ospf_router, vrf_name, area_id)
+    def initialize(ospf_router, vrf_name, area_id, instantiate=true)
       fail TypeError unless ospf_router.is_a?(String)
       fail TypeError unless vrf_name.is_a?(String)
       fail ArgumentError unless ospf_router.length > 0
       fail ArgumentError unless vrf_name.length > 0
       @area_id = area_id.to_s
       fail ArgumentError if @area_id.empty?
+
+      Feature.ospf_enable if instantiate
       # Convert to dot-notation
 
       @router = ospf_router
@@ -53,7 +55,7 @@ module Cisco
           hash[name]['default'] = {}
           area_ids.uniq.each do |area|
             hash[name]['default'][area] =
-              RouterOspfArea.new(name, 'default', area)
+              RouterOspfArea.new(name, 'default', area, false)
           end
         end
         vrf_ids = config_get('ospf', 'vrf', name: name)
@@ -66,7 +68,7 @@ module Cisco
           hash[name][vrf] = {}
           area_ids.uniq.each do |area|
             hash[name][vrf][area] =
-              RouterOspfArea.new(name, vrf, area)
+              RouterOspfArea.new(name, vrf, area, false)
           end
         end
       end

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -69,16 +69,16 @@ class TestRouterOspfArea < CiscoTestCase
     assert_equal(ad.default_authentication, ad.authentication)
     ad.authentication = 'md5'
     assert_equal('md5', ad.authentication)
-    ad.authentication = 'clear_text'
-    assert_equal('clear_text', ad.authentication)
+    ad.authentication = 'cleartext'
+    assert_equal('cleartext', ad.authentication)
     ad.authentication = ad.default_authentication
     assert_equal(ad.default_authentication, ad.authentication)
     av = create_routerospfarea_vrf
     assert_equal(av.default_authentication, av.authentication)
     av.authentication = 'md5'
     assert_equal('md5', av.authentication)
-    av.authentication = 'clear_text'
-    assert_equal('clear_text', av.authentication)
+    av.authentication = 'cleartext'
+    assert_equal('cleartext', av.authentication)
     av.authentication = av.default_authentication
     assert_equal(av.default_authentication, av.authentication)
   end
@@ -193,11 +193,6 @@ class TestRouterOspfArea < CiscoTestCase
     ad = create_routerospfarea_default
     assert_equal(ad.default_nssa, ad.nssa)
     hash[:nssa] = true
-    hash[:no_summary] = ''
-    hash[:no_redistribution] = ''
-    hash[:default_information_originate] = ''
-    hash[:route_map] = ''
-    hash[:rm] = ''
     ad.nssa_set(hash)
     assert_equal(true, ad.nssa)
     assert_equal(ad.default_nssa_default_originate, ad.nssa_default_originate)
@@ -216,11 +211,6 @@ class TestRouterOspfArea < CiscoTestCase
     av = create_routerospfarea_vrf
     assert_equal(av.default_nssa, av.nssa)
     hash[:nssa] = true
-    hash[:no_summary] = ''
-    hash[:no_redistribution] = ''
-    hash[:default_information_originate] = ''
-    hash[:route_map] = ''
-    hash[:rm] = ''
     av.nssa_set(hash)
     assert_equal(true, av.nssa)
     assert_equal(av.default_nssa_default_originate, av.nssa_default_originate)
@@ -240,24 +230,18 @@ class TestRouterOspfArea < CiscoTestCase
   def nssa_helper(ad)
     hash = {}
     hash[:nssa] = true
-    hash[:no_summary] = ''
-    hash[:no_redistribution] = ''
-    hash[:route_map] = ''
-    hash[:rm] = ''
-    hash[:default_information_originate] = 'default-information-originate'
+    hash[:nssa_default_originate] = true
     ad.nssa_set(hash)
     assert_equal(true, ad.nssa)
     assert(ad.nssa_default_originate)
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
     assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
-
     # on n8k (only), we cannot configure
     # "area <area> nssa default-information-originate",
     # properly if we reset it first. It is only configuring nssa
     # but not the other parameters. bug ID: CSCva11482
-    hash[:route_map] = 'route-map'
-    hash[:rm] = 'aaa'
+    hash[:nssa_route_map] = 'aaa'
     ad.nssa_set(hash)
     assert_equal(true, ad.nssa)
     if node.product_id[/N8/]
@@ -272,19 +256,15 @@ class TestRouterOspfArea < CiscoTestCase
     else
       assert_equal('aaa', ad.nssa_route_map)
     end
-
-    hash[:no_summary] = 'no-summary'
-    hash[:route_map] = ''
-    hash[:rm] = ''
+    hash[:nssa_no_summary] = true
+    hash.delete(:nssa_route_map)
     ad.nssa_set(hash)
     assert_equal(true, ad.nssa)
     assert_equal(true, ad.nssa_default_originate)
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
     assert_equal(true, ad.nssa_no_summary)
     assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
-
-    hash[:route_map] = 'route-map'
-    hash[:rm] = 'aaa'
+    hash[:nssa_route_map] = 'aaa'
     ad.nssa_set(hash)
     assert_equal(true, ad.nssa)
     assert_equal(true, ad.nssa_default_originate)
@@ -292,54 +272,61 @@ class TestRouterOspfArea < CiscoTestCase
     assert_equal(true, ad.nssa_no_summary)
     assert_equal('aaa', ad.nssa_route_map)
 
-    hash[:no_redistribution] = 'no-redistribution'
-    hash[:route_map] = ''
-    hash[:rm] = ''
-    hash[:no_summary] = ''
+    hash = {}
+    hash[:nssa] = true
+    hash[:nssa_default_originate] = true
+    hash[:nssa_no_redistribution] = true
     ad.nssa_set(hash)
     assert_equal(true, ad.nssa)
     assert_equal(true, ad.nssa_default_originate)
     assert_equal(true, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
     assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
-
-    hash[:route_map] = 'route-map'
-    hash[:rm] = 'aaa'
+    hash = {}
+    hash[:nssa] = true
+    hash[:nssa_default_originate] = true
+    hash[:nssa_no_redistribution] = true
+    hash[:nssa_route_map] = 'aaa'
     ad.nssa_set(hash)
     assert_equal(true, ad.nssa)
     assert_equal(true, ad.nssa_default_originate)
     assert_equal(true, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
     assert_equal('aaa', ad.nssa_route_map)
-
-    hash[:no_summary] = 'no-summary'
+    hash = {}
+    hash[:nssa] = true
+    hash[:nssa_default_originate] = true
+    hash[:nssa_no_redistribution] = true
+    hash[:nssa_route_map] = 'aaa'
+    hash[:nssa_no_summary] = true
     ad.nssa_set(hash)
     assert_equal(true, ad.nssa)
     assert_equal(true, ad.nssa_default_originate)
     assert_equal(true, ad.nssa_no_redistribution)
     assert_equal(true, ad.nssa_no_summary)
     assert_equal('aaa', ad.nssa_route_map)
-
-    hash[:route_map] = ''
-    hash[:rm] = ''
-    hash[:default_information_originate] = ''
+    hash = {}
+    hash[:nssa] = true
+    hash[:nssa_no_redistribution] = true
+    hash[:nssa_no_summary] = true
     ad.nssa_set(hash)
     assert_equal(true, ad.nssa)
     assert_equal(ad.default_nssa_default_originate, ad.nssa_default_originate)
     assert_equal(true, ad.nssa_no_redistribution)
     assert_equal(true, ad.nssa_no_summary)
     assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
-
-    hash[:no_summary] = ''
+    hash = {}
+    hash[:nssa] = true
+    hash[:nssa_no_redistribution] = true
     ad.nssa_set(hash)
     assert_equal(true, ad.nssa)
     assert_equal(ad.default_nssa_default_originate, ad.nssa_default_originate)
     assert_equal(true, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
     assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
-
-    hash[:no_summary] = 'no-summary'
-    hash[:no_redistribution] = ''
+    hash = {}
+    hash[:nssa] = true
+    hash[:nssa_no_summary] = true
     ad.nssa_set(hash)
     assert_equal(true, ad.nssa)
     assert_equal(ad.default_nssa_default_originate, ad.nssa_default_originate)

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -26,7 +26,6 @@ class TestRouterOspfArea < CiscoTestCase
     super
     remove_all_ospfs if @@pre_clean_needed
     @@pre_clean_needed = false # rubocop:disable Style/ClassVars
-    config 'feature ospf'
   end
 
   def teardown


### PR DESCRIPTION
This PR is for changing the nssa_set method in the ospf_area NU due to the review comments on the puppet side. This simplifies the previous version.

Also changed authentication 'clear_text' to 'cleartext' to keep consistency among all the other providers.
Chris has the context about this PR and so it is better if he reviews this.
