### PR TITLE
Fix half/full in test_duplex

### DIFF
--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -122,6 +122,7 @@ module Cisco
           next if k.nil? || v.nil?
           k.gsub!(/ \(.*\)/, '') # Remove any parenthetical text from key
           v.strip!
+          v.gsub!(%r{half/full}, 'half,full') if k == 'Duplex'
           hash[k] = v
         end
       end


### PR DESCRIPTION
- For some 3k, need to munge 'half/full' into csv-style 'half,full' to play nice with interface_capabilities which needs to parse these as separate options
- Tested on n3048
