### PR TITLE
Update platform_to_filter api for n9k

### DIFF
--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -441,9 +441,13 @@ module Cisco
         case platform
         when 'XRv9k'
           /XRV9/
+        when 'N9k'
+          # For non-fretta n9k platforms we need to
+          # match everything except the trailing -F
+          /^N9...(?!.*-F)/
         when 'N9k-F'
-          # fretta filter
-          /N9K-C9...-F/
+          # For fretta n9k we need to include the trailing -F
+          /^N9.*-F$/
         else
           Regexp.new platform.tr('k', '')
         end


### PR DESCRIPTION
This update fixes a bug that caused the command reference hash to pull in yaml entries for both `n9k` and `n9k-f` platforms.

With this update we now correctly match fretta or non-fretta based n9k platforms but not both.

**Testing**
 - In progress on n9k and n9k-f platforms.  Will update PR with results when available.