### PR TITLE
fix for event history on n9k-f

### DIFF
--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -513,7 +513,8 @@ module Cisco
 
     def default_event_history_events
       if Utils.image_version?(/7.0.3.I2|I3|I4/) ||
-         Utils.chassis_pid?(/N(5|6|7|8)/)
+         Utils.image_version?(/7.0.3.F1/) ||
+         Utils.chassis_pid?(/N(5|6|7)/)
         config_get_default('bgp', 'event_history_events')
       else
         config_get('bgp', 'event_history_events_bytes', @get_args)
@@ -574,7 +575,8 @@ module Cisco
 
     def default_event_history_periodic
       if Utils.image_version?(/7.0.3.I2|I3|I4/) ||
-         Utils.chassis_pid?(/N(5|6|7|8)/)
+         Utils.image_version?(/7.0.3.F1/) ||
+         Utils.chassis_pid?(/N(5|6|7)/)
         config_get_default('bgp', 'event_history_periodic')
       else
         config_get('bgp', 'event_history_periodic_bytes', @get_args)

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -62,7 +62,8 @@ end
 
 def newer_image_version?
   return false if Utils.image_version?(/7.0.3.I2|I3|I4/) ||
-                  Utils.chassis_pid?(/N(5|6|7|8)/)
+                  Utils.image_version?(/7.0.3.F1/) ||
+                  Utils.chassis_pid?(/N(5|6|7)/)
   true
 end
 


### PR DESCRIPTION
This PR is for fixing minitest failures on fretta for bgp event-history. All relevant tests pass