### PR TITLE
SNMP Community - Symbols Cause Churn

### DIFF
--- a/lib/cisco_node_utils/client/utils.rb
+++ b/lib/cisco_node_utils/client/utils.rb
@@ -130,7 +130,7 @@ class Cisco::Client
   # @param keys [Array] lookup sequence
   def self.filter_data(data: nil,
                        keys: nil)
-    return nil if data.nil?
+    return nil if data.nil? || data.empty?
     keys ||= []
     keys.each do |filter|
       # if filter is a Hash and data is an array, check each

--- a/lib/cisco_node_utils/cmd_ref/snmp_community.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_community.yaml
@@ -1,32 +1,50 @@
 # snmp_community
 ---
 
+_template:
+  N3k: &template_structured
+    get_data_format: nxapi_structured
+    get_command: "show snmp community"
+    get_context: ["TABLE_snmp_community", "ROW_snmp_community"]
+  N9k: *template_structured
+  N9k-F: *template_structured
+
 acl:
-  nexus:
-    get_command: "show running snmp all"
-    get_value: '/^snmp-server community <name> use-acl (.*)$/'
+  N3k: &acl_structured_get
+    kind: string
+    get_value: ["community_name <name>", "aclfilter", '/^(?:ACL mapped:\s+)?(\S+)/']
     set_value: "<state> snmp-server community <name> use-acl <acl>"
-    default_value: ""
+  N9k: *acl_structured_get
+  N9k-F: *acl_structured_get
   ios_xr:
     get_command: "show running snmp"
     get_value: '/^snmp-server community <name> IPv4 (.*)$/'
     set_value: "<state> snmp-server community <name> <acl>"
-    default_value: ""
+  N5k: &acl_cli_get
+    get_command: "show running snmp all"
+    get_value: '/^snmp-server community <name> use-acl (.*)$/'
+    set_value: "<state> snmp-server community <name> use-acl <acl>"
+  N6k: *acl_cli_get
+  N7k: *acl_cli_get
+  default_value: ""
 
 all_communities:
-  nexus:
-    multiple: true
+  multiple: true
+  N3k: &all_structured
+    get_value: 'community_name'
+  N9k: *all_structured
+  N9k-F: *all_structured
+  N5k: &all_cli
     get_command: "show running snmp all"
     get_value: '/^snmp-server community (\S+) /'
+  N6k: *all_cli
+  N7k: *all_cli
   ios_xr:
-    multiple: true
     get_command: "show running-config snmp"
     get_value: '/^snmp-server community (\S+)/'
 
 community:
   nexus:
-    get_command: "show running snmp all"
-    get_value: '/^snmp-server community (%s) group .*$/'
     set_value: "<state> snmp-server community <name> group <group>"
   ios_xr:
     get_command: "show running-config snmp"
@@ -34,21 +52,18 @@ community:
     set_value: "<state> snmp-server community <name>"
 
 group:
-  N3k: &structured_get
+  N3k: &group_structured_get
     kind: string
-    get_data_format: nxapi_structured
-    get_command: "show snmp community"
-    get_context: ["TABLE_snmp_community", "ROW_snmp_community"]
     get_value: ["community_name <name>", "grouporaccess", '/^(?:Community groupname:\s+)?(\S+)/']
-  N9k: *structured_get
-  N9k-F: *structured_get
-  ios_xr: &cli_based_get
+  N9k: *group_structured_get
+  N9k-F: *group_structured_get
+  ios_xr: &group_cli_based_get
     kind: string
     get_command: "show running snmp all"
     get_value: '/^snmp-server community <name> group (.*)$/'
-  N5k: *cli_based_get
-  N6k: *cli_based_get
-  N7k: *cli_based_get
+  N5k: *group_cli_based_get
+  N6k: *group_cli_based_get
+  N7k: *group_cli_based_get
   set_value: "snmp-server community <name> group <group>"
   default_value: "network-operator"
 

--- a/lib/cisco_node_utils/cmd_ref/snmp_community.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_community.yaml
@@ -34,10 +34,23 @@ community:
     set_value: "<state> snmp-server community <name>"
 
 group:
+  N3k: &structured_get
+    kind: string
+    get_data_format: nxapi_structured
+    get_command: "show snmp community"
+    get_context: ["TABLE_snmp_community", "ROW_snmp_community"]
+    get_value: ["community_name <name>", "grouporaccess", '/^(?:Community groupname:\s+)?(\S+)/']
+  N9k: *structured_get
+  N9k-F: *structured_get
+  ios_xr: &cli_based_get
+    kind: string
     get_command: "show running snmp all"
     get_value: '/^snmp-server community <name> group (.*)$/'
-    set_value: "snmp-server community <name> group <group>"
-    default_value: "network-operator"
+  N5k: *cli_based_get
+  N6k: *cli_based_get
+  N7k: *cli_based_get
+  set_value: "snmp-server community <name> group <group>"
+  default_value: "network-operator"
 
 group_community_mapping:
     get_command: "show running snmp"

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -158,18 +158,12 @@ module Cisco
       value.nil? || value
     end
 
-    def escape_chars_in_string(string)
-      pattern = %r{(\'|\"|\.|\*|\/|\-|\\|\)|\$|\+|\(|\^|\?|\!|\~|\`)}
-      string.gsub(pattern) { |match| '\\' + match }
-    end
-
     def key_substitutor(item, kwargs)
       result = item
       kwargs.each do |key, value|
-        result = result.sub("<#{key}>", escape_chars_in_string(value.to_s))
+        result = result.sub("<#{key}>", value.to_s)
       end
       unsub = result[/<(\S+)>/, 1]
-      puts "key_substitutor value: #{value}"
       fail ArgumentError, \
            "No value specified for '#{unsub}' in '#{result}'" if unsub
       result

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -158,12 +158,18 @@ module Cisco
       value.nil? || value
     end
 
+    def escape_chars_in_string(string)
+      pattern = %r{(\'|\"|\.|\*|\/|\-|\\|\)|\$|\+|\(|\^|\?|\!|\~|\`)}
+      string.gsub(pattern) { |match| '\\' + match }
+    end
+
     def key_substitutor(item, kwargs)
       result = item
       kwargs.each do |key, value|
-        result = result.sub("<#{key}>", value.to_s)
+        result = result.sub("<#{key}>", escape_chars_in_string(value.to_s))
       end
       unsub = result[/<(\S+)>/, 1]
+      puts "key_substitutor value: #{value}"
       fail ArgumentError, \
            "No value specified for '#{unsub}' in '#{result}'" if unsub
       result

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -169,7 +169,7 @@ module Cisco
         result = result.sub("<#{key}>", escape_chars_in_string(value.to_s))
       end
       unsub = result[/<(\S+)>/, 1]
-      puts "key_substitutor result: #{result}"
+      puts "key_substitutor value: #{value}"
       fail ArgumentError, \
            "No value specified for '#{unsub}' in '#{result}'" if unsub
       result

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -169,7 +169,7 @@ module Cisco
         result = result.sub("<#{key}>", escape_chars_in_string(value.to_s))
       end
       unsub = result[/<(\S+)>/, 1]
-      puts "key_substitutor value: #{value}"
+      puts "key_substitutor result: #{result}"
       fail ArgumentError, \
            "No value specified for '#{unsub}' in '#{result}'" if unsub
       result

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -87,7 +87,7 @@ module Cisco
         ref.hash['get_value'] = get_args[:value]
         ref.hash['drill_down'] = true
         get_args[:value] = nil
-        cach_flush
+        cache_flush
       end
       # cache_flush
       [get_args, ref]

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -80,6 +80,8 @@ module Cisco
       # Example: Get vlanshowbr-vlanname in the row that contains a specific
       #  vlan_id.
       # "get_value"=>["vlanshowbr-vlanid-utf <vlan_id>", "vlanshowbr-vlanname"]
+      #
+      # TBD: Why do we need to check is_a?(Array) here?
       if ref.hash['get_value'].is_a?(Array) && ref.hash['get_value'].size >= 2
         # Replace the get_value hash entry with the value after any tokens
         # specified in the yaml file have been replaced and set get_args[:value]
@@ -89,7 +91,6 @@ module Cisco
         get_args[:value] = nil
         cache_flush
       end
-      # cache_flush
       [get_args, ref]
     end
 

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -142,9 +142,16 @@ module Cisco
         return ref.default_value
       end
       if ref.multiple && ref.hash['get_data_format'] == :nxapi_structured
+        return value if value.nil?
         value = [value.to_s] if value.size == 1
       end
       return value unless ref.kind
+      value = massage_kind(value, ref)
+      Cisco::Logger.debug "Massaged to '#{value}'"
+      value
+    end
+
+    def massage_kind(value, ref)
       case ref.kind
       when :boolean
         if value.nil? || value.empty?
@@ -164,7 +171,6 @@ module Cisco
       when :symbol
         value = value.to_sym unless value.nil?
       end
-      Cisco::Logger.debug "Massaged to '#{value}'"
       value
     end
 

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -87,8 +87,9 @@ module Cisco
         ref.hash['get_value'] = get_args[:value]
         ref.hash['drill_down'] = true
         get_args[:value] = nil
+        cach_flush
       end
-      cache_flush
+      # cache_flush
       [get_args, ref]
     end
 

--- a/tests/test_snmpcommunity.rb
+++ b/tests/test_snmpcommunity.rb
@@ -193,7 +193,8 @@ class TestSnmpCommunity < CiscoTestCase
 
   def test_get_group_complex_name
     skip("Test not supported on #{product_tag} due to CSCva63814") if product_tag[/n5|6|7k/]
-    names = ['C0mplex()Community!', 'C#', 'C$', 'C%', 'C^', 'C&', 'C*', 'C-', 'C=', 'C<', 'C,', 'C.', 'C/', 'C|']
+    names = ['C0mplex()Community!', 'C#', 'C$', 'C%', 'C^', 'C&', 'C*',
+             'C-', 'C=', 'C<', 'C,', 'C.', 'C/', 'C|', 'C{}[]']
     group = 'network-admin'
     names.each do |name|
       sc = SnmpCommunity.new(name, group)

--- a/tests/test_snmpcommunity.rb
+++ b/tests/test_snmpcommunity.rb
@@ -191,6 +191,17 @@ class TestSnmpCommunity < CiscoTestCase
     cleanup_snmpcommunity(snmpcommunity)
   end
 
+  def test_get_group_complex_name
+    skip("Test not supported on #{product_tag} due to CSCva63814") if product_tag[/n5|6|7k/]
+    names = ['C0mplex()Community!', 'C#', 'C$', 'C%', 'C^', 'C&', 'C*', 'C-', 'C=', 'C<', 'C,', 'C.', 'C/', 'C|']
+    group = 'network-admin'
+    names.each do |name|
+      sc = SnmpCommunity.new(name, group)
+      assert_equal(group, sc.group)
+      cleanup_snmpcommunity(sc)
+    end
+  end
+
   def test_group_set_zero_length
     name = 'ciscogroupsetcom'
     group = 'network-operator'


### PR DESCRIPTION
**Summary:**
This update fixes the issue with the `cisco_snmp_community` provider described in https://github.com/cisco/cisco-network-puppet-module/issues/414

This is a two part fix:
 - Refactor the underlying `snmp_community` object to use nxapi structured output instead of raw cli based output.
     - NOTE: Structured output for this provider is currently only supported on `n3k`, `n9k` and `n9k-f` platforms.  `n5k`, `n6k` and `n7k` will continue to use raw cli based nxapi and hence with this fix will still be unable to handle complex `cisco_snmp_community` names.  A future commit will address this for raw cli based output.
- The infrastructure handling nxapi structured output was refactored to better query data that may include special complex characters.

Tested on: `n3k`, `n9k`, `n9k-f`, `n5k`, `n6k`, `n7k`
