### PR TITLE
Add missing commit step to yum workflow

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/yum.yaml
+++ b/lib/cisco_node_utils/cmd_ref/yum.yaml
@@ -2,6 +2,9 @@
 ---
 _exclude: [ios_xr]
 
+commit:
+  set_value: "install commit %s"
+
 deactivate:
   set_value: "install deactivate %s"
 

--- a/lib/cisco_node_utils/yum.rb
+++ b/lib/cisco_node_utils/yum.rb
@@ -61,6 +61,7 @@ module Cisco
         # therefore a post-validation check is needed here to verify the
         # actual outcome.
         validate_installed(pkg)
+        config_set('yum', 'commit', pkg)
       rescue Cisco::CliError, RuntimeError => e
         raise Cisco::CliError, "#{e.class}, #{e.message}"
       end
@@ -75,16 +76,21 @@ module Cisco
       b.nil? ? nil : b.first
     end
 
-    def self.remove(pkg)
-      config_set('yum', 'deactivate', pkg)
-      # May not be able to remove the package immediately after
-      # deactivation.
+    def self.attempt_operation(operation, pkg)
       while (try ||= 1) < 20
-        o = config_set('yum', 'remove', pkg)
+        o = config_set('yum', operation, pkg)
         break unless o[/operation is in progress, please try again later/]
         sleep 1
         try += 1
       end
+    end
+
+    def self.remove(pkg)
+      config_set('yum', 'deactivate', pkg)
+      # May not be able to commit/remove the package immediately after
+      # deactivation.
+      attempt_operation('commit', pkg)
+      attempt_operation('remove', pkg)
     end
   end
 end

--- a/tests/test_yum.rb
+++ b/tests/test_yum.rb
@@ -69,6 +69,7 @@ class TestYum < CiscoTestCase
       info 'Executing test setup... Please be patient, this will take a while.'
       steps = ["install deactivate #{@@pkg}",
                "install remove #{@@pkg} forced",
+               'install remove inactive forced',
                "install add bootflash:#{@@pkg_filename}"]
       steps.each do |step|
         info "Executing setup step: #{step}..."


### PR DESCRIPTION
Our yum provider was not removing inactive packages from the device when the `remove` method was called.  The deactivated package requires a `commit` step before final removal.