### PR TITLE
removing vlan name negative tests and fix dhcp relay munge

### DIFF
--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -474,9 +474,9 @@ module Cisco
 
     def ipv4_dhcp_relay_src_intf
       intf = config_get('interface', 'ipv4_dhcp_relay_src_intf', name: @name)
-      return intf unless intf
       # Normalize by downcasing and removing white space
-      intf.downcase.delete(' ')
+      intf = intf.downcase.delete(' ') if intf
+      intf
     end
 
     def ipv4_dhcp_relay_src_intf=(val)
@@ -651,9 +651,9 @@ module Cisco
 
     def ipv6_dhcp_relay_src_intf
       intf = config_get('interface', 'ipv6_dhcp_relay_src_intf', name: @name)
-      return intf unless intf
       # Normalize by downcasing and removing white space
-      intf.downcase.delete(' ')
+      intf = intf.downcase.delete(' ') if intf
+      intf
     end
 
     def ipv6_dhcp_relay_src_intf=(val)

--- a/tests/test_vlan.rb
+++ b/tests/test_vlan.rb
@@ -149,34 +149,6 @@ class TestVlan < CiscoTestCase
     v.destroy
   end
 
-  def test_name_too_long
-    v = Vlan.new(1000)
-    name = 'a' * VLAN_NAME_SIZE
-    assert_raises(RuntimeError, 'vlan misconfig did not raise RuntimeError') do
-      v.vlan_name = name
-    end
-    ref = cmd_ref.lookup('vlan', 'name')
-    assert(ref, 'Error, reference not found for vlan name')
-    v.destroy
-  end
-
-  def test_name_duplicate
-    # Testbed cleanup
-    v = Vlan.new(1000)
-    v.destroy
-    v = Vlan.new(1001)
-    v.destroy
-    # start test
-    v1 = Vlan.new(1000)
-    v1.vlan_name = 'test'
-    v2 = Vlan.new(1001)
-    assert_raises(RuntimeError, 'vlan misconfig did not raise RuntimeError') do
-      v2.vlan_name = 'test'
-    end
-    v1.destroy
-    v2.destroy
-  end
-
   def test_state_invalid
     v = Vlan.new(1000)
     assert_raises(CliError) do


### PR DESCRIPTION
This PR is for removing the vlan name negative tests and also fixing a munging issue for dhcp relay src intf. Mike has the context for this, so it would be better if he can review this.
Vlan tests removed:
1. name too long
2. duplicate names
The reason is that the platform code is changing the error messages and it is difficult to maintain and also these tests serve no purpose from puppet perspective, there are boundary condition tests for CLI testing.
