### PR TITLE
fix hsrp_bfd and pim_bfd

### DIFF
--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -271,6 +271,7 @@ module Cisco
     end
 
     def hsrp_bfd=(val)
+      return if val == hsrp_bfd
       state = val ? '' : 'no'
       if val
         Feature.hsrp_enable
@@ -981,6 +982,7 @@ module Cisco
     end
 
     def pim_bfd=(val)
+      return if val == pim_bfd
       state = val ? '' : 'no'
       if val
         Feature.pim_enable


### PR DESCRIPTION
This PR is for fixing hsrp_bfd and pim_bfd properties. The problem is that when an interface (like port-channel 100) which does not exist in the system yet is created and then try to set hsrp_bfd, pim_bfd to default (in beaker tests for ex.), since the interface is not ye existing, it will create and try to set them to default state. However we cannot call 'no hsrp bfd' or 'no pim bfd' unless bfd feature is enabled already. This feature gets enabled only when the property is getting enabled, not when it is set to default state. 
The right way to fix is to check in the NU if the set value is same as the current value and return. This kind of code exists for other bfd properties.
https://github.com/cisco/cisco-network-node-utils/blob/develop/lib/cisco_node_utils/interface_ospf.rb#L235
It is missing for hsrp_bfd and pim_bfd. 
The beaker test for pim_bfd is NOT failing because the interface being used is a physical interface which always exists in the system, so the puppet resource is getting the value properly before setting it. It will fail if a logical interface is used. So fixing that as well. Checked other similar boolean bfd properties and found others ok. 