### PR TITLE
Allow configuration of local nxapi session cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ If both files exist and are readable, configuration in the user-specific file wi
 
 This file specifies the host, port, username, and/or password to be used to connect to one or more nodes.
 
-* When installing this gem on NX-OS nodes, this file is generally not needed, as the default client behavior is sufficient.
+* When installing this gem on NX-OS nodes, this file is generally not needed, as the default client behavior is sufficient.  This file can be used however to override the default cookie.
+    - Nodes defined with a single `cookie` parameter will override the default cookie.
 * When developing for or testing this gem, this file can specify one or more NX-OS nodes to run tests against. In this case:
     - A node labeled as `default` will be the default node to test against.
     - Nodes with other names can be selected at test execution time.

--- a/docs/cisco_node_utils.yaml.example
+++ b/docs/cisco_node_utils.yaml.example
@@ -13,7 +13,7 @@ nxapi_remote:
 # Example config for running NXAPI on a node:
 nxapi_local:
   # (none needed)
-  
+
 # Example config for running NXAPI on a node with default cookie override:
 # User 'nxapi' must be configured with requisite privilages to configure the device.
 # This will override the default 'admin:local' cookie and use 'nxapi:local' instead.

--- a/docs/cisco_node_utils.yaml.example
+++ b/docs/cisco_node_utils.yaml.example
@@ -13,6 +13,12 @@ nxapi_remote:
 # Example config for running NXAPI on a node:
 nxapi_local:
   # (none needed)
+  
+# Example config for running NXAPI on a node with default cookie override:
+# User 'nxapi' must be configured with requisite privilages to configure the device.
+# This will override the default 'admin:local' cookie and use 'nxapi:local' instead.
+default:
+  cookie: 'nxapi:local'
 
 # Example config for running gRPC remotely:
 grpc_remote:

--- a/lib/cisco_node_utils/client/client.rb
+++ b/lib/cisco_node_utils/client/client.rb
@@ -52,7 +52,6 @@ class Cisco::Client
     @address = @port.nil? ? @host : "#{@host}:#{@port}"
     @username = kwargs[:username]
     @password = kwargs[:password]
-    @cookie = kwargs[:cookie]
     self.data_formats = data_formats
     self.platform = platform
     @cache_enable = true
@@ -75,11 +74,6 @@ class Cisco::Client
     unless password.nil?
       fail TypeError, 'invalid password' unless password.is_a?(String)
       fail ArgumentError, 'empty password' if password.empty?
-    end
-    cookie = kwargs[:cookie]
-    unless cookie.nil?
-      fail TypeError, 'invalid cookie' unless cookie.is_a?(String)
-      fail ArgumentError, 'empty cookie' if cookie.empty?
     end
   end
 

--- a/lib/cisco_node_utils/client/client.rb
+++ b/lib/cisco_node_utils/client/client.rb
@@ -52,6 +52,7 @@ class Cisco::Client
     @address = @port.nil? ? @host : "#{@host}:#{@port}"
     @username = kwargs[:username]
     @password = kwargs[:password]
+    @cookie = kwargs[:cookie]
     self.data_formats = data_formats
     self.platform = platform
     @cache_enable = true
@@ -74,6 +75,11 @@ class Cisco::Client
     unless password.nil?
       fail TypeError, 'invalid password' unless password.is_a?(String)
       fail ArgumentError, 'empty password' if password.empty?
+    end
+    cookie = kwargs[:cookie]
+    unless cookie.nil?
+      fail TypeError, 'invalid cookie' unless cookie.is_a?(String)
+      fail ArgumentError, 'empty cookie' if cookie.empty?
     end
   end
 

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -77,7 +77,7 @@ class Cisco::Client::NXAPI < Cisco::Client
     if kwargs[:host].nil?
       # Connection to UDS - no username or password either
       fail ArgumentError unless kwargs[:username].nil? && kwargs[:password].nil?
-      self.class.validate_cookie(**kwargs)
+      self.validate_cookie(**kwargs)
     else
       # Connection to remote system - username and password are required
       fail TypeError, 'username is required' if kwargs[:username].nil?

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -77,7 +77,7 @@ class Cisco::Client::NXAPI < Cisco::Client
     if kwargs[:host].nil?
       # Connection to UDS - no username or password either
       fail ArgumentError unless kwargs[:username].nil? && kwargs[:password].nil?
-      self.validate_cookie(**kwargs)
+      validate_cookie(**kwargs)
     else
       # Connection to remote system - username and password are required
       fail TypeError, 'username is required' if kwargs[:username].nil?
@@ -87,10 +87,10 @@ class Cisco::Client::NXAPI < Cisco::Client
 
   def self.validate_cookie(**kwargs)
     return if kwargs[:cookie].nil?
-    format = '<username>:local'
-    msg = "Invalid cookie: #{kwargs[:cookie]}. Format must match: #{format}"
+    format = 'Cookie format must match: <username>:local'
+    msg = "Invalid cookie: [#{kwargs[:cookie]}]. : #{format}"
 
-    fail TypeError, 'invalid cookie' unless kwargs[:cookie].is_a?(String)
+    fail TypeError, msg unless kwargs[:cookie].is_a?(String)
     fail TypeError, msg unless /\S+:local/.match(kwargs[:cookie])
     fail ArgumentError, 'empty cookie' if kwargs[:cookie].empty?
   end

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -222,9 +222,12 @@ class Cisco::Client::NXAPI < Cisco::Client
 
   def build_http_request(type, command_string)
     if @username.nil? || @password.nil?
+      cookie = @cookie.nil? ? 'admin:local' : @cookie
       request = Net::HTTP::Post.new(NXAPI_UDS_URI_PATH)
-      request['Cookie'] = 'nxapi_auth=admin:local'
+      request['Cookie'] = "nxapi_auth=#{cookie}"
+      puts "Request Cookie: #{request['Cookie']}"
     else
+      puts 'Remote nxapi authorization'
       request = Net::HTTP::Post.new(NXAPI_REMOTE_URI_PATH)
       request.basic_auth("#{@username}", "#{@password}")
     end

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -237,9 +237,7 @@ class Cisco::Client::NXAPI < Cisco::Client
       cookie = @cookie.nil? ? 'admin:local' : @cookie
       request = Net::HTTP::Post.new(NXAPI_UDS_URI_PATH)
       request['Cookie'] = "nxapi_auth=#{cookie}"
-      puts "Request Cookie: #{request['Cookie']}"
     else
-      puts 'Remote nxapi authorization'
       request = Net::HTTP::Post.new(NXAPI_REMOTE_URI_PATH)
       request.basic_auth("#{@username}", "#{@password}")
     end

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -56,6 +56,7 @@ class Cisco::Client::NXAPI < Cisco::Client
       # unit testing where the base Net::HTTP will meet our needs.
       require 'net_http_unix'
       @http = NetX::HTTPUnix.new('unix://' + NXAPI_UDS)
+      @cookie = kwargs[:cookie]
     else
       # Remote connection. This is primarily expected
       # when running e.g. from a Unix server as part of Minitest.
@@ -76,11 +77,22 @@ class Cisco::Client::NXAPI < Cisco::Client
     if kwargs[:host].nil?
       # Connection to UDS - no username or password either
       fail ArgumentError unless kwargs[:username].nil? && kwargs[:password].nil?
+      self.class.validate_cookie(**kwargs)
     else
       # Connection to remote system - username and password are required
       fail TypeError, 'username is required' if kwargs[:username].nil?
       fail TypeError, 'password is required' if kwargs[:password].nil?
     end
+  end
+
+  def self.validate_cookie(**kwargs)
+    return if kwargs[:cookie].nil?
+    format = '<username>:local'
+    msg = "Invalid cookie: #{kwargs[:cookie]}. Format must match: #{format}"
+
+    fail TypeError, 'invalid cookie' unless kwargs[:cookie].is_a?(String)
+    fail TypeError, msg unless /\S+:local/.match(kwargs[:cookie])
+    fail ArgumentError, 'empty cookie' if kwargs[:cookie].empty?
   end
 
   # Clear the cache of CLI output results.

--- a/lib/cisco_node_utils/environment.rb
+++ b/lib/cisco_node_utils/environment.rb
@@ -65,7 +65,6 @@ module Cisco
         # merge it on in!
         current_config[name].merge!(strings_to_symbols(config))
       end
-      puts "MGW: current_config: #{current_config}"
       current_config
     end
 

--- a/lib/cisco_node_utils/environment.rb
+++ b/lib/cisco_node_utils/environment.rb
@@ -39,6 +39,7 @@ module Cisco
       port:     nil, # only applicable to gRPC
       username: nil,
       password: nil,
+      cookie:   nil, # only applicable to nxapi
     }
 
     def self.environments
@@ -64,6 +65,7 @@ module Cisco
         # merge it on in!
         current_config[name].merge!(strings_to_symbols(config))
       end
+      puts "MGW: current_config: #{current_config}"
       current_config
     end
 

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -47,6 +47,7 @@ describe Cisco::Environment do
         port:     57_799,
         username: nil,
         password: nil,
+        cookie:   nil,
       } }
       expect(Cisco::Environment).to receive(:data_from_file).and_return(
         'hello' => { host: '1.1.1.1' }, 'goodbye' => { password: 'foo' })
@@ -56,12 +57,14 @@ describe Cisco::Environment do
           port:     57_799,
           username: nil,
           password: nil,
+          cookie:   nil,
         },
         'goodbye' => {
           host:     nil,
           port:     nil,
           username: nil,
           password: 'foo',
+          cookie:   nil,
         },
       )
     end
@@ -78,12 +81,14 @@ describe Cisco::Environment do
 
     global_config = {
       'default' => {
-        host: '127.0.0.1',
-        port: 57_400,
+        host:   '127.0.0.1',
+        port:   57_400,
+        cookie: nil,
       },
       'global'  => {
         username: 'global',
         password: 'global',
+        cookie:   nil,
       },
     }
 
@@ -91,10 +96,12 @@ describe Cisco::Environment do
       'default' => {
         port:     57_799,
         username: 'user',
+        cookie:   nil,
       },
       'user'    => {
         username: 'user',
         password: 'user',
+        cookie:   nil,
       },
     }
 
@@ -137,18 +144,21 @@ describe Cisco::Environment do
           port:     57_799, # user overrides global
           username: 'user', # user config
           password: nil, # auto-populated with nil
+          cookie:   nil,
         },
         'global'  => { # global config
           host:     nil,
           port:     nil,
           username: 'global',
           password: 'global',
+          cookie:   nil,
         },
         'user'    => { # user config
           host:     nil,
           port:     nil,
           username: 'user',
           password: 'user',
+          cookie:   nil,
         },
       )
     end
@@ -185,6 +195,7 @@ describe Cisco::Environment do
           port:     nil,
           username: nil,
           password: nil,
+          cookie:   nil,
         }
         it 'can be loaded explicitly by name' do
           expect(Cisco::Environment.environment('nxapi_local')).to eq(expected)
@@ -205,6 +216,7 @@ describe Cisco::Environment do
           port:     nil,
           username: 'devops',
           password: 'devops',
+          cookie:   nil,
         }
         it 'can be loaded explicitly by name' do
           expect(Cisco::Environment.environment('nxapi_remote')).to eq(expected)
@@ -225,6 +237,7 @@ describe Cisco::Environment do
           port:     57_999,
           username: 'admin',
           password: 'admin',
+          cookie:   nil,
         }
         it 'can be loaded explicitly by name' do
           expect(Cisco::Environment.environment('grpc_local')).to eq(expected)
@@ -245,6 +258,7 @@ describe Cisco::Environment do
           port:     nil,
           username: 'admin',
           password: 'admin',
+          cookie:   nil,
         }
         it 'can be loaded explicitly by name' do
           expect(Cisco::Environment.environment('grpc_remote')).to eq(expected)


### PR DESCRIPTION
**Summary of changes:**
Allow configuration within the `cisco_node_utils.yaml` file to include a user defined session cookie.  This configuration overrides the default `admin:local` cookie.  These changes add an additional configuration field called `cookie` under nodes defined in the `cisco_node_utils.yaml` configuration file.

There are three possible states when configuring a local session cookie.
- File `cisco_node_utils.yaml` does not exist.
  - Cookie defaults to `admin:local`
- File exists under `/etc/cisco_node_utils.yaml`
  - System and/or root defined cookie under the `default:` node used, else `admin:local`
- File exists under `~/cisco_node_utils.yaml`
  - User defined cookie under the `default:` node used, else `admin:local`

**Testing:**
The following test cases were executed within all 3 hosting environments on nxos for the `cisco_node_utils` gem: `native bash shell`, `guestshell`, `oac`.

The following ruby script was used for testing:
```ruby
require 'cisco_node_utils'

client1 = Cisco::Client.create()

client1.set(values: 'no feature vtp')
client1.set(values: 'feature vtp')
client1.set(values: 'vtp domain mycompany.com')

puts client1.get(command: 'show vtp status | inc Domain')
```
**NOTE:** The source code was instrumented prior to testing to display the `cisco_node_utils.yaml`  configuration and session cookie information but has been removed for the code review.

------

1. Default Case:
   - cisco_node_utils.yaml file does not exist under `/etc` or `~`
   - Cookie: `admin:local` used.

```
[root@guestshell ~]# ls -lh /etc/cisco_node_utils.yaml
ls: cannot access /etc/cisco_node_utils.yaml: No such file or directory
[root@guestshell ~]# ls -lh ~/cisco_node_utils.yaml
ls: cannot access /root/cisco_node_utils.yaml: No such file or directory
[root@guestshell ~]# 

[root@guestshell ~]# ruby /bootflash/test_cookie 
MGW: current_config: {}
MGW: current_config: {}
Request Cookie: nxapi_auth=admin:local
Request Cookie: nxapi_auth=admin:local
Request Cookie: nxapi_auth=admin:local
Request Cookie: nxapi_auth=admin:local
Request Cookie: nxapi_auth=admin:local
VTP Domain Name                 : mycompany.com
[root@guestshell ~]# 

```

------

2. Configuration file exists **ONLY** under `/etc` 

```
[root@guestshell ~]# cat /etc/cisco_node_utils.yaml 
default:
  cookie: 'mike:local'

mike:
  cookie: 'tom:local' 
[root@guestshell ~]# 

  - Cookie ‘mike:local’ is used.

[root@guestshell ~]# ruby /bootflash/test_cookie 
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"mike:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"mike:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
VTP Domain Name                 : mycompany.com
[root@guestshell ~]# 

```

------

3. Configuration file exists under `/etc` **AND** `~`

```
[root@guestshell ~]# cat ~/cisco_node_utils.yaml 
default:
  cookie: 'tom:local'

bob:
  cookie: 'foo:local'

[root@guestshell ~]# 

  - Cookie ‘tom:local’ used overriding ‘mike:local’

[root@guestshell ~]# ruby /bootflash/test_cookie 
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"mike:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}, "bob"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"foo:local"}}
Request Cookie: nxapi_auth=tom:local
Request Cookie: nxapi_auth=tom:local
Request Cookie: nxapi_auth=tom:local
Request Cookie: nxapi_auth=tom:local
Request Cookie: nxapi_auth=tom:local
VTP Domain Name                 : mycompany.com
[root@guestshell ~]# 
[root@guestshell ~]# 

```

------

4. Attempt to configure cookie for user that does not exist.
   - Config attempt should be rejected.

```
[root@guestshell ~]# ruby /bootflash/test_cookie 
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"mike:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"foo:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}, "bob"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"foo:local"}}
Request Cookie: nxapi_auth=foo:local
Request Cookie: nxapi_auth=foo:local
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/nxapi/client.rb:314:in `handle_output': 401 Error: Permission denied (Cisco::RequestFailed)
	from /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/nxapi/client.rb:224:in `req'
	from /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/nxapi/client.rb:130:in `set'
	from /bootflash/test_cookie:5:in `<main>'
[root@guestshell ~]# 
```

------

5. Attempt to configure cookie for user without admin privilages

```
n9k-109(config)# username bob password bob role dev-ops
WARNING: Minimum recommended length of 8 characters.
WARNING: Password should contain characters from at least three of the following classes: lower case letters, upper case letters, digits and special characters.
WARNING: it is WAY too short
WARNING: Configuration accepted because password strength check is disabled
n9k-109(config)# 
n9k-109(config)# sh run | inc username
username admin password 5 $5$NGLJBA$LPlD0dNMOJZ1oPLEpu0fw/I4ze3iJVi4vVyCEsEwxS2  role network-admin
username mike password 5 $5$p8DIlJmf$J.1bNg2L3X7/e1k8bJGXkyn4S54vNJe8U61KEAP9etC  role network-admin
username tom password 5 $5$IpNUCIoP$8MXHRxs2wdJb9g8m6okdomRZXD8VnwlXoyyTsBs7nsB  role network-admin
username bob password 5 $5$sAAxOKHF$ssejeJZ6aTPsFk7hG35kiu7yKjbvonNcFC5YPpeAy.A  role dev-ops
n9k-109(config)# 


[root@guestshell ~]# ruby /bootflash/test_cookie 
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"mike:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"bob:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}, "bob"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"foo:local"}}
Request Cookie: nxapi_auth=bob:local
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/nxapi/client.rb:314:in `handle_output': 401 Error: Permission denied (Cisco::RequestFailed)
	from /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/nxapi/client.rb:224:in `req'
	from /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/nxapi/client.rb:157:in `get'
	from /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/nxapi/client.rb:72:in `initialize'
	from /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/client.rb:94:in `new'
	from /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/client.rb:94:in `block in create'
	from /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/client.rb:91:in `each'
	from /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/client.rb:91:in `create'
	from /bootflash/test_cookie:3:in `<main>'
[root@guestshell ~]# 

```

------

6. Explicit configuration cookie ‘admin:local’  - Should succeed.

```
[root@guestshell ~]# cat ~/cisco_node_utils.yaml 
default:
  cookie: 'admin:local'

bob:
  cookie: 'foo:local'

[root@guestshell ~]# ruby /bootflash/test_cookie 
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"mike:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"admin:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}, "bob"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"foo:local"}}
Request Cookie: nxapi_auth=admin:local
Request Cookie: nxapi_auth=admin:local
Request Cookie: nxapi_auth=admin:local
Request Cookie: nxapi_auth=admin:local
Request Cookie: nxapi_auth=admin:local
VTP Domain Name                 : mycompany.com
[root@guestshell ~]# 
```

------

7. Mis-configure cookie

```
[root@guestshell ~]# cat ~/cisco_node_utils.yaml 
default:
  cookie: 'local'

bob:
  cookie: 'foo:local'

[root@guestshell ~]# ruby /bootflash/test_cookie 
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"mike:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}, "bob"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"foo:local"}}
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/client.rb:124:in `handle_errors': Invalid arguments: (TypeError)
Invalid cookie: [local]. : Cookie format must match: <username>:local
	from /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/client.rb:103:in `create'
	from /bootflash/test_cookie:3:in `<main>'
[root@guestshell ~]# 


[root@guestshell ~]# cat ~/cisco_node_utils.yaml 
default:
  cookie: 5 

bob:
  cookie: 'foo:local'

[root@guestshell ~]# ruby /bootflash/test_cookie 
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"mike:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>5}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}, "bob"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"foo:local"}}
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/client.rb:124:in `handle_errors': Invalid arguments: (TypeError)
Invalid cookie: [5]. : Cookie format must match: <username>:local
	from /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/client.rb:103:in `create'
	from /bootflash/test_cookie:3:in `<main>'
[root@guestshell ~]# 

[root@guestshell ~]# cat ~/cisco_node_utils.yaml 
default:
  cookie: ''

bob:
  cookie: 'foo:local'

[root@guestshell ~]# ruby /bootflash/test_cookie 
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"mike:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>""}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}, "bob"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"foo:local"}}
/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/client.rb:124:in `handle_errors': Invalid arguments: (TypeError)
Invalid cookie: []. : Cookie format must match: <username>:local
	from /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/cisco_node_utils-1.5.0/lib/cisco_node_utils/client/client.rb:103:in `create'
	from /bootflash/test_cookie:3:in `<main>'
[root@guestshell ~]# 
```

------

8. Use ~ to denote yaml default value. (yaml convention)

```
[root@guestshell ~]# cat ~/cisco_node_utils.yaml 
default:
  cookie: ~ 

bob:
  cookie: 'foo:local'

[root@guestshell ~]# ruby /bootflash/test_cookie 
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"mike:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>nil}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}, "bob"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"foo:local"}}
Request Cookie: nxapi_auth=admin:local
Request Cookie: nxapi_auth=admin:local
Request Cookie: nxapi_auth=admin:local
Request Cookie: nxapi_auth=admin:local
Request Cookie: nxapi_auth=admin:local
VTP Domain Name                 : mycompany.com
[root@guestshell ~]# 


```

------

9. Verify Cookie is ignored for nxapi remote case.


```
# N9K Environment
n9k:
  host: n9k-109 
  username: admin
  password: admin
  cookie: 'mike:local'

rtp-ads-075:/nobackup/mwiebe/NU/develop/cisco-network-node-utils> ruby tests/noop.rb -e n9k -v
Run options: -e n9k -v --seed 31568

# Running:

MGW: current_config: {}
MGW: current_config: {"n3k"=>{:host=>"n3k-103", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n3ki3"=>{:host=>"n3x-162", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n3kj"=>{:host=>"n3k-105", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n5k"=>{:host=>"n56-136", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n6k"=>{:host=>"n6k-92", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n7k"=>{:host=>"n7k-98", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n7k-j"=>{:host=>"n7k-99", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n7k-m"=>{:host=>"n7k-j", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n9k-f"=>{:host=>"n9k-157", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n9kv-f"=>{:host=>"agent-lab12-nx", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n9k"=>{:host=>"n9k-109", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>"mike:local"}, "n9kv"=>{:host=>"agents-n9kv", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n9kj"=>{:host=>"dt-n9k5-1", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n9ki4"=>{:host=>"n9k-33", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n9ki2"=>{:host=>"n9k-110", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}}
Remote nxapi authorization
Remote nxapi authorization
Remote nxapi authorization

Node under test:
Remote nxapi authorization
  - name  - n9k-109
Remote nxapi authorization
Remote nxapi authorization
  - type  - N9K-C9504
  - image - bootflash:///nxos.7.0.3.I5.1.211.bin

Noop#test_noop = 5.30 s = .

Finished in 5.297728s, 0.1888 runs/s, 0.1888 assertions/s.

1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/NU/develop/cisco-network-node-utils/coverage. 1299 / 3202 LOC (40.57%) covered.

```

------

10. Issue client connection with non-default environment.

```
root@n9k-109#cat /bootflash/test_cookie 
require 'cisco_node_utils'

client1 = Cisco::Client.create('mike')  <———— Uses the ‘mike’ environment.

client1.set(values: 'no feature vtp')
client1.set(values: 'feature vtp')
client1.set(values: 'vtp domain mycompany.com')

puts client1.get(command: 'show vtp status | inc Domain')
root@n9k-109#

root@n9k-109#cat /etc/cisco_node_utils.yaml 
default:
  cookie: 'foo:local'

mike:
  cookie: 'tom:local' 
root@n9k-109#


root@n9k-109#ruby /bootflash/test_cookie 
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"foo:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"foo:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
Request Cookie: nxapi_auth=tom:local
Request Cookie: nxapi_auth=tom:local
Request Cookie: nxapi_auth=tom:local
Request Cookie: nxapi_auth=tom:local
Request Cookie: nxapi_auth=tom:local
VTP Domain Name                 : mycompany.com
root@n9k-109#
```

------

11. Verify Cookie is ignored for nxapi remote case.


```
# N9K Environment
n9k:
  host: n9k-109 
  username: admin
  password: admin
  cookie: 'mike:local'

rtp-ads-075:/nobackup/mwiebe/NU/develop/cisco-network-node-utils> ruby tests/noop.rb -e n9k -v
Run options: -e n9k -v --seed 31568

# Running:

MGW: current_config: {}
MGW: current_config: {"n3k"=>{:host=>"n3k-103", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n3ki3"=>{:host=>"n3x-162", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n3kj"=>{:host=>"n3k-105", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n5k"=>{:host=>"n56-136", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n6k"=>{:host=>"n6k-92", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n7k"=>{:host=>"n7k-98", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n7k-j"=>{:host=>"n7k-99", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n7k-m"=>{:host=>"n7k-j", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n9k-f"=>{:host=>"n9k-157", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n9kv-f"=>{:host=>"agent-lab12-nx", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n9k"=>{:host=>"n9k-109", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>"mike:local"}, "n9kv"=>{:host=>"agents-n9kv", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n9kj"=>{:host=>"dt-n9k5-1", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n9ki4"=>{:host=>"n9k-33", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}, "n9ki2"=>{:host=>"n9k-110", :port=>nil, :username=>"admin", :password=>"admin", :cookie=>nil}}
Remote nxapi authorization
Remote nxapi authorization
Remote nxapi authorization

Node under test:
Remote nxapi authorization
  - name  - n9k-109
Remote nxapi authorization
Remote nxapi authorization
  - type  - N9K-C9504
  - image - bootflash:///nxos.7.0.3.I5.1.211.bin

Noop#test_noop = 5.30 s = .

Finished in 5.297728s, 0.1888 runs/s, 0.1888 assertions/s.

1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /nobackup/mwiebe/NU/develop/cisco-network-node-utils/coverage. 1299 / 3202 LOC (40.57%) covered.

```

------


12. Use puppet agent to connect and manage the device. (valid user)

```
root@n9k-109#puppet agent -t
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"mike:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"mike:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
Info: Caching catalog for n9k-109.cisco.com
Info: Applying configuration version '1485791116'
Request Cookie: nxapi_auth=mike:local
Request Cookie: nxapi_auth=mike:local
Notice: /Stage[main]/Main/Node[default]/Cisco_command_config[tss-lines]/command: command changed '' to 'line console
exec-timeout 15
line vty
session-limit 15
exec-timeout 15
'
Notice: Applied catalog in 1.97 seconds
root@n9k-109#

```

13. Use puppet agent to connect and manage the device (invalid user)

```
root@n9k-109#puppet agent -t
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"foo:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
MGW: current_config: {"default"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"foo:local"}, "mike"=>{:host=>nil, :port=>nil, :username=>nil, :password=>nil, :cookie=>"tom:local"}}
Request Cookie: nxapi_auth=foo:local
Request Cookie: nxapi_auth=foo:local
Request Cookie: nxapi_auth=foo:local
Request Cookie: nxapi_auth=foo:local
Request Cookie: nxapi_auth=foo:local
Request Cookie: nxapi_auth=foo:local
Request Cookie: nxapi_auth=foo:local
Request Cookie: nxapi_auth=foo:local
Request Cookie: nxapi_auth=foo:local
Request Cookie: nxapi_auth=foo:local
Request Cookie: nxapi_auth=foo:local
Request Cookie: nxapi_auth=foo:local
Info: Caching catalog for n9k-109.cisco.com
Info: Applying configuration version '1485791036'
Request Cookie: nxapi_auth=foo:local
Error: /Stage[main]/Main/Node[default]/Cisco_command_config[tss-lines]: Could not evaluate: 401 Error: Permission denied
Notice: Applied catalog in 0.53 seconds
root@n9k-109#

```