### PR TITLE
Add logic to handle EOFError

### DIFF
--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -201,7 +201,7 @@ class Cisco::Client::NXAPI < Cisco::Client
     # send the request and get the response
     debug("Sending HTTP request to NX-API at #{@http.address}:\n" \
           "#{request.to_hash}\n#{request.body}")
-    tries = 5
+    tries = 2
     begin
       # Explicitly use http to avoid EOFError
       # http://stackoverflow.com/a/23080693

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -211,7 +211,6 @@ class Cisco::Client::NXAPI < Cisco::Client
       emsg = 'Connection refused or reset. Is the NX-API feature enabled?'
       raise Cisco::ConnectionRefused, emsg
     rescue EOFError
-      puts 'EOFError detected, retry'
       tries -= 1
       retry if tries > 0
       raise

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -201,6 +201,7 @@ class Cisco::Client::NXAPI < Cisco::Client
     # send the request and get the response
     debug("Sending HTTP request to NX-API at #{@http.address}:\n" \
           "#{request.to_hash}\n#{request.body}")
+    tries = 5
     begin
       # Explicitly use http to avoid EOFError
       # http://stackoverflow.com/a/23080693
@@ -209,6 +210,11 @@ class Cisco::Client::NXAPI < Cisco::Client
     rescue Errno::ECONNREFUSED, Errno::ECONNRESET
       emsg = 'Connection refused or reset. Is the NX-API feature enabled?'
       raise Cisco::ConnectionRefused, emsg
+    rescue EOFError
+      puts 'EOFError detected, retry'
+      tries -= 1
+      retry if tries > 0
+      raise
     end
     handle_http_response(response)
     output = parse_response(response)

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -225,7 +225,10 @@ class TestFeature < CiscoTestCase
     fs = 'feature-set fex'
 
     # clean
-    config("no #{fs} ; no install #{fs}") if Feature.fex_installed?
+    if Feature.fex_installed?
+      config_no_warn("no #{fs}")
+      config_no_warn("no install #{fs}")
+    end
     refute_show_match(
       command: "show running | i '^install #{fs}$'",
       pattern: /^install #{fs}$/,


### PR DESCRIPTION
**Summary:**
- There are cases where sending an HTTP request to nxapi may encounter an `EOFError`.  This update adds retry logic to resend the request and make the client handle this condition and self heal if possible.
  - We give up after 2 attempts.
- Additionally this update fixes a problem where some platforms require both `no feature-set fex` followed by `no install feature-set fex` and some don't.  The update to the test code handles both of these cases.


Tested on: n3k, n9k, n7k