### PR TITLE
Bgp af aa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 
 #### Cisco Resources
 * span_session (@tomcooperca)
+* bgp_af_aggr_addr (@saichint)
 
 ### Added
 * Extend vpc with attributes:

--- a/lib/cisco_node_utils/ace.rb
+++ b/lib/cisco_node_utils/ace.rb
@@ -139,33 +139,6 @@ module Cisco
       config_set('acl', cmd, @set_args)
     end
 
-    # UTILITY FUNCTIONS
-    # -----------------
-
-    # extract value of property from ace
-    def extract_value(prop, prefix=nil)
-      prefix = prop if prefix.nil?
-      ace_match = ace_get
-
-      # matching ace not found
-      return nil if ace_match.nil? # no matching ace found
-
-      # property not defined for matching ace
-      return nil unless ace_match.names.include?(prop)
-
-      # extract and return value that follows prefix + <space>
-      regexp = Regexp.new("#{Regexp.escape(prefix)} (?<extracted>.*)")
-      value_match = regexp.match(ace_match[prop])
-      return nil if value_match.nil?
-      value_match[:extracted]
-    end
-
-    # prepend property name prefix/keyword to value
-    def attach_prefix(val, prop, prefix=nil)
-      prefix = prop.to_s if prefix.nil?
-      @set_args[prop] = val.to_s.empty? ? val : "#{prefix} #{val}"
-    end
-
     # PROPERTIES
     # ----------
     def seqno
@@ -272,67 +245,75 @@ module Cisco
     end
 
     def precedence
-      extract_value('precedence')
+      Utils.extract_value('precedence', nil, ace_get)
     end
 
     def precedence=(precedence)
-      attach_prefix(precedence, :precedence)
+      @set_args[:precedence] = Utils.attach_prefix(precedence, :precedence)
     end
 
     def dscp
-      extract_value('dscp')
+      Utils.extract_value('dscp', nil, ace_get)
     end
 
     def dscp=(dscp)
-      attach_prefix(dscp, :dscp)
+      @set_args[:dscp] = Utils.attach_prefix(dscp, :dscp)
     end
 
     def time_range
-      extract_value('time_range', 'time-range')
+      Utils.extract_value('time_range', 'time-range', ace_get)
     end
 
     def time_range=(time_range)
-      attach_prefix(time_range, :time_range, 'time-range')
+      @set_args[:time_range] = Utils.attach_prefix(time_range,
+                                                   :time_range,
+                                                   'time-range')
     end
 
     def packet_length
-      extract_value('packet_length', 'packet-length')
+      Utils.extract_value('packet_length', 'packet-length', ace_get)
     end
 
     def packet_length=(packet_length)
-      attach_prefix(packet_length, :packet_length, 'packet-length')
+      @set_args[:packet_length] = Utils.attach_prefix(packet_length,
+                                                      :packet_length,
+                                                      'packet-length')
     end
 
     def ttl
-      extract_value('ttl')
+      Utils.extract_value('ttl', nil, ace_get)
     end
 
     def ttl=(ttl)
-      attach_prefix(ttl, :ttl)
+      @set_args[:ttl] = Utils.attach_prefix(ttl, :ttl)
     end
 
     def http_method
-      extract_value('http_method', 'http-method')
+      Utils.extract_value('http_method', 'http-method', ace_get)
     end
 
     def http_method=(http_method)
-      attach_prefix(http_method, :http_method, 'http-method')
+      @set_args[:http_method] = Utils.attach_prefix(http_method,
+                                                    :http_method,
+                                                    'http-method')
     end
 
     def tcp_option_length
-      extract_value('tcp_option_length', 'tcp-option-length')
+      Utils.extract_value('tcp_option_length', 'tcp-option-length', ace_get)
     end
 
     def tcp_option_length=(tcp_option_length)
-      attach_prefix(tcp_option_length, :tcp_option_length, 'tcp-option-length')
+      @set_args[:tcp_option_length] = Utils.attach_prefix(tcp_option_length,
+                                                          :tcp_option_length,
+                                                          'tcp-option-length')
     end
 
     def redirect
-      extract_value('redirect')
+      Utils.extract_value('redirect', nil, ace_get)
     end
 
     def redirect=(redirect)
-      attach_prefix(redirect, :redirect)
+      @set_args[:redirect] = Utils.attach_prefix(redirect, :redirect)
     end
 
     def log

--- a/lib/cisco_node_utils/ace.rb
+++ b/lib/cisco_node_utils/ace.rb
@@ -245,7 +245,7 @@ module Cisco
     end
 
     def precedence
-      Utils.extract_value('precedence', nil, ace_get)
+      Utils.extract_value(ace_get, 'precedence')
     end
 
     def precedence=(precedence)
@@ -253,7 +253,7 @@ module Cisco
     end
 
     def dscp
-      Utils.extract_value('dscp', nil, ace_get)
+      Utils.extract_value(ace_get, 'dscp')
     end
 
     def dscp=(dscp)
@@ -261,7 +261,7 @@ module Cisco
     end
 
     def time_range
-      Utils.extract_value('time_range', 'time-range', ace_get)
+      Utils.extract_value(ace_get, 'time_range', 'time-range')
     end
 
     def time_range=(time_range)
@@ -271,7 +271,7 @@ module Cisco
     end
 
     def packet_length
-      Utils.extract_value('packet_length', 'packet-length', ace_get)
+      Utils.extract_value(ace_get, 'packet_length', 'packet-length')
     end
 
     def packet_length=(packet_length)
@@ -281,7 +281,7 @@ module Cisco
     end
 
     def ttl
-      Utils.extract_value('ttl', nil, ace_get)
+      Utils.extract_value(ace_get, 'ttl')
     end
 
     def ttl=(ttl)
@@ -289,7 +289,7 @@ module Cisco
     end
 
     def http_method
-      Utils.extract_value('http_method', 'http-method', ace_get)
+      Utils.extract_value(ace_get, 'http_method', 'http-method')
     end
 
     def http_method=(http_method)
@@ -299,7 +299,7 @@ module Cisco
     end
 
     def tcp_option_length
-      Utils.extract_value('tcp_option_length', 'tcp-option-length', ace_get)
+      Utils.extract_value(ace_get, 'tcp_option_length', 'tcp-option-length')
     end
 
     def tcp_option_length=(tcp_option_length)
@@ -309,7 +309,7 @@ module Cisco
     end
 
     def redirect
-      Utils.extract_value('redirect', nil, ace_get)
+      Utils.extract_value(ace_get, 'redirect')
     end
 
     def redirect=(redirect)

--- a/lib/cisco_node_utils/bgp_af_aggr_addr.rb
+++ b/lib/cisco_node_utils/bgp_af_aggr_addr.rb
@@ -23,13 +23,14 @@ module Cisco
     attr_reader :asn, :vrf, :afi, :safi, :aa
 
     def initialize(asn, vrf, af, aggr_addr, instantiate=true)
-      @bgp_af = RouterBgpAF.afs[asn][vrf][af]
-      fail "bgp address family #{asn vrf af} does not exist" if @bgp_af.nil?
       @asn = asn
       @vrf = vrf
       @afi, @safi = af
       @aa = aggr_addr
-
+      temp_af = [@afi.to_s, @safi.to_s]
+      @bgp_af = RouterBgpAF.afs[asn][vrf][temp_af]
+      fail "bgp address family #{asn} #{vrf} #{af} does not exist" if
+        @bgp_af.nil?
       set_args_keys_default
       create if instantiate
     end

--- a/lib/cisco_node_utils/bgp_af_aggr_addr.rb
+++ b/lib/cisco_node_utils/bgp_af_aggr_addr.rb
@@ -177,6 +177,11 @@ module Cisco
       config_get_default('bgp_af_aa', 'attribute_map')
     end
 
+    # The CLI can take many forms like:
+    # aggregate-address 1.1.1.1/32 as-set advertise-map adm
+    # aggregate-address 1.1.1.1/32 suppress-map sum attribute-map atm
+    # aggregate-address 1.1.1.1/32 summary-only
+    # aggregate-address 2.2.2.2/32 summary-only
     def aa_set(attrs)
       # reset everything before setting as some older
       # software versions require it.

--- a/lib/cisco_node_utils/bgp_af_aggr_addr.rb
+++ b/lib/cisco_node_utils/bgp_af_aggr_addr.rb
@@ -1,0 +1,212 @@
+# May 2017, Sai Chintalapudi
+#
+# Copyright (c) 2017 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'node_util'
+require_relative 'bgp_af'
+
+module Cisco
+  # node_utils class for bgp address-family aggregate address management
+  class RouterBgpAFAggrAddr < NodeUtil
+    attr_reader :asn, :vrf, :afi, :safi, :aa
+
+    def initialize(asn, vrf, af, aggr_addr, instantiate=true)
+      @bgp_af = RouterBgpAF.afs[asn][vrf][af]
+      fail "bgp address family #{asn vrf af} does not exist" if @bgp_af.nil?
+      @asn = asn
+      @vrf = vrf
+      @afi, @safi = af
+      @aa = aggr_addr
+
+      set_args_keys_default
+      create if instantiate
+    end
+
+    def self.aas
+      aa_hash = {}
+      RouterBgpAF.afs.each do |asn, vrfs|
+        aa_hash[asn] = {}
+        vrfs.each do |vrf, afs|
+          aa_hash[asn][vrf] = {}
+          afs.each do |af, _obj|
+            aa_hash[asn][vrf][af] = {}
+            afi, safi = af
+            get_args = { asnum: asn, afi: afi, safi: safi }
+            get_args[:vrf] = vrf unless vrf == 'default'
+            aa_list = config_get('bgp_af_aa', 'all_aa', get_args)
+            next if aa_list.nil?
+            aa_list.each do |aa|
+              aa_hash[asn][vrf][af][aa] =
+                RouterBgpAFAggrAddr.new(asn, vrf, af, aa, false)
+            end
+          end
+        end
+      end
+      aa_hash
+    end
+
+    # Helper method to delete @set_args hash keys
+    def set_args_keys_default
+      keys = { asnum: @asn, afi: @afi, safi: @safi, address: @aa }
+      keys[:vrf] = @vrf unless @vrf == 'default'
+      @get_args = @set_args = keys
+    end
+
+    # rubocop:disable Style/AccessorMethodName
+    def set_args_keys(hash={})
+      set_args_keys_default
+      @set_args = @get_args.merge!(hash) unless hash.empty?
+    end
+
+    ########################################################
+    #                      PROPERTIES                      #
+    ########################################################
+
+    def create
+      set_args_keys(state: '', as_set: '', summ: '', advertise: '',
+                    admap: '', suppress: '', sumap: '', attribute: '',
+                    atmap: '')
+      config_set('bgp_af_aa', 'aggr_addr', @set_args)
+    end
+
+    def destroy
+      set_args_keys(state: 'no', as_set: '', summ: '', advertise: '',
+                    admap: '', suppress: '', sumap: '', attribute: '',
+                    atmap: '')
+      config_set('bgp_af_aa', 'aggr_addr', @set_args)
+    end
+
+    # extract value of property from aggregate-address
+    def extract_value(prop, prefix=nil)
+      prefix = prop if prefix.nil?
+      aa_match = aa_maps_get
+
+      return nil if aa_match.nil?
+
+      return nil unless aa_match.names.include?(prop)
+
+      # extract and return value that follows prefix + <space>
+      regexp = Regexp.new("#{Regexp.escape(prefix)} (?<extracted>.*)")
+      value_match = regexp.match(aa_match[prop])
+      return nil if value_match.nil?
+      value_match[:extracted]
+    end
+
+    # prepend property name prefix/keyword to value
+    def attach_prefix(val, prop, prefix=nil)
+      prefix = prop.to_s if prefix.nil?
+      @set_args[prop] = val.to_s.empty? ? val : "#{prefix} #{val}"
+    end
+
+    def aa_maps_get
+      str = config_get('bgp_af_aa', 'aggr_addr', @get_args)
+      str.slice!('as-set')
+      str.slice!('summary-only')
+      str.strip!
+      return if str.empty?
+      regexp = Regexp.new(' *(?<admap>advertise-map \S+)?'\
+                          ' *(?<sumap>suppress-map \S+)?'\
+                          ' *(?<atmap>attribute-map \S+)?')
+      regexp.match(str)
+    end
+
+    def as_set
+      str = config_get('bgp_af_aa', 'aggr_addr', @get_args)
+      str.include?('as-set') ? true : false
+    end
+
+    def as_set=(val)
+      @set_args[:as_set] = val ? 'as-set' : ''
+    end
+
+    def default_as_set
+      config_get_default('bgp_af_aa', 'as_set')
+    end
+
+    def summary_only
+      str = config_get('bgp_af_aa', 'aggr_addr', @get_args)
+      str.include?('summary-only') ? true : false
+    end
+
+    def summary_only=(val)
+      @set_args[:summ] = val ? 'summary-only' : ''
+    end
+
+    def default_summary_only
+      config_get_default('bgp_af_aa', 'summary_only')
+    end
+
+    def advertise_map
+      val = extract_value('admap', 'advertise-map')
+      return default_advertise_map if val.nil?
+      val
+    end
+
+    def advertise_map=(map)
+      attach_prefix(map, :advertise, 'advertise-map')
+    end
+
+    def default_advertise_map
+      config_get_default('bgp_af_aa', 'advertise_map')
+    end
+
+    def suppress_map
+      val = extract_value('sumap', 'suppress-map')
+      return default_suppress_map if val.nil?
+      val
+    end
+
+    def suppress_map=(map)
+      attach_prefix(map, :suppress, 'suppress-map')
+    end
+
+    def default_suppress_map
+      config_get_default('bgp_af_aa', 'suppress_map')
+    end
+
+    def attribute_map
+      val = extract_value('atmap', 'attribute-map')
+      return default_attribute_map if val.nil?
+      val
+    end
+
+    def attribute_map=(map)
+      attach_prefix(map, :attribute, 'attribute-map')
+    end
+
+    def default_attribute_map
+      config_get_default('bgp_af_aa', 'attribute_map')
+    end
+
+    def aa_set(attrs)
+      set_args_keys_default
+      [:suppress_map,
+       :advertise_map,
+       :attribute_map,
+      ].each do |p|
+        attrs[p] = '' if attrs[p].nil? || attrs[p] == false
+        send(p.to_s + '=', attrs[p])
+      end
+      [:summary_only,
+       :as_set,
+      ].each do |p|
+        attrs[p] = false if attrs[p].nil?
+        send(p.to_s + '=', attrs[p])
+      end
+      @set_args[:state] = ''
+      config_set('bgp_af_aa', 'aggr_addr', @set_args)
+    end
+  end # Class
+end # Module

--- a/lib/cisco_node_utils/bgp_af_aggr_addr.rb
+++ b/lib/cisco_node_utils/bgp_af_aggr_addr.rb
@@ -133,7 +133,7 @@ module Cisco
     end
 
     def advertise_map
-      val = Utils.extract_value('admap', 'advertise-map', aa_maps_get)
+      val = Utils.extract_value(aa_maps_get, 'admap', 'advertise-map')
       return default_advertise_map if val.nil?
       val
     end
@@ -148,7 +148,7 @@ module Cisco
     end
 
     def suppress_map
-      val = Utils.extract_value('sumap', 'suppress-map', aa_maps_get)
+      val = Utils.extract_value(aa_maps_get, 'sumap', 'suppress-map')
       return default_suppress_map if val.nil?
       val
     end
@@ -163,7 +163,7 @@ module Cisco
     end
 
     def attribute_map
-      val = Utils.extract_value('atmap', 'attribute-map', aa_maps_get)
+      val = Utils.extract_value(aa_maps_get, 'atmap', 'attribute-map')
       return default_attribute_map if val.nil?
       val
     end

--- a/lib/cisco_node_utils/bgp_af_aggr_addr.rb
+++ b/lib/cisco_node_utils/bgp_af_aggr_addr.rb
@@ -91,28 +91,6 @@ module Cisco
       config_set('bgp_af_aa', 'aggr_addr', @set_args)
     end
 
-    # extract value of property from aggregate-address
-    def extract_value(prop, prefix=nil)
-      prefix = prop if prefix.nil?
-      aa_match = aa_maps_get
-
-      return nil if aa_match.nil?
-
-      return nil unless aa_match.names.include?(prop)
-
-      # extract and return value that follows prefix + <space>
-      regexp = Regexp.new("#{Regexp.escape(prefix)} (?<extracted>.*)")
-      value_match = regexp.match(aa_match[prop])
-      return nil if value_match.nil?
-      value_match[:extracted]
-    end
-
-    # prepend property name prefix/keyword to value
-    def attach_prefix(val, prop, prefix=nil)
-      prefix = prop.to_s if prefix.nil?
-      @set_args[prop] = val.to_s.empty? ? val : "#{prefix} #{val}"
-    end
-
     def aa_maps_get
       str = config_get('bgp_af_aa', 'aggr_addr', @get_args)
       return if str.nil?
@@ -155,13 +133,14 @@ module Cisco
     end
 
     def advertise_map
-      val = extract_value('admap', 'advertise-map')
+      val = Utils.extract_value('admap', 'advertise-map', aa_maps_get)
       return default_advertise_map if val.nil?
       val
     end
 
     def advertise_map=(map)
-      attach_prefix(map, :advertise, 'advertise-map')
+      @set_args[:advertise] =
+          Utils.attach_prefix(map, :advertise, 'advertise-map')
     end
 
     def default_advertise_map
@@ -169,13 +148,14 @@ module Cisco
     end
 
     def suppress_map
-      val = extract_value('sumap', 'suppress-map')
+      val = Utils.extract_value('sumap', 'suppress-map', aa_maps_get)
       return default_suppress_map if val.nil?
       val
     end
 
     def suppress_map=(map)
-      attach_prefix(map, :suppress, 'suppress-map')
+      @set_args[:suppress] =
+          Utils.attach_prefix(map, :suppress, 'suppress-map')
     end
 
     def default_suppress_map
@@ -183,13 +163,14 @@ module Cisco
     end
 
     def attribute_map
-      val = extract_value('atmap', 'attribute-map')
+      val = Utils.extract_value('atmap', 'attribute-map', aa_maps_get)
       return default_attribute_map if val.nil?
       val
     end
 
     def attribute_map=(map)
-      attach_prefix(map, :attribute, 'attribute-map')
+      @set_args[:attribute] =
+          Utils.attach_prefix(map, :attribute, 'attribute-map')
     end
 
     def default_attribute_map

--- a/lib/cisco_node_utils/bgp_af_aggr_addr.rb
+++ b/lib/cisco_node_utils/bgp_af_aggr_addr.rb
@@ -191,6 +191,9 @@ module Cisco
     end
 
     def aa_set(attrs)
+      # reset everything before setting as some older
+      # software versions require it.
+      destroy
       set_args_keys_default
       [:suppress_map,
        :advertise_map,

--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -368,8 +368,17 @@ module Cisco
       value
     end # add_quotes
 
-    # extract value of property
-    def self.extract_value(prop, prefix=nil, match_method)
+    # This method is used in config_get for CLIs which
+    # have multiple properties in the same output
+    # Given a match_method which defines regex pattern and the
+    # match criteria, this method, extracts the value of
+    # a property with or without a prefix.
+    # For ex. if the regex pattern is something like:
+    # (?<action>\S+)?
+    # the property to extract is action and prefix is nil
+    # for (?<src_port>range \S+)
+    # the property to extract is src_port and prefix is range
+    def self.extract_value(match_method, prop, prefix=nil)
       prefix = prop if prefix.nil?
       mm = match_method
 
@@ -384,7 +393,16 @@ module Cisco
       value_match[:extracted]
     end
 
-    # prepend property name prefix/keyword to value
+    # This method is used in config_set for CLIs which
+    # can set multiple properties using the same CLI.
+    # This method attaches prefix to the given property
+    # when the prefix is different from the property name
+    # else it attaches property name itself. It also
+    # appends the value to be set.
+    # For ex. if the set_value is <precedence> <time_range>
+    # the prop for precedence could be 'precedence', and
+    # for time_range, the prop and prefix could be 'time_range'
+    # and 'time-range'
     def self.attach_prefix(val, prop, prefix=nil)
       prefix = prop.to_s if prefix.nil?
       val.to_s.empty? ? val : "#{prefix} #{val}"

--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -368,7 +368,7 @@ module Cisco
       value
     end # add_quotes
 
-    # extract value of property from aggregate-address
+    # extract value of property
     def self.extract_value(prop, prefix=nil, match_method)
       prefix = prop if prefix.nil?
       mm = match_method

--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -367,5 +367,27 @@ module Cisco
         value.start_with?('"') && value.end_with?('"')
       value
     end # add_quotes
+
+    # extract value of property from aggregate-address
+    def self.extract_value(prop, prefix=nil, match_method)
+      prefix = prop if prefix.nil?
+      mm = match_method
+
+      return nil if mm.nil?
+
+      return nil unless mm.names.include?(prop)
+
+      # extract and return value that follows prefix + <space>
+      regexp = Regexp.new("#{Regexp.escape(prefix)} (?<extracted>.*)")
+      value_match = regexp.match(mm[prop])
+      return nil if value_match.nil?
+      value_match[:extracted]
+    end
+
+    # prepend property name prefix/keyword to value
+    def self.attach_prefix(val, prop, prefix=nil)
+      prefix = prop.to_s if prefix.nil?
+      val.to_s.empty? ? val : "#{prefix} #{val}"
+    end
   end # class Utils
 end   # module Cisco

--- a/lib/cisco_node_utils/cmd_ref/bgp_af_aa.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp_af_aa.yaml
@@ -1,0 +1,38 @@
+# bgp_af_aa.yaml
+---
+_exclude: [ios_xr]
+
+_template:
+  context:
+    - "router bgp <asnum>"
+    - '(?)vrf <vrf>'
+    - 'address-family <afi> <safi>'
+  get_command: 'show running bgp all'
+
+advertise_map:
+  kind: string
+  default_value: ''
+
+aggr_addr:
+  get_value: '/^aggregate-address <address> (.*)$/'
+  set_value: "<state> aggregate-address <address> <as_set> <summ> <advertise> <suppress> <attribute>"
+
+all_aa:
+  multiple: true
+  get_value: '/^aggregate-address (\S+)/'
+
+as_set:
+  kind: boolean
+  default_value: false
+
+attribute_map:
+  kind: string
+  default_value: ''
+
+summary_only:
+  kind: boolean
+  default_value: false
+
+suppress_map:
+  kind: string
+  default_value: ''

--- a/lib/cisco_node_utils/itd_device_group.rb
+++ b/lib/cisco_node_utils/itd_device_group.rb
@@ -67,30 +67,6 @@ module Cisco
       @set_args = @get_args.merge!(hash) unless hash.empty?
     end
 
-    # extract value of property from probe
-    def extract_value(prop, prefix=nil)
-      prefix = prop if prefix.nil?
-      probe_match = probe_get
-
-      # matching probe not found
-      return nil if probe_match.nil? # no matching probe found
-
-      # property not defined for matching probe
-      return nil unless probe_match.names.include?(prop)
-
-      # extract and return value that follows prefix + <space>
-      regexp = Regexp.new("#{Regexp.escape(prefix)} (?<extracted>.*)")
-      value_match = regexp.match(probe_match[prop])
-      return nil if value_match.nil?
-      value_match[:extracted]
-    end
-
-    # prepend property name prefix/keyword to value
-    def attach_prefix(val, prop, prefix=nil)
-      prefix = prop.to_s if prefix.nil?
-      @set_args[prop] = val.to_s.empty? ? val : "#{prefix} #{val}"
-    end
-
     # probe configuration is all done in a single line (like below)
     # probe tcp port 32 frequency 10 timeout 5 retry-down-count 3 ...
     # probe udp port 23 frequency 10 timeout 5 retry-down-count 3 ...
@@ -113,7 +89,7 @@ module Cisco
     end
 
     def probe_control
-      val = extract_value('control')
+      val = Utils.extract_value('control', nil, probe_get)
       return default_probe_control if val.nil?
       val == 'enable' ? true : default_probe_control
     end
@@ -131,21 +107,21 @@ module Cisco
     end
 
     def probe_dns_host
-      extract_value('dns_host', 'host')
+      Utils.extract_value('dns_host', 'host', probe_get)
     end
 
     def probe_dns_host=(dns_host)
-      attach_prefix(dns_host, :dns_host, 'host')
+      @set_args[:dns_host] = Utils.attach_prefix(dns_host, :dns_host, 'host')
     end
 
     def probe_frequency
-      val = extract_value('frequency')
+      val = Utils.extract_value('frequency', nil, probe_get)
       return default_probe_frequency if val.nil?
       val.to_i
     end
 
     def probe_frequency=(frequency)
-      attach_prefix(frequency, :frequency)
+      @set_args[:frequency] = Utils.attach_prefix(frequency, :frequency)
     end
 
     def default_probe_frequency
@@ -153,22 +129,24 @@ module Cisco
     end
 
     def probe_port
-      val = extract_value('port')
+      val = Utils.extract_value('port', nil, probe_get)
       val.to_i unless val.nil?
     end
 
     def probe_port=(port)
-      attach_prefix(port, :port)
+      @set_args[:port] = Utils.attach_prefix(port, :port)
     end
 
     def probe_retry_down
-      val = extract_value('retry_down', 'retry-down-count')
+      val = Utils.extract_value('retry_down', 'retry-down-count', probe_get)
       return default_probe_retry_down if val.nil?
       val.to_i
     end
 
     def probe_retry_down=(rdc)
-      attach_prefix(rdc, :retry_down_count, 'retry-down-count')
+      @set_args[:retry_down_count] = Utils.attach_prefix(rdc,
+                                                         :retry_down_count,
+                                                         'retry-down-count')
     end
 
     def default_probe_retry_down
@@ -176,13 +154,15 @@ module Cisco
     end
 
     def probe_retry_up
-      val = extract_value('retry_up', 'retry-up-count')
+      val = Utils.extract_value('retry_up', 'retry-up-count', probe_get)
       return default_probe_retry_up if val.nil?
       val.to_i
     end
 
     def probe_retry_up=(ruc)
-      attach_prefix(ruc, :retry_up_count, 'retry-up-count')
+      @set_args[:retry_up_count] = Utils.attach_prefix(ruc,
+                                                       :retry_up_count,
+                                                       'retry-up-count')
     end
 
     def default_probe_retry_up
@@ -190,13 +170,13 @@ module Cisco
     end
 
     def probe_timeout
-      val = extract_value('timeout')
+      val = Utils.extract_value('timeout', nil, probe_get)
       return default_probe_timeout if val.nil?
       val.to_i
     end
 
     def probe_timeout=(timeout)
-      attach_prefix(timeout, :timeout)
+      @set_args[:timeout] = Utils.attach_prefix(timeout, :timeout)
     end
 
     def default_probe_timeout

--- a/lib/cisco_node_utils/itd_device_group.rb
+++ b/lib/cisco_node_utils/itd_device_group.rb
@@ -89,7 +89,7 @@ module Cisco
     end
 
     def probe_control
-      val = Utils.extract_value('control', nil, probe_get)
+      val = Utils.extract_value(probe_get, 'control')
       return default_probe_control if val.nil?
       val == 'enable' ? true : default_probe_control
     end
@@ -107,7 +107,7 @@ module Cisco
     end
 
     def probe_dns_host
-      Utils.extract_value('dns_host', 'host', probe_get)
+      Utils.extract_value(probe_get, 'dns_host', 'host')
     end
 
     def probe_dns_host=(dns_host)
@@ -115,7 +115,7 @@ module Cisco
     end
 
     def probe_frequency
-      val = Utils.extract_value('frequency', nil, probe_get)
+      val = Utils.extract_value(probe_get, 'frequency')
       return default_probe_frequency if val.nil?
       val.to_i
     end
@@ -129,7 +129,7 @@ module Cisco
     end
 
     def probe_port
-      val = Utils.extract_value('port', nil, probe_get)
+      val = Utils.extract_value(probe_get, 'port')
       val.to_i unless val.nil?
     end
 
@@ -138,7 +138,7 @@ module Cisco
     end
 
     def probe_retry_down
-      val = Utils.extract_value('retry_down', 'retry-down-count', probe_get)
+      val = Utils.extract_value(probe_get, 'retry_down', 'retry-down-count')
       return default_probe_retry_down if val.nil?
       val.to_i
     end
@@ -154,7 +154,7 @@ module Cisco
     end
 
     def probe_retry_up
-      val = Utils.extract_value('retry_up', 'retry-up-count', probe_get)
+      val = Utils.extract_value(probe_get, 'retry_up', 'retry-up-count')
       return default_probe_retry_up if val.nil?
       val.to_i
     end
@@ -170,7 +170,7 @@ module Cisco
     end
 
     def probe_timeout
-      val = Utils.extract_value('timeout', nil, probe_get)
+      val = Utils.extract_value(probe_get, 'timeout')
       return default_probe_timeout if val.nil?
       val.to_i
     end

--- a/lib/cisco_node_utils/itd_service.rb
+++ b/lib/cisco_node_utils/itd_service.rb
@@ -80,30 +80,6 @@ module Cisco
       @set_args = @get_args.merge!(hash) unless hash.empty?
     end
 
-    # extract value of property from load-balance
-    def extract_value(prop, prefix=nil)
-      prefix = prop if prefix.nil?
-      lb_match = lb_get
-
-      # matching lb not found
-      return nil if lb_match.nil? # no matching lb found
-
-      # property not defined for matching lb
-      return nil unless lb_match.names.include?(prop)
-
-      # extract and return value that follows prefix + <space>
-      regexp = Regexp.new("#{Regexp.escape(prefix)} (?<extracted>.*)")
-      value_match = regexp.match(lb_match[prop])
-      return nil if value_match.nil?
-      value_match[:extracted]
-    end
-
-    # prepend property name prefix/keyword to value
-    def attach_prefix(val, prop, prefix=nil)
-      prefix = prop.to_s if prefix.nil?
-      @set_args[prop] = val.to_s.empty? ? val : "#{prefix} #{val}"
-    end
-
     def access_list
       config_get('itd_service', 'access_list', @get_args)
     end
@@ -270,13 +246,13 @@ module Cisco
     end
 
     def load_bal_buckets
-      val = extract_value('buckets')
+      val = Utils.extract_value('buckets', nil, lb_get)
       return default_load_bal_buckets if val.nil?
       val.to_i
     end
 
     def load_bal_buckets=(buckets)
-      attach_prefix(buckets, :buckets)
+      @set_args[:buckets] = Utils.attach_prefix(buckets, :buckets)
     end
 
     def default_load_bal_buckets
@@ -284,13 +260,13 @@ module Cisco
     end
 
     def load_bal_mask_pos
-      val = extract_value('mask', 'mask-position')
+      val = Utils.extract_value('mask', 'mask-position', lb_get)
       return default_load_bal_mask_pos if val.nil?
       val.to_i
     end
 
     def load_bal_mask_pos=(mask)
-      attach_prefix(mask, :mask, 'mask-position')
+      @set_args[:mask] = Utils.attach_prefix(mask, :mask, 'mask-position')
     end
 
     def default_load_bal_mask_pos
@@ -313,13 +289,14 @@ module Cisco
     end
 
     def load_bal_method_bundle_select
-      val = extract_value('bundle_select', 'method')
+      val = Utils.extract_value('bundle_select', 'method', lb_get)
       return default_load_bal_method_bundle_select if val.nil?
       val
     end
 
     def load_bal_method_bundle_select=(bs)
-      attach_prefix(bs, :bundle_select, 'method')
+      @set_args[:bundle_select] =
+          Utils.attach_prefix(bs, :bundle_select, 'method')
     end
 
     def default_load_bal_method_bundle_select
@@ -342,13 +319,13 @@ module Cisco
     end
 
     def load_bal_method_start_port
-      val = extract_value('start_port', 'range')
+      val = Utils.extract_value('start_port', 'range', lb_get)
       return default_load_bal_method_start_port if val.nil?
       val.to_i
     end
 
     def load_bal_method_start_port=(start)
-      attach_prefix(start, :start_port, 'range')
+      @set_args[:start_port] = Utils.attach_prefix(start, :start_port, 'range')
     end
 
     def default_load_bal_method_start_port

--- a/lib/cisco_node_utils/itd_service.rb
+++ b/lib/cisco_node_utils/itd_service.rb
@@ -246,7 +246,7 @@ module Cisco
     end
 
     def load_bal_buckets
-      val = Utils.extract_value('buckets', nil, lb_get)
+      val = Utils.extract_value(lb_get, 'buckets')
       return default_load_bal_buckets if val.nil?
       val.to_i
     end
@@ -260,7 +260,7 @@ module Cisco
     end
 
     def load_bal_mask_pos
-      val = Utils.extract_value('mask', 'mask-position', lb_get)
+      val = Utils.extract_value(lb_get, 'mask', 'mask-position')
       return default_load_bal_mask_pos if val.nil?
       val.to_i
     end
@@ -289,7 +289,7 @@ module Cisco
     end
 
     def load_bal_method_bundle_select
-      val = Utils.extract_value('bundle_select', 'method', lb_get)
+      val = Utils.extract_value(lb_get, 'bundle_select', 'method')
       return default_load_bal_method_bundle_select if val.nil?
       val
     end
@@ -319,7 +319,7 @@ module Cisco
     end
 
     def load_bal_method_start_port
-      val = Utils.extract_value('start_port', 'range', lb_get)
+      val = Utils.extract_value(lb_get, 'start_port', 'range')
       return default_load_bal_method_start_port if val.nil?
       val.to_i
     end

--- a/lib/cisco_node_utils/route_map.rb
+++ b/lib/cisco_node_utils/route_map.rb
@@ -470,7 +470,7 @@ module Cisco
     end
 
     def match_ipv4_multicast_src_addr
-      val = Utils.extract_value('src', 'source', match_ipv4_multicast_get)
+      val = Utils.extract_value(match_ipv4_multicast_get, 'src', 'source')
       return default_match_ipv4_multicast_src_addr if val.nil?
       val
     end
@@ -484,7 +484,7 @@ module Cisco
     end
 
     def match_ipv4_multicast_group_addr
-      val = Utils.extract_value('grp', 'group', match_ipv4_multicast_get)
+      val = Utils.extract_value(match_ipv4_multicast_get, 'grp', 'group')
       return default_match_ipv4_multicast_group_addr if val.nil?
       val
     end
@@ -498,8 +498,8 @@ module Cisco
     end
 
     def match_ipv4_multicast_group_range_begin_addr
-      val = Utils.extract_value('grp_range_start', 'group-range',
-                                match_ipv4_multicast_get)
+      val = Utils.extract_value(match_ipv4_multicast_get,
+                                'grp_range_start', 'group-range')
       return default_match_ipv4_multicast_group_range_begin_addr if val.nil?
       val
     end
@@ -515,7 +515,7 @@ module Cisco
     end
 
     def match_ipv4_multicast_group_range_end_addr
-      val = Utils.extract_value('grp_range_end', 'to', match_ipv4_multicast_get)
+      val = Utils.extract_value(match_ipv4_multicast_get, 'grp_range_end', 'to')
       return default_match_ipv4_multicast_group_range_end_addr if val.nil?
       val
     end
@@ -530,7 +530,7 @@ module Cisco
     end
 
     def match_ipv4_multicast_rp_addr
-      val = Utils.extract_value('rp', nil, match_ipv4_multicast_get)
+      val = Utils.extract_value(match_ipv4_multicast_get, 'rp')
       return default_match_ipv4_multicast_rp_addr if val.nil?
       val
     end
@@ -544,7 +544,7 @@ module Cisco
     end
 
     def match_ipv4_multicast_rp_type
-      val = Utils.extract_value('rp_type', 'rp-type', match_ipv4_multicast_get)
+      val = Utils.extract_value(match_ipv4_multicast_get, 'rp_type', 'rp-type')
       return default_match_ipv4_multicast_rp_type if val.nil?
       val
     end
@@ -727,7 +727,7 @@ module Cisco
     end
 
     def match_ipv6_multicast_src_addr
-      val = Utils.extract_value('src', 'source', match_ipv6_multicast_get)
+      val = Utils.extract_value(match_ipv6_multicast_get, 'src', 'source')
       return default_match_ipv6_multicast_src_addr if val.nil?
       val
     end
@@ -741,7 +741,7 @@ module Cisco
     end
 
     def match_ipv6_multicast_group_addr
-      val = Utils.extract_value('grp', 'group', match_ipv6_multicast_get)
+      val = Utils.extract_value(match_ipv6_multicast_get, 'grp', 'group')
       return default_match_ipv6_multicast_group_addr if val.nil?
       val
     end
@@ -755,8 +755,8 @@ module Cisco
     end
 
     def match_ipv6_multicast_group_range_begin_addr
-      val = Utils.extract_value('grp_range_start', 'group-range',
-                                match_ipv6_multicast_get)
+      val = Utils.extract_value(match_ipv6_multicast_get,
+                                'grp_range_start', 'group-range')
       return default_match_ipv6_multicast_group_range_begin_addr if val.nil?
       val
     end
@@ -772,7 +772,7 @@ module Cisco
     end
 
     def match_ipv6_multicast_group_range_end_addr
-      val = Utils.extract_value('grp_range_end', 'to', match_ipv6_multicast_get)
+      val = Utils.extract_value(match_ipv6_multicast_get, 'grp_range_end', 'to')
       return default_match_ipv6_multicast_group_range_end_addr if val.nil?
       val
     end
@@ -787,7 +787,7 @@ module Cisco
     end
 
     def match_ipv6_multicast_rp_addr
-      val = Utils.extract_value('rp', nil, match_ipv6_multicast_get)
+      val = Utils.extract_value(match_ipv6_multicast_get, 'rp')
       return default_match_ipv6_multicast_rp_addr if val.nil?
       val
     end
@@ -801,7 +801,7 @@ module Cisco
     end
 
     def match_ipv6_multicast_rp_type
-      val = Utils.extract_value('rp_type', 'rp-type', match_ipv6_multicast_get)
+      val = Utils.extract_value(match_ipv6_multicast_get, 'rp_type', 'rp-type')
       return default_match_ipv6_multicast_rp_type if val.nil?
       val
     end

--- a/lib/cisco_node_utils/route_map.rb
+++ b/lib/cisco_node_utils/route_map.rb
@@ -453,31 +453,6 @@ module Cisco
       config_get_default('route_map', 'match_ipv4_route_src_prefix_list')
     end
 
-    # extract value of property from match ip multicast
-    def extract_value(type, prop, prefix=nil)
-      prefix = prop if prefix.nil?
-      match =
-        type == 'ipv4' ? match_ipv4_multicast_get : match_ipv6_multicast_get
-
-      # matching not found
-      return nil if match.nil? # no matching found
-
-      # property not defined for matching
-      return nil unless match.names.include?(prop)
-
-      # extract and return value that follows prefix + <space>
-      regexp = Regexp.new("#{Regexp.escape(prefix)} (?<extracted>.*)")
-      value_match = regexp.match(match[prop])
-      return nil if value_match.nil?
-      value_match[:extracted]
-    end
-
-    # prepend property name prefix/keyword to value
-    def attach_prefix(val, prop, prefix=nil)
-      prefix = prop.to_s if prefix.nil?
-      @set_args[prop] = val.to_s.empty? ? val : "#{prefix} #{val}"
-    end
-
     # match ip multicast source 242.1.1.1/32 group 239.2.2.2/32 rp 242.1.1.1/32
     #                    rp-type ASM
     # match ip multicast source 242.1.1.1/32 group-range
@@ -495,13 +470,13 @@ module Cisco
     end
 
     def match_ipv4_multicast_src_addr
-      val = extract_value('ipv4', 'src', 'source')
+      val = Utils.extract_value('src', 'source', match_ipv4_multicast_get)
       return default_match_ipv4_multicast_src_addr if val.nil?
       val
     end
 
     def match_ipv4_multicast_src_addr=(src_addr)
-      attach_prefix(src_addr, :source)
+      @set_args[:source] = Utils.attach_prefix(src_addr, :source)
     end
 
     def default_match_ipv4_multicast_src_addr
@@ -509,13 +484,13 @@ module Cisco
     end
 
     def match_ipv4_multicast_group_addr
-      val = extract_value('ipv4', 'grp', 'group')
+      val = Utils.extract_value('grp', 'group', match_ipv4_multicast_get)
       return default_match_ipv4_multicast_group_addr if val.nil?
       val
     end
 
     def match_ipv4_multicast_group_addr=(grp_addr)
-      attach_prefix(grp_addr, :group)
+      @set_args[:group] = Utils.attach_prefix(grp_addr, :group)
     end
 
     def default_match_ipv4_multicast_group_addr
@@ -523,13 +498,15 @@ module Cisco
     end
 
     def match_ipv4_multicast_group_range_begin_addr
-      val = extract_value('ipv4', 'grp_range_start', 'group-range')
+      val = Utils.extract_value('grp_range_start', 'group-range',
+                                match_ipv4_multicast_get)
       return default_match_ipv4_multicast_group_range_begin_addr if val.nil?
       val
     end
 
     def match_ipv4_multicast_group_range_begin_addr=(begin_addr)
-      attach_prefix(begin_addr, :group_range, :'group-range')
+      @set_args[:group_range] =
+          Utils.attach_prefix(begin_addr, :group_range, :'group-range')
     end
 
     def default_match_ipv4_multicast_group_range_begin_addr
@@ -538,13 +515,13 @@ module Cisco
     end
 
     def match_ipv4_multicast_group_range_end_addr
-      val = extract_value('ipv4', 'grp_range_end', 'to')
+      val = Utils.extract_value('grp_range_end', 'to', match_ipv4_multicast_get)
       return default_match_ipv4_multicast_group_range_end_addr if val.nil?
       val
     end
 
     def match_ipv4_multicast_group_range_end_addr=(end_addr)
-      attach_prefix(end_addr, :to)
+      @set_args[:to] = Utils.attach_prefix(end_addr, :to)
     end
 
     def default_match_ipv4_multicast_group_range_end_addr
@@ -553,13 +530,13 @@ module Cisco
     end
 
     def match_ipv4_multicast_rp_addr
-      val = extract_value('ipv4', 'rp')
+      val = Utils.extract_value('rp', nil, match_ipv4_multicast_get)
       return default_match_ipv4_multicast_rp_addr if val.nil?
       val
     end
 
     def match_ipv4_multicast_rp_addr=(rp_addr)
-      attach_prefix(rp_addr, :rp)
+      @set_args[:rp] = Utils.attach_prefix(rp_addr, :rp)
     end
 
     def default_match_ipv4_multicast_rp_addr
@@ -567,13 +544,13 @@ module Cisco
     end
 
     def match_ipv4_multicast_rp_type
-      val = extract_value('ipv4', 'rp_type', 'rp-type')
+      val = Utils.extract_value('rp_type', 'rp-type', match_ipv4_multicast_get)
       return default_match_ipv4_multicast_rp_type if val.nil?
       val
     end
 
     def match_ipv4_multicast_rp_type=(type)
-      attach_prefix(type, :rp_type, :'rp-type')
+      @set_args[:rp_type] = Utils.attach_prefix(type, :rp_type, :'rp-type')
     end
 
     def default_match_ipv4_multicast_rp_type
@@ -750,13 +727,13 @@ module Cisco
     end
 
     def match_ipv6_multicast_src_addr
-      val = extract_value('ipv6', 'src', 'source')
+      val = Utils.extract_value('src', 'source', match_ipv6_multicast_get)
       return default_match_ipv6_multicast_src_addr if val.nil?
       val
     end
 
     def match_ipv6_multicast_src_addr=(src_addr)
-      attach_prefix(src_addr, :source)
+      @set_args[:source] = Utils.attach_prefix(src_addr, :source)
     end
 
     def default_match_ipv6_multicast_src_addr
@@ -764,13 +741,13 @@ module Cisco
     end
 
     def match_ipv6_multicast_group_addr
-      val = extract_value('ipv6', 'grp', 'group')
+      val = Utils.extract_value('grp', 'group', match_ipv6_multicast_get)
       return default_match_ipv6_multicast_group_addr if val.nil?
       val
     end
 
     def match_ipv6_multicast_group_addr=(grp_addr)
-      attach_prefix(grp_addr, :group)
+      @set_args[:group] = Utils.attach_prefix(grp_addr, :group)
     end
 
     def default_match_ipv6_multicast_group_addr
@@ -778,13 +755,15 @@ module Cisco
     end
 
     def match_ipv6_multicast_group_range_begin_addr
-      val = extract_value('ipv6', 'grp_range_start', 'group-range')
+      val = Utils.extract_value('grp_range_start', 'group-range',
+                                match_ipv6_multicast_get)
       return default_match_ipv6_multicast_group_range_begin_addr if val.nil?
       val
     end
 
     def match_ipv6_multicast_group_range_begin_addr=(begin_addr)
-      attach_prefix(begin_addr, :group_range, :'group-range')
+      @set_args[:group_range] =
+          Utils.attach_prefix(begin_addr, :group_range, :'group-range')
     end
 
     def default_match_ipv6_multicast_group_range_begin_addr
@@ -793,13 +772,13 @@ module Cisco
     end
 
     def match_ipv6_multicast_group_range_end_addr
-      val = extract_value('ipv6', 'grp_range_end', 'to')
+      val = Utils.extract_value('grp_range_end', 'to', match_ipv6_multicast_get)
       return default_match_ipv6_multicast_group_range_end_addr if val.nil?
       val
     end
 
     def match_ipv6_multicast_group_range_end_addr=(end_addr)
-      attach_prefix(end_addr, :to)
+      @set_args[:to] = Utils.attach_prefix(end_addr, :to)
     end
 
     def default_match_ipv6_multicast_group_range_end_addr
@@ -808,13 +787,13 @@ module Cisco
     end
 
     def match_ipv6_multicast_rp_addr
-      val = extract_value('ipv6', 'rp')
+      val = Utils.extract_value('rp', nil, match_ipv6_multicast_get)
       return default_match_ipv6_multicast_rp_addr if val.nil?
       val
     end
 
     def match_ipv6_multicast_rp_addr=(rp_addr)
-      attach_prefix(rp_addr, :rp)
+      @set_args[:rp] = Utils.attach_prefix(rp_addr, :rp)
     end
 
     def default_match_ipv6_multicast_rp_addr
@@ -822,13 +801,13 @@ module Cisco
     end
 
     def match_ipv6_multicast_rp_type
-      val = extract_value('ipv6', 'rp_type', 'rp-type')
+      val = Utils.extract_value('rp_type', 'rp-type', match_ipv6_multicast_get)
       return default_match_ipv6_multicast_rp_type if val.nil?
       val
     end
 
     def match_ipv6_multicast_rp_type=(type)
-      attach_prefix(type, :rp_type, :'rp-type')
+      @set_args[:rp_type] = Utils.attach_prefix(type, :rp_type, :'rp-type')
     end
 
     def default_match_ipv6_multicast_rp_type

--- a/tests/test_bgp_af_aa.rb
+++ b/tests/test_bgp_af_aa.rb
@@ -1,0 +1,108 @@
+# Copyright (c) 2017 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/bgp_af'
+require_relative '../lib/cisco_node_utils/bgp_af_aggr_addr'
+
+include Cisco
+# TestBgpAfAggrAddr - Minitest for BgpAFAggrAddr class
+class TestBgpAfAggrAddr < CiscoTestCase
+  @@pre_clean_needed = true # rubocop:disable Style/ClassVars
+
+  def setup
+    super
+    config('no feature bgp')
+    remove_all_vrfs if @@pre_clean_needed
+    @@pre_clean_needed = false # rubocop:disable Style/ClassVars
+  end
+
+  def teardown
+    config('no feature bgp')
+    remove_all_vrfs
+    super
+  end
+
+  def test_collection_empty
+    node.cache_flush
+    aas = RouterBgpAFAggrAddr.aas
+    assert_empty(aas, 'BGP AF Aggregate Address collection is not empty')
+  end
+
+  def test_collection_not_empty
+    bgp_af = []
+    bgp_af_aa = []
+    %w(default red).each do |vrf|
+      [%w(ipv4 unicast), %w(ipv6 unicast),
+       %w(ipv4 multicast), %w(ipv6 multicast)].each do |af|
+        bgp_af.push(RouterBgpAF.new(55, vrf, af))
+        if af[0] == 'ipv4'
+          ['1.1.1.0/24', '2.2.2.2/32'].each do |addr|
+            bgp_af_aa.push(RouterBgpAFAggrAddr.new(55, vrf, af, addr))
+          end
+        else
+          ['2001::12/128', '2000::31/128'].each do |addr|
+            bgp_af_aa.push(RouterBgpAFAggrAddr.new(55, vrf, af, addr))
+          end
+        end
+        assert_equal(2, RouterBgpAFAggrAddr.aas[55][vrf][af].size)
+      end
+    end
+  end
+
+  def test_destroy
+    af = %w(ipv4 unicast)
+    RouterBgpAF.new(55, 'red', af)
+    obj = RouterBgpAFAggrAddr.new(55, 'red', af, '1.1.1.0/24')
+    aas = RouterBgpAFAggrAddr.aas[55]['red'][af]
+    assert_equal(1, aas.size)
+    obj.destroy
+    aas = RouterBgpAFAggrAddr.aas[55]['red'][af]
+    assert_empty(aas, 'BGP AF Aggregate Address collection is not empty')
+  end
+
+  def aa_helper(props)
+    af = %w(ipv4 unicast)
+    RouterBgpAF.new(55, 'red', af)
+    obj = RouterBgpAFAggrAddr.new(55, 'red', af, '1.1.1.0/24')
+    test_hash = {
+      advertise_map: obj.default_advertise_map,
+      as_set:        obj.default_as_set,
+      attribute_map: obj.default_attribute_map,
+      summary_only:  obj.default_summary_only,
+      suppress_map:  obj.default_suppress_map,
+    }.merge!(props)
+    obj.aa_set(test_hash)
+    obj
+  end
+
+  def test_aa
+    obj = aa_helper(advertise_map: 'adm',
+                    as_set:        true,
+                    attribute_map: 'atm',
+                    suppress_map:  'sum')
+    assert(obj.as_set)
+    assert_equal('adm', obj.advertise_map)
+    assert_equal('atm', obj.attribute_map)
+    assert_equal('sum', obj.suppress_map)
+    obj = aa_helper(advertise_map: 'adm',
+                    as_set:        true,
+                    attribute_map: 'atm',
+                    summary_only:  true)
+    assert(obj.as_set)
+    assert(obj.summary_only)
+    assert_equal('adm', obj.advertise_map)
+    assert_equal('atm', obj.attribute_map)
+  end
+end


### PR DESCRIPTION
This PR is for adding a new provider bgp_af_aggr_addr which was requested in the enhancement https://github.com/cisco/cisco-network-puppet-module/issues/452

Also couple of methods "attach_prefix" and "extract_value" have been moved to Utils as they are being used in many providers and same code is getting copied in many places. 

All tests pass on all platforms.