### PR TITLE
fix for double quotes errors for passwords

### DIFF
--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -360,5 +360,12 @@ module Cisco
       end
       merged
     end # merge_range
+
+    def self.add_quotes(value)
+      return value if image_version?(/7.3.0/)
+      value = "\"#{value}\"" unless
+        value.start_with?('"') && value.end_with?('"')
+      value
+    end # add_quotes
   end # class Utils
 end   # module Cisco

--- a/lib/cisco_node_utils/cmd_ref/radius_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/radius_global.yaml
@@ -7,7 +7,7 @@ _template:
     get_command: "show running-config radius-server"
 
 key:
-  get_value: '/^radius-server key \d+\s+(\S+)/'
+  get_value: '/^radius-server key \d+\s+(.*)/'
   set_value: '<state> radius-server key <key>'
 
 key_format:

--- a/lib/cisco_node_utils/cmd_ref/radius_server.yaml
+++ b/lib/cisco_node_utils/cmd_ref/radius_server.yaml
@@ -62,7 +62,7 @@ hosts:
 key:
   default_value: ~
   nexus:
-    get_value: '/^radius-server host <ip>.* key \d+\s+(\S+)/'
+    get_value: '/^radius-server host <ip>.* key \d+\s+(.*)/'
     set_value: '<state> radius-server host <ip> key <key>'
   ios_xr:
     context: ["radius-server host <ip> auth-port <auth_port> acct-port <acct_port>"]

--- a/lib/cisco_node_utils/cmd_ref/tacacs_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/tacacs_global.yaml
@@ -4,7 +4,7 @@ encryption:
   set_value: "<state> tacacs-server key <option> <key>"
 
 key:
-  get_value: '/^tacacs-server key (\d+)\s+(\S+)/'
+  get_value: '/^tacacs-server key (\d+)\s+(.*)/'
   default_value: ""
   nexus:
     get_command: "show run tacacs all"

--- a/lib/cisco_node_utils/cmd_ref/tacacs_server.yaml
+++ b/lib/cisco_node_utils/cmd_ref/tacacs_server.yaml
@@ -22,7 +22,7 @@ encryption:
   set_value: "<state> tacacs-server key <option> <key>"
 
 encryption_password:
-  get_value: '/^tacacs-server key (\d+)\s+(\S+)/'
+  get_value: '/^tacacs-server key (\d+)\s+(.*)/'
   default_value: ""
   nexus:
     get_command: "show run tacacs all"

--- a/lib/cisco_node_utils/cmd_ref/tacacs_server_host.yaml
+++ b/lib/cisco_node_utils/cmd_ref/tacacs_server_host.yaml
@@ -16,7 +16,7 @@ encryption:
 encryption_password:
   default_value: ""
   nexus:
-    get_value: '/^tacacs-server host <ip> key \d+\s+(\S+)/'
+    get_value: '/^tacacs-server host <ip> key \d+\s+(.*)/'
   ios_xr:
     context: ["tacacs-server host <ip> port <port>"]
     get_value: '/key \d+\s+(\S+)$/'

--- a/lib/cisco_node_utils/radius_global.rb
+++ b/lib/cisco_node_utils/radius_global.rb
@@ -104,8 +104,7 @@ module Cisco
       str = config_get('radius_global', 'key')
       return if str.nil?
       str = str.strip
-      str = "\"#{str}\"" unless str.start_with?('"') && str.end_with?('"')
-      str
+      Utils.add_quotes(str)
     end
 
     def key_set(value, format)
@@ -125,15 +124,13 @@ module Cisco
                    state: 'no',
                    key:   "#{key_format} #{key}")
       elsif !format.nil?
-        value = "\"#{value}\"" unless
-          value.start_with?('"') && value.end_with?('"')
+        value = Utils.add_quotes(value)
         config_set('radius_global',
                    'key',
                    state: '',
                    key:   "#{format} #{value}")
       else
-        value = "\"#{value}\"" unless
-          value.start_with?('"') && value.end_with?('"')
+        value = Utils.add_quotes(value)
         config_set('radius_global',
                    'key',
                    state: '',

--- a/lib/cisco_node_utils/radius_global.rb
+++ b/lib/cisco_node_utils/radius_global.rb
@@ -101,7 +101,11 @@ module Cisco
     end
 
     def key
-      config_get('radius_global', 'key')
+      str = config_get('radius_global', 'key')
+      return if str.nil?
+      str = str.strip
+      str = "\"#{str}\"" unless str.start_with?('"') && str.end_with?('"')
+      str
     end
 
     def key_set(value, format)
@@ -121,11 +125,15 @@ module Cisco
                    state: 'no',
                    key:   "#{key_format} #{key}")
       elsif !format.nil?
+        value = "\"#{value}\"" unless
+          value.start_with?('"') && value.end_with?('"')
         config_set('radius_global',
                    'key',
                    state: '',
                    key:   "#{format} #{value}")
       else
+        value = "\"#{value}\"" unless
+          value.start_with?('"') && value.end_with?('"')
         config_set('radius_global',
                    'key',
                    state: '',

--- a/lib/cisco_node_utils/radius_server.rb
+++ b/lib/cisco_node_utils/radius_server.rb
@@ -369,6 +369,11 @@ module Cisco
                        acct_port: @acct_port)
 
       val = val[0] if val.is_a?(Array)
+      return if val.nil? || val.empty?
+      index = val.index('auth-port')
+      val = val[0..index - 2] unless index.nil?
+      val = val.strip
+      val = "\"#{val}\"" unless val.start_with?('"') && val.end_with?('"')
       val
     end
 
@@ -395,6 +400,8 @@ module Cisco
                    acct_port: @acct_port,
                    key:       "#{key_format} #{key}")
       elsif !format.nil?
+        value = "\"#{value}\"" unless
+          value.start_with?('"') && value.end_with?('"')
         config_set('radius_server',
                    'key',
                    state:     '',
@@ -403,6 +410,8 @@ module Cisco
                    acct_port: @acct_port,
                    key:       "#{format} #{value}")
       else
+        value = "\"#{value}\"" unless
+          value.start_with?('"') && value.end_with?('"')
         config_set('radius_server',
                    'key',
                    state:     '',

--- a/lib/cisco_node_utils/radius_server.rb
+++ b/lib/cisco_node_utils/radius_server.rb
@@ -373,8 +373,7 @@ module Cisco
       index = val.index('auth-port')
       val = val[0..index - 2] unless index.nil?
       val = val.strip
-      val = "\"#{val}\"" unless val.start_with?('"') && val.end_with?('"')
-      val
+      Utils.add_quotes(val)
     end
 
     def key_set(value, format)
@@ -400,8 +399,7 @@ module Cisco
                    acct_port: @acct_port,
                    key:       "#{key_format} #{key}")
       elsif !format.nil?
-        value = "\"#{value}\"" unless
-          value.start_with?('"') && value.end_with?('"')
+        value = Utils.add_quotes(value)
         config_set('radius_server',
                    'key',
                    state:     '',
@@ -410,8 +408,7 @@ module Cisco
                    acct_port: @acct_port,
                    key:       "#{format} #{value}")
       else
-        value = "\"#{value}\"" unless
-          value.start_with?('"') && value.end_with?('"')
+        value = Utils.add_quotes(value)
         config_set('radius_server',
                    'key',
                    state:     '',

--- a/lib/cisco_node_utils/tacacs_global.rb
+++ b/lib/cisco_node_utils/tacacs_global.rb
@@ -80,8 +80,11 @@ module Cisco
     end
 
     def key
-      match = config_get('tacacs_global', 'key')
-      match.empty? ? TacacsGlobal.default_key : match[1]
+      str = config_get('tacacs_global', 'key')
+      return TacacsGlobal.default_encryption_password if str.empty?
+      str = str[1].strip
+      str = "\"#{str}\"" unless str.start_with?('"') && str.end_with?('"')
+      str
     end
 
     # Get default encryption password
@@ -90,6 +93,8 @@ module Cisco
     end
 
     def encryption_key_set(key_format, key)
+      key = "\"#{key}\"" unless
+        key.start_with?('"') && key.end_with?('"')
       if key_format == TACACS_GLOBAL_ENC_UNKNOWN
         config_set('tacacs_server', 'encryption', state: 'no',
                     option: key_format, key: key)

--- a/lib/cisco_node_utils/tacacs_global.rb
+++ b/lib/cisco_node_utils/tacacs_global.rb
@@ -81,10 +81,9 @@ module Cisco
 
     def key
       str = config_get('tacacs_global', 'key')
-      return TacacsGlobal.default_encryption_password if str.empty?
+      return TacacsGlobal.default_key if str.empty?
       str = str[1].strip
-      str = "\"#{str}\"" unless str.start_with?('"') && str.end_with?('"')
-      str
+      Utils.add_quotes(str)
     end
 
     # Get default encryption password
@@ -93,8 +92,7 @@ module Cisco
     end
 
     def encryption_key_set(key_format, key)
-      key = "\"#{key}\"" unless
-        key.start_with?('"') && key.end_with?('"')
+      key = Utils.add_quotes(key)
       if key_format == TACACS_GLOBAL_ENC_UNKNOWN
         config_set('tacacs_server', 'encryption', state: 'no',
                     option: key_format, key: key)

--- a/lib/cisco_node_utils/tacacs_server.rb
+++ b/lib/cisco_node_utils/tacacs_server.rb
@@ -148,8 +148,7 @@ module Cisco
       str = config_get('tacacs_server', 'encryption_password')
       return TacacsServer.default_encryption_password if str.empty?
       str = str[1].strip
-      str = "\"#{str}\"" unless str.start_with?('"') && str.end_with?('"')
-      str
+      Utils.add_quotes(str)
     end
 
     # Get default encryption password
@@ -159,8 +158,7 @@ module Cisco
 
     # Set encryption type and password
     def encryption_key_set(enctype, password)
-      password = "\"#{password}\"" unless
-        password.start_with?('"') && password.end_with?('"')
+      password = Utils.add_quotes(password)
       # if enctype is TACACS_SERVER_ENC_UNKNOWN, we will unset the key
       if enctype == TACACS_SERVER_ENC_UNKNOWN
         # if current encryption type is not TACACS_SERVER_ENC_UNKNOWN, we

--- a/lib/cisco_node_utils/tacacs_server.rb
+++ b/lib/cisco_node_utils/tacacs_server.rb
@@ -145,8 +145,11 @@ module Cisco
 
     # Get encryption password
     def encryption_password
-      match = config_get('tacacs_server', 'encryption_password')
-      match.empty? ? TacacsServer.default_encryption_password : match[1]
+      str = config_get('tacacs_server', 'encryption_password')
+      return TacacsServer.default_encryption_password if str.empty?
+      str = str[1].strip
+      str = "\"#{str}\"" unless str.start_with?('"') && str.end_with?('"')
+      str
     end
 
     # Get default encryption password
@@ -156,6 +159,8 @@ module Cisco
 
     # Set encryption type and password
     def encryption_key_set(enctype, password)
+      password = "\"#{password}\"" unless
+        password.start_with?('"') && password.end_with?('"')
       # if enctype is TACACS_SERVER_ENC_UNKNOWN, we will unset the key
       if enctype == TACACS_SERVER_ENC_UNKNOWN
         # if current encryption type is not TACACS_SERVER_ENC_UNKNOWN, we

--- a/lib/cisco_node_utils/tacacs_server_host.rb
+++ b/lib/cisco_node_utils/tacacs_server_host.rb
@@ -148,8 +148,7 @@ module Cisco
       index = str.index('port')
       str = str[0..index - 2] unless index.nil?
       str = str.strip
-      str = "\"#{str}\"" unless str.start_with?('"') && str.end_with?('"')
-      str
+      Utils.add_quotes(str)
     end
 
     def self.default_encryption_password
@@ -162,10 +161,7 @@ module Cisco
                                           TACACS_SERVER_ENC_CISCO_TYPE_7,
                                           TACACS_SERVER_ENC_UNKNOWN,
                                          ].include?(enctype)
-      unless password.empty?
-        password = "\"#{password}\"" unless
-          password.start_with?('"') && password.end_with?('"')
-      end
+      password = Utils.add_quotes(password) unless password.empty?
       # if enctype is TACACS_SERVER_ENC_UNKNOWN, we'll unset the key
       if enctype == TACACS_SERVER_ENC_UNKNOWN
         # if current encryption type is not TACACS_SERVER_ENC_UNKNOWN, we need

--- a/lib/cisco_node_utils/tacacs_server_host.rb
+++ b/lib/cisco_node_utils/tacacs_server_host.rb
@@ -140,10 +140,16 @@ module Cisco
     end
 
     def encryption_password
-      config_get('tacacs_server_host',
-                 'encryption_password',
-                 ip:   @name,
-                 port: @port)
+      str = config_get('tacacs_server_host',
+                       'encryption_password',
+                       ip:   @name,
+                       port: @port)
+      return str if str.nil? || str.empty?
+      index = str.index('port')
+      str = str[0..index - 2] unless index.nil?
+      str = str.strip
+      str = "\"#{str}\"" unless str.start_with?('"') && str.end_with?('"')
+      str
     end
 
     def self.default_encryption_password
@@ -156,6 +162,10 @@ module Cisco
                                           TACACS_SERVER_ENC_CISCO_TYPE_7,
                                           TACACS_SERVER_ENC_UNKNOWN,
                                          ].include?(enctype)
+      unless password.empty?
+        password = "\"#{password}\"" unless
+          password.start_with?('"') && password.end_with?('"')
+      end
       # if enctype is TACACS_SERVER_ENC_UNKNOWN, we'll unset the key
       if enctype == TACACS_SERVER_ENC_UNKNOWN
         # if current encryption type is not TACACS_SERVER_ENC_UNKNOWN, we need

--- a/tests/test_route_map.rb
+++ b/tests/test_route_map.rb
@@ -32,12 +32,6 @@ def dplus_n9k?
   false
 end
 
-def evergreen_dplus_n9k?
-  return true if Utils.image_version?(/7.0.3.I4|I5/) &&
-                 node.product_id[/N9K/]
-  false
-end
-
 # TestRouteMap - Minitest for RouteMap
 # node utility class
 class TestRouteMap < CiscoTestCase
@@ -1352,8 +1346,8 @@ class TestRouteMap < CiscoTestCase
   end
 
   def test_extcommunity_rt
-    # bug CSCvc92395 on fretta and n9k running dplus or higher
-    skip('platform not supported for this test') if node.product_id[/N9.*-F/] || evergreen_dplus_n9k?
+    # bug CSCvc92395 on fretta and n9k
+    skip('platform not supported for this test') if node.product_id[/N9/]
     rm = create_route_map
     assert_equal(rm.default_set_extcommunity_rt_additive,
                  rm.set_extcommunity_rt_additive)


### PR DESCRIPTION
This PR is for fixing errors while setting encryption passwords for tacacs and radius. The fix is basically to add double quotes to passwords if they are not already present when we do 'config get' or 'config_set'. The corresponding PR for puppet module is also being opened. The code works in tandem, so please refer to that PR as well.