### PR TITLE
Interface channel group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Changelog
 * Extend interface with attributes:
    * `purge_config`
 
+* Extend interface_channel_group with attributes:
+   * `channel_group_mode`
+
 ### Changed
 
 ### Removed

--- a/lib/cisco_node_utils/cmd_ref/interface_channel_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_channel_group.yaml
@@ -22,6 +22,10 @@ channel_group:
     get_value: '/^bundle id (\d+).*$/'
     set_value: '<state> bundle id <group>'
 
+channel_group_mode:
+  _exclude: [ios_xr]
+  default_value: false
+
 description:
   kind: string
   get_value: '/^description (.*)/'

--- a/lib/cisco_node_utils/cmd_ref/interface_channel_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_channel_group.yaml
@@ -13,20 +13,14 @@ all_interfaces:
   get_value: '/^interface (Ethernet.*)/i'
 
 channel_group:
-  kind: int
   default_value: false
   nexus:
-    get_value: '/^channel-group (\d+)/'
-    set_value: '<state> channel-group <group> <force>'
+    get_value: '/^channel-group (\d+)(?:\s+mode\s+(\S+))?$/'
+    set_value: '<state> channel-group <group> <force> <mode> <val>'
   ios_xr:
+    kind: int
     get_value: '/^bundle id (\d+).*$/'
     set_value: '<state> bundle id <group>'
-
-channel_group_mode:
-  kind: string
-  get_value: '/^channel-group \d+\s\S+\s(\w+)$/'
-  set_value: '<state> channel-group <group> <force> mode <mode>'
-  default_value: false
 
 description:
   kind: string

--- a/lib/cisco_node_utils/cmd_ref/interface_channel_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_channel_group.yaml
@@ -32,16 +32,6 @@ description:
   set_value: '<state> description <desc>'
   default_value: ''
 
-feature_lacp:
-  kind: boolean
-  nexus:
-    get_command: "show running | i ^feature"
-    context: ~
-    get_value: '/^feature lacp$/'
-    set_value: "<state> feature lacp"
-  ios_xr:
-    default_only: true
-
 shutdown:
   kind: boolean
   get_value: '/^(?:no )?shutdown$/'

--- a/lib/cisco_node_utils/interface_channel_group.rb
+++ b/lib/cisco_node_utils/interface_channel_group.rb
@@ -64,24 +64,25 @@ module Cisco
     def channel_group_mode
       match = config_get('interface_channel_group', 'channel_group', @get_args)
       return match unless match
-      mode = match[1].nil? ? 'on' : match[1]
+      mode = match[1].nil? ? default_channel_group_mode : match[1]
       mode
     end
 
-    def channel_group_mode_set(group, mode='on')
+    def channel_group_mode_set(group, mode=false)
       cgroup = channel_group
       set_args_keys(state: 'no', group: cgroup, force: '', mode: '', val: '')
       config_set('interface_channel_group', 'channel_group', @set_args) if
         cgroup
       return unless group
-      if mode == 'on'
-        set_args_keys(state: '', group: group, force: 'force',
-                      mode: '', val: '')
-        config_set('interface_channel_group', 'channel_group', @set_args)
-      else
-        Cisco::Feature.lacp_enable if mode == 'active' || mode == 'passive'
+      mode = false if mode && mode.to_str == 'on'
+      if mode
+        Cisco::Feature.lacp_enable
         set_args_keys(state: '', group: group, force: 'force',
                       mode: 'mode', val: mode)
+        config_set('interface_channel_group', 'channel_group', @set_args)
+      else
+        set_args_keys(state: '', group: group, force: 'force',
+                      mode: '', val: '')
         config_set('interface_channel_group', 'channel_group', @set_args)
       end
     end
@@ -94,6 +95,10 @@ module Cisco
 
     def default_channel_group
       config_get_default('interface_channel_group', 'channel_group')
+    end
+
+    def default_channel_group_mode
+      config_get_default('interface_channel_group', 'channel_group_mode')
     end
 
     # ----------------------------

--- a/lib/cisco_node_utils/interface_channel_group.rb
+++ b/lib/cisco_node_utils/interface_channel_group.rb
@@ -62,54 +62,34 @@ module Cisco
     ########################################################
 
     def channel_group_mode
-      mode = config_get('interface_channel_group', 'channel_group_mode',
-                        @get_args)
-      mode = mode ? mode : 'on' if channel_group
+      match = config_get('interface_channel_group', 'channel_group', @get_args)
+      return match unless match
+      mode = match[1].nil? ? 'on' : match[1]
       mode
     end
 
-    def channel_group_mode=(mode)
-      group = channel_group
-
-      set_args_keys(state: 'no', group: group, force: '')
-      config_set('interface_channel_group', 'channel_group', @set_args)
-      if mode
-        Cisco::Feature.lacp_enable if mode == 'active' || mode == 'passive'
-        set_args_keys(state: '', group: group, force: 'force', mode: mode)
-        config_set('interface_channel_group', 'channel_group_mode', @set_args)
+    def channel_group_mode_set(group, mode='on')
+      cgroup = channel_group
+      set_args_keys(state: 'no', group: cgroup, force: '', mode: '', val: '')
+      config_set('interface_channel_group', 'channel_group', @set_args) if
+        cgroup
+      return unless group
+      if mode == 'on'
+        set_args_keys(state: '', group: group, force: 'force',
+                      mode: '', val: '')
+        config_set('interface_channel_group', 'channel_group', @set_args)
       else
-        set_args_keys(state: '', group: group, force: 'force')
+        Cisco::Feature.lacp_enable if mode == 'active' || mode == 'passive'
+        set_args_keys(state: '', group: group, force: 'force',
+                      mode: 'mode', val: mode)
         config_set('interface_channel_group', 'channel_group', @set_args)
       end
     end
 
     def channel_group
-      config_get('interface_channel_group', 'channel_group', @get_args)
-    end
-
-    def channel_group=(group)
-      # 'force' is needed by NXOS to handle the case where a port-channel
-      # interface is created prior to the channel-group cli; in which case
-      # the properties of the port-channel interface will be different from
-      # the ethernet interface. 'force' is not needed if the port-channel is
-      # created as a result of the channel-group cli but since it does no
-      # harm we will use it every time.
-      # IOS XR simply ignores 'force'
-      if group
-        state = ''
-        force = 'force'
-      else
-        state = 'no'
-        group = force = ''
-      end
-      config_set('interface_channel_group', 'channel_group',
-                 set_args_keys(state: state, group: group, force: force))
-    rescue Cisco::CliError => e
-      # Some XR platforms do not support channel-group configuration
-      # on some OS versions. Since this is an OS version difference and not
-      # a platform difference, we can't handle this in the YAML.
-      raise unless e.message[/the entered commands do not exist/]
-      raise Cisco::UnsupportedError.new('interface', 'channel_group')
+      match = config_get('interface_channel_group', 'channel_group', @get_args)
+      return match unless match
+      match[0].to_i
     end
 
     def default_channel_group

--- a/tests/test_interface_channel_group.rb
+++ b/tests/test_interface_channel_group.rb
@@ -62,7 +62,7 @@ class TestInterfaceChanGrp < CiscoTestCase
     # group = 55, mode = on
     i.channel_group_mode_set(group)
     assert_equal(group, i.channel_group)
-    assert_equal('on', i.channel_group_mode)
+    assert_equal(i.default_channel_group_mode, i.channel_group_mode)
 
     # group = 55, mode = active
     i.channel_group_mode_set(group, 'active')
@@ -77,7 +77,7 @@ class TestInterfaceChanGrp < CiscoTestCase
     # group = 55, mode = on
     i.channel_group_mode_set(group, 'on')
     assert_equal(group, i.channel_group)
-    assert_equal('on', i.channel_group_mode)
+    assert_equal(i.default_channel_group_mode, i.channel_group_mode)
 
     # group = 66, mode = active
     group = 66
@@ -88,7 +88,7 @@ class TestInterfaceChanGrp < CiscoTestCase
     # group = 66, mode = on
     i.channel_group_mode_set(group)
     assert_equal(group, i.channel_group)
-    assert_equal('on', i.channel_group_mode)
+    assert_equal(i.default_channel_group_mode, i.channel_group_mode)
 
     # Default Case: group = mode = false
     i.channel_group_mode_set(i.default_channel_group)

--- a/tests/test_interface_channel_group.rb
+++ b/tests/test_interface_channel_group.rb
@@ -32,6 +32,7 @@ class TestInterfaceChanGrp < CiscoTestCase
   end
 
   def test_channel_group
+    skip if platform == :nexus
     i = @intf
     group = 200
     i.channel_group = group
@@ -50,6 +51,7 @@ class TestInterfaceChanGrp < CiscoTestCase
   end
 
   def test_channel_group_mode
+    skip if platform == :ios_xr
     i = @intf
     group = 55
 
@@ -58,39 +60,38 @@ class TestInterfaceChanGrp < CiscoTestCase
     refute(i.channel_group_mode)
 
     # group = 55, mode = on
-    i.channel_group = group
+    i.channel_group_mode_set(group)
     assert_equal(group, i.channel_group)
     assert_equal('on', i.channel_group_mode)
 
     # group = 55, mode = active
-    i.channel_group_mode = 'active'
+    i.channel_group_mode_set(group, 'active')
     assert_equal(group, i.channel_group)
     assert_equal('active', i.channel_group_mode)
 
     # group = 55, mode = passive
-    i.channel_group_mode = 'passive'
+    i.channel_group_mode_set(group, 'passive')
     assert_equal(group, i.channel_group)
     assert_equal('passive', i.channel_group_mode)
 
     # group = 55, mode = on
-    i.channel_group_mode = 'on'
+    i.channel_group_mode_set(group, 'on')
     assert_equal(group, i.channel_group)
     assert_equal('on', i.channel_group_mode)
 
     # group = 66, mode = active
     group = 66
-    i.channel_group = group
-    i.channel_group_mode = 'active'
+    i.channel_group_mode_set(group, 'active')
     assert_equal(group, i.channel_group)
     assert_equal('active', i.channel_group_mode)
 
     # group = 66, mode = on
-    i.channel_group_mode = false
+    i.channel_group_mode_set(group)
     assert_equal(group, i.channel_group)
     assert_equal('on', i.channel_group_mode)
 
     # Default Case: group = mode = false
-    i.channel_group = i.default_channel_group
+    i.channel_group_mode_set(i.default_channel_group)
     refute(i.channel_group)
     refute(i.channel_group_mode)
   end


### PR DESCRIPTION
This PR is for fixing interface_channel_group provider for the channel_group_mode. Some methods were merged to make it more clean and compact. All tests pass on all platforms.