### PR TITLE
(POC) product_id qualifier for 8k rebrand

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vrf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vrf.yaml
@@ -32,7 +32,11 @@ description:
   get_value: '/^description (.*)/'
   set_value: '<state> description <desc>'
   kind: string
-  default_value: ''
+  # default_value: ''
+  N9k-R:
+    default_value: 'I am fretta! :-)'
+  else:
+    default_value: "I am not fretta :-("
 
 destroy:
   context: ~

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -434,13 +434,16 @@ module Cisco
       puts "DEBUG: #{text}" if @@debug
     end
 
-    KNOWN_PLATFORMS = %w(C3064 C3132 C3172 N3k N5k N6k N7k N8k N9k XRv9k)
+    KNOWN_PLATFORMS = %w(C3064 C3132 C3172 N3k N5k N6k N7k N8k N9k N9k-R XRv9k)
 
     def self.platform_to_filter(platform)
       if KNOWN_PLATFORMS.include?(platform)
         case platform
         when 'XRv9k'
           /XRV9/
+        when 'N9k-R'
+          # fretta filter
+          /N9K-C9...-R/
         else
           Regexp.new platform.tr('k', '')
         end

--- a/spec/schema.yaml
+++ b/spec/schema.yaml
@@ -21,6 +21,7 @@ mapping:
           - 'N7k'
           - 'N8k'
           - 'N9k'
+          - 'N9k-R'
 
   =: &base # default rule - apply to all properties
     type: map
@@ -38,6 +39,7 @@ mapping:
       N7k: *base
       N8k: *base
       N9k: *base
+      N9k-R: *base
       # 'else' case if not matching any filter above
       else: *base
       # Generally applicable attributes

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -24,6 +24,8 @@ class TestVrf < CiscoTestCase
 
   def setup
     super
+    puts "minitest: #{Vrf.new('test', false).default_description}"
+    exit
     remove_all_vrfs if @@pre_clean_needed
     @@pre_clean_needed = false # rubocop:disable Style/ClassVars
   end


### PR DESCRIPTION
- This is just a POC diff for adding add'l checks to determine the product_id. 

**DO NOT MERGE THIS CODE.**
- The requirement here is to create a unique product_id for switches that share the same product_id but have a fundamental difference; e.g.
  - 8k may only be differentiated by the presense of 8k fabric modules
  - n3k-in-n9k-mode will have the same product_id as a "regular" n3k
