### PR TITLE
New nxapi_structured infra features

### DIFF
--- a/lib/cisco_node_utils/client/utils.rb
+++ b/lib/cisco_node_utils/client/utils.rb
@@ -144,7 +144,13 @@ class Cisco::Client
         fail "No match found for #{filter}" if data.length == 0
         data = data[0]
       else # data is array or hash
-        filter = filter.to_i if data.is_a? Array
+        if data.is_a? Array
+          final = []
+          data.each do |row|
+            final << row[filter]
+          end
+          return final
+        end
         fail "No key \"#{filter}\" in #{data}" if data[filter].nil?
         data = data[filter]
       end

--- a/lib/cisco_node_utils/cmd_ref/README_YAML.md
+++ b/lib/cisco_node_utils/cmd_ref/README_YAML.md
@@ -329,8 +329,8 @@ productid:
   ios_xr:
     get_value: '/PID: ([^ ,]+)/'
   nexus:
-    get_context: ["TABLE_inv", "ROW_inv", 0]
-    get_value: "productid"
+    get_context: ["TABLE_inv", "ROW_inv"]
+    get_value: ["name Chassis", "productid"]
 ```
 
 Using platform variants and product variants together:
@@ -361,7 +361,7 @@ productid:
   get_command: 'show inventory'
   nexus:
     get_data_format: nxapi_structured
-    get_context: ['TABLE_inv', 'ROW_inv', 0]
+    get_context: ['TABLE_inv', 'ROW_inv']
 ```
 
 ### `get_command`
@@ -378,7 +378,7 @@ area:
 
 ### `get_context`
 
-`get_context` is an optional sequence of tokens used to filter the output from the `get_command` down to the desired context where the `get_value` can be found. For CLI properties, these tokens are implicitly Regexps used to filter down through the hierarchical CLI output, while for `nxapi_structured` properties, the tokens are used as string keys.
+`get_context` is an optional sequence of tokens used to filter the output from the `get_command` down to the desired context where the `get_value` can be found. For CLI properties, these tokens are implicitly Regexps used to filter down through the hierarchical CLI output, while for `nxapi_structured` properties, the tokens are used as string keys. For `nxapi_structured` properties, both `get_context` and `get_value` can specify a sequence of tokens used to filter the output from the `get_command` down to the desired `get_value`.  This feature can be used to retrive data from `TABLE` data the contains multiple `ROWS`.
 
 
 ```yaml
@@ -387,10 +387,38 @@ productid:
   get_command: 'show inventory'
   nexus:
     get_data_format: nxapi_structured
-    get_context: ['TABLE_inv', 'ROW_inv', 0]
-    get_value: 'productid'
+    get_context: ['TABLE_inv', 'ROW_inv']
+    get_value: ["name Chassis", "productid"]
     # config_get('inventory', 'productid') returns
-    # structured_output['TABLE_inv']['ROW_inv'][0]['productid']
+    # 'productid' for the row that contains 'name Chassis'
+```
+
+```yaml
+# vlan.yaml
+name:
+  get_command: "show vlan brief"
+  nexus:
+    kind: string
+    get_data_format: nxapi_structured
+    get_context: ["TABLE_vlanbriefxbrief", "ROW_vlanbriefxbrief"]
+    get_value: ["vlanshowbr-vlanid-utf <vlanid>", "vlanshowbr-vlanname"]
+    # config_get('vlan', 'name', @vlan_id) returns
+    # 'vlanshowbr-vlanname' for @vlan_id.
+    # NOTE: `<vlanid>` in the `get_value` is replaced by `@vlan_id` prior to lookup.
+```
+
+```yaml
+# vlan.yaml
+shutdown:
+  get_command: "show vlan brief"
+  nexus:
+    kind: boolean
+    get_data_format: nxapi_structured
+    get_context: ["TABLE_vlanbriefxbrief", "ROW_vlanbriefxbrief"]
+    get_value: ["vlanshowbr-vlanid-utf <vlanid>", "vlanshowbr-shutstate", '/^shutdown$/']
+    # config_get('vlan', 'shutdown', @vlan_id) returns
+    # true if data in 'vlanshowbr-shutstate' matches regex '/^shutdown$/' else false.
+    # NOTE: `<vlanid>` in the `get_value` is replaced by `@vlan_id` prior to lookup.
 ```
 
 ```yaml

--- a/lib/cisco_node_utils/cmd_ref/inventory.yaml
+++ b/lib/cisco_node_utils/cmd_ref/inventory.yaml
@@ -6,11 +6,10 @@ _template:
     data_format: cli
   nexus:
     data_format: nxapi_structured
+    get_context: ["TABLE_inv", "ROW_inv"]
 
 all:
   multiple: true
-  nexus:
-    get_context: ["TABLE_inv", "ROW_inv"]
 
 chassis:
   nexus:
@@ -22,19 +21,16 @@ productid:
   ios_xr:
     get_value: '/"Rack 0".*\n.*PID: ([^ ,]+)/'
   nexus:
-    get_context: ["TABLE_inv", "ROW_inv"]
     get_value: ["name Chassis", "productid"]
 
 serialnum:
   ios_xr:
     get_value: '/"Rack 0".*\n.*SN: ([^ ,]+)/'
   nexus:
-    get_context: ["TABLE_inv", "ROW_inv"]
     get_value: ["name Chassis", "serialnum"]
 
 versionid:
   ios_xr:
     get_value: '/"Rack 0".*\n.*VID: ([^ ,]+)/'
   nexus:
-    get_context: ["TABLE_inv", "ROW_inv"]
     get_value: ["name Chassis", "vendorid"]

--- a/lib/cisco_node_utils/cmd_ref/inventory.yaml
+++ b/lib/cisco_node_utils/cmd_ref/inventory.yaml
@@ -29,12 +29,12 @@ serialnum:
   ios_xr:
     get_value: '/"Rack 0".*\n.*SN: ([^ ,]+)/'
   nexus:
-    get_context: ["TABLE_inv", "ROW_inv", '0']
-    get_value: "serialnum"
+    get_context: ["TABLE_inv", "ROW_inv"]
+    get_value: ["name Chassis", "serialnum"]
 
 versionid:
   ios_xr:
     get_value: '/"Rack 0".*\n.*VID: ([^ ,]+)/'
   nexus:
-    get_context: ["TABLE_inv", "ROW_inv", '0']
-    get_value: "vendorid"
+    get_context: ["TABLE_inv", "ROW_inv"]
+    get_value: ["name Chassis", "vendorid"]

--- a/lib/cisco_node_utils/cmd_ref/inventory.yaml
+++ b/lib/cisco_node_utils/cmd_ref/inventory.yaml
@@ -22,8 +22,8 @@ productid:
   ios_xr:
     get_value: '/"Rack 0".*\n.*PID: ([^ ,]+)/'
   nexus:
-    get_context: ["TABLE_inv", "ROW_inv", '0']
-    get_value: "productid"
+    get_context: ["TABLE_inv", "ROW_inv"]
+    get_value: ["name Chassis", "productid"]
 
 serialnum:
   ios_xr:

--- a/lib/cisco_node_utils/cmd_ref/vlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vlan.yaml
@@ -4,8 +4,10 @@ _exclude: [ios_xr]
 
 all_vlans:
   multiple: true
+  get_data_format: nxapi_structured
   get_command: "show vlan brief"
-  get_value: '/^(\d+)\s/'
+  get_context: ["TABLE_vlanbriefxbrief", "ROW_vlanbriefxbrief"]
+  get_value: "vlanshowbr-vlanid-utf"
 
 create:
   set_value: "vlan %s"
@@ -59,10 +61,11 @@ mode:
   default_value: 'CE'
 
 name:
-  multiple: true
+  kind: string
   get_data_format: nxapi_structured
   get_command: "show vlan brief"
   get_context: ["TABLE_vlanbriefxbrief", "ROW_vlanbriefxbrief"]
+  get_value: ["vlanshowbr-vlanid-utf <vlanid>", "vlanshowbr-vlanname"]
   set_context: ["vlan %d"]
   set_value: "%s name %s ; end"
 
@@ -85,10 +88,11 @@ pvlan_type:
   default_value: ""
 
 shutdown:
-  multiple: true
+  kind: boolean
   get_data_format: nxapi_structured
   get_command: "show vlan brief"
   get_context: ["TABLE_vlanbriefxbrief", "ROW_vlanbriefxbrief"]
+  get_value: ["vlanshowbr-vlanid-utf <vlanid>", "vlanshowbr-shutstate", '/^shutdown$/']
   set_context: ["vlan %d"]
   set_value: "%s shutdown ; end"
   default_value: false

--- a/lib/cisco_node_utils/cmd_ref/vlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vlan.yaml
@@ -59,8 +59,10 @@ mode:
   default_value: 'CE'
 
 name:
+  multiple: true
+  get_data_format: nxapi_structured
   get_command: "show vlan brief"
-  get_value: '/^%d\s+(\S+)\s/'
+  get_context: ["TABLE_vlanbriefxbrief", "ROW_vlanbriefxbrief"]
   set_context: ["vlan %d"]
   set_value: "%s name %s ; end"
 
@@ -83,8 +85,10 @@ pvlan_type:
   default_value: ""
 
 shutdown:
+  multiple: true
+  get_data_format: nxapi_structured
   get_command: "show vlan brief"
-  get_value: '/^%d\s+\S+\s+(\S+)\s/'
+  get_context: ["TABLE_vlanbriefxbrief", "ROW_vlanbriefxbrief"]
   set_context: ["vlan %d"]
   set_value: "%s shutdown ; end"
   default_value: false

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -56,18 +56,76 @@ module Cisco
       # If we have a default value but no getter, just return the default
       return ref.default_value if ref.default_value? && !ref.getter?
 
-      get_args = ref.getter(*args)
-      massage(get(command:     ref.get_command,
-                  data_format: get_args[:data_format],
-                  context:     get_args[:context],
-                  value:       get_args[:value]),
-              ref)
+      get_args, ref = massage_structured(ref.getter(*args).clone, ref)
+      foo = massage(get(command:     ref.get_command,
+                        data_format: get_args[:data_format],
+                        context:     get_args[:context],
+                        value:       get_args[:value]),
+                    ref)
+      foo
+    end
+
+    # The yaml file may specifiy an Array as the get_value to drill down into
+    # nxapi_structured table output.  The table may contain multiple rows but
+    # only one of the rows has the interesting data.
+    def massage_structured(get_args, ref)
+      # Nothing to do unless nxapi_structured.
+      return [get_args, ref] unless
+        ref.hash['get_data_format'] == :nxapi_structured
+
+      # The CmdRef object will contain a get_value Array with 2 values.
+      # The first value is the key to identify the correct row in the table
+      # of structured output and the second is the key to identify the data
+      # to retrieve.
+      #
+      # Example: Get vlanshowbr-vlanname in the row that contains a specific
+      #  vlan_id.
+      # "get_value"=>["vlanshowbr-vlanid-utf <vlan_id>", "vlanshowbr-vlanname"]
+      if ref.hash['get_value'].is_a?(Array) && ref.hash['get_value'].size >= 2
+        # Replace the get_value hash entry with the value after any tokens
+        # specified in the yaml file have been replaced and set get_args[:value]
+        # to nil so that the structured table data can be retrieved properly.
+        ref.hash['get_value'] = get_args[:value]
+        ref.hash['drill_down'] = true
+        get_args[:value] = nil
+      end
+      [get_args, ref]
+    end
+
+    # Drill down into structured nxapi table data and return value from the
+    # row specified by a two part key.
+    #
+    # Example: Get vlanshowbr-vlanname in the row that contains vlan id 1000
+    # "get_value"=>["vlanshowbr-vlanid-utf 1000", "vlanshowbr-vlanname"]
+    # Example with optional regexp match
+    # "get_value"=>["vlanshowbr-vlanid-utf 1000", "vlanshowbr-vlanname",
+    #                '/^shutdown$/']
+    def drill_down_structured(value, ref)
+      # Nothing to do unless nxapi_structured
+      return value unless ref.hash['drill_down']
+
+      row_key = ref.hash['get_value'][0][/^\S+/]
+      row_index = ref.hash['get_value'][0][/\S+$/]
+      data_key = ref.hash['get_value'][1]
+      regexp_filter = nil
+      regexp_filter = ref.hash['get_value'][2] if ref.hash['get_value'][2]
+
+      # Get the value using the row_key, row_index and data_key
+      data = value.find { |item| item[row_key].to_s[/#{row_index}/] }
+      return value if data.nil?
+      if regexp_filter
+        filtered = regexp_filter.match(data[data_key])
+        return filtered.nil? ? filtered : filtered[0]
+      end
+      cache_flush
+      data[data_key]
     end
 
     # Attempt to massage the given value into the format specified by the
     # given CmdRef object.
     def massage(value, ref)
       Cisco::Logger.debug "Massaging '#{value}' (#{value.inspect})"
+      value = drill_down_structured(value, ref)
       if value.is_a?(Array) && !ref.multiple
         fail "Expected zero/one value but got '#{value}'" if value.length > 1
         value = value[0]
@@ -75,6 +133,9 @@ module Cisco
       if (value.nil? || value.empty?) && ref.default_value? && ref.auto_default
         Cisco::Logger.debug "Default: #{ref.default_value}"
         return ref.default_value
+      end
+      if ref.multiple && ref.hash['get_data_format'] == :nxapi_structured
+        value = [value.to_s] if value.size == 1
       end
       return value unless ref.kind
       case ref.kind

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -57,12 +57,11 @@ module Cisco
       return ref.default_value if ref.default_value? && !ref.getter?
 
       get_args, ref = massage_structured(ref.getter(*args).clone, ref)
-      foo = massage(get(command:     ref.get_command,
-                        data_format: get_args[:data_format],
-                        context:     get_args[:context],
-                        value:       get_args[:value]),
-                    ref)
-      foo
+      massage(get(command:     ref.get_command,
+                  data_format: get_args[:data_format],
+                  context:     get_args[:context],
+                  value:       get_args[:value]),
+              ref)
     end
 
     # The yaml file may specifiy an Array as the get_value to drill down into
@@ -118,7 +117,6 @@ module Cisco
         filtered = regexp_filter.match(data[data_key])
         return filtered.nil? ? filtered : filtered[0]
       end
-      cache_flush
       data[data_key]
     end
 

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -130,7 +130,7 @@ module Cisco
         fail "Expected zero/one value but got '#{value}'" if value.length > 1
         value = value[0]
       end
-      if (value.nil? || value.empty?) && ref.default_value? && ref.auto_default
+      if (value.nil? || value.to_s.empty?) && ref.default_value? && ref.auto_default
         Cisco::Logger.debug "Default: #{ref.default_value}"
         return ref.default_value
       end

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -111,6 +111,7 @@ module Cisco
       regexp_filter = ref.hash['get_value'][2] if ref.hash['get_value'][2]
 
       # Get the value using the row_key, row_index and data_key
+      value = value.is_a?(Hash) ? [value] : value
       data = value.find { |item| item[row_key].to_s[/#{row_index}/] }
       return value if data.nil?
       if regexp_filter

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -130,7 +130,8 @@ module Cisco
         fail "Expected zero/one value but got '#{value}'" if value.length > 1
         value = value[0]
       end
-      if (value.nil? || value.to_s.empty?) && ref.default_value? && ref.auto_default
+      if (value.nil? || value.to_s.empty?) &&
+         ref.default_value? && ref.auto_default
         Cisco::Logger.debug "Default: #{ref.default_value}"
         return ref.default_value
       end

--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -141,8 +141,13 @@ module Cisco
     end
 
     def vlan_name
-      result = config_get('vlan', 'name', @vlan_id)
-      result.nil? ? default_vlan_name : result
+      node.cache_flush
+      all = config_get('vlan', 'name')
+      return default_vlan_name if all.nil?
+
+      vlans = all.find { |item| item['vlanshowbr-vlanid'][/#{@vlan_id}/] }
+      return default_vlan_name if vlans.nil?
+      vlans['vlanshowbr-vlanname']
     end
 
     def vlan_name=(str)
@@ -184,9 +189,13 @@ module Cisco
     end
 
     def shutdown
-      result = config_get('vlan', 'shutdown', @vlan_id)
-      # Valid result is either: "active"(aka no shutdown) or "shutdown"
-      result[/shut/] ? true : false
+      node.cache_flush
+      all = config_get('vlan', 'shutdown')
+      return default_shutdown if all.nil?
+
+      vlans = all.find { |item| item['vlanshowbr-vlanid'][/#{@vlan_id}/] }
+      return default_shutdown if vlans.nil?
+      vlans['vlanshowbr-shutstate'][/noshutdown/] ? false : true
     end
 
     def shutdown=(val)

--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -141,15 +141,7 @@ module Cisco
     end
 
     def vlan_name
-      node.cache_flush
-      all = config_get('vlan', 'name')
-      return default_vlan_name if all.nil?
-
-      key = 'vlanshowbr-vlanid-utf'
-      value = 'vlanshowbr-vlanname'
-      vlans = all.find { |item| item[key].to_s[/#{@vlan_id}/] }
-      return default_vlan_name if vlans.nil?
-      vlans[value]
+      config_get('vlan', 'name', vlanid: @vlan_id)
     end
 
     def vlan_name=(str)
@@ -191,15 +183,7 @@ module Cisco
     end
 
     def shutdown
-      node.cache_flush
-      all = config_get('vlan', 'shutdown')
-      return default_shutdown if all.nil?
-
-      key = 'vlanshowbr-vlanid-utf'
-      value = 'vlanshowbr-shutstate'
-      vlans = all.find { |item| item[key].to_s[/#{@vlan_id}/] }
-      return default_shutdown if vlans.nil?
-      vlans[value][/noshutdown/] ? false : true
+      config_get('vlan', 'shutdown', vlanid: @vlan_id)
     end
 
     def shutdown=(val)

--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -145,9 +145,11 @@ module Cisco
       all = config_get('vlan', 'name')
       return default_vlan_name if all.nil?
 
-      vlans = all.find { |item| item['vlanshowbr-vlanid'][/#{@vlan_id}/] }
+      key = 'vlanshowbr-vlanid-utf'
+      value = 'vlanshowbr-vlanname'
+      vlans = all.find { |item| item[key].to_s[/#{@vlan_id}/] }
       return default_vlan_name if vlans.nil?
-      vlans['vlanshowbr-vlanname']
+      vlans[value]
     end
 
     def vlan_name=(str)
@@ -193,9 +195,11 @@ module Cisco
       all = config_get('vlan', 'shutdown')
       return default_shutdown if all.nil?
 
-      vlans = all.find { |item| item['vlanshowbr-vlanid'][/#{@vlan_id}/] }
+      key = 'vlanshowbr-vlanid-utf'
+      value = 'vlanshowbr-shutstate'
+      vlans = all.find { |item| item[key].to_s[/#{@vlan_id}/] }
       return default_shutdown if vlans.nil?
-      vlans['vlanshowbr-shutstate'][/noshutdown/] ? false : true
+      vlans[value][/noshutdown/] ? false : true
     end
 
     def shutdown=(val)

--- a/lib/cisco_node_utils/yum.rb
+++ b/lib/cisco_node_utils/yum.rb
@@ -55,15 +55,15 @@ module Cisco
 
       begin
         config_set('yum', 'install', pkg, vrf)
+
+        # HACK: The current nxos host installer is a multi-part command
+        # which may fail at a later stage yet return a false positive;
+        # therefore a post-validation check is needed here to verify the
+        # actual outcome.
+        validate_installed(pkg)
       rescue Cisco::CliError, RuntimeError => e
         raise Cisco::CliError, "#{e.class}, #{e.message}"
       end
-
-      # HACK: The current nxos host installer is a multi-part command
-      # which may fail at a later stage yet return a false positive;
-      # therefore a post-validation check is needed here to verify the
-      # actual outcome.
-      validate_installed(pkg)
     end
 
     # returns version of package, or false if package doesn't exist

--- a/spec/schema.yaml
+++ b/spec/schema.yaml
@@ -62,7 +62,7 @@ mapping:
       get_data_format: *data_format
       get_context: *context
       get_value:
-        type: str
+        type: any
       kind:
         type: str
         enum: [boolean, int, string, symbol]

--- a/tests/test_vlan.rb
+++ b/tests/test_vlan.rb
@@ -156,7 +156,7 @@ class TestVlan < CiscoTestCase
     v.vlan_name = name
     assert_equal(name, v.vlan_name)
     name = 'LONG_NAME' + ('E' * 120)
-    assert_raises(RuntimeError) do
+    assert_raises(Cisco::CliError) do
       v.vlan_name = name
     end
     v.destroy

--- a/tests/test_vlan.rb
+++ b/tests/test_vlan.rb
@@ -149,6 +149,20 @@ class TestVlan < CiscoTestCase
     v.destroy
   end
 
+  def test_name_long
+    config 'system vlan long-name'
+    v = Vlan.new(1000)
+    name = 'LONG_NAME' + ('E' * 119)
+    v.vlan_name = name
+    assert_equal(name, v.vlan_name)
+    name = 'LONG_NAME' + ('E' * 120)
+    assert_raises(RuntimeError) do
+      v.vlan_name = name
+    end
+    v.destroy
+    config 'no system vlan long-name'
+  end
+
   def test_state_invalid
     v = Vlan.new(1000)
     assert_raises(CliError) do


### PR DESCRIPTION
**Summary:**
This change introduces additional capability when using `nxapi_structured` as the `get_data_format`.  Often the data that gets returned is a table that contains multiple rows of data that have similar characteristics but only one of the rows is desired.  This update makes use of `get_context` and `get_value` yaml keys to specify enough context to easily drill down to the desired row.

Properties that use `nxapi_structured` where possible have been updated to use the new infrastructure features.  This change also allows us to fix issue: https://github.com/cisco/cisco-network-puppet-module/issues/408.

**Spot Check Testing On: n3k(I5), n5k, n6k, n7k(Helsinki and Atherton), n9k(I2), n9k fretta**

Full minitest regression in progress.