### PR TITLE
Refactor yum patch test

### DIFF
--- a/tests/test_yum.rb
+++ b/tests/test_yum.rb
@@ -39,7 +39,7 @@ class TestYum < CiscoTestCase
     @@pkg_ver = pkginfo[@@pv]['version']
 
     @@incompatible_rpm_msg =
-      ": Sample rpm is compatible version #{Platform.image_version}."  \
+      ": Sample rpm is compatible with version #{Platform.image_version}."  \
       'This test will fail with other versions.'
     # rubocop:enable Style/ClassVars
   end

--- a/tests/test_yum.rb
+++ b/tests/test_yum.rb
@@ -34,8 +34,8 @@ class TestYum < CiscoTestCase
     # rubocop:disable Style/ClassVars
     #
     # Replace [.,(,)] characters with '_' for yaml key lookup.
-    # Image Version before gsub: 7.0(3)I3(1) 
-    # Image Version after  gsub: 7_0_3_I3_1_ 
+    # Image Version before gsub: 7.0(3)I3(1)
+    # Image Version after  gsub: 7_0_3_I3_1_
     @@pv = Platform.image_version.gsub(/[.()]/, '_')[/\S+/]
     info "Image version detected: #{Platform.image_version}"
     @@pkg_filename = pkginfo[@@pv]['filename']

--- a/tests/test_yum.rb
+++ b/tests/test_yum.rb
@@ -39,8 +39,8 @@ class TestYum < CiscoTestCase
     @@pkg_ver = pkginfo[@@pv]['version']
 
     @@incompatible_rpm_msg =
-      ": Sample rpm is compatible with NX-OS release version #{@@pv}."  \
-      'This test may fail with other versions.'
+      ": Sample rpm is compatible version #{Platform.image_version}."  \
+      'This test will fail with other versions.'
     # rubocop:enable Style/ClassVars
   end
 

--- a/tests/test_yum.rb
+++ b/tests/test_yum.rb
@@ -32,6 +32,10 @@ class TestYum < CiscoTestCase
     pkginfo = YAML.load(File.read(path))
 
     # rubocop:disable Style/ClassVars
+    #
+    # Replace [.,(,)] characters with '_' for yaml key lookup.
+    # Image Version before gsub: 7.0(3)I3(1) 
+    # Image Version after  gsub: 7_0_3_I3_1_ 
     @@pv = Platform.image_version.gsub(/[.()]/, '_')[/\S+/]
     info "Image version detected: #{Platform.image_version}"
     @@pkg_filename = pkginfo[@@pv]['filename']

--- a/tests/yum_package.yaml
+++ b/tests/yum_package.yaml
@@ -1,0 +1,25 @@
+# Sample Patch RPM's
+#
+
+# N3K and N9K Sample Patches
+
+7_0_3_I2_1_:
+  filename: 'n9000_sample-1.0.0-7.0.3.x86_64.rpm'
+  name:     'n9000_sample'
+  version:  '1.0.0-7.0.3'
+
+7_0_3_I3_1_:
+  filename: 'CSCuxdublin-1.0.0-7.0.3.I3.1.lib32_n9000.rpm'
+  name:     'CSCuxdublin'
+  version:  '1.0.0-7.0.3.I3.1'
+
+7_0_3_I4_1_:
+  filename: 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I4.1.lib32_n9000.rpm'
+  name:     'nxos.sample-n9k_EOR'
+  version:  '1.0.0-7.0.3.I4.1'
+
+7_0_3_I5_1_:
+  filename: 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I5.1.lib32_n9000.rpm'
+  name:     'nxos.sample-n9k_EOR'
+  version:  '1.0.0-7.0.3.I5.1'
+


### PR DESCRIPTION
This update removes the hard coded sample rpm references in the test file and moves this into a yaml data file.  We then dynamically detect the image version and use this as a yaml lookup key to select the correct patch for the image.

**NOTE:** The CI framework is responsible for ensuring that the correct patch for the image is copied to the device under test.  Patches for nightly builds will be overwritten for each new build.

**Testing:**

**I2**

```
# Running:


Node under test:
  - name  - n9k-108
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I2.1.bin

I, [2016-08-22T12:28:17.567018 #26530]  INFO -- : Image version detected: 7.0(3)I2(1)
I, [2016-08-22T12:28:17.610796 #26530]  INFO -- : Executing test setup... Please be patient, this will take a while.
I, [2016-08-22T12:28:17.610879 #26530]  INFO -- : Executing setup step: install deactivate n9000_sample...
I, [2016-08-22T12:28:38.033078 #26530]  INFO -- : Executing setup step: install commit n9000_sample...
I, [2016-08-22T12:28:59.432284 #26530]  INFO -- : Executing setup step: install remove n9000_sample forced...
I, [2016-08-22T12:29:19.433024 #26530]  INFO -- : Executing setup step: install add bootflash:n9000_sample-1.0.0-7.0.3.x86_64.rpm...
TestYum#test_ambiguous_package_error = 83.03 s = .
TestYum#test_package_does_not_exist_error = 7.51 s = .
TestYum#test_install_remove = 51.94 s = .
TestYum#test_query = 44.24 s = .

Finished in 187.774444s, 0.0213 runs/s, 0.0479 assertions/s.

4 runs, 9 assertions, 0 failures, 0 errors, 0 skips
```

**I3**

```
Node under test:
  - name  - n9k-108
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I3.1.bin

I, [2016-08-22T12:00:40.186808 #9149]  INFO -- : Image version detected: 7.0(3)I3(1)
I, [2016-08-22T12:00:40.233351 #9149]  INFO -- : Executing test setup... Please be patient, this will take a while.
I, [2016-08-22T12:00:40.233431 #9149]  INFO -- : Executing setup step: install deactivate CSCuxdublin...
I, [2016-08-22T12:01:00.635172 #9149]  INFO -- : Executing setup step: install commit CSCuxdublin...
I, [2016-08-22T12:01:21.816533 #9149]  INFO -- : Executing setup step: install remove CSCuxdublin forced...
I, [2016-08-22T12:01:41.817266 #9149]  INFO -- : Executing setup step: install add bootflash:CSCuxdublin-1.0.0-7.0.3.I3.1.lib32_n9000.rpm...
TestYum#test_query = 125.90 s = .
TestYum#test_package_does_not_exist_error = 11.86 s = .
TestYum#test_install_remove = 58.76 s = .
TestYum#test_ambiguous_package_error = 1.16 s = .

Finished in 198.880665s, 0.0201 runs/s, 0.0453 assertions/s.

4 runs, 9 assertions, 0 failures, 0 errors, 0 skips
```

**I4**

```
Node under test:
  - name  - n9k-108
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I4.1.bin

I, [2016-08-22T11:49:26.292463 #2344]  INFO -- : Image version detected: 7.0(3)I4(1)
I, [2016-08-22T11:49:26.336983 #2344]  INFO -- : Executing test setup... Please be patient, this will take a while.
I, [2016-08-22T11:49:26.337060 #2344]  INFO -- : Executing setup step: install deactivate nxos.sample-n9k_EOR...
I, [2016-08-22T11:49:46.737133 #2344]  INFO -- : Executing setup step: install commit nxos.sample-n9k_EOR...
I, [2016-08-22T11:50:07.922871 #2344]  INFO -- : Executing setup step: install remove nxos.sample-n9k_EOR forced...
I, [2016-08-22T11:50:27.923486 #2344]  INFO -- : Executing setup step: install add bootflash:nxos.sample-n9k_EOR-1.0.0-7.0.3.I4.1.lib32_n9000.rpm...
TestYum#test_package_does_not_exist_error = 93.67 s = .
TestYum#test_ambiguous_package_error = 1.20 s = .
TestYum#test_install_remove = 61.05 s = .
TestYum#test_query = 44.41 s = .

Finished in 201.498775s, 0.0199 runs/s, 0.0447 assertions/s.

4 runs, 9 assertions, 0 failures, 0 errors, 0 skips
```

**I5**

```
Node under test:
  - name  - n9k-108
  - type  - N9K-C9396PX
  - image - bootflash:///nxos.7.0.3.I5.0.68.bin

I, [2016-08-22T11:16:38.662576 #14087]  INFO -- : Image version detected: 7.0(3)I5(1) [build 7.0(3)I5(0.68)]
I, [2016-08-22T11:16:38.706698 #14087]  INFO -- : Executing test setup... Please be patient, this will take a while.
I, [2016-08-22T11:16:38.706741 #14087]  INFO -- : Executing setup step: install deactivate nxos.sample-n9k_EOR...
I, [2016-08-22T11:17:01.136137 #14087]  INFO -- : Executing setup step: install commit nxos.sample-n9k_EOR...
I, [2016-08-22T11:17:21.136710 #14087]  INFO -- : Executing setup step: install remove nxos.sample-n9k_EOR forced...
I, [2016-08-22T11:17:41.137588 #14087]  INFO -- : Executing setup step: install add bootflash:nxos.sample-n9k_EOR-1.0.0-7.0.3.I5.1.lib32_n9000.rpm...
TestYum#test_query = 127.37 s = .
TestYum#test_install_remove = 64.48 s = .
TestYum#test_ambiguous_package_error = 1.53 s = .
TestYum#test_package_does_not_exist_error = 1.09 s = .

Finished in 195.708909s, 0.0204 runs/s, 0.0460 assertions/s.

4 runs, 9 assertions, 0 failures, 0 errors, 0 skips
```
