### PR TITLE
bgp send-community fix

### DIFF
--- a/lib/cisco_node_utils/bgp_neighbor_af.rb
+++ b/lib/cisco_node_utils/bgp_neighbor_af.rb
@@ -573,8 +573,7 @@ module Cisco
     #  NOTE: 'standard' is default but does not nvgen on some platforms
     #  Returns: none, both, extended, or standard
     def send_community_nexus(val)
-      return 'both' if val.sort ==
-                       ['send-community extended', 'send-community standard']
+      return 'both' if val.grep(/extended|standard/).size == 2
       val = val[0].split.last
       return 'standard' if val[/send-community/] # Workaround
       val

--- a/lib/cisco_node_utils/bgp_neighbor_af.rb
+++ b/lib/cisco_node_utils/bgp_neighbor_af.rb
@@ -565,7 +565,7 @@ module Cisco
     # sense to split up the individual methods to support them
     def send_community
       val = config_get('bgp_neighbor_af', 'send_community', @get_args)
-      return default_send_community if val.nil?
+      return default_send_community if val.nil? || val.empty?
       platform == :nexus ? send_community_nexus(val) : send_community_xr(val)
     end
 
@@ -573,7 +573,8 @@ module Cisco
     #  NOTE: 'standard' is default but does not nvgen on some platforms
     #  Returns: none, both, extended, or standard
     def send_community_nexus(val)
-      val = val.split.last
+      return 'both' if val.size > 1
+      val = val[0].split.last
       return 'standard' if val[/send-community/] # Workaround
       val
     end

--- a/lib/cisco_node_utils/bgp_neighbor_af.rb
+++ b/lib/cisco_node_utils/bgp_neighbor_af.rb
@@ -573,7 +573,8 @@ module Cisco
     #  NOTE: 'standard' is default but does not nvgen on some platforms
     #  Returns: none, both, extended, or standard
     def send_community_nexus(val)
-      return 'both' if val.size > 1
+      return 'both' if val.sort ==
+                       ['send-community extended', 'send-community standard']
       val = val[0].split.last
       return 'standard' if val[/send-community/] # Workaround
       val

--- a/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
@@ -168,13 +168,13 @@ route_reflector_client:
   default_value: false
 
 send_community:
+  multiple:
   auto_default: false
   default_value: 'none'
   nexus:
     get_value: '/^send-community(?: .*)?/'
     set_value: '<state> send-community <attr>'
   ios_xr:
-    multiple:
     # XR three seperate commands: send-community-ebgp  send-community-gshut-ebgp
     # and send-extended-community-ebgp
     # send-community-ebgp' and 'send-extended-community-ebgp' are the equivalents

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -566,6 +566,7 @@ class TestInterface < CiscoTestCase
       assert_raises(Cisco::UnsupportedError) { interface.bfd_echo = false }
       return
     end
+    interface.switchport_mode = :disabled
     assert_equal(interface.default_bfd_echo,
                  interface.bfd_echo)
     interface.bfd_echo = false


### PR DESCRIPTION
This PR is for fixing couple of issues.
1. If send-community CLI is set to 'both', the platform nvgens 2 lines of running config (standard and extended) in the latest images. The fix is to expect the get command output as an array and the process it, so that, this will be compatible with older releases as well and there is no need to check for software versions which is a costly operation.
2. Occasionally, the 'bfd echo' cmd is failing the minitest due to cleanup issues. This command works on layer 3 interfaces and so the fix is to turn off the switchmode on the interface being tested.

Both these fixes are tested on n9k and n3k, however, the item 1 is not passing on n3k with latest image due to difference of behavior between n9k and n3k , once that is fixed, this will pass automatically.
