### PR TITLE
fix bgp neighbor & af issue with remote_as

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/bgp_neighbor.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp_neighbor.yaml
@@ -5,7 +5,11 @@ _template:
     get_command: "show running router bgp"
   nexus:
     get_command: "show running bgp all"
-  context:
+  get_context:
+    - "router bgp <asnum>"
+    - "(?)vrf <vrf>"
+    - "neighbor <nbr>(?: remote-as <ra>)?"
+  set_context:
     - "router bgp <asnum>"
     - "(?)vrf <vrf>"
     - "neighbor <nbr>"
@@ -15,10 +19,10 @@ af:
 
 all_neighbors:
   multiple: true
-  context:
+  get_context:
     - "router bgp <asnum>"
     - "(?)vrf <vrf>"
-  get_value: '/^neighbor (\S+)$/'
+  get_value: '/^neighbor (\S+)(?:\s+remote-as (\d+))?$/'
 
 bfd:
   _exclude: [ios_xr]

--- a/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
@@ -5,7 +5,12 @@ _template:
     get_command: 'show running bgp all'
   ios_xr:
     get_command: 'show run router bgp'
-  context:
+  get_context:
+    - 'router bgp <asnum>'
+    - '(?)vrf <vrf>'
+    - 'neighbor <nbr>(?: remote-as <ra>)?'
+    - 'address-family <afi> <safi>'
+  set_context:
     - 'router bgp <asnum>'
     - '(?)vrf <vrf>'
     - 'neighbor <nbr>'
@@ -40,10 +45,10 @@ advertise_map_non_exist:
 
 all_afs:
   multiple: true
-  context:
+  get_context:
     - 'router bgp <asnum>'
     - '(?)vrf <vrf>'
-    - 'neighbor <nbr>'
+    - 'neighbor <nbr>(?: remote-as <ra>)?'
   get_value: '/^address-family (\S+) (\S+)$/'
 
 allowas_in:

--- a/tests/test_bgp_neighbor_af.rb
+++ b/tests/test_bgp_neighbor_af.rb
@@ -64,10 +64,10 @@ class TestBgpNeighborAF < CiscoTestCase
     asn, vrf, nbr, af = af_args
     dbg = sprintf('[VRF %s NBR %s AF %s]', vrf, nbr, af.join('/'))
 
-    obj_nbr = RouterBgpNeighbor.new(asn, vrf, nbr, true)
+    obj_nbr = RouterBgpNeighbor.new(asn, vrf, nbr)
     obj_nbr.remote_as = ebgp ? asn + 1 : asn
 
-    obj_af = RouterBgpNeighborAF.new(asn, vrf, nbr, af, true)
+    obj_af = RouterBgpNeighborAF.new(asn, vrf, nbr, af)
 
     # clean up address-family only
     obj_af.destroy
@@ -160,7 +160,7 @@ class TestBgpNeighborAF < CiscoTestCase
     @@matrix.each do |k, v|
       asn, vrf, nbr, af = v
       dbg = sprintf('[VRF %s NBR %s AF %s]', vrf, nbr, af)
-      obj[k] = RouterBgpNeighborAF.new(asn, vrf, nbr, af, true)
+      obj[k] = RouterBgpNeighborAF.new(asn, vrf, nbr, af)
       # TBD: This flush should not be needed but we see an intermittent problem
       # with certain rake test seed values, where 'afs' below is not detecting
       # vrf 'aa' AF.
@@ -193,13 +193,13 @@ class TestBgpNeighborAF < CiscoTestCase
         # so make sure to catch the error
         assert_raises(UnsupportedError,
                       'Neighbors do not support slash notation') do
-          RouterBgpNeighborAF.new(asn, vrf, nbr, af, true)
+          RouterBgpNeighborAF.new(asn, vrf, nbr, af)
         end
         next
       end
       next if platform == :ios_xr
       dbg = sprintf('[VRF %s NBR %s AF %s]', vrf, nbr, af.join('/'))
-      obj[k] = RouterBgpNeighborAF.new(asn, vrf, nbr, af, true)
+      obj[k] = RouterBgpNeighborAF.new(asn, vrf, nbr, af)
       nbr_munged = Utils.process_network_mask(nbr)
       # TBD: This flush should not be needed but we see an intermittent problem
       # with certain rake test seed values, where 'afs' below is not detecting
@@ -217,7 +217,7 @@ class TestBgpNeighborAF < CiscoTestCase
       if platform == :ios_xr
         assert_raises(UnsupportedError,
                       'Neighbors do not support slash notation') do
-          RouterBgpNeighborAF.new(asn, vrf, nbr, af, true)
+          RouterBgpNeighborAF.new(asn, vrf, nbr, af)
         end
         next
       end


### PR DESCRIPTION
This PR is for fixing remote-as problem on the older n3k platforms.

https://github.com/cisco/cisco-network-puppet-module/issues/419

The issue is that on older n3k platforms, the remote-as is nvgen next to the neighbor (when it is configured that way) and the context in the yaml is only looking for neighbor without remote-as. Also remote-as can be configured under neighbor with or without remote-as configured next to the neighbor. The remote-as configured under the neighbor context MUST have precedence over the other one. 
All minitest pass on all platforms for bgp_neighbor and bgp_neighbor_af providers.
And when the puppet resource command is run for the configuration mentioned in the 
https://github.com/cisco/cisco-network-puppet-module/issues/419
the following output is shown.

```puppet
root@n3x-161#puppet resource cisco_bgp_neighbor
cisco_bgp_neighbor { '65080 T1-INET 185.48.100.253':
  ensure                 => 'present',              
  bfd                    => 'true',                 
  capability_negotiation => 'true',                 
  connected_check        => 'true',                 
  description            => 'DSD Primary',          
  dynamic_capability     => 'true',                 
  ebgp_multihop          => 'false',                
  local_as               => '0',                    
  log_neighbor_changes   => 'inherit',              
  low_memory_exempt      => 'false',                
  maximum_peers          => '0',                    
  remote_as              => '29462',                
  remove_private_as      => 'disable',              
  shutdown               => 'false',                
  suppress_4_byte_as     => 'false',                
  timers_holdtime        => '180',                  
  timers_keepalive       => '60',                   
  transport_passive_mode => 'none',                 
  transport_passive_only => 'false',                
}                                                   
cisco_bgp_neighbor { '65080 T1-INET 185.48.102.14': 
  ensure                 => 'present',              
  bfd                    => 'true',                 
  capability_negotiation => 'true',                 
  connected_check        => 'true',                 
  description            => 'DC1RT0001',            
  dynamic_capability     => 'true',                 
  ebgp_multihop          => 'false',                
  local_as               => '0',                    
  log_neighbor_changes   => 'inherit',              
  low_memory_exempt      => 'false',                
  maximum_peers          => '0',                    
  remote_as              => '65080',                
  remove_private_as      => 'disable',              
  shutdown               => 'false',                
  suppress_4_byte_as     => 'false',                
  timers_holdtime        => '180',                  
  timers_keepalive       => '60',                   
  transport_passive_mode => 'none',                 
  transport_passive_only => 'false',                
  update_source          => 'port-channel1.450',    
}                                                   
cisco_bgp_neighbor { '65080 T8-ATT 10.3.252.1':     
  ensure                 => 'present',              
  bfd                    => 'true',                 
  capability_negotiation => 'true',                 
  connected_check        => 'true',                 
  description            => 'AT&T primary',         
  dynamic_capability     => 'true',                 
  ebgp_multihop          => 'false',                
  local_as               => '0',                    
  log_neighbor_changes   => 'inherit',              
  low_memory_exempt      => 'false',                
  maximum_peers          => '0',                    
  remote_as              => '65001',                
  remove_private_as      => 'disable',              
  shutdown               => 'false',                
  suppress_4_byte_as     => 'false',                
  timers_holdtime        => '180',                  
  timers_keepalive       => '60',                   
  transport_passive_mode => 'none',                 
  transport_passive_only => 'false',                
}                                                   
cisco_bgp_neighbor { '65080 T8-ATT 10.3.252.18':    
  ensure                 => 'present',              
  bfd                    => 'true',                 
  capability_negotiation => 'true',                 
  connected_check        => 'true',                 
  description            => 'DC1RT0001',            
  dynamic_capability     => 'true',                 
  ebgp_multihop          => 'false',                
  local_as               => '0',                    
  log_neighbor_changes   => 'inherit',              
  low_memory_exempt      => 'false',                
  maximum_peers          => '0',                    
  remote_as              => '65080',                
  remove_private_as      => 'disable',              
  shutdown               => 'false',                
  suppress_4_byte_as     => 'false',                
  timers_holdtime        => '180',                  
  timers_keepalive       => '60',                   
  transport_passive_mode => 'none',                 
  transport_passive_only => 'false',                
  update_source          => 'port-channel1.462',    
}                                                   
root@n3x-161#puppet resource cisco_bgp_neighbor_af  
cisco_bgp_neighbor_af { '65080 T1-INET 185.48.100.253 ipv4 unicast':
  ensure                   => 'present',                            
  additional_paths_receive => 'inherit',                            
  additional_paths_send    => 'inherit',                            
  allowas_in               => 'false',                              
  allowas_in_max           => '3',                                  
  as_override              => 'false',                              
  default_originate        => 'false',                              
  disable_peer_as_check    => 'false',                              
  next_hop_self            => 'false',                              
  next_hop_third_party     => 'true',                               
  prefix_list_in           => 'DSD-BGP-IN',                         
  prefix_list_out          => 'DSD-BGP-OUT',                        
  route_reflector_client   => 'false',                              
  send_community           => 'none',                               
  soft_reconfiguration_in  => 'inherit',                            
  suppress_inactive        => 'false',                              
  weight                   => 'false',                              
}                                                                   
cisco_bgp_neighbor_af { '65080 T1-INET 185.48.102.14 ipv4 unicast': 
  ensure                   => 'present',                            
  additional_paths_receive => 'inherit',                            
  additional_paths_send    => 'inherit',                            
  allowas_in               => 'false',                              
  allowas_in_max           => '3',                                  
  as_override              => 'false',                              
  default_originate        => 'false',                              
  disable_peer_as_check    => 'false',                              
  next_hop_self            => 'true',                               
  next_hop_third_party     => 'true',                               
  route_reflector_client   => 'false',                              
  send_community           => 'none',                               
  soft_reconfiguration_in  => 'inherit',                            
  suppress_inactive        => 'false',                              
  weight                   => 'false',                              
}                                                                   
cisco_bgp_neighbor_af { '65080 T8-ATT 10.3.252.1 ipv4 unicast':     
  ensure                   => 'present',                            
  additional_paths_receive => 'inherit',                            
  additional_paths_send    => 'inherit',                            
  allowas_in               => 'false',                              
  allowas_in_max           => '3',                                  
  as_override              => 'false',                              
  default_originate        => 'false',                              
  disable_peer_as_check    => 'false',                              
  next_hop_self            => 'false',                              
  next_hop_third_party     => 'true',                               
  prefix_list_in           => 'ATT-BGP-IN',                         
  prefix_list_out          => 'ATT-BGP-OUT',
  route_map_in             => 'ATT-BGP-IN',
  route_reflector_client   => 'false',
  send_community           => 'none',
  soft_reconfiguration_in  => 'inherit',
  suppress_inactive        => 'false',
  weight                   => 'false',
}
cisco_bgp_neighbor_af { '65080 T8-ATT 10.3.252.18 ipv4 unicast':
  ensure                   => 'present',
  additional_paths_receive => 'inherit',
  additional_paths_send    => 'inherit',
  allowas_in               => 'false',
  allowas_in_max           => '3',
  as_override              => 'false',
  default_originate        => 'false',
  disable_peer_as_check    => 'false',
  next_hop_self            => 'true',
  next_hop_third_party     => 'true',
  route_reflector_client   => 'false',
  send_community           => 'none',
  soft_reconfiguration_in  => 'inherit',
  suppress_inactive        => 'false',
  weight                   => 'false',
}
root@n3x-161#
```