### PR TITLE
skip_legacy_defect method

### DIFF
--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -181,11 +181,9 @@ class CiscoTestCase < TestCase
     @image ||= Platform.system_image
   end
 
-  def defect?(pattern, msg)
-    return false unless system_image.match(Regexp.new(pattern))
-    msg = "#{self.class}##{caller[0][/`.*'/][1..-2]} -> NOT TESTED <- [#{msg}]"
-    Cisco::Logger.warn(msg)
-    true
+  def skip_legacy_defect?(pattern, msg)
+    msg = "Defect in legacy image: [#{msg}]"
+    skip(msg) if system_image.match(Regexp.new(pattern))
   end
 
   def interfaces

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -108,8 +108,8 @@ class TestVrf < CiscoTestCase
   end
 
   def test_description
-    return if defect?('7.3.0.(N1|D1).1.bin',
-                      'CSCuy36637: Cannot remove description')
+    skip_legacy_defect?('7.3.0.(N1|D1).1.bin',
+                        'CSCuy36637: Cannot remove description')
     v = Vrf.new('test_description')
     desc = 'tested by minitest'
     v.description = desc


### PR DESCRIPTION
- Rework previous `defect?` method to do skip instead of return
- Tested on n3-I2, n5
- New test result when skipped:

```

  1) Skipped:
TestVrf#test_description [/nobackup/cvanheuv/git.nu/cisco-network-node-utils/tests/ciscotest.rb:186]:
Defect in legacy image: [CSCuy36637: Cannot remove description]

```
