### PR TITLE
AaaAuthorizationService prevent method local removal on unsupported platforms

### DIFF
--- a/lib/cisco_node_utils/aaa_authorization_service.rb
+++ b/lib/cisco_node_utils/aaa_authorization_service.rb
@@ -70,6 +70,8 @@ module Cisco
                      'no', t_str, @name)
         end
       else
+        # Removal of auth method local is not supported on all platforms.
+        m_str = AaaAuthorizationService.remove_local_auth ? m_str : ''
         config_set('aaa_authorization_service', 'groups',
                    'no', t_str, @name, g_str, m_str)
       end


### PR DESCRIPTION
Fixes case where the `destroy` method for `AaaAuthorizationService` attempts to remove authentication method `local` on all nexus platforms.  This is no longer supported on `n3k` and `n9k` platforms but is required on `n5-7k`.

This fix makes use of a previously added lookup api and no longer attempts to remove local if not supported.

Tested on: `n3k, n6k, n5k, n9k(I2,edev)`
