### PR TITLE
Add load-interval properties to interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changelog
 
 ### Added
 
+* Extend interface with attributes:
+   * `load_interval_counter_1_delay`
+   * `load_interval_counter_2_delay`
+   * `load_interval_counter_3_delay`
+
 ### Changed
 
 ### Removed

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -296,6 +296,31 @@ ipv6_dhcp_relay_src_intf:
   set_value: "<state> ipv6 dhcp relay source-interface <intf>"
   default_value: false
 
+load_interval_counter_1_delay:
+  _exclude: [ios_xr]
+  kind: int
+  get_value: '/^load-interval counter 1 (\d+)$/'
+  set_value: "load-interval counter 1 <delay>"
+  default_value: 30
+
+load_interval_counter_1_delay_vlan_bdi:
+  kind: int
+  default_value: 60
+
+load_interval_counter_2_delay:
+  _exclude: [ios_xr]
+  kind: int
+  get_value: '/^load-interval counter 2 (\d+)$/'
+  set_value: "load-interval counter 2 <delay>"
+  default_value: 300
+
+load_interval_counter_3_delay:
+  _exclude: [ios_xr]
+  kind: int
+  get_value: '/^load-interval counter 3 (\d+)$/'
+  set_value: "<state> load-interval counter 3 <delay>"
+  default_value: false
+
 mtu_loopback:
   kind: boolean
   default_only: ~

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -806,6 +806,61 @@ module Cisco
       config_set('interface', 'feature_lacp', state: val ? '' : 'no')
     end
 
+    def load_interval_counter_1_delay
+      return nil if @name[/loop/i]
+      config_get('interface', 'load_interval_counter_1_delay', name: @name)
+    end
+
+    def load_interval_counter_1_delay=(val)
+      fail ArgumentError, 'Interface cannot be loopback' if @name[/loop/i]
+      config_set('interface', 'load_interval_counter_1_delay',
+                 name: @name, delay: val)
+    end
+
+    def default_load_interval_counter_1_delay
+      return nil if @name[/loop/i]
+      # for vlan and bdi the default is 60
+      if @name[/(vlan|bdi)/i]
+        config_get_default('interface',
+                           'load_interval_counter_1_delay_vlan_bdi')
+      else
+        config_get_default('interface', 'load_interval_counter_1_delay')
+      end
+    end
+
+    def load_interval_counter_2_delay
+      return nil if @name[/loop/i]
+      config_get('interface', 'load_interval_counter_2_delay', name: @name)
+    end
+
+    def load_interval_counter_2_delay=(val)
+      fail ArgumentError, 'Interface cannot be loopback' if @name[/loop/i]
+      config_set('interface', 'load_interval_counter_2_delay',
+                 name: @name, delay: val)
+    end
+
+    def default_load_interval_counter_2_delay
+      config_get_default('interface', 'load_interval_counter_2_delay')
+    end
+
+    def load_interval_counter_3_delay
+      return nil if @name[/loop/i]
+      config_get('interface', 'load_interval_counter_3_delay', name: @name)
+    end
+
+    def load_interval_counter_3_delay=(val)
+      fail ArgumentError, 'Interface cannot be loopback' if
+        @name[/loop/i]
+      state = val ? '' : 'no'
+      delay = val ? val : ''
+      config_set('interface', 'load_interval_counter_3_delay',
+                 name: @name, state: state, delay: delay)
+    end
+
+    def default_load_interval_counter_3_delay
+      config_get_default('interface', 'load_interval_counter_3_delay')
+    end
+
     def mtu_lookup_string
       case @name
       when /loopback/i

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -807,18 +807,18 @@ module Cisco
     end
 
     def load_interval_counter_1_delay
-      return nil if @name[/loop/i]
+      return nil if @name[/loop/] || @name[/ethernet.*\S+\.\d+$/]
       config_get('interface', 'load_interval_counter_1_delay', name: @name)
     end
 
     def load_interval_counter_1_delay=(val)
-      fail ArgumentError, 'Interface cannot be loopback' if @name[/loop/i]
+      fail ArgumentError, 'Interface cannot be sub-intf or loopback' if
+        @name[/loop/] || @name[/ethernet.*\S+\.\d+$/]
       config_set('interface', 'load_interval_counter_1_delay',
                  name: @name, delay: val)
     end
 
     def default_load_interval_counter_1_delay
-      return nil if @name[/loop/i]
       # for vlan and bdi the default is 60
       if @name[/(vlan|bdi)/i]
         config_get_default('interface',
@@ -829,12 +829,13 @@ module Cisco
     end
 
     def load_interval_counter_2_delay
-      return nil if @name[/loop/i]
+      return nil if @name[/loop/] || @name[/ethernet.*\S+\.\d+$/]
       config_get('interface', 'load_interval_counter_2_delay', name: @name)
     end
 
     def load_interval_counter_2_delay=(val)
-      fail ArgumentError, 'Interface cannot be loopback' if @name[/loop/i]
+      fail ArgumentError, 'Interface cannot be sub-intf or loopback' if
+        @name[/loop/] || @name[/ethernet.*\S+\.\d+$/]
       config_set('interface', 'load_interval_counter_2_delay',
                  name: @name, delay: val)
     end
@@ -844,13 +845,13 @@ module Cisco
     end
 
     def load_interval_counter_3_delay
-      return nil if @name[/loop/i]
+      return nil if @name[/loop/] || @name[/ethernet.*\S+\.\d+$/]
       config_get('interface', 'load_interval_counter_3_delay', name: @name)
     end
 
     def load_interval_counter_3_delay=(val)
-      fail ArgumentError, 'Interface cannot be loopback' if
-        @name[/loop/i]
+      fail ArgumentError, 'Interface cannot be sub-intf or loopback' if
+        @name[/loop/] || @name[/ethernet.*\S+\.\d+$/]
       state = val ? '' : 'no'
       delay = val ? val : ''
       config_set('interface', 'load_interval_counter_3_delay',

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1740,4 +1740,67 @@ class TestInterface < CiscoTestCase
     interface.pim_bfd = interface.default_pim_bfd
     assert_equal(interface.default_pim_bfd, interface.pim_bfd)
   end
+
+  def test_load_interval_counter_1_delay
+    inf_name = interfaces[0]
+    interface = Interface.new(inf_name)
+    if validate_property_excluded?('interface',
+                                   'load_interval_counter_1_delay')
+      assert_nil(interface.load_interval_counter_1_delay)
+      assert_raises(Cisco::UnsupportedError) do
+        interface.load_interval_counter_1_delay = 100
+      end
+      return
+    end
+    assert_equal(interface.default_load_interval_counter_1_delay,
+                 interface.load_interval_counter_1_delay)
+    interface.load_interval_counter_1_delay = 100
+    assert_equal(100, interface.load_interval_counter_1_delay)
+    interface.load_interval_counter_1_delay =
+      interface.default_load_interval_counter_1_delay
+    assert_equal(interface.default_load_interval_counter_1_delay,
+                 interface.load_interval_counter_1_delay)
+  end
+
+  def test_load_interval_counter_2_delay
+    inf_name = interfaces[0]
+    interface = Interface.new(inf_name)
+    if validate_property_excluded?('interface',
+                                   'load_interval_counter_2_delay')
+      assert_nil(interface.load_interval_counter_2_delay)
+      assert_raises(Cisco::UnsupportedError) do
+        interface.load_interval_counter_2_delay = 200
+      end
+      return
+    end
+    assert_equal(interface.default_load_interval_counter_2_delay,
+                 interface.load_interval_counter_2_delay)
+    interface.load_interval_counter_2_delay = 200
+    assert_equal(200, interface.load_interval_counter_2_delay)
+    interface.load_interval_counter_2_delay =
+      interface.default_load_interval_counter_2_delay
+    assert_equal(interface.default_load_interval_counter_2_delay,
+                 interface.load_interval_counter_2_delay)
+  end
+
+  def test_load_interval_counter_3_delay
+    inf_name = interfaces[0]
+    interface = Interface.new(inf_name)
+    if validate_property_excluded?('interface',
+                                   'load_interval_counter_3_delay')
+      assert_nil(interface.load_interval_counter_3_delay)
+      assert_raises(Cisco::UnsupportedError) do
+        interface.load_interval_counter_3_delay = 150
+      end
+      return
+    end
+    assert_equal(interface.default_load_interval_counter_3_delay,
+                 interface.load_interval_counter_3_delay)
+    interface.load_interval_counter_3_delay = 150
+    assert_equal(150, interface.load_interval_counter_3_delay)
+    interface.load_interval_counter_3_delay =
+      interface.default_load_interval_counter_3_delay
+    assert_equal(interface.default_load_interval_counter_3_delay,
+                 interface.load_interval_counter_3_delay)
+  end
 end

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1760,6 +1760,15 @@ class TestInterface < CiscoTestCase
       interface.default_load_interval_counter_1_delay
     assert_equal(interface.default_load_interval_counter_1_delay,
                  interface.load_interval_counter_1_delay)
+    # check nil for subintf and loopback
+    subif = Interface.new(interfaces[0] + '.1')
+    assert_nil(subif.load_interval_counter_1_delay)
+    assert_raises(ArgumentError) { subif.load_interval_counter_1_delay = 100 }
+    lb = Interface.new('loopback0')
+    assert_nil(lb.load_interval_counter_1_delay)
+    assert_raises(ArgumentError) { lb.load_interval_counter_1_delay = 100 }
+    subif.destroy
+    lb.destroy
   end
 
   def test_load_interval_counter_2_delay
@@ -1781,6 +1790,15 @@ class TestInterface < CiscoTestCase
       interface.default_load_interval_counter_2_delay
     assert_equal(interface.default_load_interval_counter_2_delay,
                  interface.load_interval_counter_2_delay)
+    # check nil for subintf and loopback
+    subif = Interface.new(interfaces[0] + '.1')
+    assert_nil(subif.load_interval_counter_2_delay)
+    assert_raises(ArgumentError) { subif.load_interval_counter_2_delay = 100 }
+    lb = Interface.new('loopback0')
+    assert_nil(lb.load_interval_counter_2_delay)
+    assert_raises(ArgumentError) { lb.load_interval_counter_2_delay = 100 }
+    subif.destroy
+    lb.destroy
   end
 
   def test_load_interval_counter_3_delay
@@ -1802,5 +1820,14 @@ class TestInterface < CiscoTestCase
       interface.default_load_interval_counter_3_delay
     assert_equal(interface.default_load_interval_counter_3_delay,
                  interface.load_interval_counter_3_delay)
+    # check nil for subintf and loopback
+    subif = Interface.new(interfaces[0] + '.1')
+    assert_nil(subif.load_interval_counter_3_delay)
+    assert_raises(ArgumentError) { subif.load_interval_counter_3_delay = 100 }
+    lb = Interface.new('loopback0')
+    assert_nil(lb.load_interval_counter_3_delay)
+    assert_raises(ArgumentError) { lb.load_interval_counter_3_delay = 100 }
+    subif.destroy
+    lb.destroy
   end
 end


### PR DESCRIPTION
This PR is for adding load-interval delay properties to interface provider. All tests pass on all platforms.