### PR TITLE
fixes for freeport issues

### DIFF
--- a/lib/cisco_node_utils/route_map.rb
+++ b/lib/cisco_node_utils/route_map.rb
@@ -1596,14 +1596,17 @@ module Cisco
     end
 
     def set_metric_set(plus, bndw, del, reliability, eff_bw, mtu)
-      state = bndw ? '' : 'no'
+      set_args_keys(state: 'no', additive: '', bw: '', delay: '',
+                    rel: '', eff: '', mtu: '')
+      config_set('route_map', 'set_metric', @set_args)
+      return unless bndw
       additive = plus ? '+' : ''
       bw = bndw ? bndw : ''
       delay = del ? del : ''
       rel = reliability ? reliability : ''
       eff = eff_bw ? eff_bw : ''
       lmtu = mtu ? mtu : ''
-      set_args_keys(state: state, additive: additive, bw: bw, delay: delay,
+      set_args_keys(state: '', additive: additive, bw: bw, delay: delay,
                     rel: rel, eff: eff, mtu: lmtu)
       config_set('route_map', 'set_metric', @set_args)
     end

--- a/lib/cisco_node_utils/snmpuser.rb
+++ b/lib/cisco_node_utils/snmpuser.rb
@@ -241,7 +241,7 @@ module Cisco
         # Retrieve password hashes
         hashed_pw = SnmpUser.auth_password('dummy_user', @engine_id)
         if hashed_pw.nil?
-          fail "SNMP dummy user #{dummy_user} #{@engine_id} was configured " \
+          fail "SNMP dummy user dummy_user #{@engine_id} was configured " \
                "but password is missing?\n" \
                + @@node.get(command: 'show run snmp all')
         end
@@ -289,7 +289,7 @@ module Cisco
         dummyau = SnmpUser.auth_password('dummy_user', @engine_id)
         hashed_pw = SnmpUser.priv_password('dummy_user', @engine_id)
         if hashed_pw.nil?
-          fail "SNMP dummy user #{dummy_user} #{@engine_id} was configured " \
+          fail "SNMP dummy user dummy_user #{@engine_id} was configured " \
                "but password is missing?\n" \
                + @@node.get(command: 'show run snmp all')
         end

--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -76,7 +76,7 @@ module Cisco
         (result[2]['body'].split(errors) - ['']).each_slice(2).map(&:join)
       error_list.each do |msg|
         next if ignore_message && msg.to_s.include?(ignore_message)
-        fail Cisco::CliError
+        fail Cisco::CliError, result[2]['body']
       end
     end
 

--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -76,7 +76,7 @@ module Cisco
         (result[2]['body'].split(errors) - ['']).each_slice(2).map(&:join)
       error_list.each do |msg|
         next if ignore_message && msg.to_s.include?(ignore_message)
-        fail result[2]['body']
+        fail Cisco::CliError
       end
     end
 

--- a/tests/test_ace.rb
+++ b/tests/test_ace.rb
@@ -112,15 +112,20 @@ class TestAce < CiscoTestCase
     assert_equal(val, a.src_addr)
     assert_equal(val, a.dst_addr)
 
+    config_no_warn('object-group ip address my_addrgroup_ipv4')
+    config_no_warn('object-group ipv6 address my_addrgroup_ipv6')
     %w(ipv4 ipv6).each do |afi|
       val = "addrgroup my_addrgroup_#{afi}"
       a = ace_helper(afi, src_addr: val, dst_addr: val)
       assert_equal(val, a.src_addr)
       assert_equal(val, a.dst_addr)
     end
+    config_no_warn('no object-group ip address my_addrgroup_ipv4')
+    config_no_warn('no object-group ipv6 address my_addrgroup_ipv6')
   end
 
   def test_ports
+    config_no_warn('object-group ip port my_pg')
     %w(ipv4 ipv6).each do |afi|
       ['eq 2', 'neq 2', 'gt 2', 'lt 2',
        'portgroup my_pg'].each do |val|
@@ -129,6 +134,7 @@ class TestAce < CiscoTestCase
         assert_equal(val, a.dst_port)
       end
     end
+    config_no_warn('no object-group ip port my_pg')
   end
 
   def test_dscp

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -171,7 +171,7 @@ class TestBgpAF < CiscoTestCase
         case Platform.image_version
         when /8.0/
           expect = :success
-        when /I5.2/
+        when /I5.2|I6/
           expect = :success if test == :maximum_paths || test == :maximum_paths_ibgp
         else
           expect = :CliError

--- a/tests/test_vlan.rb
+++ b/tests/test_vlan.rb
@@ -207,7 +207,7 @@ class TestVlan < CiscoTestCase
 
   def test_shutdown_extended
     v = Vlan.new(2000)
-    assert_raises(RuntimeError, 'vlan misconfig did not raise RuntimeError') do
+    assert_raises(CliError, 'vlan misconfig did not raise RuntimeError') do
       v.shutdown = 'shutdown'
     end
     v.destroy
@@ -338,7 +338,7 @@ class TestVlan < CiscoTestCase
     assert(vlan.fabric_control)
     another_vlan = Vlan.new(101)
 
-    assert_raises(RuntimeError,
+    assert_raises(CliError,
                   'VLAN misconfig did not raise CliError') do
       another_vlan.fabric_control = true
     end

--- a/tests/test_vlan.rb
+++ b/tests/test_vlan.rb
@@ -207,7 +207,7 @@ class TestVlan < CiscoTestCase
 
   def test_shutdown_extended
     v = Vlan.new(2000)
-    assert_raises(CliError, 'vlan misconfig did not raise RuntimeError') do
+    assert_raises(CliError, 'vlan misconfig did not raise CliError') do
       v.shutdown = 'shutdown'
     end
     v.destroy

--- a/tests/test_vlan_private.rb
+++ b/tests/test_vlan_private.rb
@@ -381,7 +381,7 @@ class TestVlanPVlan < CiscoTestCase
       assert_equal(result, v1.pvlan_association)
 
       pv_type = 'isolated'
-      assert_raises(CliError, 'vlan misconf did not raise RuntimeError') do
+      assert_raises(CliError, 'vlan misconf did not raise CliError') do
         v3.pvlan_type = pv_type
       end
 

--- a/tests/test_vlan_private.rb
+++ b/tests/test_vlan_private.rb
@@ -381,7 +381,7 @@ class TestVlanPVlan < CiscoTestCase
       assert_equal(result, v1.pvlan_association)
 
       pv_type = 'isolated'
-      assert_raises(RuntimeError, 'vlan misconf did not raise RuntimeError') do
+      assert_raises(CliError, 'vlan misconf did not raise RuntimeError') do
         v3.pvlan_type = pv_type
       end
 


### PR DESCRIPTION
This PR is for fixing minitest errors when the tests are run against freeport code. All relevant tests are run on n3k/n9k (beaker too) and they pass.