### PR TITLE
ciscotest: first_or_last_teardown

### DIFF
--- a/tests/test_overlay_global.rb
+++ b/tests/test_overlay_global.rb
@@ -25,10 +25,15 @@ class TestOverlayGlobal < CiscoTestCase
 
   def setup
     super
-    vxlan_linecard?
-    vdc_lc_state('f3')
+    vdc_limit_f3_no_intf_needed(:set)
     config_no_warn('no feature fabric forwarding')
     config_no_warn('no nv overlay evpn')
+  end
+
+  def teardown
+    config_no_warn('no feature fabric forwarding')
+    config_no_warn('no nv overlay evpn')
+    vdc_limit_f3_no_intf_needed(:clear) if first_or_last_teardown
   end
 
   def test_dup_host_ip_addr_detection


### PR DESCRIPTION
- f3 setup/teardown on N7k's can be very time consuming (60+ seconds) so it's expensive to do this for every testcase
- This hack limits the vdc teardowns to the first and last testcase (f3 setup is ignored if it's already set to f3)
  - We have to check for first because a test may use -n to limit the run to a single test
- Minitest.after_run is not really an option for this: it's designed to run at the end of an entire test suite and actually runs at_exit, at which point we no longer have access to our ciscotest methods.
