### PR TITLE
Remove broken xr snmpuser support

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/snmp_user.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_user.yaml
@@ -1,64 +1,49 @@
 # snmp_user
 ---
+_exclude: [ios_xr]
+
 _template:
   multiple: true
-  ios_xr:
-    get_command: "show running-config snmp-server"
-  nexus:
-    get_command: "show run snmp all"
 
 auth_password:
-  ios_xr:
-    get_value: '/snmp-server user (\S+) \S+ \S+ auth \S+ \S+ (\S+)/'
-  nexus:
-    get_value: '/snmp-server user (\S+) \S+ auth \S+ (\S+)/'
+  get_command: "show run snmp all"
+  get_value: '/snmp-server user (\S+) \S+ auth \S+ (\S+)/'
   default_value: ""
 
 # The getter format will not have group info if engine id is configured.
 auth_password_with_engine_id:
-  _exclude: [ios_xr]
-  nexus:
-    get_value: '/snmp-server user (\S+) auth \S+ (\S+) .*engineID (\S+)/'
+  get_command: "show run snmp all"
+  get_value: '/snmp-server user (\S+) auth \S+ (\S+) .*engineID (\S+)/'
   default_value: ""
 
 auth_protocol:
   default_value: "md5"
-  ios_xr:
-    get_value: '/snmp-server user (\S+) \S+ \S+ auth (\S+)'
   N9k:
     # TODO: is this really N9K-specific?
     get_value: "auth"
 
 engine_id:
-  _exclude: [ios_xr]
   default_value: ""
 
 group:
   default_value: "network-operator"
-  ios_xr:
-    get_value: '/snmp-server user (\S+) (\S+)'
   N9k:
     # TODO: is this really N9K-specific?
     get_value: "group"
 
 priv_password:
-  ios_xr:
-    get_value: '/snmp-server user (\S+).*priv.*encrypted (\S+)/'
-  nexus:
-    get_value: '/snmp-server user (\S+) \S+ auth \S+ \S+ priv.*(0x\S+)/'
+  get_command: "show run snmp all"
+  get_value: '/snmp-server user (\S+) \S+ auth \S+ \S+ priv.*(0x\S+)/'
   default_value: ""
 
 # The getter format will not have group info if engine id is configured.
 priv_password_with_engine_id:
-  _exclude: [ios_xr]
-  nexus:
-    get_value: '/snmp-server user (\S+) auth \S+ \S+ priv .*(0x\S+) .*engineID (\S+)/'
+  get_command: "show run snmp all"
+  get_value: '/snmp-server user (\S+) auth \S+ \S+ priv .*(0x\S+) .*engineID (\S+)/'
   default_value: ""
 
 priv_protocol:
   default_value: "des"
-  ios_xr:
-    get_value: '/snmp-server user (\S+).*priv (3des|aes 128|aes 192|aes 256|des56)/'
   N9k:
     # TODO: is this really N9K-specific?
     get_value: "priv"
@@ -67,15 +52,6 @@ priv_protocol:
 # [no] snmp-server user <user> [group] [auth {md5|sha} <passwd1> \
 #       [priv [aes-128] <passwd2>] [localizedkey] [engineID <id>]]
 user:
-  get_value: '/^snmp-server user (.*)$/'
-  ios_xr:
-    set_value: "<state> snmp-server user <name> <group> <version> <auth> <priv>"
-  nexus:
-    get_command: "show run snmp all | i 'snmp-server user'"
-    set_value: "<state> snmp-server user <name> <group> <auth> <priv> <localizedKey> <engineId>"
-
-version:
-  _exclude: [nexus]
-  get_value: '/snmp-server user (\S+) \S+ (\S+)/'
-  default_value: ""
-
+  get_command: "show run snmp all | i 'snmp-server user'"
+  get_value: '/^snmp.server user (.*)$/'
+  set_value: "%s snmp-server user %s %s %s %s %s %s"

--- a/lib/cisco_node_utils/snmpuser.rb
+++ b/lib/cisco_node_utils/snmpuser.rb
@@ -18,10 +18,9 @@ module Cisco
   # SnmpUser - node utility class for SNMP user configuration management
   class SnmpUser < NodeUtil
     def initialize(name, groups, authproto, authpass, privproto,
-                   privpass, localizedkey, engineid, instantiate=true,
-                   version=nil)
+                   privpass, localizedkey, engineid, instantiate=true)
       initialize_validator(name, groups, authproto, authpass, privproto,
-                           privpass, engineid, version, instantiate)
+                           privpass, engineid, instantiate)
       @name = name
       @engine_id = engineid
 
@@ -33,7 +32,6 @@ module Cisco
       privprotostr = _priv_sym_to_str(privproto)
 
       return unless instantiate
-
       # Config string syntax:
       # [no] snmp-server user <user> [group] ...
       #      [auth {md5|sha} <passwd1>
@@ -42,28 +40,18 @@ module Cisco
       # Assume if multiple groups, apply all config to each
       groups = [''] if groups.empty?
       groups.each do |group|
-        if platform == :ios_xr
-          authstr = "auth #{authprotostr} encrypted #{authpass}"
-          privstr = "priv #{privprotostr} encrypted #{privpass}"
-        else
-          authstr = "auth #{authprotostr} #{authpass}"
-          privstr = "priv #{privprotostr} #{privpass}"
-        end
-
-        config_set('snmp_user', 'user',
-                   state:        '',
-                   name:         name,
-                   group:        group,
-                   version:      version.to_s,
-                   auth:         authpass.empty? ? '' : authstr,
-                   priv:         privpass.empty? ? '' : privstr,
-                   localizedKey: localizedkey ? 'localizedkey' : '',
-                   engineId:     engineid.empty? ? '' : "engineID #{engineid}")
+        config_set('snmp_user', 'user', '',
+                   name,
+                   group,
+                   authpass.empty? ? '' : "auth #{authprotostr} #{authpass}",
+                   privpass.empty? ? '' : "priv #{privprotostr} #{privpass}",
+                   localizedkey ? 'localizedkey' : '',
+                   engineid.empty? ? '' : "engineID #{engineid}")
       end
     end
 
     def initialize_validator(name, groups, authproto, authpass, privproto,
-                             privpass, engineid, version, instantiate)
+                             privpass, engineid, instantiate)
       fail TypeError unless name.is_a?(String) &&
                             groups.is_a?(Array) &&
                             authproto.is_a?(Symbol) &&
@@ -72,15 +60,6 @@ module Cisco
                             privpass.is_a?(String) &&
                             engineid.is_a?(String)
       fail ArgumentError if name.empty?
-
-      if platform == :ios_xr && instantiate
-        fail TypeError \
-          unless [:v1, :v2c, :v3].include?(version)
-
-        fail TypeError \
-          if groups.length > 1
-      end
-
       # empty password but protocol provided = bad
       # non-empty password and no protocol provided = bad
       if authpass.empty?
@@ -89,12 +68,9 @@ module Cisco
         fail ArgumentError unless [:sha, :md5].include?(authproto)
       end
       if privpass.empty?
-        fail ArgumentError \
-          if [:des, :aes128, :aes192, :aes256].include?(privproto) &&
-             instantiate
+        fail ArgumentError if [:des, :aes128].include?(privproto) && instantiate
       else
-        fail ArgumentError \
-          unless [:des, :aes128, :aes192, :aes256].include?(privproto)
+        fail ArgumentError unless [:des, :aes128].include?(privproto)
       end
     end
 
@@ -131,8 +107,7 @@ module Cisco
         users_hash[index] = SnmpUser.new(name, groups_arr.flatten, auth,
                                          '', priv, '', false,
                                          engineid,
-                                         false,
-                                         nil)
+                                         false)
       end
       users_hash
     end
@@ -148,29 +123,10 @@ module Cisco
       unless priv_password.nil? || priv_password.empty?
         priv_str = "priv #{_priv_sym_to_str(priv_protocol)} #{priv_password}"
       end
-
-      if platform == :ios_xr
-        groups.each do |group|
-          config_set('snmp_user', 'user',
-                     state:   'no',
-                     name:    @name,
-                     group:   group,
-                     version: version.to_s,
-                     auth:    '',
-                     priv:    '')
-        end
-      else
-        engineidstr = @engine_id.empty? ? '' : "engineID #{@engine_id}"
-        config_set('snmp_user', 'user',
-                   state:        'no',
-                   name:         @name,
-                   group:        '',
-                   auth:         auth_str,
-                   priv:         priv_str,
-                   localizedKey: local_str,
-                   engineId:     engineidstr)
-        SnmpUser.users.delete(@name + ' ' + @engine_id)
-      end
+      config_set('snmp_user', 'user', 'no',
+                 @name, '', auth_str, priv_str, local_str,
+                 @engine_id.empty? ? '' : "engineID #{@engine_id}")
+      SnmpUser.users.delete(@name + ' ' + @engine_id)
     end
 
     attr_reader :name
@@ -247,21 +203,6 @@ module Cisco
       config_get_default('snmp_user', 'priv_password')
     end
 
-    def self.version(name)
-      users = config_get('snmp_user', 'version')
-      unless users.nil? || users.empty?
-        users.each_entry { |user| return user[1] if user[0] == name }
-      end
-    end
-
-    def version
-      SnmpUser.version(@name)
-    end
-
-    def self.default_version
-      config_get_default('snmp_user', 'version')
-    end
-
     attr_reader :engine_id
 
     def self.default_engine_id
@@ -291,40 +232,25 @@ module Cisco
         # In this case passed in password is clear text while the running
         # config is hashed value. We need to hash the passed in clear text.
 
-        group = platform == :ios_xr ? 'network-operator' : ''
-        authstr = "auth #{_auth_sym_to_str(auth_protocol)} #{input_pw}"
-        engineidstr = @engine_id.empty? ? '' : "engineID #{@engine_id}"
         # Create dummy user
-        config_set('snmp_user', 'user',
-                   state:        '',
-                   name:         'dummy_user',
-                   group:        group,
-                   version:      'v3',
-                   auth:         authstr,
-                   priv:         '',
-                   localizedKey: '',
-                   engineId:     engineidstr)
+        config_set('snmp_user', 'user', '', 'dummy_user', '',
+                   "auth #{_auth_sym_to_str(auth_protocol)} #{input_pw}",
+                   '', '',
+                   @engine_id.empty? ? '' : "engineID #{@engine_id}")
 
         # Retrieve password hashes
         hashed_pw = SnmpUser.auth_password('dummy_user', @engine_id)
         if hashed_pw.nil?
-          fail "SNMP dummy user 'dummy_user' #{@engine_id} was configured " \
+          fail "SNMP dummy user #{dummy_user} #{@engine_id} was configured " \
                "but password is missing?\n" \
                + @@node.get(command: 'show run snmp all')
         end
 
-        authstr = "auth #{_auth_sym_to_str(auth_protocol)} #{hashed_pw}"
-        engineidstr = @engine_id.empty? ? '' : "engineID #{@engine_id}"
         # Delete dummy user
-        config_set('snmp_user', 'user',
-                   state:        'no',
-                   name:         'dummy_user',
-                   group:        group,
-                   version:      'v3',
-                   auth:         authstr,
-                   priv:         '',
-                   localizedKey: 'localizedkey',
-                   engineId:     engineidstr)
+        config_set('snmp_user', 'user', 'no', 'dummy_user', '',
+                   "auth #{_auth_sym_to_str(auth_protocol)} #{hashed_pw}",
+                   '', 'localizedkey',
+                   @engine_id.empty? ? '' : "engineID #{@engine_id}")
       end
       hashed_pw == current_pw
     end
@@ -352,42 +278,28 @@ module Cisco
         # In this case passed in password is clear text while the running
         # config is hashed value. We need to hash the passed in clear text.
 
-        group = platform == :ios_xr ? 'network-operator' : ''
-        authstr = "auth #{_auth_sym_to_str(auth_protocol)} #{input_pw}"
-        privstr = "priv #{_priv_sym_to_str(priv_protocol)} #{input_pw}"
-        engineidstr = @engine_id.empty? ? '' : "engineID #{@engine_id}"
         # Create dummy user
-        config_set('snmp_user', 'user',
-                   state:        '',
-                   name:         'dummy_user',
-                   group:        group,
-                   auth:         authstr,
-                   priv:         privstr,
-                   localizedKey: '',
-                   engineId:     engineidstr)
+        config_set('snmp_user', 'user', '', 'dummy_user', '',
+                   "auth #{_auth_sym_to_str(auth_protocol)} #{input_pw}",
+                   "priv #{_priv_sym_to_str(priv_protocol)} #{input_pw}",
+                   '',
+                   @engine_id.empty? ? '' : "engineID #{@engine_id}")
 
         # Retrieve password hashes
         dummyau = SnmpUser.auth_password('dummy_user', @engine_id)
         hashed_pw = SnmpUser.priv_password('dummy_user', @engine_id)
         if hashed_pw.nil?
-          fail "SNMP dummy user 'dummy_user' #{@engine_id} was configured " \
+          fail "SNMP dummy user #{dummy_user} #{@engine_id} was configured " \
                "but password is missing?\n" \
                + @@node.get(command: 'show run snmp all')
         end
 
-        group = platform == :ios_xr ? 'network-operator' : ''
-        authstr = "auth #{_auth_sym_to_str(auth_protocol)} #{dummyau}"
-        privstr = "priv #{_priv_sym_to_str(priv_protocol)} #{hashed_pw}"
-        engineidstr = @engine_id.empty? ? '' : "engineID #{@engine_id}"
         # Delete dummy user
-        config_set('snmp_user', 'user',
-                   state:        'no',
-                   name:         'dummy_user',
-                   group:        group,
-                   auth:         authstr,
-                   priv:         privstr,
-                   localizedKey: 'localizedkey',
-                   engineId:     engineidstr)
+        config_set('snmp_user', 'user', 'no', 'dummy_user', '',
+                   "auth #{_auth_sym_to_str(auth_protocol)} #{dummyau}",
+                   "priv #{_priv_sym_to_str(priv_protocol)} #{hashed_pw}",
+                   'localizedkey',
+                   @engine_id.empty? ? '' : "engineID #{@engine_id}")
       end
       hashed_pw == current_pw
     end
@@ -408,13 +320,7 @@ module Cisco
       # privproto always comes after priv_index if priv exists
       pri = priv_index.nil? ? '' : lparams[priv_index + 1]
       # for the empty priv protocol default
-      if platform == :ios_xr
-        if pri == 'aes'
-          pri = "#{lparams[priv_index + 1]} #{lparams[priv_index + 2]}"
-        end
-      else
-        pri = 'des' unless pri.empty? || pri == 'aes-128'
-      end
+      pri = 'des' unless pri.empty? || pri == 'aes-128'
       auth = _auth_str_to_sym(aut)
       priv = _priv_str_to_sym(pri)
       user_var[:name] = name
@@ -455,15 +361,9 @@ module Cisco
     def _priv_sym_to_str(sym)
       case sym
       when :des
-        return 'des56'
-      when :'3des'
-        return '3des'
+        return '' # no protocol specified defaults to DES
       when :aes128
-        if platform == :ios_xr
-          return 'aes 128'
-        else
-          return 'aes-128'
-        end
+        return 'aes-128'
       else
         return ''
       end
@@ -490,30 +390,13 @@ module Cisco
     end
 
     def self._priv_str_to_sym(str)
-      if platform == :ios_xr
-        case str
-        when /3des/i
-          return :'3des'
-        when /des/i
-          return :des
-        when /aes 128/i
-          return :aes128
-        when /aes 192/i
-          return :aes192
-        when /aes 256/i
-          return :aes256
-        else
-          return :none
-        end
+      case str
+      when /des/i
+        return :des
+      when /aes/i
+        return :aes128
       else
-        case str
-        when /des/i
-          return :des
-        when /aes/i
-          return :aes128
-        else
-          return :none
-        end
+        return :none
       end
     end
   end

--- a/tests/test_snmpuser.rb
+++ b/tests/test_snmpuser.rb
@@ -65,13 +65,13 @@ class TestSnmpUser < CiscoTestCase
 
   ## test cases starts here
 
-  def test_snmpuser_collection_not_empty
+  def test_collection_not_empty
     create_user('tester')
     refute_empty(SnmpUser.users,
                  'SnmpUser collection is empty')
   end
 
-  def test_snmpuser_create_invalid_args
+  def test_create_invalid_args
     args_list = [
       ['Empty name',
        ['', ['network-admin'],
@@ -91,7 +91,7 @@ class TestSnmpUser < CiscoTestCase
     end
   end
 
-  def test_snmpuser_create_invalid_cli
+  def test_create_invalid_cli
     args_list = [
       ['Cleartext password with localized key',
        ['userv3testauthsha1', ['network-admin'],
@@ -135,7 +135,7 @@ class TestSnmpUser < CiscoTestCase
     assert(found_tester2)
   end
 
-  def test_snmpuser_create_with_single_group_noauth_nopriv
+  def test_noauth_nopriv
     name = 'userv3test2'
     groups = ['network-admin']
     snmpuser = SnmpUser.new(name,
@@ -149,7 +149,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_create_with_multi_group_noauth_nopriv
+  def test_noauth_nopriv_multi
     name = 'userv3test3'
     groups = ['network-admin', 'vdc-admin']
     snmpuser = SnmpUser.new(name,
@@ -165,7 +165,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_destroy
+  def test_destroy
     name = 'userv3testdestroy'
     group = 'network-operator'
     create_user(name, group)
@@ -184,7 +184,7 @@ class TestSnmpUser < CiscoTestCase
     assert_nil(SnmpUser.users[name])
   end
 
-  def test_snmpuser_auth_password_equal_invalid_param
+  def test_auth_pw_equal_invalid_param
     name = 'testV3PwEqualInvalid2'
     auth_pw = 'TeSt297534'
     create_user(name, "network-admin auth md5 #{auth_pw}")
@@ -193,7 +193,7 @@ class TestSnmpUser < CiscoTestCase
     refute(SnmpUser.users[name].auth_password_equal?('', false))
   end
 
-  def test_snmpuser_auth_priv_password_equal_invalid_param
+  def test_auth_priv_pw_equal_invalid_param
     name = 'testV3PwEqualInvalid'
     auth_pw = 'XXWWPass0wrf'
     create_user(name, "network-admin auth md5 #{auth_pw} priv #{auth_pw}")
@@ -204,7 +204,7 @@ class TestSnmpUser < CiscoTestCase
     refute(snmpuser.priv_password_equal?('', false))
   end
 
-  def test_snmpuser_auth_password_equal_priv_invalid_param
+  def test_auth_pw_equal_priv_invalid_param
     name = 'testV3PwEqualInvalid'
     auth_pw = 'XXWWPass0wrf'
     create_user(name, "network-operator auth md5 #{auth_pw} priv #{auth_pw}")
@@ -215,7 +215,7 @@ class TestSnmpUser < CiscoTestCase
     refute(snmpuser.priv_password_equal?('', false))
   end
 
-  def test_snmpuser_auth_password_not_equal
+  def test_auth_pw_not_equal
     name = 'testV3PwEqual'
     auth_pw = 'xxwwpass0r!f'
     create_user(name, "network-admin auth md5 #{auth_pw}")
@@ -225,7 +225,7 @@ class TestSnmpUser < CiscoTestCase
     refute(snmpuser.auth_password_equal?('xxwwpass0r!', false))
   end
 
-  def test_snmpuser_auth_password_equal
+  def test_auth_pw_equal
     name = 'testV3PwEqual'
     auth_pw = 'XXWWPass0wrf'
     create_user(name, "network-admin auth md5 #{auth_pw}")
@@ -234,7 +234,7 @@ class TestSnmpUser < CiscoTestCase
     assert(SnmpUser.users[name].auth_password_equal?(auth_pw, false))
   end
 
-  def test_snmpuser_auth_priv_password_equal_empty
+  def test_auth_priv_pw_equal_empty
     name = 'testV3PwEmpty'
     create_user(name, 'network-admin')
     # nil and "" are treated interchangeably
@@ -244,7 +244,7 @@ class TestSnmpUser < CiscoTestCase
     assert(SnmpUser.users[name].priv_password_equal?(nil, false))
   end
 
-  def test_snmpuser_auth_password_equal_localizedkey
+  def test_auth_pw_equal_localizedkey
     name = 'testV3PwEqual'
     auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
     create_user(name, "network-admin auth md5 #{auth_pw} localizedkey")
@@ -256,7 +256,7 @@ class TestSnmpUser < CiscoTestCase
     refute(snmpuser.auth_password_equal?('0xFe6c', true))
   end
 
-  def test_snmpuser_auth_priv_password_equal_localizedkey
+  def test_auth_priv_pw_equal_localizedkey
     name = 'testV3PwEqual'
     auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
     priv_pw = '0x29916eac22d90362598abef1b9045018'
@@ -270,7 +270,7 @@ class TestSnmpUser < CiscoTestCase
     refute(snmpuser.priv_password_equal?('0x2291', true))
   end
 
-  def test_snmpuser_auth_priv_des_password_equal
+  def test_auth_priv_des_pw_equal
     name = 'testV3PwEqual'
     auth_pw = 'XXWWPass0wrf'
     priv_pw = 'WWXXPaas0wrf'
@@ -282,7 +282,7 @@ class TestSnmpUser < CiscoTestCase
     assert(snmpuser.priv_password_equal?(priv_pw, false))
   end
 
-  def test_snmpuser_create_with_single_group_auth_md5_nopriv
+  def test_auth_md5_nopriv
     name = 'userv3test5'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -298,7 +298,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_create_with_single_group_auth_md5_nopriv_pw_localized
+  def test_auth_md5_nopriv_pw_localized
     name = 'userv3testauth'
     groups = ['network-admin']
     auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
@@ -316,7 +316,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_create_with_single_group_auth_sha_nopriv
+  def test_auth_sha_nopriv
     name = 'userv3testsha'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -334,7 +334,7 @@ class TestSnmpUser < CiscoTestCase
 
   # If the auth pw is in hex and localized key param in constructor is false,
   # then the pw got localized by the device again.
-  def test_create_1_group_auth_sha_nopriv_pw_localized_localizedkey_false
+  def test_auth_sha_nopriv_pw_localized_false
     name = 'userv3testauthsha3'
     groups = ['network-admin']
     auth_pw = '0xFe6cf9aea159c2c38e0a79ec23ed3cbb'
@@ -351,7 +351,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_create_with_single_group_auth_sha_nopriv_pw_localized
+  def test_auth_sha_nopriv_pw_localized
     name = 'userv3testauthsha4'
     groups = ['network-admin']
     auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
@@ -367,7 +367,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_create_with_single_group_auth_md5_priv_des
+  def test_auth_md5_priv_des
     name = 'userv3test6'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -384,7 +384,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_create_with_single_group_auth_md5_priv_des_pw_localized
+  def test_auth_md5_priv_des_pw_localized
     name = 'userv3testauth'
     groups = ['network-admin']
     auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
@@ -401,7 +401,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_create_with_single_group_auth_md5_priv_aes128
+  def test_auth_md5_priv_aes128
     name = 'userv3test7'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -418,7 +418,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_create_with_single_group_auth_md5_priv_aes128_pw_localized
+  def test_auth_md5_priv_aes128_pw_localized
     name = 'userv3testauth'
     groups = ['network-admin']
     auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
@@ -435,7 +435,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_create_with_single_group_auth_sha_priv_des
+  def test_auth_sha_priv_des
     name = 'userv3test8'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -452,7 +452,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_create_with_single_group_auth_md5_priv_sha_pw_localized
+  def test_auth_md5_priv_sha_pw_localized
     name = 'userv3testauth'
     groups = ['network-admin']
     auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
@@ -469,7 +469,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_create_with_single_group_auth_sha_priv_aes128
+  def test_auth_sha_priv_aes128
     name = 'userv3test9'
     groups = ['network-admin']
     auth_pw = 'XXWWPass0wrf'
@@ -486,7 +486,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_create_with_single_group_auth_sha_priv_aes128_pw_localized
+  def test_auth_sha_priv_aes128_pw_localized
     name = 'userv3testauth'
     groups = ['network-admin']
     auth_pw = '0xfe6cf9aea159c2c38e0a79ec23ed3cbb'
@@ -503,7 +503,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_create_destroy_with_engine_id
+  def test_create_destroy_with_engine_id
     name = 'test_with_engine_id'
     auth_pw = 'XXWWPass0wrf'
     priv_pw = 'XXWWPass0wrf'
@@ -526,7 +526,7 @@ class TestSnmpUser < CiscoTestCase
     assert_nil(SnmpUser.users["#{name} #{engine_id}"])
   end
 
-  def test_snmpuser_authpassword
+  def test_authpassword
     name = 'test_authpassword'
     auth_pw = '0x123456'
     snmpuser = SnmpUser.new(name, [''], :md5, auth_pw, :none, '', true, '')
@@ -536,7 +536,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_authpassword_with_engineid
+  def test_authpassword_with_engineid
     name = 'test_authpassword'
     auth_pw = '0x123456'
     engine_id = '128:12:12:12:12'
@@ -548,7 +548,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_privpassword
+  def test_privpassword
     name = 'test_privpassword'
     priv_password = '0x123456'
     snmpuser = SnmpUser.new(name, [''], :md5, priv_password,
@@ -565,7 +565,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_privpassword_with_engineid
+  def test_privpassword_with_engineid
     name = 'test_privpassword2'
     priv_password = '0x123456'
     engine_id = '128:12:12:12:12'
@@ -582,7 +582,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_auth_password_equal_with_engineid
+  def test_auth_password_equal_with_engineid
     name = 'test_authpass_equal'
     auth_pass = 'XXWWPass0wrf'
     engine_id = '128:12:12:12:12'
@@ -596,7 +596,7 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_priv_password_equal_with_engineid
+  def test_priv_password_equal_with_engineid
     name = 'test_privpass_equal'
     priv_pass = 'XXWWPass0wrf'
     engine_id = '128:12:12:12:12'
@@ -614,31 +614,31 @@ class TestSnmpUser < CiscoTestCase
     snmpuser.destroy
   end
 
-  def test_snmpuser_default_groups
+  def test_default_groups
     groups = [DEFAULT_SNMP_USER_GROUP_NAME]
     assert_equal(groups, SnmpUser.default_groups,
                  'Error: Wrong default groups')
   end
 
-  def test_snmpuser_default_auth_protocol
+  def test_default_auth_protocol
     assert_equal(:md5,
                  SnmpUser.default_auth_protocol,
                  'Error: Wrong default auth protocol')
   end
 
-  def test_snmpuser_default_auth_password
+  def test_default_auth_password
     assert_equal(DEFAULT_SNMP_USER_AUTH_PASSWORD,
                  SnmpUser.default_auth_password,
                  'Error: Wrong default auth password')
   end
 
-  def test_snmpuser_default_priv_protocol
+  def test_default_priv_protocol
     assert_equal(:des,
                  SnmpUser.default_priv_protocol,
                  'Error: Wrong default priv protocol')
   end
 
-  def test_snmpuser_default_priv_password
+  def test_default_priv_password
     assert_equal(DEFAULT_SNMP_USER_PRIV_PASSWORD,
                  SnmpUser.default_priv_password,
                  'Error: Wrong default priv password')


### PR DESCRIPTION
The addition of XR support for snmpuser resulted in significant breakage to nxos support.  This commit removes XR support.

This update is simply a replacement of the following files in `develop` with the versions from the `release_1.3.1` branch.
- `lib/cisco_node_utils/cmd_ref/snmp_user.yaml`
- `lib/cisco_node_utils/snmpuser.rb`
- `tests/test_snmpuser.rb`

**Test Results with XR support:**

```
Node under test:
  - name  - n9k-108
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.IED5.0.176.bin

TestSnmpUser#test_auth_md5_nopriv_pw_localized = 2.53 s = .
TestSnmpUser#test_auth_md5_priv_aes128_pw_localized = 2.43 s = .
TestSnmpUser#test_auth_pw_not_equal = 2.79 s = .
TestSnmpUser#test_auth_sha_nopriv_pw_localized_false = 2.17 s = .
TestSnmpUser#test_auth_pw_equal = 2.80 s = .
TestSnmpUser#test_auth_sha_nopriv = 2.23 s = .
TestSnmpUser#test_default_groups = 1.05 s = .
TestSnmpUser#test_noauth_nopriv = 2.28 s = .
TestSnmpUser#test_auth_md5_priv_des_pw_localized = 1.43 s = E
TestSnmpUser#test_collection_not_empty = 2.03 s = .
TestSnmpUser#test_default_priv_password = 1.11 s = .
TestSnmpUser#test_auth_md5_priv_aes128 = 2.27 s = .
TestSnmpUser#test_create_invalid_cli = 1.50 s = .
TestSnmpUser#test_auth_priv_pw_equal_invalid_param = 1.98 s = .
TestSnmpUser#test_default_auth_protocol = 1.07 s = .
TestSnmpUser#test_destroy = 8.01 s = .
TestSnmpUser#test_auth_priv_pw_equal_empty = 1.94 s = .
TestSnmpUser#test_privpassword = 1.46 s = E
TestSnmpUser#test_auth_sha_priv_des = 1.39 s = E
TestSnmpUser#test_auth_pw_equal_priv_invalid_param = 2.92 s = .
TestSnmpUser#test_auth_md5_priv_sha_pw_localized = 1.38 s = E
TestSnmpUser#test_auth_priv_pw_equal_localizedkey = 2.42 s = .
TestSnmpUser#test_auth_priv_des_pw_equal = 3.30 s = E
TestSnmpUser#test_auth_md5_nopriv = 2.16 s = .
TestSnmpUser#test_create_destroy_with_engine_id = 1.42 s = E
TestSnmpUser#test_privpassword_with_engineid = 1.42 s = E
TestSnmpUser#test_authpassword = 1.87 s = .
TestSnmpUser#test_create_invalid_args = 1.08 s = .
TestSnmpUser#test_auth_md5_priv_des = 1.37 s = E
TestSnmpUser#test_engine_id_valid_and_none = 3.13 s = .
TestSnmpUser#test_priv_password_equal_with_engineid = 1.39 s = E
TestSnmpUser#test_auth_pw_equal_localizedkey = 2.32 s = .
TestSnmpUser#test_auth_sha_priv_aes128 = 2.24 s = .
TestSnmpUser#test_noauth_nopriv_multi = 2.15 s = .
TestSnmpUser#test_auth_pw_equal_invalid_param = 1.96 s = .
TestSnmpUser#test_default_auth_password = 1.02 s = .
TestSnmpUser#test_auth_sha_priv_aes128_pw_localized = 2.10 s = .
TestSnmpUser#test_auth_sha_nopriv_pw_localized = 2.17 s = .
TestSnmpUser#test_default_priv_protocol = 1.04 s = .
TestSnmpUser#test_auth_password_equal_with_engineid = 3.33 s = .
TestSnmpUser#test_authpassword_with_engineid = 1.81 s = .

Finished in 87.715218s, 0.4674 runs/s, 1.8697 assertions/s.
41 runs, 164 assertions, 0 failures, 9 errors, 0 skips
```

**Test results with XR support removed**

```
Node under test:
  - name  - n9k-108
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.IED5.0.176.bin

TestSnmpUser#test_auth_md5_priv_aes128 = 2.51 s = .
TestSnmpUser#test_noauth_nopriv = 2.11 s = .
TestSnmpUser#test_auth_sha_priv_des = 2.24 s = .
TestSnmpUser#test_auth_priv_pw_equal_localizedkey = 2.31 s = .
TestSnmpUser#test_default_auth_password = 1.02 s = .
TestSnmpUser#test_auth_priv_pw_equal_empty = 2.02 s = .
TestSnmpUser#test_auth_md5_nopriv = 2.14 s = .
TestSnmpUser#test_auth_sha_nopriv = 2.21 s = .
TestSnmpUser#test_auth_md5_nopriv_pw_localized = 2.20 s = .
TestSnmpUser#test_create_invalid_args = 1.07 s = .
TestSnmpUser#test_auth_md5_priv_des = 2.15 s = .
TestSnmpUser#test_default_auth_protocol = 1.05 s = .
TestSnmpUser#test_create_destroy_with_engine_id = 2.78 s = .
TestSnmpUser#test_engine_id_valid_and_none = 3.29 s = .
TestSnmpUser#test_auth_priv_des_pw_equal = 3.65 s = .
TestSnmpUser#test_default_priv_protocol = 1.09 s = .
TestSnmpUser#test_destroy = 8.11 s = .
TestSnmpUser#test_auth_priv_pw_equal_invalid_param = 2.06 s = .
TestSnmpUser#test_auth_sha_nopriv_pw_localized_false = 2.13 s = .
TestSnmpUser#test_collection_not_empty = 1.96 s = .
TestSnmpUser#test_auth_pw_equal = 2.77 s = .
TestSnmpUser#test_authpassword = 1.84 s = .
TestSnmpUser#test_privpassword = 2.74 s = .
TestSnmpUser#test_create_invalid_cli = 1.53 s = .
TestSnmpUser#test_privpassword_with_engineid = 2.64 s = .
TestSnmpUser#test_default_groups = 1.05 s = .
TestSnmpUser#test_auth_md5_priv_sha_pw_localized = 2.35 s = .
TestSnmpUser#test_auth_sha_nopriv_pw_localized = 2.07 s = .
TestSnmpUser#test_auth_pw_equal_priv_invalid_param = 2.80 s = .
TestSnmpUser#test_noauth_nopriv_multi = 2.18 s = .
TestSnmpUser#test_auth_pw_not_equal = 3.00 s = .
TestSnmpUser#test_auth_pw_equal_invalid_param = 1.95 s = .
TestSnmpUser#test_auth_sha_priv_aes128_pw_localized = 2.21 s = .
TestSnmpUser#test_auth_pw_equal_localizedkey = 2.23 s = .
TestSnmpUser#test_priv_password_equal_with_engineid = 5.59 s = .
TestSnmpUser#test_auth_password_equal_with_engineid = 3.50 s = .
TestSnmpUser#test_default_priv_password = 1.06 s = .
TestSnmpUser#test_auth_sha_priv_aes128 = 2.28 s = .
TestSnmpUser#test_auth_md5_priv_des_pw_localized = 2.14 s = .
TestSnmpUser#test_auth_md5_priv_aes128_pw_localized = 2.18 s = .
TestSnmpUser#test_authpassword_with_engineid = 2.37 s = .

Finished in 99.844048s, 0.4106 runs/s, 1.9731 assertions/s.

41 runs, 197 assertions, 0 failures, 0 errors, 0 skips
```
