### PR TITLE
Add defect/image check to minitest

### DIFF
--- a/lib/cisco_node_utils/logger.rb
+++ b/lib/cisco_node_utils/logger.rb
@@ -45,6 +45,9 @@ module Cisco::Logger
       @@logger = Chef::Log # rubocop:disable Style/ClassVars
     else
       @@logger = Logger.new(STDOUT) # rubocop:disable Style/ClassVars
+      @@logger.formatter = proc do |severity, _datetime, _progname, msg|
+        "#{severity} -- : #{msg}\n"
+      end
       @@logger.level = Logger::INFO
 
       def level

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -183,7 +183,7 @@ class CiscoTestCase < TestCase
 
   def defect?(pattern, msg)
     return false unless system_image.match(Regexp.new(pattern))
-    msg = "#{self.class}##{caller[0][/`.*'/][1..-2]} -> NOOP <- [#{msg}]"
+    msg = "#{self.class}##{caller[0][/`.*'/][1..-2]} -> NOT TESTED <- [#{msg}]"
     Cisco::Logger.warn(msg)
     true
   end

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -16,10 +16,11 @@ require 'ipaddr'
 require 'resolv'
 require_relative 'basetest'
 require_relative 'platform_info'
+require_relative '../lib/cisco_node_utils/bridge_domain'
 require_relative '../lib/cisco_node_utils/interface'
 require_relative '../lib/cisco_node_utils/node'
+require_relative '../lib/cisco_node_utils/platform'
 require_relative '../lib/cisco_node_utils/vlan'
-require_relative '../lib/cisco_node_utils/bridge_domain'
 
 include Cisco
 
@@ -174,6 +175,16 @@ class CiscoTestCase < TestCase
   def skip_nexus_i2_image?
     skip("This property is not supported on Nexus 'I2' images") if
       Utils.nexus_i2_image
+  end
+
+  def system_image
+    @image ||= Platform.system_image
+  end
+
+  def defect?(pattern, msg)
+    return false unless system_image.match(Regexp.new(pattern))
+    puts "\n#{self.class}##{caller[0][/`.*'/][1..-2]} -> NOOP <- [#{msg}]"
+    true
   end
 
   def interfaces

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -183,7 +183,8 @@ class CiscoTestCase < TestCase
 
   def defect?(pattern, msg)
     return false unless system_image.match(Regexp.new(pattern))
-    puts "\n#{self.class}##{caller[0][/`.*'/][1..-2]} -> NOOP <- [#{msg}]"
+    msg = "#{self.class}##{caller[0][/`.*'/][1..-2]} -> NOOP <- [#{msg}]"
+    Cisco::Logger.warn(msg)
     true
   end
 

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -108,6 +108,8 @@ class TestVrf < CiscoTestCase
   end
 
   def test_description
+    return if defect?('7.3.0.(N1|D1).1.bin',
+                      'CSCuy36637: Cannot remove description')
     v = Vrf.new('test_description')
     desc = 'tested by minitest'
     v.description = desc


### PR DESCRIPTION
- Bails out of testcase if image matches pattern; no skip, no assert
- Prints 'NOOP' message and any add'l helpful text, e.g.:

```
Node under test:
  - name  - n5k-136
  - type  - N5K-C56128P
  - image - bootflash:///n6000-uk9.7.3.0.N1.1.bin

TestVrf#test_name_zero_length = 4.88 s = .
TestVrf#test_route_distinguisher = 11.79 s = .
TestVrf#test_remote_route_filtering = 2.01 s = .
TestVrf#test_name_too_long = 1.93 s = .
TestVrf#test_vpn_id = 2.07 s = .
TestVrf#test_vni = 2.85 s = S
TestVrf#test_mhost = 1.96 s = .

TestVrf#test_description -> NOOP <- [CSCuy36637: Cannot remove description]
TestVrf#test_description = 2.91 s = .
TestVrf#test_collection_default = 1.01 s = .
TestVrf#test_create_and_destroy = 2.89 s = .
TestVrf#test_name_type_invalid = 1.05 s = .
TestVrf#test_shutdown = 26.73 s = .

Finished in 62.072465s, 0.1933 runs/s, 0.4189 assertions/s.
12 runs, 26 assertions, 0 failures, 0 errors, 1 skips
```
