### PR TITLE
Enable nv_overlay_evpn fix

### DIFF
--- a/lib/cisco_node_utils/bgp_neighbor_af.rb
+++ b/lib/cisco_node_utils/bgp_neighbor_af.rb
@@ -99,7 +99,10 @@ module Cisco
     # rubocop:enable Style/AccessorMethodNamefor
 
     def create
-      Feature.bgp_enable if platform == :nexus
+      if platform == :nexus
+        Feature.bgp_enable
+        Feature.nv_overlay_evpn_enable if @safi[/evpn/]
+      end
       set_args_keys(state: '')
       config_set('bgp_neighbor', 'af', @set_args)
     end


### PR DESCRIPTION
This code exists in `bgp_af.rb` but was missing in `bgp_neighbor_af.rb`.  Without this fix, we get a `The command ' address-family l2vpn evpn' was rejected with error` in beaker.

Tested on: n9k and n5k.
