### PR TITLE
Span session fixes:

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/span_session.yaml
+++ b/lib/cisco_node_utils/cmd_ref/span_session.yaml
@@ -1,10 +1,11 @@
 # SPAN session
 ---
+_exclude: [N5k, N6k, N7k]
+
 _template:
-  nexus:
-    get_command: "show running monitor all"
-    get_context: ["monitor session <id>(?: .*)?"]
-    set_context: ["monitor session <id>"]
+  get_command: "show running monitor all"
+  get_context: ["monitor session <id>(?: .*)?"]
+  set_context: ["monitor session <id>"]
 
 all_sessions:
   multiple:
@@ -44,15 +45,16 @@ shutdown:
   get_value: '/^no shut$/'
   set_value: '<state> shut'
 
-source_interface:
-  kind: string
+source_interfaces:
+  multiple:
   get_value: '/^source interface (\S+) (\w+)$/'
   set_value: '<state> source interface <int_name> <direction>'
+  default_value: []
 
-source_vlan:
-  kind: int
+source_vlans:
   get_value: '/^source vlan (\S+) (\w+)$/'
   set_value: '<state> source vlan <vlans> <direction>'
+  default_value: []
 
 type:
   kind: string

--- a/lib/cisco_node_utils/span_session.rb
+++ b/lib/cisco_node_utils/span_session.rb
@@ -89,9 +89,10 @@ module Cisco
 
     def source_interfaces=(sources)
       fail TypeError unless sources.is_a?(Hash)
-      delta_hash = Utils.delta_add_remove(sources.to_a, source_interfaces.to_a)
+      delta_hash = Utils.delta_add_remove(sources.to_a, source_interfaces.to_a,
+                                          :updates_not_allowed)
       return if delta_hash.values.flatten.empty?
-      [:add, :remove].each do |action|
+      [:remove, :add].each do |action|
         delta_hash[action].each do |name, dir|
           state = (action == :add) ? '' : 'no'
           config_set('span_session', 'source_interfaces', id: @session_id,

--- a/tests/test_span_session.rb
+++ b/tests/test_span_session.rb
@@ -89,7 +89,7 @@ class TestSpanSession < CiscoTestCase
     assert_equal(intlb.to_a.sort, span.source_interfaces.sort)
 
     # intla/c same size but 1 element different
-    intlc = { int2            => 'tx',
+    intlc = { int2            => 'both',
               int1            => 'rx',
               'port-channel1' => 'both',
               'sup-eth0'      => 'rx' }

--- a/tests/test_span_session.rb
+++ b/tests/test_span_session.rb
@@ -60,33 +60,95 @@ class TestSpanSession < CiscoTestCase
     assert_equal(span.description, desc)
   end
 
-  def test_session_source_interface
+  def test_session_source_interfaces
     span = SpanSession.new(4)
     po_int = Interface.new('port-channel1')
-    ints = { 'Ethernet1/1'   => 'rx',
-             'Ethernet1/2'   => 'tx',
-             'port-channel1' => 'both',
-             'sup-eth0'      => 'rx' }
-    span.source_interface = ints
-    ints.keys.each do |int_name|
-      assert_equal(span.source_interface, int_name,
-                   "source interface #{int_name} does not match")
-    end
+    int1 = interfaces[0]
+    int2 = interfaces[1]
+    int3 = interfaces[2]
+
+    # Test default case
+    assert_equal(span.default_source_interfaces, span.source_interfaces)
+
+    # Non-default case
+    intla = { int1            => 'rx',
+              int2            => 'tx',
+              'port-channel1' => 'both',
+              'sup-eth0'      => 'rx' }
+
+    span.source_interfaces = intla
+    assert_equal(intla.to_a.sort, span.source_interfaces.sort)
+
+    # intla and intlb are identical
+    intlb = { int1            => 'rx',
+              int2            => 'tx',
+              'port-channel1' => 'both',
+              'sup-eth0'      => 'rx' }
+
+    span.source_interfaces = intlb
+    assert_equal(intlb.to_a.sort, span.source_interfaces.sort)
+
+    # intla/c same size but 1 element different
+    intlc = { int2            => 'tx',
+              int1            => 'rx',
+              'port-channel1' => 'both',
+              'sup-eth0'      => 'rx' }
+
+    span.source_interfaces = intlc
+    assert_equal(intlc.to_a.sort, span.source_interfaces.sort)
+
+    # intla/d different sizes and diff/same elements
+    intld = { int2            => 'tx',
+              int1            => 'both',
+              'port-channel1' => 'both' }
+
+    span.source_interfaces = intld
+    assert_equal(intld.to_a.sort, span.source_interfaces.sort)
+
+    # Empty list
+    intle = {}
+
+    span.source_interfaces = intle
+    assert_equal(intle.to_a.sort, span.source_interfaces.sort)
+
+    # intlf is larger then intla
+    intlf = { int3            => 'both',
+              int1            => 'rx',
+              int2            => 'tx',
+              'port-channel1' => 'both',
+              'sup-eth0'      => 'rx' }
+
+    span.source_interfaces = intlf
+    assert_equal(intlf.to_a.sort, span.source_interfaces.sort)
+
     po_int.destroy
   end
 
   def test_session_source_vlans
-    vlans = [2..5, 8, 10, 13]
-    vlans = vlans.join(',') if vlans.is_a?(Array)
-    vlans = Utils.normalize_range_array(vlans, :string) unless vlans == 'none'
     span = SpanSession.new(5)
-    span.source_vlan = { vlans: vlans, direction: 'rx' }
-    assert_equal(span.source_vlan[:vlans], vlans)
+
+    # Default case
+    assert_equal(span.source_vlans, span.default_source_vlans)
+
+    # Non-default case
+    vlans = %w(1 2-5 6)
+    span.source_vlans = { vlans: vlans, direction: 'rx' }
+    assert_equal(%w(1-6), span.source_vlans[0])
+    assert_equal('rx', span.source_vlans[1])
+
+    vlans = %w(1 3-4 6)
+    span.source_vlans = { vlans: vlans, direction: 'rx' }
+    assert_equal(%w(1 3-4 6), span.source_vlans[0])
+    assert_equal('rx', span.source_vlans[1])
+
+    # Set back to default
+    span.source_vlans = { vlans: [], direction: '' }
+    assert_equal(span.source_vlans, span.default_source_vlans)
   end
 
   def test_session_destination_int
     span = SpanSession.new(6)
-    dest_int = 'Ethernet1/3'
+    dest_int = interfaces[2]
     span.destination = dest_int
     assert_equal(span.destination, dest_int)
   end


### PR DESCRIPTION
Summary of changes:
  * Completes the `source_interfaces` and `source_vlans` properties that were originally submitted under https://github.com/cisco/cisco-network-node-utils/pull/539
  * Add proper `_exclude` yaml entry for unsupported platforms

This update allows both `source_interfaces` and `source_vlans` to be set using a ruby hash which was requested by @tomcooperca.  The puppet manifest will use a hash instead of an array for these properties.

Tested on: N3k, N9k and N9k-F.  Verified to skip on N7k.