### PR TITLE
Fix/command config issue

### DIFF
--- a/lib/cisco_node_utils/configparser_lib.rb
+++ b/lib/cisco_node_utils/configparser_lib.rb
@@ -125,12 +125,6 @@ module Cisco
             existing << submode.compare_with(config_submode)
             next
           end # if
-
-          prefix, base = base_commands(command)
-          if prefix != '' && !config.include_command?(base)
-            existing << config_line
-            next
-          end
         end
         existing
       end # compare_with

--- a/tests/cmd_config.yaml
+++ b/tests/cmd_config.yaml
@@ -28,6 +28,7 @@ nexus:
             no feature lacp
             no feature dhcp
             no feature vtp
+    nvgen: false
 
   feature-snmp-comm-acl-ro:
     command: |
@@ -45,7 +46,8 @@ nexus:
               description testloopback
 
   feature-int-portchannel:
-    command: >
+    command: |
+            feature bfd
             interface port-channel100
               description test-portchannel
 

--- a/tests/cmd_config.yaml
+++ b/tests/cmd_config.yaml
@@ -46,10 +46,14 @@ nexus:
               description testloopback
 
   feature-int-portchannel:
+    setup: |
+          interface port-channel100
+            no switchport
     command: |
             feature bfd
             interface port-channel100
               description test-portchannel
+              no bfd echo
 
 ios_xr:
   name-server:

--- a/tests/cmd_config.yaml
+++ b/tests/cmd_config.yaml
@@ -41,7 +41,7 @@ nexus:
              snmp-server community admincom use-acl SNMP_RW
 
   feature-int-loopback:
-    command: >
+    command: |
             interface loopback0
               description testloopback
 

--- a/tests/test_command_config.rb
+++ b/tests/test_command_config.rb
@@ -71,6 +71,7 @@ class TestCommandConfig < CiscoTestCase
     config_cmd_hash.each do |k, v|
       v.each do |k1, v1|
         next if k1 == 'nvgen'
+        config(v1) if k1 == 'setup'
         # Send commands
         cfg_cmd_str = "#{v1.gsub(/^/, '  ')}"
         cfg_string = remove_whitespace(cfg_cmd_str)

--- a/tests/test_command_config.rb
+++ b/tests/test_command_config.rb
@@ -44,7 +44,7 @@ class TestCommandConfig < CiscoTestCase
     commands.gsub(/^\s*$\n/, '')
   end # remove_whitespace
 
-  def compare_with_results(desired_config_str, current_key)
+  def compare_with_results(desired_config_str, _current_key, nvgen)
     retrieve_command = 'show running all'
     running_config_str = node.get(command: retrieve_command)
 
@@ -58,14 +58,19 @@ class TestCommandConfig < CiscoTestCase
       puts e.what
     end
     # puts "Existing command block:\n#{existing}"
-    assert_equal(existing.empty?, false,
-                 "Error: Expected configuration \n'#{desired_config_str}'\n " \
-                 "does not exist.\nHash Key: #{current_key}")
+    if nvgen == false
+      msg = "The following configuration should be removed: #{desired_config_str}"
+      assert_equal(existing.empty?, true, msg)
+    else
+      msg = "The following configuration should exist but doesn't: #{desired_config_str}"
+      assert_equal(existing.empty?, false, msg)
+    end
   end
 
   def send_device_config(config_cmd_hash)
     config_cmd_hash.each do |k, v|
-      v.each_value do |v1|
+      v.each do |k1, v1|
+        next if k1 == 'nvgen'
         # Send commands
         cfg_cmd_str = "#{v1.gsub(/^/, '  ')}"
         cfg_string = remove_whitespace(cfg_cmd_str)
@@ -73,7 +78,7 @@ class TestCommandConfig < CiscoTestCase
         begin
           node.set(values: cfg_string)
           # make sure config is present in success case
-          compare_with_results(v1, k)
+          compare_with_results(v1, k, config_cmd_hash[k]['nvgen'])
         rescue CliError => e
           known_failure = e.message[/ERROR:.*port channel not present/]
           refute(known_failure, 'ERROR: port channel not present')

--- a/tests/test_command_config.rb
+++ b/tests/test_command_config.rb
@@ -118,10 +118,10 @@ class TestCommandConfig < CiscoTestCase
   def test_valid_scale
     show_int_count = "show int brief | i '^\S+\s+--' | count"
     pre = @device.cmd(show_int_count)[/^(\d+)$/]
-
     # Add 1024 loopback interfaces
     cfg_hash_add = Hash.new { |h, k| h[k] = Hash.new(&h.default_proc) }
     cfg_hash_add ['loopback-int-add']['command'] = "#{build_int_scale_config}"
+    cfg_hash_add ['loopback-int-add']['nvgen'] = true
     begin
       send_device_config(cfg_hash_add)
     rescue Timeout::Error
@@ -136,6 +136,7 @@ class TestCommandConfig < CiscoTestCase
     cfg_hash_remove = Hash.new { |h, k| h[k] = Hash.new(&h.default_proc) }
     cfg_hash_remove['loopback-int-add']['command'] = \
       "#{build_int_scale_config(false)}"
+    cfg_hash_remove ['loopback-int-add']['nvgen'] = false
     begin
       send_device_config(cfg_hash_remove)
     rescue Timeout::Error


### PR DESCRIPTION
**Problem Statement:**
Our agents code does the following for any commands that are pre-pended with ‘no’

Example: 'no bfd echo'
- Searches for the complete command ‘no bfd echo’ in the 'show running all' output.
- If it fails to find the command it strips the ‘no’ and searches for the command again in the proper context.
- If it still fails to find the command without the ‘no’ prefix then it assumes the attribute is already disabled and removes it from the list of commands that need to be applied so that we only apply the minimum set of commands to ensure idempotency.

Unfortunately this does not work for commands like ‘no bfd echo’ that do not nvgen when enabled.

This fix addresses the issue in the following ways.
- Removed the logic to strip the 'no' and search for the command again.  This allows commands to be applied in cases where we cannot determine if the feature is enabled or disabled.  This occurs when the command does not nvgen properly in either the enabled or disabled case.  
  - **NOTE:** This will break idempotency for some commands but this is our only option for the `cisco_command_config` provider.  It's more important for the command to be applied in this case.  If idempotency is important, then an existing provider that supports the feature should be used or a new one should be developed.
- Added the ability to specify a new test yaml key `nvgen: false` so that tests don't expect the specified test configuration to be present in the 'show running all' config.
- Added the ability to specify a new test yaml key `setup:` so specify any dependent configuration needed for the test.

Tested on: n3k(I2, I3, I5), n9k(I2, I3, I5), n6k, n7k
