### PR TITLE
Remove unneeded test steps in test_aaa_authentication_login_service.rb

### DIFF
--- a/tests/test_aaa_authentication_login_service.rb
+++ b/tests/test_aaa_authentication_login_service.rb
@@ -83,8 +83,6 @@ class TestAaaAuthenticationLoginService < CiscoTestCase
     aaaauthloginservice_list = AaaAuthenticationLoginService.services
     refute_empty(aaaauthloginservice_list,
                  'Error: service collection is not filled')
-    assert_equal(1, aaaauthloginservice_list.size,
-                 'Error:  collection not reporting correct ')
     assert(aaaauthloginservice_list.key?('default'),
            'Error:  collection does contain default')
     aaaauthloginservice_list.each do |name, aaaauthloginservice|
@@ -647,13 +645,6 @@ class TestAaaAuthenticationLoginService < CiscoTestCase
     aaaauthloginservice.groups_method_set(groups, method)
     assert_show_match(command: 'show run aaa all | no-more',
                       pattern: Regexp.new(prefix + groups.join(' ')))
-
-    # default group and method
-    method = aaaauthloginservice.default_method
-    groups = aaaauthloginservice.default_groups
-    aaaauthloginservice.groups_method_set(groups, method)
-    refute_show_match(command: 'show run aaa all | no-more',
-                      pattern: /^aaa authentication login console local/)
 
     aaaauthloginservice_detach(aaaauthloginservice)
     unconfig_tacacs


### PR DESCRIPTION
This test suite contains a couple of test steps that verify the number of default aaa authentication login groups.

The test expectation is that only one group is configured by default
- `aaa authentication login default local`

The behavior has changed in `edev` such that now the following groups are configured by default.
- `aaa authentication login default local`
- `aaa authentication login console local`

**NOTE:** I confirmed with the aaa development team that the new behavior is expected.

This update removes the unneeded steps that were validating against a single group.

Tested on: n9k(I2/Edev), n8k, n5k
