### PR TITLE
Fix test_lacp_suspend_individual to address behavior change

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
@@ -49,10 +49,13 @@ lacp_min_links:
 
 lacp_suspend_individual:
   kind: boolean
-  auto_default: false
   get_value: '/^lacp suspend.individual$/'
   set_value: "%s lacp suspend-individual"
-  default_value: true
+  N3k:
+    default_value: false
+  else:
+    auto_default: false
+    default_value: true
 
 port_hash_distribution:
   _exclude: [N6k, N5k]

--- a/tests/test_interface_portchannel.rb
+++ b/tests/test_interface_portchannel.rb
@@ -15,7 +15,6 @@
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/interface'
 require_relative '../lib/cisco_node_utils/interface_portchannel'
-require 'pry'
 
 # TestX__CLASS_NAME__X - Minitest for X__CLASS_NAME__X node utility class
 class TestInterfacePortChannel < CiscoTestCase

--- a/tests/test_interface_portchannel.rb
+++ b/tests/test_interface_portchannel.rb
@@ -15,6 +15,7 @@
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/interface'
 require_relative '../lib/cisco_node_utils/interface_portchannel'
+require 'pry'
 
 # TestX__CLASS_NAME__X - Minitest for X__CLASS_NAME__X node utility class
 class TestInterfacePortChannel < CiscoTestCase
@@ -94,8 +95,24 @@ class TestInterfacePortChannel < CiscoTestCase
 
   def test_lacp_suspend_individual
     interface = create_port_channel
-    interface.lacp_suspend_individual = false
-    assert_equal(false, interface.lacp_suspend_individual)
+
+    # Create interface object to manage the admin state
+    # of the port-channel interface.
+    # The port-channel interface needs to be in admin state down
+    # before this property can be set.
+    int_obj = Interface.new(interface.name)
+    int_obj.shutdown = true
+
+    # Test initial default case
+    assert_equal(interface.default_lacp_suspend_individual,
+                 interface.lacp_suspend_individual)
+
+    # Test non-default value
+    val = !interface.default_lacp_suspend_individual
+    interface.lacp_suspend_individual = val
+    assert_equal(val, interface.lacp_suspend_individual)
+
+    # Set back to default
     interface.lacp_suspend_individual =
       interface.default_lacp_suspend_individual
     assert_equal(interface.default_lacp_suspend_individual,


### PR DESCRIPTION
Following the resolution of CSCvb64317 a behavior change was introduced for the `lacp_suspend_individual` property on port-channel interfaces.  The interface must be in an admin down state before the property can be changed on all platforms except the n3k.
- On all nxos platforms except `n3k` the default value is `lacp suspend-individual`.
- On the `n3k` platform it's `no lacp suspend-individual`

This fix does the following:
- Set the expected default for `n3k` and all other platforms in the yaml file.
- Put the port-channel interface into the admin down state before attempting to set the property.

Tested on:  `n3k(I2 & I5), n9k(I2 & I5), n5k, n7k`
