### PR TITLE
Rel140/refactor yum

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/yum.yaml
+++ b/lib/cisco_node_utils/cmd_ref/yum.yaml
@@ -2,6 +2,9 @@
 ---
 _exclude: [ios_xr]
 
+deactivate:
+  set_value: "install deactivate %s"
+
 install:
   set_value: "install add %s %s activate"
 
@@ -18,4 +21,4 @@ query_all:
   default_value: []
 
 remove:
-  set_value: "install deactivate %s"
+  set_value: "install remove %s forced"

--- a/lib/cisco_node_utils/yum.rb
+++ b/lib/cisco_node_utils/yum.rb
@@ -71,6 +71,7 @@ module Cisco
     end
 
     def self.remove(pkg)
+      config_set('yum', 'deactivate', pkg)
       config_set('yum', 'remove', pkg)
     end
   end

--- a/lib/cisco_node_utils/yum.rb
+++ b/lib/cisco_node_utils/yum.rb
@@ -75,7 +75,7 @@ module Cisco
       # May not be able to remove the package immediately after
       # deactivation.
       try = 1
-      while try < 50
+      while try < 20
         o = config_set('yum', 'remove', pkg)
         break unless o[/operation is in progress, please try again later/]
         sleep 1

--- a/lib/cisco_node_utils/yum.rb
+++ b/lib/cisco_node_utils/yum.rb
@@ -74,11 +74,11 @@ module Cisco
       config_set('yum', 'deactivate', pkg)
       # May not be able to remove the package immediately after
       # deactivation.
-      try = 1
-      while try < 20
+      while (try ||= 1) < 20
         o = config_set('yum', 'remove', pkg)
         break unless o[/operation is in progress, please try again later/]
         sleep 1
+        try += 1
       end
     end
   end

--- a/lib/cisco_node_utils/yum.rb
+++ b/lib/cisco_node_utils/yum.rb
@@ -77,7 +77,7 @@ module Cisco
       try = 1
       while try < 50
         o = config_set('yum', 'remove', pkg)
-        break unless o[/.*operation is in progress, please try again later/]
+        break unless o[/operation is in progress, please try again later/]
         sleep 1
       end
     end

--- a/lib/cisco_node_utils/yum.rb
+++ b/lib/cisco_node_utils/yum.rb
@@ -72,7 +72,14 @@ module Cisco
 
     def self.remove(pkg)
       config_set('yum', 'deactivate', pkg)
-      config_set('yum', 'remove', pkg)
+      # May not be able to remove the package immediately after
+      # deactivation.
+      try = 1
+      while try < 50
+        o = config_set('yum', 'remove', pkg)
+        break unless o[/.*operation is in progress, please try again later/]
+        sleep 1
+      end
     end
   end
 end

--- a/tests/yum_package.yaml
+++ b/tests/yum_package.yaml
@@ -8,15 +8,25 @@
   name:     'n9000_sample'
   version:  '1.0.0-7.0.3'
 
+7_0_3_I2_2e_:
+  filename: 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I2.2e.lib32_n9000.rpm'
+  name:     'nxos.sample-n9k_EOR'
+  version:  '1.0.0-7.0.3.I2.2e'
+
 7_0_3_I3_1_:
-  filename: 'CSCuxdublin-1.0.0-7.0.3.I3.1.lib32_n9000.rpm'
-  name:     'CSCuxdublin'
+  filename: 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I3.1.lib32_n9000.rpm'
+  name:     'nxos.sample-n9k_EOR'
   version:  '1.0.0-7.0.3.I3.1'
 
 7_0_3_I4_1_:
   filename: 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I4.1.lib32_n9000.rpm'
   name:     'nxos.sample-n9k_EOR'
   version:  '1.0.0-7.0.3.I4.1'
+
+7_0_3_I4_2_:
+  filename: 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I4.2.lib32_n9000.rpm'
+  name:     'nxos.sample-n9k_EOR'
+  version:  '1.0.0-7.0.3.I4.2'
 
 7_0_3_I5_1_:
   filename: 'nxos.sample-n9k_EOR-1.0.0-7.0.3.I5.1.lib32_n9000.rpm'


### PR DESCRIPTION
**Summary of changes:**
- Our yum provider would only deactivate a patch when calling `Yum.remove`.  This update calls both `install deactivate <pkg_name>` and `install remove <pkg_name> forced` so that the package is really removed when `Yum.remove` is called.
  - This was causing an install failure when attempting to install the same pkg_name(built for different image versions) because the previous package was only getting deactivated, not actually removed.
- Refactor to install/query/and remove in the same test for efficiency.
- Enable additional nxos releases.

Tested on: n9k (I2, I3, I4, I5), n3k (I5).
Also Tested with beaker using puppet `develop` branch: n9k (I2, I3, I4, I5) (Native and Guestshell)
