### PR TITLE
Fix suppress-fib-pending lib and test code

### DIFF
--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -867,7 +867,8 @@ module Cisco
 
     # Supress Fib Pending (Getter/Setter/Default)
     def suppress_fib_pending
-      config_get('bgp', 'suppress_fib_pending', @get_args)
+      val = config_get('bgp', 'suppress_fib_pending', @get_args)
+      val.nil? ? false : val
     end
 
     def suppress_fib_pending=(enable)

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -331,12 +331,12 @@ shutdown:
     default_value: false
 
 suppress_fib_pending:
-  # Note: Does not exist in IOS XR
-  nexus:
-    kind: boolean
-    get_value: 'suppress-fib-pending'
-    set_value: '<state> suppress-fib-pending'
-    default_value: false
+  _exclude: [ios_xr]
+  kind: boolean
+  get_value: '/^(?:no )?suppress-fib-pending$/'
+  set_value: '<state> suppress-fib-pending'
+  default_value: true
+  auto_default: false
 
 timer_bestpath_limit:
   # Note: Does not exist in IOS XR

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -1167,13 +1167,9 @@ class TestRouterBgp < CiscoTestCase
       bgp.suppress_fib_pending = false
       refute(bgp.suppress_fib_pending,
              'bgp suppress_fib_pending should be disabled')
+      bgp.suppress_fib_pending = bgp.default_suppress_fib_pending
+      assert_equal(bgp.default_suppress_fib_pending, bgp.suppress_fib_pending)
     end
-    bgp.destroy
-  end
-
-  def test_default_suppress_fib_pending
-    bgp = setup_default
-    assert_equal(bgp.default_suppress_fib_pending, bgp.suppress_fib_pending)
     bgp.destroy
   end
 

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -1155,39 +1155,25 @@ class TestRouterBgp < CiscoTestCase
   end
 
   def test_suppress_fib_pending
-    %w(test_default test_vrf).each do |t|
-      if t == 'test_default'
-        bgp = setup_default
-      else
-        bgp = setup_vrf
-      end
-      if platform == :ios_xr
-        assert_raises(Cisco::UnsupportedError) do
-          bgp.suppress_fib_pending = true
-        end
-      else
-        bgp.suppress_fib_pending = true
-        assert(bgp.suppress_fib_pending,
-               "vrf #{@vrf}: bgp suppress_fib_pending should be enabled")
-        bgp.suppress_fib_pending = false
-        refute(bgp.suppress_fib_pending,
-               "vrf #{@vrf}: bgp suppress_fib_pending should be disabled")
-      end
-      bgp.destroy
-    end
-  end
-
-  def test_suppress_fib_pending_not_configured
     bgp = setup_default
-    refute(bgp.suppress_fib_pending,
-           'bgp suppress_fib_pending should be disabled')
+    if validate_property_excluded?('bgp', 'suppress_fib_pending')
+      assert_raises(Cisco::UnsupportedError) do
+        bgp.suppress_fib_pending = true
+      end
+    else
+      bgp.suppress_fib_pending = true
+      assert(bgp.suppress_fib_pending,
+             'bgp suppress_fib_pending should be enabled')
+      bgp.suppress_fib_pending = false
+      refute(bgp.suppress_fib_pending,
+             'bgp suppress_fib_pending should be disabled')
+    end
     bgp.destroy
   end
 
   def test_default_suppress_fib_pending
     bgp = setup_default
-    refute(bgp.default_suppress_fib_pending,
-           'bgp suppress_fib_pending default value should be false')
+    assert_equal(bgp.default_suppress_fib_pending, bgp.suppress_fib_pending)
     bgp.destroy
   end
 


### PR DESCRIPTION
## Lib Fixes
- Explicitly exclude `ios_xr` as a platform
- Fix incorrect default value
- Add `auto_default` attribute to handle legacy nxos code that failed to nvgen `suppress-fib-pending`
  - Handle `nil` value for `config_get`
- Fix regexp for property
## Test Fixes
- Latest nxos branch removes `suppress-fib-pending` as a property under vrf contexts. This PR updates test code to handle this change.
- Add `validate_property_excluded` method to check for unsupported platforms
- Remove `test_suppress_fib_pending_not_configured` that was actually testing the property's default value and moved the code to `test_default_suppress_fib_pending` which was essentially performing a no-op in the test.
## Platforms Tested
- n3k - `dublin`
- n5k
- n6k
- n7k
- n8kv
- n9k - `e-dev`
- n9kv - `camden`
