### PR TITLE
New overlay_global behaviors

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/overlay_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/overlay_global.yaml
@@ -25,9 +25,6 @@ dup_host_mac_detection:
   get_value: '/^l2rib dup-host-mac-detection (\d+) (\d+)$/'
   set_value: "l2rib dup-host-mac-detection <host_moves> <timeout>"
 
-dup_host_mac_detection_default:
-  set_value: "l2rib dup-host-mac-detection default"
-
 dup_host_mac_detection_host_moves:
   default_value: 5
 

--- a/lib/cisco_node_utils/overlay_global.rb
+++ b/lib/cisco_node_utils/overlay_global.rb
@@ -31,7 +31,6 @@ module Cisco
 
     # dup-host-ip-addr-detection
     def dup_host_ip_addr_detection
-      return nil unless Feature.nv_overlay_evpn_enabled?
       match = config_get('overlay_global', 'dup_host_ip_addr_detection')
       if match.nil?
         default_dup_host_ip_addr_detection
@@ -99,16 +98,7 @@ module Cisco
 
     def dup_host_mac_detection_set(host_moves, timeout)
       set_args = { host_moves: host_moves, timeout: timeout }
-      if host_moves == default_dup_host_mac_detection_host_moves &&
-         timeout == default_dup_host_mac_detection_timeout
-        dup_host_mac_detection_default
-      else
-        config_set('overlay_global', 'dup_host_mac_detection', set_args)
-      end
-    end
-
-    def dup_host_mac_detection_default
-      config_set('overlay_global', 'dup_host_mac_detection_default')
+      config_set('overlay_global', 'dup_host_mac_detection', set_args)
     end
 
     def default_dup_host_mac_detection
@@ -126,7 +116,6 @@ module Cisco
 
     # anycast-gateway-mac
     def anycast_gateway_mac
-      return nil unless Feature.nv_overlay_evpn_enabled?
       mac = config_get('overlay_global', 'anycast_gateway_mac')
       mac.nil? || mac.empty? ? default_anycast_gateway_mac : mac.downcase
     end

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -288,9 +288,10 @@ class CiscoTestCase < TestCase
     #   '9  12  10/40 Gbps Ethernet Module  N77-F312FQ-25 ok'
     #   '2   6  Nexus 6xQSFP Ethernet Module  N5K-C5672UP-M6Q ok'
     #   '2   6  Nexus xxQSFP Ethernet Module  N6K-C6004-96Q/EF ok'
+    #   '2   4  Nexus 4xQSFP Ethernet Module  N6K-C6001-M4Q ok'
     if node.product_id[/N(5|6)K/]
       sh_mod_string = @device.cmd("sh mod | i '^[0-9]+.*N[56]K-C[56]'")
-      sh_mod = sh_mod_string[/^(\d+)\s.*N[56]K-C(56|6004)/]
+      sh_mod = sh_mod_string[/^(\d+)\s.*N[56]K-C(56|600[14])/]
       skip('Unable to find compatible interface in chassis') if sh_mod.nil?
     elsif node.product_id[/N7K/]
       mt_full_interface?

--- a/tests/test_overlay_global.rb
+++ b/tests/test_overlay_global.rb
@@ -29,7 +29,6 @@ class TestOverlayGlobal < CiscoTestCase
     vdc_lc_state('f3')
     config_no_warn('no feature fabric forwarding')
     config_no_warn('no nv overlay evpn')
-    config_no_warn('l2rib dup-host-mac-detection default')
   end
 
   def test_dup_host_ip_addr_detection
@@ -42,9 +41,10 @@ class TestOverlayGlobal < CiscoTestCase
       return
     end
 
-    # Before enabling 'nv overlay evpn', these properties do not exist
-    assert_nil(o.dup_host_ip_addr_detection_host_moves)
-    assert_nil(o.dup_host_ip_addr_detection_timeout)
+    assert_equal(o.default_dup_host_ip_addr_detection_host_moves,
+                 o.dup_host_ip_addr_detection_host_moves)
+    assert_equal(o.default_dup_host_ip_addr_detection_timeout,
+                 o.dup_host_ip_addr_detection_timeout)
 
     # Set them to the default value and they should now be present
     default = [o.default_dup_host_ip_addr_detection_host_moves,
@@ -64,11 +64,6 @@ class TestOverlayGlobal < CiscoTestCase
 
   def test_dup_host_mac_detection
     o = OverlayGlobal.new
-    # These properties always exist, even without 'nv overlay evpn'
-    default = [o.default_dup_host_mac_detection_host_moves,
-               o.default_dup_host_mac_detection_timeout]
-    assert_equal(default, o.dup_host_mac_detection)
-    refute(Feature.nv_overlay_evpn_enabled?)
 
     # Set to a non-default value
     val = [160, 16]
@@ -76,12 +71,9 @@ class TestOverlayGlobal < CiscoTestCase
     assert_equal(val, o.dup_host_mac_detection)
     refute(Feature.nv_overlay_evpn_enabled?)
 
-    # Use the special defaulter method
-    o.dup_host_mac_detection_default
-    assert_equal(default, o.dup_host_mac_detection)
-    refute(Feature.nv_overlay_evpn_enabled?)
-
-    # Set explicitly to default too
+    # These properties always exist, even without 'nv overlay evpn'
+    default = [o.default_dup_host_mac_detection_host_moves,
+               o.default_dup_host_mac_detection_timeout]
     o.dup_host_mac_detection_set(*default)
     assert_equal(default, o.dup_host_mac_detection)
     refute(Feature.nv_overlay_evpn_enabled?)
@@ -94,8 +86,7 @@ class TestOverlayGlobal < CiscoTestCase
       return
     end
 
-    # Before enabling 'nv overlay evpn', this property does not exist
-    assert_nil(o.anycast_gateway_mac)
+    assert_equal(o.default_anycast_gateway_mac, o.anycast_gateway_mac)
 
     # Explicitly set to default and it should be enabled
     o.anycast_gateway_mac = o.default_anycast_gateway_mac


### PR DESCRIPTION
- DME changes for l2rib properties resulted in removal of the 'default' keyword from the cli:
  
  `l2rib dup-host-mac-detection default`
- Prior to this change, 'default' was the only way to reset the host_moves & timeout properties back to default; there was/is no 'no' command, so the only way to reset it now is to re-enter the command with the default values.
- This change necessitates changes to the setter, minitest, and beaker. ~~I also changed the default values to actual integer values instead of empty strings.~~
- Tested minitest & beaker for: n9-edev,n9-I4,n5,n6. Skips for n3 (normal) and n7 (requires F3 card).
