### PR TITLE
Rel150/atherton fretta fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
+++ b/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
@@ -82,8 +82,8 @@ loadbalance_multicast_has_vlan:
   _exclude: [N5k, N6k]
   kind: boolean
   auto_default: false
-  get_command: 'show run fabricpath all'
-  get_value: '/^fabricpath load-balance multicast .*include-vlan/'
+  get_command: "show fabricpath load-balance | begin Ftag"
+  get_value: '/^Use VLAN: TRUE/'
   default_value: true
 
 loadbalance_multicast_reset:
@@ -104,8 +104,8 @@ loadbalance_multicast_set:
 loadbalance_unicast_has_vlan:
   kind: boolean
   auto_default: false
-  get_command: 'show run fabricpath all'
-  get_value: '/^fabricpath load-balance unicast .*include-vlan/'
+  get_command: "show fabricpath load-balance | begin ECMP next 4"
+  get_value: '/^Use VLAN: TRUE/'
   set_value: "<state> fabricpath load-balance unicast include-vlan"
   default_value: true
 

--- a/lib/cisco_node_utils/cmd_ref/vlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vlan.yaml
@@ -48,7 +48,7 @@ mapped_vni_requires_nv_overlay:
     default_only: false
 
 mode:
-  _exclude: [N3k, N9k]
+  _exclude: [N3k, N9k, N9k-F]
   multiple: true
   get_command: "show vlan"
   # TBD: 'show vlan' is problematic and should be converted to use show run

--- a/lib/cisco_node_utils/yum.rb
+++ b/lib/cisco_node_utils/yum.rb
@@ -52,7 +52,12 @@ module Cisco
 
     def self.install(pkg, vrf=nil)
       vrf = vrf.nil? ? detect_vrf : "vrf #{vrf}"
-      config_set('yum', 'install', pkg, vrf)
+
+      begin
+        config_set('yum', 'install', pkg, vrf)
+      rescue Cisco::CliError, RuntimeError => e
+        raise Cisco::CliError, "#{e.class}, #{e.message}"
+      end
 
       # HACK: The current nxos host installer is a multi-part command
       # which may fail at a later stage yet return a false positive;

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -579,6 +579,11 @@ class TestInterface < CiscoTestCase
     Interface.new(inf_name).destroy
 
     interface = Interface.new(inf_name)
+
+    # The newly created port-channel interface
+    # will default to switchport in some cases
+    # so we need to disable it.
+    interface.switchport_mode = :disabled
     assert_equal(interface.default_bfd_echo,
                  interface.bfd_echo)
     interface.bfd_echo = false

--- a/tests/test_yum.rb
+++ b/tests/test_yum.rb
@@ -122,10 +122,10 @@ class TestYum < CiscoTestCase
   end
 
   def test_package_does_not_exist_error
-    assert_raises(RuntimeError) do
+    assert_raises(Cisco::CliError) do
       Yum.install('bootflash:this_is_not_real.rpm', 'management')
     end
-    assert_raises(RuntimeError) do
+    assert_raises(Cisco::CliError) do
       Yum.install('also_not_real', 'management')
     end
   end


### PR DESCRIPTION
Fixes needed for fretta_camden and atherton enablement.

- Fabricpath was broken by a previous commit.  Restored the correct yaml entries.
- Added missing exclude for vlan.
- Added a rescue for the yum provider to catch two classes of errors but raise the same error in both cases.  There are times when install fails because of either of the two error classes.