### PR TITLE
Fix 'cannot disable local method' issue

### DIFF
--- a/lib/cisco_node_utils/aaa_authentication_login_service.rb
+++ b/lib/cisco_node_utils/aaa_authentication_login_service.rb
@@ -57,7 +57,7 @@ module Cisco
 
       if g_str.empty?
         # cannot remove default local, so do nothing in this case
-        unless m == :local && @name == 'default'
+        unless m == :local
           unless node.product_id[/N8/]
             # TBD: These 'no' commands currently error on N8k
             #   no aaa authentication login console local


### PR DESCRIPTION
In edev, the AAA team has introduced a change in behavior where attempting to delete the `local` authentication method generates the following error:

`The command 'no aaa authentication login console local' was rejected with error:
can not disable  local  method for authentication`

This fixes the NU object to never attempt to delete local as it's not supported.

Tested on N3K, N9K, N8K, N5K, N6K

Testing Before The Fix:

```
Node under test:
  - name  - n9k-108
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.IED5.0.173.bin

TestAaaAuthenticationLoginService#test_service_default_and_console_mix = 5.49 s = E
TestAaaAuthenticationLoginService#test_collection_with_service_default = 1.45 s = F
TestAaaAuthenticationLoginService#test_service_console_get_groups = 2.45 s = E
TestAaaAuthenticationLoginService#test_collection_with_service_default_and_console = 1.81 s = E
TestAaaAuthenticationLoginService#test_service_default_get_method = 2.14 s = .
TestAaaAuthenticationLoginService#test_create_service_default = 1.50 s = .
TestAaaAuthenticationLoginService#test_service_default_get_groups = 2.19 s = .
TestAaaAuthenticationLoginService#test_service_set_groups_invalid_groups = 2.52 s = E
TestAaaAuthenticationLoginService#test_service_default_set_groups = 2.40 s = .
TestAaaAuthenticationLoginService#test_create_service_console = 1.65 s = E
TestAaaAuthenticationLoginService#test_service_console_set_groups = 2.13 s = F
TestAaaAuthenticationLoginService#test_get_default_groups = 2.04 s = E
TestAaaAuthenticationLoginService#test_create_empty_service = 1.06 s = .
TestAaaAuthenticationLoginService#test_service_console_get_method = 2.39 s = E
TestAaaAuthenticationLoginService#test_collection_with_service_default_and_console_with_group = 2.29 s = .
TestAaaAuthenticationLoginService#test_service_set_groups_invalid_method = 2.03 s = E
TestAaaAuthenticationLoginService#test_create_invalid_service = 1.08 s = .
TestAaaAuthenticationLoginService#test_get_default_method = 1.93 s = E
18 runs, 140 assertions, 2 failures, 9 errors, 0 skips
```

Testing After the Fix:

```

Node under test:
  - name  - n9k-108
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.IED5.0.173.bin

TestAaaAuthenticationLoginService#test_create_empty_service = 1.06 s = .
TestAaaAuthenticationLoginService#test_service_default_get_groups = 2.15 s = .
TestAaaAuthenticationLoginService#test_service_default_set_groups = 2.56 s = .
TestAaaAuthenticationLoginService#test_service_default_get_method = 2.25 s = .
TestAaaAuthenticationLoginService#test_service_set_groups_invalid_groups = 2.26 s = .
TestAaaAuthenticationLoginService#test_get_default_groups = 1.79 s = .
TestAaaAuthenticationLoginService#test_service_set_groups_invalid_method = 1.86 s = .
TestAaaAuthenticationLoginService#test_create_service_console = 1.51 s = .
TestAaaAuthenticationLoginService#test_service_default_and_console_mix = 5.50 s = .
TestAaaAuthenticationLoginService#test_create_service_default = 1.61 s = .
TestAaaAuthenticationLoginService#test_create_invalid_service = 1.06 s = .
TestAaaAuthenticationLoginService#test_service_console_set_groups = 2.15 s = F
TestAaaAuthenticationLoginService#test_collection_with_service_default_and_console_with_group = 2.28 s = .
TestAaaAuthenticationLoginService#test_get_default_method = 1.77 s = .
TestAaaAuthenticationLoginService#test_service_console_get_groups = 2.22 s = .
TestAaaAuthenticationLoginService#test_collection_with_service_default = 1.42 s = F
TestAaaAuthenticationLoginService#test_collection_with_service_default_and_console = 1.84 s = E
TestAaaAuthenticationLoginService#test_service_console_get_method = 2.26 s = .

Finished in 38.855684s, 0.4633 runs/s, 3.6031 assertions/s.
18 runs, 140 assertions, 2 failures, 1 errors, 0 skips
```

The 3 remaining failures are beyond the scope of this fix.
