### PR TITLE
Rel141/lacp suspend

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
@@ -61,10 +61,10 @@ lacp_suspend_shut_needed:
   # This is used to determine if the port-channel interface
   # must be shutdown before setting lacp_suspend_individual
   kind: boolean
-  N3k:
-    default_only: false
-  else:
+  N9k:
     default_only: true
+  else:
+    default_only: false
 
 port_hash_distribution:
   _exclude: [N6k, N5k]

--- a/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
@@ -57,6 +57,15 @@ lacp_suspend_individual:
     auto_default: false
     default_value: true
 
+lacp_suspend_shut_needed:
+  # This is used to determine if the port-channel interface
+  # must be shutdown before setting lacp_suspend_individual
+  kind: boolean
+  N3k:
+    default_only: false
+  else:
+    default_only: true
+
 port_hash_distribution:
   _exclude: [N6k, N5k]
   set_context:  ['terminal dont-ask', "interface %s"]

--- a/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
@@ -49,10 +49,13 @@ lacp_min_links:
 
 lacp_suspend_individual:
   kind: boolean
-  auto_default: false
   get_value: '/^lacp suspend.individual$/'
   set_value: "%s lacp suspend-individual"
-  default_value: true
+  N3k:
+    default_value: false
+  else:
+    auto_default: false
+    default_value: true
 
 port_hash_distribution:
   _exclude: [N6k, N5k]

--- a/lib/cisco_node_utils/interface_portchannel.rb
+++ b/lib/cisco_node_utils/interface_portchannel.rb
@@ -126,7 +126,7 @@ module Cisco
     def lacp_suspend_individual=(state)
       no_cmd = (state ? '' : 'no')
       # This property can only be set if the port-channel is shutdown on
-      # most nexus platforms.
+      # some platforms.
       # This setter will:
       # 1) Query the current state of the port-channel interface.
       # 2) Shutdown the port-channel interface if needed.

--- a/lib/cisco_node_utils/interface_portchannel.rb
+++ b/lib/cisco_node_utils/interface_portchannel.rb
@@ -115,14 +115,29 @@ module Cisco
       config_get_default('interface_portchannel', 'lacp_min_links')
     end
 
+    def lacp_suspend_shut_needed?
+      config_get('interface_portchannel', 'lacp_suspend_shut_needed')
+    end
+
     def lacp_suspend_individual
       config_get('interface_portchannel', 'lacp_suspend_individual', @name)
     end
 
     def lacp_suspend_individual=(state)
       no_cmd = (state ? '' : 'no')
+      # This property can only be set if the port-channel is shutdown on
+      # most nexus platforms.
+      # This setter will:
+      # 1) Query the current state of the port-channel interface.
+      # 2) Shutdown the port-channel interface if needed.
+      # 3) Set the lacp_suspend_individual property.
+      # 4) Restore the original state of the port-channel interface if needed.
+      int = Interface.new(@name, false)
+      current_state = int.shutdown
+      int.shutdown = true if lacp_suspend_shut_needed? && !current_state
       config_set('interface_portchannel',
                  'lacp_suspend_individual', @name, no_cmd)
+      int.shutdown = current_state unless current_state == int.shutdown
     end
 
     def default_lacp_suspend_individual

--- a/tests/test_interface_portchannel.rb
+++ b/tests/test_interface_portchannel.rb
@@ -15,7 +15,6 @@
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/interface'
 require_relative '../lib/cisco_node_utils/interface_portchannel'
-require 'pry'
 
 # TestX__CLASS_NAME__X - Minitest for X__CLASS_NAME__X node utility class
 class TestInterfacePortChannel < CiscoTestCase

--- a/tests/test_interface_portchannel.rb
+++ b/tests/test_interface_portchannel.rb
@@ -95,27 +95,31 @@ class TestInterfacePortChannel < CiscoTestCase
   def test_lacp_suspend_individual
     interface = create_port_channel
 
-    # Create interface object to manage the admin state
-    # of the port-channel interface.
-    # The port-channel interface needs to be in admin state down
-    # before this property can be set.
+    # Run this test with the portchannel in both a 'shutdown'
+    # and 'no shutdown' state.
     int_obj = Interface.new(interface.name)
-    int_obj.shutdown = true
+    [true, false].each do |state|
+      int_obj.shutdown = state
 
-    # Test initial default case
-    assert_equal(interface.default_lacp_suspend_individual,
-                 interface.lacp_suspend_individual)
+      # Test initial default case
+      assert_equal(interface.default_lacp_suspend_individual,
+                   interface.lacp_suspend_individual)
 
-    # Test non-default value
-    val = !interface.default_lacp_suspend_individual
-    interface.lacp_suspend_individual = val
-    assert_equal(val, interface.lacp_suspend_individual)
+      # Test non-default value
+      val = !interface.default_lacp_suspend_individual
+      interface.lacp_suspend_individual = val
+      assert_equal(val, interface.lacp_suspend_individual)
 
-    # Set back to default
-    interface.lacp_suspend_individual =
-      interface.default_lacp_suspend_individual
-    assert_equal(interface.default_lacp_suspend_individual,
-                 interface.lacp_suspend_individual)
+      # Set back to default
+      interface.lacp_suspend_individual =
+        interface.default_lacp_suspend_individual
+      assert_equal(interface.default_lacp_suspend_individual,
+                   interface.lacp_suspend_individual)
+
+      # Make sure interface ends up in the same state.
+      assert_equal(state, int_obj.shutdown,
+                   "Interface #{int_obj.name} incorrect state after setting property")
+    end
   end
 
   def test_port_load_defer

--- a/tests/test_interface_portchannel.rb
+++ b/tests/test_interface_portchannel.rb
@@ -15,6 +15,7 @@
 require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/interface'
 require_relative '../lib/cisco_node_utils/interface_portchannel'
+require 'pry'
 
 # TestX__CLASS_NAME__X - Minitest for X__CLASS_NAME__X node utility class
 class TestInterfacePortChannel < CiscoTestCase
@@ -94,8 +95,24 @@ class TestInterfacePortChannel < CiscoTestCase
 
   def test_lacp_suspend_individual
     interface = create_port_channel
-    interface.lacp_suspend_individual = false
-    assert_equal(false, interface.lacp_suspend_individual)
+
+    # Create interface object to manage the admin state
+    # of the port-channel interface.
+    # The port-channel interface needs to be in admin state down
+    # before this property can be set.
+    int_obj = Interface.new(interface.name)
+    int_obj.shutdown = true
+
+    # Test initial default case
+    assert_equal(interface.default_lacp_suspend_individual,
+                 interface.lacp_suspend_individual)
+
+    # Test non-default value
+    val = !interface.default_lacp_suspend_individual
+    interface.lacp_suspend_individual = val
+    assert_equal(val, interface.lacp_suspend_individual)
+
+    # Set back to default
     interface.lacp_suspend_individual =
       interface.default_lacp_suspend_individual
     assert_equal(interface.default_lacp_suspend_individual,


### PR DESCRIPTION
PR https://github.com/cisco/cisco-network-node-utils/pull/489 modified tests validating `lacp_suspend` functionality to shutdown the interface before setting the property.

This PR further refactors the property to automatically shutdown the interface when needed so that this can be managed via puppet without needing to create more then one manifest.

Tested on: n3k, n9k, n5k, n6k
