### PR TITLE
Snmp packet_size fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
@@ -39,18 +39,18 @@ packet_size:
   N3k: &n3k_default_packet_size
     # Prior to the 7.0(3)I4(1) release, the default packet size
     # was incorrectly displayed as 0.  CSCuz14217 fixed this to
-    # properly display 1500.
+    # corectly display 1500.
     default_value: 1500
-  N8k: *n3k_default_packet_size
   N9k: *n3k_default_packet_size
   N5k: &n5k_default_packet_size
     # N5|6|7k platforms still incorrectly display the packet
-    # size as 0 and therefore still used as the default
-    # value. The default yaml entry will be changed to
-    # 1500 when the issue is resolved.
+    # size as 0. This value is therefore still used as the
+    # default. This yaml entry will be changed to match
+    # the n3|9k behavior when the issue is resolved.
     default_value: 0
   N6k: *n5k_default_packet_size
   N7k: *n5k_default_packet_size
+  N8k: *n5k_default_packet_size
 
 protocol:
   kind: boolean

--- a/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
@@ -36,7 +36,21 @@ packet_size:
   get_command: "show snmp internal globals"
   get_value: '/SNMP Max packet size :(\d+)/'
   set_value: "%s snmp-server packetsize %d"
-  default_value: 1500
+  N3k: &n3k_default_packet_size
+    # Prior to the 7.0(3)I4(1) release, the default packet size
+    # was incorrectly displayed as 0.  CSCuz14217 fixed this to
+    # properly display 1500.
+    default_value: 1500
+  N8k: *n3k_default_packet_size
+  N9k: *n3k_default_packet_size
+  N5k: &n5k_default_packet_size
+    # N5|6|7k platforms still incorrectly display the packet
+    # size as 0 and therefore still used as the default
+    # value. The default yaml entry will be changed to
+    # 1500 when the issue is resolved.
+    default_value: 0
+  N6k: *n5k_default_packet_size
+  N7k: *n5k_default_packet_size
 
 protocol:
   kind: boolean

--- a/tests/test_snmpserver.rb
+++ b/tests/test_snmpserver.rb
@@ -258,7 +258,7 @@ class TestSnmpServer < CiscoTestCase
   def test_snmpserver_packetsize_set_default
     snmpserver = SnmpServer.new
     refute_show_match(pattern: /snmp-server packetsize (\d+)/)
-    assert_equal(0, snmpserver.packet_size,
+    assert_equal(snmpserver.default_packet_size, snmpserver.packet_size,
                  'Error: Snmp Server, packet size not default')
 
     snmpserver.packet_size = 850
@@ -268,13 +268,8 @@ class TestSnmpServer < CiscoTestCase
                  'Error: Snmp Server, packet size not default')
 
     snmpserver.packet_size = snmpserver.default_packet_size
-    # TODO: this seems weird, why is default_packet_size not 0 as above?
-    line = assert_show_match(pattern: /snmp-server packetsize (\d+)/)
-    packetsize = line.to_s.split(' ').last.to_i
-    assert_equal(packetsize, snmpserver.packet_size,
+    assert_equal(snmpserver.default_packet_size, snmpserver.packet_size,
                  'Error: Snmp Server, packet size not default')
-    # set to default
-    snmpserver.packet_size = 0
   end
 
   def test_snmpserver_packetsize_unset
@@ -284,7 +279,7 @@ class TestSnmpServer < CiscoTestCase
     org_packet_size = snmpserver.packet_size
     snmpserver.packet_size = 0
     refute_show_match(pattern: /snmp-server packetsize (\d+)/)
-    assert_equal(0, snmpserver.packet_size,
+    assert_equal(snmpserver.default_packet_size, snmpserver.packet_size,
                  'Error: Snmp Server, packet size not unset')
 
     # Restore packet size


### PR DESCRIPTION
Previously, our snmp_server tests where testing against a default packet_size of `0`.  The correct default packet_size for all nxos plaforms should be `1500`.  This is now fixed in recent `n3|n9k` images but still displays as `0` on n5|6|7k images.

The yaml file has been updated to reflect the differences between the platforms along with comments to clarify the behavior.

Tested on: n3k, n5k, n6k, n7k, n8k, n9k
