### PR TITLE
Initial refactor N8k --> N9k-F

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ open source management tools.
 
 This CiscoNodeUtils gem release supports the following:
 
-Platform         | OS     | OS Version           |
------------------|--------|----------------------|
-Cisco Nexus N9k  | NX-OS  | 7.0(3)I2(1) and later
-Cisco Nexus N3k  | NX-OS  | 7.0(3)I2(1) and later
-Cisco Nexus N5k  | NX-OS  | 7.3(0)N1(1) and later
-Cisco Nexus N6k  | NX-OS  | 7.3(0)N1(1) and later
-Cisco Nexus N7k  | NX-OS  | 7.3(0)D1(1) and later
-Cisco Nexus N8k  | NX-OS  | 7.0(3)F1(1) and later
+Platform          | OS     | OS Version           |
+------------------|--------|----------------------|
+Cisco Nexus N9k   | NX-OS  | 7.0(3)I2(1) and later
+Cisco Nexus N3k   | NX-OS  | 7.0(3)I2(1) and later
+Cisco Nexus N5k   | NX-OS  | 7.3(0)N1(1) and later
+Cisco Nexus N6k   | NX-OS  | 7.3(0)N1(1) and later
+Cisco Nexus N7k   | NX-OS  | 7.3(0)D1(1) and later
+Cisco Nexus N9K-F | NX-OS  | 7.0(3)F1(1) and later
 
 Please note: For Cisco Nexus 3k and 9k platforms, a virtual Nexus N9000/N3000 may be helpful for development and testing. Users with a valid [cisco.com](http://cisco.com) user ID can obtain a copy of a virtual Nexus N9000/N3000 by sending their [cisco.com](http://cisco.com) user ID in an email to <get-n9kv@cisco.com>. If you do not have a [cisco.com](http://cisco.com) user ID please register for one at [https://tools.cisco.com/IDREG/guestRegistration](https://tools.cisco.com/IDREG/guestRegistration)
 

--- a/docs/README-maintainers.md
+++ b/docs/README-maintainers.md
@@ -48,7 +48,6 @@ When we are considering publishing a new release, all of the following steps mus
     - N56xx
     - N6xxx
     - N7xxx
-    - N8xxx
     - N9xxx
 
 3. Triage any minitest failures.

--- a/lib/cisco_node_utils/aaa_authentication_login_service.rb
+++ b/lib/cisco_node_utils/aaa_authentication_login_service.rb
@@ -58,8 +58,8 @@ module Cisco
       if g_str.empty?
         # cannot remove default local, so do nothing in this case
         unless m == :local
-          unless node.product_id[/N8/]
-            # TBD: These 'no' commands currently error on N8k
+          unless node.product_id[/N9K-F/]
+            # TBD: These 'no' commands currently error on N9K-F
             #   no aaa authentication login console local
             #   no aaa authentication login console none
             config_set('aaa_auth_login_service', 'method',

--- a/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
+++ b/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
@@ -17,7 +17,7 @@ private_vlan_any:
 
 private_vlan_association:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'pvlan_association'
-  _exclude: [N8k]
+  _exclude: [N9k-F]
   multiple: true
   get_command: "show vlan private-vlan"
   get_context: ~
@@ -28,7 +28,7 @@ private_vlan_association:
 
 private_vlan_mapping:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'pvlan_mapping'
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N9k-F]
   multiple: true
   get_value: '/^private-vlan mapping (.*)$/'
   set_value: "<state> private-vlan mapping <vlans>"
@@ -36,7 +36,7 @@ private_vlan_mapping:
 
 private_vlan_type:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'pvlan_type'
-  _exclude: [N8k]
+  _exclude: [N9k-F]
   kind: string
   get_command: 'show vlan private-vlan type'
   get_context: ~
@@ -47,14 +47,14 @@ private_vlan_type:
 
 switchport_mode_private_vlan_host:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_host'
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N9k-F]
   get_value: '/^switchport mode private-vlan (.*)$/'
   set_value: "<state> switchport mode private-vlan <mode>"
   default_value: :disabled
 
 switchport_mode_private_vlan_host_association:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_host_association'
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N9k-F]
   multiple: true
   get_value: '/^switchport private-vlan host-association (.*)$/'
   set_value: "<state> switchport private-vlan host-association <vlan_pr> <vlan_sec>"
@@ -62,7 +62,7 @@ switchport_mode_private_vlan_host_association:
 
 switchport_mode_private_vlan_host_promiscous:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_promiscuous'
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N9k-F]
   multiple: true
   get_value: '/^switchport private-vlan mapping (\d+.*)$/'
   set_value: "<state> switchport private-vlan mapping <vlan_pr> <vlans>"
@@ -70,7 +70,7 @@ switchport_mode_private_vlan_host_promiscous:
 
 switchport_mode_private_vlan_trunk_promiscuous:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_trunk_promiscuous'
-  _exclude: [ios_xr, N3k, N8k]
+  _exclude: [ios_xr, N3k, N9k-F]
   kind: boolean
   get_value: '/^switchport mode private-vlan trunk promiscuous$/'
   set_value: "<state> switchport mode private-vlan trunk promiscuous"
@@ -78,7 +78,7 @@ switchport_mode_private_vlan_trunk_promiscuous:
 
 switchport_mode_private_vlan_trunk_secondary:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_trunk_secondary'
-  _exclude: [ios_xr, N3k, N8k]
+  _exclude: [ios_xr, N3k, N9k-F]
   kind: boolean
   get_value: '/^switchport mode private-vlan trunk secondary$/'
   set_value: "<state> switchport mode private-vlan trunk secondary"
@@ -86,7 +86,7 @@ switchport_mode_private_vlan_trunk_secondary:
 
 switchport_private_vlan_association_trunk:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_trunk_association'
-  _exclude: [ios_xr, N3k, N8k]
+  _exclude: [ios_xr, N3k, N9k-F]
   multiple: true
   #get_value: '/^switchport private-vlan association trunk (.*) (.*)$/'
   get_value: '/^switchport private-vlan association trunk (.*)$/'
@@ -95,7 +95,7 @@ switchport_private_vlan_association_trunk:
 
 switchport_private_vlan_mapping_trunk:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_mapping_trunk'
-  _exclude: [ios_xr, N3k, N8k]
+  _exclude: [ios_xr, N3k, N9k-F]
   multiple: true
   get_value: '/^switchport private-vlan mapping trunk (.*)$/'
   set_value: "<state> switchport private-vlan mapping trunk <vlan_pr> <vlans>"
@@ -103,7 +103,7 @@ switchport_private_vlan_mapping_trunk:
 
 switchport_private_vlan_trunk_allowed_vlan:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_trunk_allowed_vlan'
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N9k-F]
   multiple: true
   get_value: '/^switchport private-vlan trunk allowed vlan (.*)$/'
   set_value: "<state> switchport private-vlan trunk allowed vlan <oper> <vlans>"
@@ -111,7 +111,7 @@ switchport_private_vlan_trunk_allowed_vlan:
 
 switchport_private_vlan_trunk_native_vlan:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_trunk_native_vlan'
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N9k-F]
   kind: int
   get_value: '/^switchport private-vlan trunk native vlan (.*)$/'
   set_value: "<state> switchport private-vlan trunk native vlan <vlan>"

--- a/lib/cisco_node_utils/cmd_ref/aaa_authorization_service.yaml
+++ b/lib/cisco_node_utils/cmd_ref/aaa_authorization_service.yaml
@@ -28,7 +28,7 @@ remove_local_auth:
   N3k: &remove_local_allowed
     default_only: true
   N9k: *remove_local_allowed
-  N8k: *remove_local_allowed
+  N9k-F: *remove_local_allowed
   N5k: *remove_local_allowed
   N6k: *remove_local_allowed
   N7k: *remove_local_allowed

--- a/lib/cisco_node_utils/cmd_ref/bfd_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bfd_global.yaml
@@ -23,27 +23,27 @@ echo_rx_interval:
     default_value: 50
 
 fabricpath_interval:
-  _exclude: [N3k, N8k, N9k]
+  _exclude: [N3k, N9k-F, N9k]
   get_value: '/^bfd fabricpath interval (\d+) min_rx (\d+) multiplier (\d+)$/'
   set_value: '<state> bfd fabricpath interval <interval> min_rx <min_rx> multiplier <multiplier>'
   default_value: ['50', '50', '3']
 
 fabricpath_slow_timer:
-  _exclude: [N3k, N8k, N9k]
+  _exclude: [N3k, N9k-F, N9k]
   kind: int
   get_value: '/^bfd fabricpath slow-timer (\d+)$/'
   set_value: '<state> bfd fabricpath slow-timer <timer>'
   default_value: 2000
 
 fabricpath_vlan:
-  _exclude: [N3k, N8k, N9k]
+  _exclude: [N3k, N9k-F, N9k]
   kind: int
   get_value: '/^bfd fabricpath vlan (\d+)$/'
   set_value: '<state> bfd fabricpath vlan <vlan>'
   default_value: 1
 
 interval:
-  _exclude: [N8k, N9k] # TBD: bug on n8k, n9k this is not working now
+  _exclude: [N9k-F, N9k] # TBD: bug on n9k-f, n9k this is not working now
   get_value: '/^bfd interval (\d+) min_rx (\d+) multiplier (\d+)$/'
   set_value: '<state> bfd interval <interval> min_rx <min_rx> multiplier <multiplier>'
   N3k:

--- a/lib/cisco_node_utils/cmd_ref/bgp_af.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp_af.yaml
@@ -11,7 +11,7 @@ _template:
     get_command: 'show running-config router bgp'
 
 additional_paths_install:
-  _exclude: [ios_xr, N3k, N8k, N9k]
+  _exclude: [ios_xr, N3k, N9k-F, N9k]
   kind: boolean
   get_value: '/^additional-paths install backup$/'
   set_value: '<state> additional-paths install backup'

--- a/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
@@ -189,7 +189,7 @@ soft_reconfiguration_in:
     get_value: '/^soft-reconfiguration inbound(?: always)?/'
     set_value: '<state> soft-reconfiguration inbound <always>'
   N3k: *soft_recon_always
-  N8k: *soft_recon_always
+  N9k-F: *soft_recon_always
   N9k: *soft_recon_always
   else:
     get_value: '/^soft-reconfiguration inbound/'

--- a/lib/cisco_node_utils/cmd_ref/bridge_domain.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bridge_domain.yaml
@@ -1,7 +1,7 @@
 # bridge_domain
 # bridge_domain feature is available only on n7k
 ---
-_exclude: [N3k, N5k, N6k, N8k, N9k, ios_xr]
+_exclude: [N3k, N5k, N6k, N9k-F, N9k, ios_xr]
 
 # For the below name, shutdown commands we are going to use show running-config
 # bridge-domain cli which displays as below

--- a/lib/cisco_node_utils/cmd_ref/bridge_domain_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bridge_domain_vni.yaml
@@ -1,6 +1,6 @@
 # bridge_domain
 ---
-_exclude: [N3k, N5k, N6k, N8k, N9k, ios_xr]
+_exclude: [N3k, N5k, N6k, N9k-F, N9k, ios_xr]
 
 create:
   set_value: "bridge-domain <bd>"

--- a/lib/cisco_node_utils/cmd_ref/dhcp_relay_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/dhcp_relay_global.yaml
@@ -47,7 +47,7 @@ ipv4_relay:
     default_value: false
   N6k: *relay_default_false
   N7k: *relay_default_true
-  N8k: *relay_default_true
+  N9k-F: *relay_default_true
   N9k: *relay_default_true
 
 ipv4_smart_relay:
@@ -57,7 +57,7 @@ ipv4_smart_relay:
   default_value: false
 
 ipv4_src_addr_hsrp:
-  _exclude: [N3k, N8k, N9k]
+  _exclude: [N3k, N9k-F, N9k]
   kind: boolean
   get_value: '/^ip dhcp relay source-address hsrp$/'
   set_value: "<state> ip dhcp relay source-address hsrp"
@@ -69,14 +69,14 @@ ipv4_src_intf:
   default_value: false
 
 ipv4_sub_option_circuit_id_custom:
-  _exclude: [N7k, N8k]
+  _exclude: [N7k, N9k-F]
   kind: boolean
   get_value: '/^ip dhcp relay sub-option circuit-id customized$/'
   set_value: "<state> ip dhcp relay sub-option circuit-id customized"
   default_value: false
 
 ipv4_sub_option_circuit_id_string:
-  _exclude: [N5k, N6k, N7k, N8k, N9k]
+  _exclude: [N5k, N6k, N7k, N9k-F, N9k]
   get_value: '/^ip dhcp relay sub-option circuit-id format-type string format (.*)$/'
   set_value: "<state> ip dhcp relay sub-option circuit-id format-type string <format> <word>"
   default_value: false
@@ -116,7 +116,7 @@ ipv6_relay:
     default_value: false
   N6k: *v6_relay_default_false
   N7k: *v6_relay_default_true
-  N8k: *v6_relay_default_true
+  N9k-F: *v6_relay_default_true
   N9k: *v6_relay_default_true
 
 ipv6_src_intf:

--- a/lib/cisco_node_utils/cmd_ref/encapsulation.yaml
+++ b/lib/cisco_node_utils/cmd_ref/encapsulation.yaml
@@ -1,7 +1,7 @@
 # encapsulation_profile_vni
 # encapsulation_profile_vni feature is available only on n7k
 ---
-_exclude: [N3k, N5k, N6k, N8k, N9k, ios_xr]
+_exclude: [N3k, N5k, N6k, N9k-F, N9k, ios_xr]
 
 all_encaps:
   multiple: true

--- a/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
+++ b/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
@@ -1,6 +1,6 @@
 # fabricpath
 ---
-_exclude: [N3k, N8k, N9k, ios_xr]
+_exclude: [N3k, N9k-F, N9k, ios_xr]
 
 aggregate_multicast_routes:
   _exclude: [N5k, N6k]

--- a/lib/cisco_node_utils/cmd_ref/fabricpath_topology.yaml
+++ b/lib/cisco_node_utils/cmd_ref/fabricpath_topology.yaml
@@ -1,7 +1,7 @@
 # fabricpath_topology
 ---
 # Fabricpath feature is not available on N3K and N9K
-_exclude: [N3k, N8k, N9k, ios_xr]
+_exclude: [N3k, N9k-F, N9k, ios_xr]
 
 _template:
   get_command: 'show running-config fabricpath all'

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -21,7 +21,7 @@ dhcp:
   set_value: "feature dhcp"
 
 fabric:
-  _exclude: [N3k, N8k, N9k]
+  _exclude: [N3k, N9k-F, N9k]
   get_command: "show feature-set"
   get_value: '/^fabric[\s\d]+(\w+)/'
   set_value: "<state> feature-set fabric"
@@ -32,7 +32,7 @@ fabric_forwarding:
   set_value: "feature fabric forwarding"
 
 fex:
-  _exclude: [C3064, C3132, N5k, N6k, N8k]
+  _exclude: [C3064, C3132, N5k, N6k, N9k-F]
   get_command: "show feature-set"
   get_value: '/^fex[\s\d]+(\w+)/'
   set_value: "<state> feature-set fex"
@@ -68,7 +68,7 @@ pim:
   set_value: 'feature pim'
 
 private_vlan:
-  _exclude: [N8k]
+  _exclude: [N9k-F]
   kind: boolean
   get_value: '/^feature private-vlan$/'
   set_value: "feature private-vlan"

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -147,7 +147,7 @@ ipv4_dhcp_relay_info_trust:
   default_value: false
 
 ipv4_dhcp_relay_src_addr_hsrp:
-  _exclude: [ios_xr, N3k, N8k, N9k]
+  _exclude: [ios_xr, N3k, N9k-F, N9k]
   kind: boolean
   get_value: '/^ip dhcp relay source-address hsrp$/'
   set_value: "<state> ip dhcp relay source-address hsrp"
@@ -295,7 +295,7 @@ pvlan_any:
 # 'switchport_pvlan_mapping_trunk' is the switchport-pvlan-trunk command
 pvlan_mapping:
   # SVI-only property
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N9k-F]
   get_value: '/^private-vlan mapping (.*)/'
   set_value: "<state> private-vlan mapping <vlan>"
   default_value: []
@@ -493,68 +493,68 @@ switchport_mode_port_channel:
   default_value: ""
 
 switchport_pvlan_host:
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N9k-F]
   kind: boolean
   get_value: '/^switchport mode private-vlan host$/'
   set_value: "<state> switchport mode private-vlan host"
   default_value: false
 
 switchport_pvlan_host_association:
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N9k-F]
   # Note this is NOT a multiple, unlike trunk association.
   get_value: '/^switchport private-vlan host-association (\d+) (\d+)$/'
   set_value: "<state> switchport private-vlan host-association <pri> <sec>"
   default_value: []
 
 switchport_pvlan_mapping:
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N9k-F]
   get_value: '/^switchport private-vlan mapping (\d+) (.*)$/'
   set_value: "<state> switchport private-vlan mapping <primary> <vlan>"
   default_value: []
 
 switchport_pvlan_mapping_trunk:
-  _exclude: [ios_xr, N3k, N8k]
+  _exclude: [ios_xr, N3k, N9k-F]
   multiple:
   get_value: '/^switchport private-vlan mapping trunk (\d+) (.*)$/'
   set_value: "<state> switchport private-vlan mapping trunk <primary> <range>"
   default_value: []
 
 switchport_pvlan_promiscuous:
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N9k-F]
   kind: boolean
   get_value: '/^switchport mode private-vlan promiscuous$/'
   set_value: "<state> switchport mode private-vlan promiscuous"
   default_value: false
 
 switchport_pvlan_trunk_allowed_vlan:
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N9k-F]
   multiple: true
   get_value: '/^switchport private-vlan trunk allowed vlan (?:add )?(\S+)$/'
   set_value: "switchport private-vlan trunk allowed vlan <range>"
   default_value: 'none'
 
 switchport_pvlan_trunk_association:
-  _exclude: [ios_xr, N3k, N8k]
+  _exclude: [ios_xr, N3k, N9k-F]
   multiple:
   get_value: '/^switchport private-vlan association trunk (\d+) (\d+)$/'
   set_value: "<state> switchport private-vlan association trunk <pri> <sec>"
   default_value: []
 
 switchport_pvlan_trunk_native_vlan:
-  _exclude: [ios_xr, N8k]
+  _exclude: [ios_xr, N9k-F]
   get_value: '/^switchport private-vlan trunk native vlan (.*)$/'
   set_value: "switchport private-vlan trunk native vlan <vlan>"
   default_value: '1'
 
 switchport_pvlan_trunk_promiscuous:
-  _exclude: [ios_xr, N3k, N8k]
+  _exclude: [ios_xr, N3k, N9k-F]
   kind: boolean
   get_value: '/^switchport mode private-vlan trunk promiscuous$/'
   set_value: "<state> switchport mode private-vlan trunk promiscuous"
   default_value: false
 
 switchport_pvlan_trunk_secondary:
-  _exclude: [ios_xr, N3k, N8k]
+  _exclude: [ios_xr, N3k, N9k-F]
   kind: boolean
   get_value: '/^switchport mode private-vlan trunk secondary$/'
   set_value: "<state> switchport mode private-vlan trunk secondary"
@@ -617,14 +617,14 @@ system_default_switchport_shutdown:
     default_only: true
 
 vlan_mapping:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   multiple:
   get_value: '/^switchport vlan mapping (\d+) (\d+)/'
   set_value: '<state> switchport vlan mapping <original> <translated>'
   default_value: []
 
 vlan_mapping_enable:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   kind: boolean
   get_value: '/^(no )?switchport vlan mapping enable/'
   set_value: '<state> switchport vlan mapping enable'

--- a/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
@@ -38,7 +38,7 @@ lacp_max_bundle:
     default_value: 16
   N6k: *lacp_max_bundle_16
   N7k: *lacp_max_bundle_16
-  N8k: *lacp_max_bundle_32
+  N9k-F: *lacp_max_bundle_32
   N9k: *lacp_max_bundle_32
 
 lacp_min_links:

--- a/lib/cisco_node_utils/cmd_ref/interface_service_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_service_vni.yaml
@@ -1,6 +1,6 @@
 # interface_service_vni
 ---
-_exclude: [N3k, N5k, N6k, N8k, N9k, ios_xr]
+_exclude: [N3k, N5k, N6k, N9k-F, N9k, ios_xr]
 
 _template:
   get_command: 'show running interface all'

--- a/lib/cisco_node_utils/cmd_ref/itd_device_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/itd_device_group.yaml
@@ -1,6 +1,6 @@
 # itd_device_group
 ---
-_exclude: [N3k, N5k, N6k, N8k, ios_xr]
+_exclude: [N3k, N5k, N6k, N9k-F, ios_xr]
 
 _template:
   get_command: "show running-config all | section itd"

--- a/lib/cisco_node_utils/cmd_ref/itd_service.yaml
+++ b/lib/cisco_node_utils/cmd_ref/itd_service.yaml
@@ -1,6 +1,6 @@
 # itd_service
 ---
-_exclude: [N3k, N5k, N6k, N8k, ios_xr]
+_exclude: [N3k, N5k, N6k, N9k-F, ios_xr]
 
 _template:
   get_command: "show running-config all | section itd"

--- a/lib/cisco_node_utils/cmd_ref/ospf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf.yaml
@@ -32,7 +32,7 @@ log_adjacency:
   default_value: :none
 
 process_initialized:
-  _exclude: [ios_xr, N3k, N7k, N8k, N9k]
+  _exclude: [ios_xr, N3k, N7k, N9k-F, N9k]
   # ospf process initialization state
   kind: boolean
   context: ~

--- a/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
@@ -6,7 +6,7 @@ _template:
   get_command: "show running all"
 
 asymmetric:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   default_value: false
 
 bundle_hash:
@@ -15,7 +15,7 @@ bundle_hash:
   N5k: *bundle_hash_ip
   N6k: *bundle_hash_ip
   N7k: *bundle_hash_ip
-  N8k: &bundle_hash_ip_l4port
+  N9k-F: &bundle_hash_ip_l4port
     default_value: 'ip-l4port'
   N9k: *bundle_hash_ip_l4port
 
@@ -23,18 +23,18 @@ bundle_select:
   default_value: 'src-dst'
 
 concatenation:
-  _exclude: [N3k, N5k, N6k, N7k, N8k]
+  _exclude: [N3k, N5k, N6k, N7k, N9k-F]
   default_value: false
 
 hash_distribution:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   get_value: '/^port.channel hash.distribution (.*)$/'
   set_context:  ['terminal dont-ask']
   set_value: "port-channel hash-distribution %s"
   default_value: 'adaptive'
 
 hash_poly:
-  _exclude: [N3k, N7k, N8k, N9k]
+  _exclude: [N3k, N7k, N9k-F, N9k]
   default_value: ~
 
 load_balance_type:
@@ -46,13 +46,13 @@ load_balance_type:
   N6k: *load_balance_type_ethernet
   N7k: &load_balance_type_asymmetric
     default_only: "asymmetric"
-  N8k: &load_balance_type_no_hash
+  N9k-F: &load_balance_type_no_hash
     default_only: "no_hash"
   N9k: &load_balance_type_symmetry
     default_only: "symmetry"
 
 load_defer:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   kind: int
   get_value: '/^port.channel load.defer (\d+)$/'
   set_value: "port-channel load-defer %s"
@@ -64,7 +64,7 @@ port_channel_load_balance:
   set_value: "port-channel load-balance %s %s %s %s %s %s"
 
 resilient:
-  _exclude: [N5k, N6k, N7k, N8k]
+  _exclude: [N5k, N6k, N7k, N9k-F]
   kind: boolean
   get_value: '/^port-channel load-balance resilient$/'
   set_value: "%s port-channel load-balance resilient"
@@ -80,5 +80,5 @@ rotate:
   default_value: 0
 
 symmetry:
-  _exclude: [N5k, N6k, N7k, N8k]
+  _exclude: [N5k, N6k, N7k, N9k-F]
   default_value: false

--- a/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
@@ -63,7 +63,7 @@ packet_size:
     default_value: 0
   N6k: *n5k_default_packet_size
   N7k: *n5k_default_packet_size
-  N8k: *n5k_default_packet_size
+  N9k-F: *n5k_default_packet_size
 
 protocol:
   _exclude: [ios_xr]

--- a/lib/cisco_node_utils/cmd_ref/stp_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/stp_global.yaml
@@ -7,7 +7,7 @@ _template:
   get_command: "show running-config spanning-tree"
 
 bd_designated_priority:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   multiple:
   get_context: ['/^spanning-tree pseudo-information$/']
   get_value: '/^bridge-domain (.*) designated priority (.*)$/'
@@ -16,40 +16,40 @@ bd_designated_priority:
   default_value: []
 
 bd_forward_time:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   multiple:
   get_value: '/^spanning-tree bridge-domain (.*) forward-time (.*)$/'
   set_value: "<state> spanning-tree bridge-domain <range> forward-time <val>"
   default_value: []
 
 bd_hello_time:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   multiple:
   get_value: '/^spanning-tree bridge-domain (.*) hello-time (.*)$/'
   set_value: "<state> spanning-tree bridge-domain <range> hello-time <val>"
   default_value: []
 
 bd_max_age:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   multiple:
   get_value: '/^spanning-tree bridge-domain (.*) max-age (.*)$/'
   set_value: "<state> spanning-tree bridge-domain <range> max-age <val>"
   default_value: []
 
 bd_priority:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   multiple:
   get_value: '/^spanning-tree bridge-domain (.*) priority (.*)$/'
   set_value: "<state> spanning-tree bridge-domain <range> priority <val>"
   default_value: []
 
 bd_range:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   kind: string
   default_only: "2-3967"
 
 bd_root_priority:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   multiple:
   get_context: ['/^spanning-tree pseudo-information$/']
   get_value: '/^bridge-domain (.*) root priority (.*)$/'
@@ -78,7 +78,7 @@ bridge_assurance:
   default_value: true
 
 domain:
-  _exclude: [N3k, N8k, N9k]
+  _exclude: [N3k, N9k-F, N9k]
   kind: int
   get_value: '/^spanning-tree domain (\d+)$/'
   set_value: "<state> spanning-tree domain <domain>"

--- a/lib/cisco_node_utils/cmd_ref/vdc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vdc.yaml
@@ -3,7 +3,7 @@
 # The current simplified implementation assumes no admin-vdc and that the
 # default vdc name uses id 1. Full multi-vdc support is TBD.
 ---
-_exclude: [N3k, N5k, N6k, N8k, N9k, ios_xr]
+_exclude: [N3k, N5k, N6k, N9k-F, N9k, ios_xr]
 
 _template:
   get_command: 'show run vdc all'

--- a/lib/cisco_node_utils/cmd_ref/vlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vlan.yaml
@@ -14,7 +14,7 @@ destroy:
   set_value: "no vlan %s"
 
 fabric_control:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   kind: boolean
   get_command: "show running-config vlan"
   get_context: ['/^vlan <vlan>/']
@@ -27,7 +27,7 @@ mapped_vni:
   _exclude: [N7k]
   N3k: &mapped_vni_n3_8_9k
     get_command: 'show running vlan'
-  N8k: *mapped_vni_n3_8_9k
+  N9k-F: *mapped_vni_n3_8_9k
   N9k: *mapped_vni_n3_8_9k
   N5k: &mapped_vni_n5_6k
     get_command: 'show running vlan 1-4094'
@@ -65,7 +65,7 @@ name:
   set_value: "%s name %s ; end"
 
 pvlan_association:
-  _exclude: [N8k]
+  _exclude: [N9k-F]
   multiple: true
   get_command: "show vlan private-vlan"
   get_value: '/^<id>\s+(\d+)/'
@@ -74,7 +74,7 @@ pvlan_association:
   default_value: []
 
 pvlan_type:
-  _exclude: [N8k]
+  _exclude: [N9k-F]
   kind: string
   get_command: 'show vlan private-vlan type'
   get_value: '/^<id>\s+(\S+)/'

--- a/lib/cisco_node_utils/cmd_ref/vpc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vpc.yaml
@@ -1,6 +1,6 @@
 # vpc
 ---
-_exclude: [ios_xr, N8k]
+_exclude: [ios_xr, N9k-F]
 
 _template:
   get_command:  'show running-config vpc all'
@@ -58,7 +58,7 @@ dual_active_exclude_interface_vlan_bridge_domain:
   default_value: 'none'
 
 fabricpath_emulated_switch_id:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   kind: int
   set_context:  ['terminal dont-ask', 'vpc domain <domain>']
   get_value: '/^fabricpath switch-id\s+(\d+)$/'
@@ -66,7 +66,7 @@ fabricpath_emulated_switch_id:
   default_value: false
 
 fabricpath_multicast_load_balance:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   kind: boolean
   get_value: '/^fabricpath multicast load-balance$/'
   set_value: "<state> fabricpath multicast load-balance"
@@ -90,7 +90,7 @@ graceful_consistency_check:
 
 layer3_peer_routing:
   kind: boolean
-  _exclude: [N3k, N8k, N9k]
+  _exclude: [N3k, N9k-F, N9k]
   get_value: '/^layer3 peer-router$/'
   set_value: "<state> layer3 peer-router"
   default_value: false
@@ -105,14 +105,14 @@ peer_gateway:
 # Exclude everyone for now till the BD command is fully supported
 peer_gateway_exclude_bridge_domain:
   kind: string
-  _exclude: [N3k, N5k, N6k, N7k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N7k, N9k-F, N9k]
   set_context:  ['terminal dont-ask', 'vpc domain <domain>']
   get_value: '/^peer-gateway exclude bridge-domain\s+(\S+)/'
   set_value: "peer-gateway exclude-bridge-domain <range>"
   default_value: ''
 
 peer_gateway_exclude_vlan:
-  _exclude: [N3k, N8k, N9k]
+  _exclude: [N3k, N9k-F, N9k]
   kind: string
   set_context:  ['terminal dont-ask', 'vpc domain <domain>']
   get_value: '/^peer-gateway exclude-vlan\s(\S+)/'
@@ -161,11 +161,11 @@ peer_keepalive_vrf:
   default_value: 'management'
 
 phy_port_vpc_module_pids:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   default_only: 'N7[K7]-(?:F2|F3|F4|M3)'
 
 port_channel_limit:
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   auto_default: false
   kind: boolean
   get_value: '/^port-channel limit/'
@@ -180,14 +180,14 @@ role_priority:
 
 self_isolation:
   kind: boolean
-  _exclude: [N3k, N5k, N6k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
   get_value: '/^self-isolation/'
   set_value: "<state> self-isolation"
   default_value: false
 
 shutdown:
   kind: boolean
-  _exclude: [N3k, N8k, N9k]
+  _exclude: [N3k, N9k-F, N9k]
   get_value: '/^shutdown/'
   set_value: "<state> shutdown"
   default_value: false
@@ -207,7 +207,7 @@ system_priority:
 # Exclude everyone for now till the track command is fully supported
 track:
   kind: int
-  _exclude: [N3k, N5k, N6k, N7k, N8k, N9k]
+  _exclude: [N3k, N5k, N6k, N7k, N9k-F, N9k]
   get_value: '/^track\s+(\d+)/'
   set_value: "<state> track <val>"
   default_value: 0

--- a/lib/cisco_node_utils/cmd_ref/vrf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vrf.yaml
@@ -32,7 +32,11 @@ description:
   get_value: '/^description (.*)/'
   set_value: '<state> description <desc>'
   kind: string
-  default_value: ''
+  # default_value: ''
+  N9k-R:
+    default_value: 'I am fretta! :-)'
+  else:
+    default_value: "I am not fretta :-("
 
 destroy:
   context: ~

--- a/lib/cisco_node_utils/cmd_ref/vrf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vrf.yaml
@@ -32,11 +32,7 @@ description:
   get_value: '/^description (.*)/'
   set_value: '<state> description <desc>'
   kind: string
-  # default_value: ''
-  N9k-R:
-    default_value: 'I am fretta! :-)'
-  else:
-    default_value: "I am not fretta :-("
+  default_value: ''
 
 destroy:
   context: ~

--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
@@ -31,7 +31,7 @@ mt_lite_support:
   kind: boolean
   N9k: &mt_lite_default
     default_only: true
-  N8k: *mt_lite_default
+  N9k-F: *mt_lite_default
   N6k: *mt_lite_default
   N5k: *mt_lite_default
   else:

--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
@@ -49,7 +49,7 @@ suppress_arp:
   default_value: false
 
 suppress_uuc:
-  _exclude: [N7k, N8k, N9k]
+  _exclude: [N7k, N9k-F, N9k]
   kind: boolean
   get_value: '/^suppress-unknown-unicast$/'
   set_value: '<state> suppress-unknown-unicast'

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -434,13 +434,16 @@ module Cisco
       puts "DEBUG: #{text}" if @@debug
     end
 
-    KNOWN_PLATFORMS = %w(C3064 C3132 C3172 N3k N5k N6k N7k N8k N9k XRv9k)
+    KNOWN_PLATFORMS = %w(C3064 C3132 C3172 N3k N5k N6k N7k N8k N9k N9k-R XRv9k)
 
     def self.platform_to_filter(platform)
       if KNOWN_PLATFORMS.include?(platform)
         case platform
         when 'XRv9k'
           /XRV9/
+        when 'N9k-R'
+          # fretta filter
+          /N9K-C9...-R/
         else
           Regexp.new platform.tr('k', '')
         end

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -434,16 +434,16 @@ module Cisco
       puts "DEBUG: #{text}" if @@debug
     end
 
-    KNOWN_PLATFORMS = %w(C3064 C3132 C3172 N3k N5k N6k N7k N8k N9k N9k-R XRv9k)
+    KNOWN_PLATFORMS = %w(C3064 C3132 C3172 N3k N5k N6k N7k N9k N9k-F XRv9k)
 
     def self.platform_to_filter(platform)
       if KNOWN_PLATFORMS.include?(platform)
         case platform
         when 'XRv9k'
           /XRV9/
-        when 'N9k-R'
+        when 'N9k-F'
           # fretta filter
-          /N9K-C9...-R/
+          /N9K-C9...-F/
         else
           Regexp.new platform.tr('k', '')
         end

--- a/lib/cisco_node_utils/portchannel_global.rb
+++ b/lib/cisco_node_utils/portchannel_global.rb
@@ -113,7 +113,7 @@ module Cisco
           _parse_ethernet_params(hash, params)
         when :asymmetric # n7k
           _parse_asymmetric_params(hash, params, line)
-        when :no_hash # n8k
+        when :no_hash # n9k-f
           _parse_no_hash_params(hash, params)
         when :symmetry # n9k
           _parse_symmetry_params(hash, params, line)
@@ -213,7 +213,7 @@ module Cisco
         # port-channel load-balance dst ip-l4port rotate 4 asymmetric
         config_set('portchannel_global', 'port_channel_load_balance',
                    bselect, bhash, 'rotate', rot.to_s, asym, '')
-      when :no_hash # n8k
+      when :no_hash # n9k-f
         # port-channel load-balance dst ip-l4port rotate 4
         rot_str = rot.zero? ? '' : 'rotate'
         rot_val = rot.zero? ? '' : rot.to_s

--- a/spec/schema.yaml
+++ b/spec/schema.yaml
@@ -19,9 +19,8 @@ mapping:
           - 'N5k'
           - 'N6k'
           - 'N7k'
-          - 'N8k'
           - 'N9k'
-          - 'N9k-R'
+          - 'N9k-F'
 
   =: &base # default rule - apply to all properties
     type: map
@@ -37,9 +36,8 @@ mapping:
       N5k: *base
       N6k: *base
       N7k: *base
-      N8k: *base
       N9k: *base
-      N9k-R: *base
+      N9k-F: *base
       # 'else' case if not matching any filter above
       else: *base
       # Generally applicable attributes

--- a/spec/schema.yaml
+++ b/spec/schema.yaml
@@ -21,6 +21,7 @@ mapping:
           - 'N7k'
           - 'N8k'
           - 'N9k'
+          - 'N9k-R'
 
   =: &base # default rule - apply to all properties
     type: map
@@ -38,6 +39,7 @@ mapping:
       N7k: *base
       N8k: *base
       N9k: *base
+      N9k-R: *base
       # 'else' case if not matching any filter above
       else: *base
       # Generally applicable attributes

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -260,7 +260,7 @@ class CiscoTestCase < TestCase
     Vrf.vrfs.each do |vrf, obj|
       next if vrf[/management/]
       # TBD: Remove vrf workaround below after CSCuz56697 is resolved
-      config 'vrf context ' + vrf if node.product_id[/N8/]
+      config 'vrf context ' + vrf if node.product_id[/N9K-F/]
       obj.destroy
     end
   end
@@ -424,7 +424,7 @@ class CiscoTestCase < TestCase
   # Returns the output of the command.
   def shell_command(command, context='bash')
     fail "shell_command api not supported on #{node.product_id}" unless
-      node.product_id[/N3K|N8K|N9K/]
+      node.product_id[/N3K|N9K-F|N9K/]
     unless context == 'bash' || context == 'guestshell'
       fail "Context must be either 'bash' or 'guestshell'"
     end
@@ -434,7 +434,7 @@ class CiscoTestCase < TestCase
   def backup_resolv_file(context='bash')
     # Configuration bleeding is only a problem on some platforms, so
     # only backup the resolv.conf file on required plaforms.
-    return unless node.product_id[/N3K|N8K|N9K/]
+    return unless node.product_id[/N3K|N9K-F|N9K/]
     time_stamp = Time.now.strftime('%Y-%m-%d_%H-%M-%S')
     backup_filename = "/tmp/resolv.conf.#{time_stamp}"
     shell_command("cp /etc/resolv.conf #{backup_filename}", context)
@@ -442,7 +442,7 @@ class CiscoTestCase < TestCase
   end
 
   def restore_resolv_file(filename, context='bash')
-    return unless node.product_id[/N3K|N8K|N9K/]
+    return unless node.product_id[/N3K|N9K-F|N9K/]
     shell_command("sudo cp #{filename} /etc/resolv.conf", context)
     shell_command("rm #{filename}", context)
   end

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -52,16 +52,16 @@ class TestRouterOspfArea < CiscoTestCase
     av.stub = true
     assert_equal(2, RouterOspfArea.areas['Wolfpack'].size)
     av.destroy
-    # on n8k (only), we cannot remove "area <area> default-cost 1",
+    # on n9k-f (only), we cannot remove "area <area> default-cost 1",
     # unless the entire ospf router is removed. The default value of
     # default_cost is 1 and so this is just a cosmetic issue but
     # need to skip the below test as the size will be wrong.
     # platform as the size will be wrong. bug ID: CSCva04066
     assert_equal(1, RouterOspfArea.areas['Wolfpack'].size) unless
-      /N8/ =~ node.product_id
+      /N9K-F/ =~ node.product_id
     ad.destroy
     assert_empty(RouterOspfArea.areas) unless
-      /N8/ =~ node.product_id
+      /N9K-F/ =~ node.product_id
   end
 
   def test_authentication
@@ -237,21 +237,21 @@ class TestRouterOspfArea < CiscoTestCase
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
     assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
-    # on n8k (only), we cannot configure
+    # on n9k-f (only), we cannot configure
     # "area <area> nssa default-information-originate",
     # properly if we reset it first. It is only configuring nssa
     # but not the other parameters. bug ID: CSCva11482
     hash[:nssa_route_map] = 'aaa'
     ad.nssa_set(hash)
     assert_equal(true, ad.nssa)
-    if node.product_id[/N8/]
+    if node.product_id[/N9K-F/]
       refute(ad.nssa_default_originate)
     else
       assert(ad.nssa_default_originate)
     end
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
-    if node.product_id[/N8/]
+    if node.product_id[/N9K-F/]
       refute_equal('aaa', ad.nssa_route_map)
     else
       assert_equal('aaa', ad.nssa_route_map)

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -24,6 +24,8 @@ class TestVrf < CiscoTestCase
 
   def setup
     super
+    puts "minitest: #{Vrf.new('test', false).default_description}"
+    exit
     remove_all_vrfs if @@pre_clean_needed
     @@pre_clean_needed = false # rubocop:disable Style/ClassVars
   end

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -24,8 +24,6 @@ class TestVrf < CiscoTestCase
 
   def setup
     super
-    puts "minitest: #{Vrf.new('test', false).default_description}"
-    exit
     remove_all_vrfs if @@pre_clean_needed
     @@pre_clean_needed = false # rubocop:disable Style/ClassVars
   end


### PR DESCRIPTION
**Overview:**
This is the infrastructure rebrand the N8k to be an N9k-F.  The new n9k is a fretta camden N9k which currently runs a different image then N9K's running `7.0(3)(I2|I3|I4|I5` images.

**Test Results:**
** N9K Evergreen:**
```
Overall Stats
    Passed     : 73
    Passx      : 0
    Failed     : 1
    Aborted    : 0
    Blocked    : 0
    Skipped    : 15
    Errored    : 0

    TOTAL      : 89

Success Rate   : 98.88 %
```
Failure is not related to the fretta changes.

** N9K Fretta Camden **
```
Overall Stats
    Passed     : 60
    Passx      : 0
    Failed     : 3
    Aborted    : 0
    Blocked    : 0
    Skipped    : 20
    Errored    : 6

    TOTAL      : 89

Success Rate   : 89.89 %
```
The failures on fretta camden are fretta camden bugs or additional refactoring that needs to be done to handle fretta camden differences.

These issues are outside the scope of this review and will be handled in subsequent pull requests.
