### PR TITLE
Munge 'no event-history events' to size_disable

### DIFF
--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -462,7 +462,7 @@ module Cisco
     def event_history_events
       match = config_get('bgp', 'event_history_events', @get_args)
       if match.is_a?(Array)
-        return 'false' if match[0] == 'no '
+        return 'size_disable' if match[0] == 'no '
         return 'size_' + match[1] if match[1]
       end
       default_event_history_events

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -610,6 +610,7 @@ class TestRouterBgp < CiscoTestCase
       bgp.send("event_history_#{opt}=", 'false')
       result = bgp.send("event_history_#{opt}")
       expected = (opt == :detail) ? bgp.default_event_history_detail : 'false'
+      expected = 'size_disable' if opt == :events
       assert_equal(expected, result,
                    "event_history_#{opt}: Failed to set state to False")
 


### PR DESCRIPTION
Due to recent platform changes, the CLI for `event_history events
size disable` now results in the config `no event-history events`

This change munges the `no event-history events` to `size_disable`
in order to handle behavior changes between different nxos releases.
This code change should be backwards compatible.
### Tested Platforms
- n3k-51 - I3
- n5k
- n6k
- n7k
- n9k - I4
- n9k - I5
- n9kv - I2
