### PR TITLE
bgp event_history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Changelog
 
 ### Added
 
+* Extend bgp with attributes:
+   * `event_history_errors`
+   * `event_history_objstore`
+
 ### Changed
 
 ### Removed

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -463,6 +463,32 @@ module Cisco
       config_get_default('bgp', 'event_history_detail')
     end
 
+    # event-history errors [ size <size> ]
+    # Nvgen as True With optional 'size <size>
+    def event_history_errors
+      match = config_get('bgp', 'event_history_errors', @get_args)
+      if match.is_a?(Array)
+        return 'false' if match[0] == 'no '
+        if match[1]
+          return match[1] if match[1][/\A\d+\z/]
+          return 'size_' + match[1]
+        end
+      end
+      default_event_history_errors
+    end
+
+    def event_history_errors=(val)
+      size = val[/small|medium|large|disable|\A\d+\z/]
+      @set_args[:size] = size.nil? ? '' : "size #{size}"
+      @set_args[:state] = val[/false/] ? 'no' : ''
+      config_set('bgp', 'event_history_errors', @set_args)
+      set_args_keys_default
+    end
+
+    def default_event_history_errors
+      config_get_default('bgp', 'event_history_errors')
+    end
+
     # event-history events [ size <size> ]
     # Nvgen as True With optional 'size <size>
     def event_history_events
@@ -486,7 +512,39 @@ module Cisco
     end
 
     def default_event_history_events
-      config_get_default('bgp', 'event_history_events')
+      if Utils.image_version?(/7.0.3.I2|I3|I4/) ||
+         Utils.chassis_pid?(/N(5|6|7|8)/)
+        config_get_default('bgp', 'event_history_events')
+      else
+        config_get('bgp', 'event_history_events_bytes', @get_args)
+      end
+    end
+
+    # event-history objstore [ size <size> ]
+    # Nvgen as True With optional 'size <size>
+    def event_history_objstore
+      match = config_get('bgp', 'event_history_objstore', @get_args)
+      # This property requires auto_default=false
+      if match.is_a?(Array)
+        return 'false' if match[0] == 'no '
+        if match[1]
+          return match[1] if match[1][/\A\d+\z/]
+          return 'size_' + match[1]
+        end
+      end
+      default_event_history_objstore
+    end
+
+    def event_history_objstore=(val)
+      size = val[/small|medium|large|disable|\A\d+\z/]
+      @set_args[:size] = size.nil? ? '' : "size #{size}"
+      @set_args[:state] = val[/false/] ? 'no' : ''
+      config_set('bgp', 'event_history_objstore', @set_args)
+      set_args_keys_default
+    end
+
+    def default_event_history_objstore
+      config_get_default('bgp', 'event_history_objstore')
     end
 
     # event-history periodic [ size <size> ]

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -440,13 +440,13 @@ module Cisco
     # Nvgen as True With optional 'size <size>
     def event_history_detail
       match = config_get('bgp', 'event_history_detail', @get_args)
-      # This property requires auto_default=false
       if match.is_a?(Array)
         return 'false' if match[0] == 'no '
         if match[1]
           return match[1] if match[1][/\A\d+\z/]
           return 'size_' + match[1]
         end
+        return 'true'
       end
       default_event_history_detail
     end
@@ -494,7 +494,7 @@ module Cisco
     def event_history_events
       match = config_get('bgp', 'event_history_events', @get_args)
       if match.is_a?(Array)
-        return 'size_disable' if match[0] == 'no '
+        return 'false' if match[0] == 'no '
         if match[1]
           return match[1] if match[1][/\A\d+\z/]
           return 'size_' + match[1]
@@ -524,13 +524,13 @@ module Cisco
     # Nvgen as True With optional 'size <size>
     def event_history_objstore
       match = config_get('bgp', 'event_history_objstore', @get_args)
-      # This property requires auto_default=false
       if match.is_a?(Array)
         return 'false' if match[0] == 'no '
         if match[1]
           return match[1] if match[1][/\A\d+\z/]
           return 'size_' + match[1]
         end
+        return 'true'
       end
       default_event_history_objstore
     end

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -156,8 +156,7 @@ event_history_detail:
   _exclude: [ios_xr]
   get_value: '/^(no )?event-history detail(?: size (\S+))?$/'
   set_value: '<state> event-history detail <size>'
-  auto_default: false
-  default_value: 'size_disable'
+  default_value: 'false'
 
 event_history_errors:
   _exclude: [ios_xr]
@@ -178,8 +177,7 @@ event_history_objstore:
   _exclude: [ios_xr]
   get_value: '/^(no )?event-history objstore(?: size (\S+))?$/'
   set_value: '<state> event-history objstore <size>'
-  auto_default: false
-  default_value: 'size_disable'
+  default_value: 'false'
 
 event_history_periodic:
   _exclude: [ios_xr]

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -159,11 +159,27 @@ event_history_detail:
   auto_default: false
   default_value: 'size_disable'
 
+event_history_errors:
+  _exclude: [ios_xr]
+  get_value: '/^(no )?event-history errors(?: size (\S+))?$/'
+  set_value: '<state> event-history errors <size>'
+  default_value: 'size_medium'
+
 event_history_events:
   _exclude: [ios_xr]
   get_value: '/^(no )?event-history events(?: size (\S+))?$/'
   set_value: '<state> event-history events <size>'
   default_value: 'size_small'
+
+event_history_events_bytes:
+  default_only: 'size_large'
+
+event_history_objstore:
+  _exclude: [ios_xr]
+  get_value: '/^(no )?event-history objstore(?: size (\S+))?$/'
+  set_value: '<state> event-history objstore <size>'
+  auto_default: false
+  default_value: 'size_disable'
 
 event_history_periodic:
   _exclude: [ios_xr]

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -588,10 +588,10 @@ class TestRouterBgp < CiscoTestCase
 
   def test_event_history_cli
     bgp = setup_default
-    if validate_property_excluded?('bgp', 'event_history_detail')
-      assert_nil(bgp.event_history_detail)
+    if validate_property_excluded?('bgp', 'event_history_cli')
+      assert_nil(bgp.event_history_cli)
       assert_raises(Cisco::UnsupportedError) do
-        bgp.event_history_detail = 'true'
+        bgp.event_history_cli = 'true'
       end
       return
     end
@@ -607,11 +607,13 @@ class TestRouterBgp < CiscoTestCase
     bgp.event_history_cli = 'size_medium'
     assert_equal('size_medium', bgp.event_history_cli)
     bgp.event_history_cli = 'size_disable'
-    assert_equal('size_disable', bgp.event_history_cli)
     if newer_image_version?
-      bgp.event_history_cli = '100000'
-      assert_equal('100000', bgp.event_history_cli)
+      assert_equal('false', bgp.event_history_cli)
+    else
+      assert_equal('size_disable', bgp.event_history_cli)
     end
+    bgp.event_history_cli = '100000'
+    assert_equal('100000', bgp.event_history_cli)
     bgp.event_history_cli = bgp.default_event_history_cli
     assert_equal(bgp.default_event_history_cli, bgp.event_history_cli)
   end
@@ -638,12 +640,39 @@ class TestRouterBgp < CiscoTestCase
     assert_equal('size_medium', bgp.event_history_detail)
     bgp.event_history_detail = 'size_disable'
     assert_equal('size_disable', bgp.event_history_detail)
-    if newer_image_version?
-      bgp.event_history_detail = '100000'
-      assert_equal('100000', bgp.event_history_detail)
-    end
+    bgp.event_history_detail = '100000'
+    assert_equal('100000', bgp.event_history_detail)
     bgp.event_history_detail = bgp.default_event_history_detail
     assert_equal(bgp.default_event_history_detail, bgp.event_history_detail)
+  end
+
+  def test_event_history_errors
+    bgp = setup_default
+    if validate_property_excluded?('bgp', 'event_history_errors')
+      assert_nil(bgp.event_history_errors)
+      assert_raises(Cisco::UnsupportedError) do
+        bgp.event_history_errors = 'true'
+      end
+      return
+    end
+    skip('platform not supported for this test') unless newer_image_version?
+    assert_equal(bgp.default_event_history_errors, bgp.event_history_errors)
+    bgp.event_history_errors = 'true'
+    assert_equal(bgp.default_event_history_errors, bgp.event_history_errors)
+    bgp.event_history_errors = 'false'
+    assert_equal('false', bgp.event_history_errors)
+    bgp.event_history_errors = 'size_small'
+    assert_equal('size_small', bgp.event_history_errors)
+    bgp.event_history_errors = 'size_large'
+    assert_equal('size_large', bgp.event_history_errors)
+    bgp.event_history_errors = 'size_medium'
+    assert_equal('size_medium', bgp.event_history_errors)
+    bgp.event_history_errors = 'size_disable'
+    assert_equal('false', bgp.event_history_errors)
+    bgp.event_history_errors = '100000'
+    assert_equal('100000', bgp.event_history_errors)
+    bgp.event_history_errors = bgp.default_event_history_errors
+    assert_equal(bgp.default_event_history_errors, bgp.event_history_errors)
   end
 
   def test_event_history_events
@@ -668,12 +697,39 @@ class TestRouterBgp < CiscoTestCase
     assert_equal('size_medium', bgp.event_history_events)
     bgp.event_history_events = 'size_disable'
     assert_equal('size_disable', bgp.event_history_events)
-    if newer_image_version?
-      bgp.event_history_events = '100000'
-      assert_equal('100000', bgp.event_history_events)
-    end
+    bgp.event_history_events = '100000'
+    assert_equal('100000', bgp.event_history_events)
     bgp.event_history_events = bgp.default_event_history_events
     assert_equal(bgp.default_event_history_events, bgp.event_history_events)
+  end
+
+  def test_event_history_objstore
+    bgp = setup_default
+    if validate_property_excluded?('bgp', 'event_history_objstore')
+      assert_nil(bgp.event_history_objstore)
+      assert_raises(Cisco::UnsupportedError) do
+        bgp.event_history_objstore = 'true'
+      end
+      return
+    end
+    skip('platform not supported for this test') unless newer_image_version?
+    assert_equal(bgp.default_event_history_objstore, bgp.event_history_objstore)
+    bgp.event_history_objstore = 'true'
+    assert_equal(bgp.default_event_history_objstore, bgp.event_history_objstore)
+    bgp.event_history_objstore = 'false'
+    assert_equal(bgp.default_event_history_objstore, bgp.event_history_objstore)
+    bgp.event_history_objstore = 'size_small'
+    assert_equal('size_small', bgp.event_history_objstore)
+    bgp.event_history_objstore = 'size_large'
+    assert_equal('size_large', bgp.event_history_objstore)
+    bgp.event_history_objstore = 'size_medium'
+    assert_equal('size_medium', bgp.event_history_objstore)
+    bgp.event_history_objstore = 'size_disable'
+    assert_equal('size_disable', bgp.event_history_objstore)
+    bgp.event_history_objstore = '100000'
+    assert_equal('100000', bgp.event_history_objstore)
+    bgp.event_history_objstore = bgp.default_event_history_objstore
+    assert_equal(bgp.default_event_history_objstore, bgp.event_history_objstore)
   end
 
   def test_event_history_periodic
@@ -695,13 +751,17 @@ class TestRouterBgp < CiscoTestCase
     assert_equal('size_large', bgp.event_history_periodic)
     bgp.event_history_periodic = 'size_medium'
     assert_equal('size_medium', bgp.event_history_periodic)
+    bgp.event_history_periodic = '100000'
+    assert_equal('100000', bgp.event_history_periodic)
     bgp.event_history_periodic = 'size_disable'
-    assert_equal('size_disable', bgp.event_history_periodic)
+    if newer_image_version?
+      assert_equal('false', bgp.event_history_periodic)
+    else
+      assert_equal('size_disable', bgp.event_history_periodic)
+    end
     bgp.event_history_periodic = 'true'
     if newer_image_version?
       assert_equal('true', bgp.event_history_periodic)
-      bgp.event_history_periodic = '100000'
-      assert_equal('100000', bgp.event_history_periodic)
     else
       assert_equal(bgp.default_event_history_periodic,
                    bgp.event_history_periodic)

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -629,7 +629,7 @@ class TestRouterBgp < CiscoTestCase
     end
     assert_equal(bgp.default_event_history_detail, bgp.event_history_detail)
     bgp.event_history_detail = 'true'
-    assert_equal(bgp.default_event_history_detail, bgp.event_history_detail)
+    assert_equal('true', bgp.event_history_detail)
     bgp.event_history_detail = 'false'
     assert_equal(bgp.default_event_history_detail, bgp.event_history_detail)
     bgp.event_history_detail = 'size_small'
@@ -639,7 +639,11 @@ class TestRouterBgp < CiscoTestCase
     bgp.event_history_detail = 'size_medium'
     assert_equal('size_medium', bgp.event_history_detail)
     bgp.event_history_detail = 'size_disable'
-    assert_equal('size_disable', bgp.event_history_detail)
+    if newer_image_version?
+      assert_equal('false', bgp.event_history_detail)
+    else
+      assert_equal('size_disable', bgp.event_history_detail)
+    end
     bgp.event_history_detail = '100000'
     assert_equal('100000', bgp.event_history_detail)
     bgp.event_history_detail = bgp.default_event_history_detail
@@ -688,7 +692,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.event_history_events = 'true'
     assert_equal(bgp.default_event_history_events, bgp.event_history_events)
     bgp.event_history_events = 'false'
-    assert_equal('size_disable', bgp.event_history_events)
+    assert_equal('false', bgp.event_history_events)
     bgp.event_history_events = 'size_small'
     assert_equal('size_small', bgp.event_history_events)
     bgp.event_history_events = 'size_large'
@@ -696,7 +700,11 @@ class TestRouterBgp < CiscoTestCase
     bgp.event_history_events = 'size_medium'
     assert_equal('size_medium', bgp.event_history_events)
     bgp.event_history_events = 'size_disable'
-    assert_equal('size_disable', bgp.event_history_events)
+    if newer_image_version?
+      assert_equal('false', bgp.event_history_events)
+    else
+      assert_equal('size_disable', bgp.event_history_events)
+    end
     bgp.event_history_events = '100000'
     assert_equal('100000', bgp.event_history_events)
     bgp.event_history_events = bgp.default_event_history_events
@@ -715,7 +723,7 @@ class TestRouterBgp < CiscoTestCase
     skip('platform not supported for this test') unless newer_image_version?
     assert_equal(bgp.default_event_history_objstore, bgp.event_history_objstore)
     bgp.event_history_objstore = 'true'
-    assert_equal(bgp.default_event_history_objstore, bgp.event_history_objstore)
+    assert_equal('true', bgp.event_history_objstore)
     bgp.event_history_objstore = 'false'
     assert_equal(bgp.default_event_history_objstore, bgp.event_history_objstore)
     bgp.event_history_objstore = 'size_small'
@@ -725,7 +733,7 @@ class TestRouterBgp < CiscoTestCase
     bgp.event_history_objstore = 'size_medium'
     assert_equal('size_medium', bgp.event_history_objstore)
     bgp.event_history_objstore = 'size_disable'
-    assert_equal('size_disable', bgp.event_history_objstore)
+    assert_equal('false', bgp.event_history_objstore)
     bgp.event_history_objstore = '100000'
     assert_equal('100000', bgp.event_history_objstore)
     bgp.event_history_objstore = bgp.default_event_history_objstore
@@ -755,7 +763,8 @@ class TestRouterBgp < CiscoTestCase
     assert_equal('100000', bgp.event_history_periodic)
     bgp.event_history_periodic = 'size_disable'
     if newer_image_version?
-      assert_equal('false', bgp.event_history_periodic)
+      assert_equal(bgp.default_event_history_periodic,
+                   bgp.event_history_periodic)
     else
       assert_equal('size_disable', bgp.event_history_periodic)
     end


### PR DESCRIPTION
This PR is for adding event_history_errors and event_history_objstore to the bgp provider. It also fixes event_history_detail which has some issues. Finally it includes some minor fixes in the other event_history properties as the defaults and some enums are set differently from the older releases to evergreen.
