### PR TITLE
Switchport trunk allowed vlan now accepts 'vlan add' lines (#423)

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -446,7 +446,8 @@ switchport_pvlan_promiscuous:
 
 switchport_pvlan_trunk_allowed_vlan:
   _exclude: [ios_xr, N8k]
-  get_value: '/^switchport private-vlan trunk allowed vlan (.*)$/'
+  multiple: true
+  get_value: '/^switchport private-vlan trunk allowed vlan (?:add )?(\S+)$/'
   set_value: "switchport private-vlan trunk allowed vlan <range>"
   default_value: 'none'
 
@@ -479,12 +480,10 @@ switchport_pvlan_trunk_secondary:
 
 switchport_trunk_allowed_vlan:
   _exclude: [ios_xr]
-  get_value: '/^switchport trunk allowed vlan (.*)$/'
+  multiple: true
+  get_value: '/^switchport trunk allowed vlan (?:add )?(\S+)$/'
   set_value: "<state> switchport trunk allowed vlan <vlan>"
-  default_value: "1-4094"
-  # TBD: default should be 'none'; no need for state. See pvlan version.
-  # set_value: "switchport trunk allowed vlan <range>"
-  # default_value: 'none'
+  default_value: '1-4094'
 
 switchport_trunk_native_vlan:
   _exclude: [ios_xr]

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -933,7 +933,11 @@ module Cisco
     end
 
     def switchport_trunk_allowed_vlan
-      config_get('interface', 'switchport_trunk_allowed_vlan', name: @name)
+      vlans = config_get('interface', 'switchport_trunk_allowed_vlan',
+                         name: @name)
+      vlans = vlans.join(',') if vlans.is_a?(Array)
+      vlans = Utils.normalize_range_array(vlans, :string) unless vlans == 'none'
+      vlans
     end
 
     def switchport_trunk_allowed_vlan=(val)
@@ -1229,8 +1233,11 @@ module Cisco
     # Note that range is handled as a string because the entire range is
     # replaced instead of individually adding or removing vlans from the range.
     def switchport_pvlan_trunk_allowed_vlan
-      config_get('interface', 'switchport_pvlan_trunk_allowed_vlan',
-                 name: @name)
+      vlans = config_get('interface', 'switchport_pvlan_trunk_allowed_vlan',
+                         name: @name)
+      vlans = vlans.join(',') if vlans.is_a?(Array)
+      vlans = Utils.normalize_range_array(vlans, :string) unless vlans == 'none'
+      vlans
     end
 
     def switchport_pvlan_trunk_allowed_vlan=(range)

--- a/tests/test_interface_private_vlan.rb
+++ b/tests/test_interface_private_vlan.rb
@@ -321,6 +321,14 @@ class TestInterfacePrivateVlan < CiscoTestCase
 
     i.switchport_pvlan_trunk_allowed_vlan = default
     assert_equal(default, i.switchport_pvlan_trunk_allowed_vlan)
+
+    vlans = '500-528,530,532,534,587,590-593'
+    all_vlans = '500-528,530,532,534,587,590-593,597-598'
+    config("interface #{i.name}",
+           "switchport private-vlan trunk allowed vlan #{vlans}",
+           'switchport private-vlan trunk allowed vlan add 597',
+           'switchport private-vlan trunk allowed vlan add 598')
+    assert_equal(all_vlans, i.switchport_pvlan_trunk_allowed_vlan)
   end
 
   def test_switchport_pvlan_trunk_native_vlan

--- a/tests/test_interface_switchport.rb
+++ b/tests/test_interface_switchport.rb
@@ -55,7 +55,6 @@ end
 # TestSwitchport - general interface switchport tests.
 class TestSwitchport < TestInterfaceSwitchport
   DEFAULT_IF_ACCESS_VLAN = 1
-  DEFAULT_IF_SWITCHPORT_ALLOWED_VLAN = '1-4094'
   DEFAULT_IF_SWITCHPORT_NATIVE_VLAN = 1
 
   def system_default_switchport(state='')
@@ -257,7 +256,7 @@ class TestSwitchport < TestInterfaceSwitchport
     else
       interface.switchport_enable
       interface.switchport_trunk_allowed_vlan = 'all'
-      assert_equal(DEFAULT_IF_SWITCHPORT_ALLOWED_VLAN,
+      assert_equal(interface.default_switchport_trunk_allowed_vlan,
                    interface.switchport_trunk_allowed_vlan)
 
       interface.switchport_trunk_allowed_vlan = '20'
@@ -268,7 +267,7 @@ class TestSwitchport < TestInterfaceSwitchport
 
       interface.switchport_trunk_allowed_vlan =
         interface.default_switchport_trunk_allowed_vlan
-      assert_equal(DEFAULT_IF_SWITCHPORT_ALLOWED_VLAN,
+      assert_equal(interface.default_switchport_trunk_allowed_vlan,
                    interface.switchport_trunk_allowed_vlan)
 
       assert_raises(RuntimeError) do
@@ -280,6 +279,16 @@ class TestSwitchport < TestInterfaceSwitchport
 
       interface.switchport_trunk_allowed_vlan = '20, 30'
       assert_equal('20,30', interface.switchport_trunk_allowed_vlan)
+
+      # Some images have behavior where 'vlan add' is separate line
+      # This behavior is triggered for vlan ranges that exceed character limit
+      vlans = '500-528,530,532,534,587,590-593'
+      all_vlans = vlans + ',597-598'
+      config("interface #{interface.name}",
+             "switchport trunk allowed vlan #{vlans}",
+             'switchport trunk allowed vlan add 597',
+             'switchport trunk allowed vlan add 598')
+      assert_equal(all_vlans, interface.switchport_trunk_allowed_vlan)
     end
   end
 


### PR DESCRIPTION
- Fix regexp to only accept vlan ranges
- Trunk allowed vlan now handles 'vlan add' lines
