### PR TITLE
fix itd ingress intf issue

### DIFF
--- a/lib/cisco_node_utils/itd_service.rb
+++ b/lib/cisco_node_utils/itd_service.rb
@@ -192,12 +192,15 @@ module Cisco
     # so translate back to the input format
     def ingress_interface
       list = config_get('itd_service', 'ingress_interface', @get_args)
-      list.each do |intf, _next_hop|
+      rlist = []
+      list.each do |intf, next_hop|
         intf.gsub!('Eth', 'ethernet ')
         intf.gsub!('Po', 'port-channel ')
         intf.gsub!('Vlan', 'vlan ')
+        next_hop = '' if next_hop.nil?
+        rlist << [intf, next_hop]
       end
-      list
+      rlist
     end
 
     def ingress_interface_cleanup

--- a/tests/test_itd_service.rb
+++ b/tests/test_itd_service.rb
@@ -103,6 +103,10 @@ class TestItdSvc < CiscoTestCase
           ['port-channel 100', '3.3.3.3']]
     itd.ingress_interface = ii
     assert_equal(itd.ingress_interface, ii)
+    ii = [['vlan 2', ''],
+          ['port-channel 100', '']]
+    itd.ingress_interface = ii
+    assert_equal(itd.ingress_interface, ii)
     itd.ingress_interface = itd.default_ingress_interface
     assert_equal(itd.ingress_interface, itd.default_ingress_interface)
     config 'no interface port-channel 100'


### PR DESCRIPTION
This PR is for fixing ingress interface issue for itd service. The ingress interface has a next-hop property which is optional. The current code has an issue when the next-hop property is not specified. This PR fixes that issue.