### PR TITLE
Refactor aaa local auth removal

### DIFF
--- a/lib/cisco_node_utils/aaa_authorization_service.rb
+++ b/lib/cisco_node_utils/aaa_authorization_service.rb
@@ -39,6 +39,10 @@ module Cisco
       config_set('aaa_authorization_service', 'method', '', type_str, name)
     end
 
+    def self.remove_local_auth
+      config_get('aaa_authorization_service', 'remove_local_auth')
+    end
+
     def self.services
       servs = {}
       servs_arr = config_get('aaa_authorization_service', 'services')

--- a/lib/cisco_node_utils/cmd_ref/aaa_authorization_service.yaml
+++ b/lib/cisco_node_utils/cmd_ref/aaa_authorization_service.yaml
@@ -19,6 +19,19 @@ method:
   set_value: "%s aaa authorization %s %s local"
   default_value: :local
 
+remove_local_auth:
+  # Used for determining if removal of authentication method
+  # 'local' is permitted.
+  kind: boolean
+  N3k: &remove_local_disallowed
+    default_only: false
+  N8k: *remove_local_disallowed
+  N9k: *remove_local_disallowed
+  N5k: &remove_local_allowed
+    default_only: true
+  N6k: *remove_local_allowed
+  N7k: *remove_local_allowed
+ 
 services:
   get_command: "show run aaa all"
   get_value: '/^aaa authorization (\S+) (\S+) .*(?:local)? ?$/'

--- a/lib/cisco_node_utils/cmd_ref/aaa_authorization_service.yaml
+++ b/lib/cisco_node_utils/cmd_ref/aaa_authorization_service.yaml
@@ -31,7 +31,7 @@ remove_local_auth:
     default_only: true
   N6k: *remove_local_allowed
   N7k: *remove_local_allowed
- 
+
 services:
   get_command: "show run aaa all"
   get_value: '/^aaa authorization (\S+) (\S+) .*(?:local)? ?$/'


### PR DESCRIPTION
**Summary of changes:**
- Add yaml entry to indicate which platforms support removal of authentication method `local`
- Update tests to strip `local` from the config cleanup if removal of `local` is not supported.
- Renamed a few variables to make them shorter.

Tested on: n9k and n5k.
