### PR TITLE
fix for send-community

### DIFF
--- a/lib/cisco_node_utils/bgp_neighbor_af.rb
+++ b/lib/cisco_node_utils/bgp_neighbor_af.rb
@@ -573,7 +573,8 @@ module Cisco
     #  NOTE: 'standard' is default but does not nvgen on some platforms
     #  Returns: none, both, extended, or standard
     def send_community_nexus(val)
-      return 'both' if val.grep(/extended|standard/).size == 2
+      reg = 'send-community extended|send-community standard|send-community'
+      return 'both' if val.grep(/#{reg}/).size == 2
       val = val[0].split.last
       return 'standard' if val[/send-community/] # Workaround
       val


### PR DESCRIPTION
This PR is for fixing bgp neighbir af, send_community. The issue was that 'send-community standard' is being nvgen as 'send-community'. The fix is to look for all possible cases in the grep pattern.
