### PR TITLE
Object_group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## [Unreleased]
 
+#### Cisco Resources
+* ObjectGroup
+  * object_group (@saichint)
+  * object_group_entry (@saichint)
+
 ## [v1.7.0]
 
 ### New feature support

--- a/lib/cisco_node_utils/cmd_ref/object_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/object_group.yaml
@@ -1,6 +1,6 @@
 # object_group
 ---
-_exclude: [ios_xr]
+_exclude: [N5k, N6k, ios_xr]
 
 _template:
   get_command: "show running-config | section object-group"

--- a/lib/cisco_node_utils/cmd_ref/object_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/object_group.yaml
@@ -1,0 +1,32 @@
+# object_group
+---
+_exclude: [ios_xr]
+
+_template:
+  get_command: "show running-config | section object-group"
+  get_context: ['/^object-group <afi> <type> <grp_name>/']
+  set_context: ["object-group <afi> <type> <grp_name>"]
+
+all_entries:
+  multiple:
+  get_value: '/^(\d+) .+$/'
+
+all_object_groups:
+  multiple:
+  get_context: ~
+  get_value: '/^object-group (\S+) (\S+) (\S+)$/'
+
+create:
+  set_context: ~
+  set_value: "object-group <afi> <type> <grp_name>"
+
+destroy:
+  set_context: ~
+  set_value: "no object-group <afi> <type> <grp_name>"
+
+entry:
+  get_value: '/^<seqno> .+$/'
+  set_value: "<state> <seqno> <address> <port>"
+
+entry_destroy:
+  set_value: 'no <seqno>'

--- a/lib/cisco_node_utils/object_group.rb
+++ b/lib/cisco_node_utils/object_group.rb
@@ -1,0 +1,75 @@
+#
+# May 2017, Sai Chintalapudi
+#
+# Copyright (c) 2017 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'node_util'
+require_relative 'acl'
+
+module Cisco
+  # node_utils class for object_group
+  class ObjectGroup < NodeUtil
+    attr_reader :afi, :type, :grp_name
+
+    def initialize(afi, type, name, instantiate=true)
+      fail TypeError unless name.is_a?(String)
+      fail ArgumentError unless type[/address|port/]
+      @afi = Acl.afi_cli(afi)
+      @type = type
+      @grp_name = name
+
+      set_args_keys_default
+      create if instantiate
+    end
+
+    # Helper method to delete @set_args hash keys
+    def set_args_keys_default
+      @set_args = { afi: @afi, type: @type, grp_name: @grp_name }
+      @get_args = @set_args
+    end
+
+    # rubocop:disable Style/AccessorMethodName
+    def set_args_keys(hash={})
+      set_args_keys_default
+      @set_args = @get_args.merge!(hash) unless hash.empty?
+    end
+
+    def create
+      config_set('object_group', 'create', @set_args)
+    end
+
+    def destroy
+      config_set('object_group', 'destroy', @set_args)
+    end
+
+    def ==(other)
+      grp_name == other.grp_name && afi == other.afi && type == other.type
+    end
+
+    def self.object_groups
+      hash = {}
+      grps = config_get('object_group', 'all_object_groups')
+      return hash if grps.nil?
+      grps.each do |afi, type, name|
+        lafi = afi
+        lafi = 'ipv4' if afi == 'ip'
+        hash[lafi] ||= {}
+        hash[lafi][type] ||= {}
+        hash[lafi][type][name] = ObjectGroup.new(lafi, type, name, false)
+      end
+      hash
+    end
+  end # class
+end # module

--- a/lib/cisco_node_utils/object_group_entry.rb
+++ b/lib/cisco_node_utils/object_group_entry.rb
@@ -1,0 +1,142 @@
+#
+# May 2017, Sai Chintalapudi
+#
+# Copyright (c) 2017 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'node_util'
+require_relative 'acl'
+require_relative 'object_group'
+
+module Cisco
+  # node_utils class for object_group_entry
+  class ObjectGroupEntry < NodeUtil
+    attr_reader :afi, :type, :grp_name
+
+    def initialize(afi, type, name, seqno)
+      fail TypeError unless name.is_a?(String)
+      fail ArgumentError unless type[/address|port/]
+      @afi = Acl.afi_cli(afi)
+      @type = type
+      @grp_name = name
+      @seqno = seqno
+      og = ObjectGroup.object_groups[afi][type][name]
+      fail "ObjectGroup #{afi} #{type} #{name} does not exist" if
+        og.nil?
+      set_args_keys_default
+    end
+
+    # Helper method to delete @set_args hash keys
+    def set_args_keys_default
+      @set_args = { afi: @afi, type: @type, grp_name: @grp_name, seqno: @seqno }
+      @get_args = @set_args
+    end
+
+    # rubocop:disable Style/AccessorMethodName
+    def set_args_keys(hash={})
+      set_args_keys_default
+      @set_args = @get_args.merge!(hash) unless hash.empty?
+    end
+
+    def destroy
+      config_set('object_group', 'entry_destroy', @set_args)
+    end
+
+    def self.object_group_entries
+      hash = {}
+      grps = config_get('object_group', 'all_object_groups')
+      return hash if grps.nil?
+      grps.each do |afi, type, name|
+        lafi = afi
+        lafi = 'ipv4' if afi == 'ip'
+        hash[lafi] ||= {}
+        hash[lafi][type] ||= {}
+        hash[lafi][type][name] ||= {}
+        entries = config_get('object_group', 'all_entries',
+                             afi:      Acl.afi_cli(afi),
+                             type:     type,
+                             grp_name: name)
+        next if entries.nil?
+        entries.each do |seqno|
+          hash[lafi][type][name][seqno] =
+            ObjectGroupEntry.new(afi, type, name, seqno)
+        end
+      end
+      hash
+    end
+
+    def entry_get
+      str = config_get('object_group', 'entry', @get_args)
+      return nil if str.nil?
+      str = str.strip
+
+      # rubocop:disable Metrics/LineLength
+      regexp = Regexp.new('(?<seqno>\d+)'\
+                          ' *(?<address>host \S+|[:\.0-9a-fA-F]+ [:\.0-9a-fA-F]+|[:\.0-9a-fA-F]+\/\d+)?'\
+                          ' *(?<port>range \S+ \S+|(lt|eq|gt|neq) \S+)?')
+      # rubocop:enable Metrics/LineLength
+      regexp.match(str)
+    end
+
+    def entry_set(attrs)
+      if attrs.empty?
+        attrs[:state] = 'no'
+      else
+        destroy if seqno
+        attrs[:state] = ''
+      end
+      set_args_keys_default
+      set_args_keys(attrs)
+      [:address,
+       :port,
+      ].each do |p|
+        attrs[p] = '' if attrs[p].nil?
+        send(p.to_s + '=', attrs[p])
+      end
+      @get_args = @set_args
+      config_set('object_group', 'entry', @set_args)
+    end
+
+    # PROPERTIES
+    # ----------
+    def seqno
+      match = entry_get
+      return nil if match.nil?
+      match.names.include?('seqno') ? match[:seqno] : nil
+    end
+
+    def address
+      match = entry_get
+      return nil if match.nil? || !match.names.include?('address')
+      addr = match[:address]
+      # Normalize addr. Some platforms zero_pad ipv6 addrs.
+      addr.gsub!(/^0*/, '').gsub!(/:0*/, ':')
+      addr
+    end
+
+    def address=(address)
+      @set_args[:address] = address
+    end
+
+    def port
+      match = entry_get
+      return nil if match.nil?
+      match.names.include?('port') ? match[:port] : nil
+    end
+
+    def port=(port)
+      @set_args[:port] = port
+    end
+  end # class
+end # module

--- a/lib/cisco_node_utils/object_group_entry.rb
+++ b/lib/cisco_node_utils/object_group_entry.rb
@@ -31,7 +31,7 @@ module Cisco
       @type = type
       @grp_name = name
       @seqno = seqno
-      og = ObjectGroup.object_groups[afi][type][name]
+      og = ObjectGroup.object_groups[afi.to_s][type.to_s][name.to_s]
       fail "ObjectGroup #{afi} #{type} #{name} does not exist" if
         og.nil?
       set_args_keys_default
@@ -64,13 +64,13 @@ module Cisco
         hash[lafi][type] ||= {}
         hash[lafi][type][name] ||= {}
         entries = config_get('object_group', 'all_entries',
-                             afi:      Acl.afi_cli(afi),
+                             afi:      Acl.afi_cli(lafi),
                              type:     type,
                              grp_name: name)
         next if entries.nil?
         entries.each do |seqno|
           hash[lafi][type][name][seqno] =
-            ObjectGroupEntry.new(afi, type, name, seqno)
+            ObjectGroupEntry.new(lafi, type, name, seqno)
         end
       end
       hash
@@ -118,8 +118,9 @@ module Cisco
 
     def address
       match = entry_get
-      return nil if match.nil? || !match.names.include?('address')
+      return nil if match.nil?
       addr = match[:address]
+      return nil if addr.nil?
       # Normalize addr. Some platforms zero_pad ipv6 addrs.
       addr.gsub!(/^0*/, '').gsub!(/:0*/, ':')
       addr

--- a/tests/test_object_group.rb
+++ b/tests/test_object_group.rb
@@ -1,0 +1,125 @@
+# Copyright (c) 2017 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative 'ciscotest'
+require_relative '../lib/cisco_node_utils/object_group'
+require_relative '../lib/cisco_node_utils/object_group_entry'
+
+# TestObject_group - Minitest for Object_group
+# node utility class
+class TestObjectGroup < CiscoTestCase
+  def setup
+    super
+    @og_name_v4 = 'test-my-v4'
+    @og_name_v6 = 'test-my-v6'
+    @og_name_port = 'test-my-port'
+    no_og_list_my
+  end
+
+  def teardown
+    no_og_list_my
+    super
+  end
+
+  def no_og_list_my
+    %w(ip ipv6).each do |afi|
+      og_name = afi[/ipv6/] ? @og_name_v6 : @og_name_v4
+      config_no_warn('no object-group ' + afi + ' address ' + og_name)
+    end
+    config_no_warn('no object-group ip port ' + @og_name_port)
+  end
+
+  def test_create_object_group
+    %w(ipv4 ipv6).each do |afi|
+      og_name = afi[/ipv6/] ? @og_name_v6 : @og_name_v4
+      og = ObjectGroup.new(afi, 'address', og_name)
+      assert(ObjectGroup.object_groups[afi]['address'].key?(og_name))
+      og.destroy
+      assert_nil(ObjectGroup.object_groups[afi])
+    end
+    og_name = @og_name_port
+    og = ObjectGroup.new('ipv4', 'port', og_name)
+    assert(ObjectGroup.object_groups['ipv4']['port'].key?(og_name))
+    og.destroy
+    assert_nil(ObjectGroup.object_groups['ipv4'])
+  end
+
+  def entry_helper(afi, type, name, props=nil)
+    test_hash = {
+      address: 'host 1.1.1.1',
+      port:    'eq 200',
+    }
+    test_hash.merge!(props) unless props.nil?
+
+    ObjectGroup.new(afi, type, name)
+    e = ObjectGroupEntry.new(afi, type, name, 10)
+    e.entry_set(test_hash)
+    e
+  end
+
+  def test_ipv4_address_host
+    e = entry_helper('ipv4', 'address', @og_name_v4, port: nil)
+    assert_equal('host 1.1.1.1', e.address)
+    e = entry_helper('ipv4', 'address', @og_name_v4, address: 'host 2.2.2.2', port: nil)
+    assert_equal('host 2.2.2.2', e.address)
+  end
+
+  def test_ipv4_address_prefix
+    e = entry_helper('ipv4', 'address', @og_name_v4, address: '2.2.2.2/17', port: nil)
+    assert_equal('2.2.2.2/17', e.address)
+    e = entry_helper('ipv4', 'address', @og_name_v4, address: '3.3.3.3/31', port: nil)
+    assert_equal('3.3.3.3/31', e.address)
+  end
+
+  def test_ipv4_address_netmask
+    e = entry_helper('ipv4', 'address', @og_name_v4, address: '2.2.2.2 255.255.255.0', port: nil)
+    assert_equal('2.2.2.2 255.255.255.0', e.address)
+    e = entry_helper('ipv4', 'address', @og_name_v4, address: '3.3.3.3 10.11.12.13', port: nil)
+    assert_equal('3.3.3.3 10.11.12.13', e.address)
+  end
+
+  def test_ipv6_address_host
+    e = entry_helper('ipv6', 'address', @og_name_v6, address: 'host 2000::1', port: nil)
+    assert_equal('host 2000::1', e.address)
+    e = entry_helper('ipv6', 'address', @og_name_v6, address: 'host 2001::2', port: nil)
+    assert_equal('host 2001::2', e.address)
+  end
+
+  def test_ipv6_address_prefix
+    e = entry_helper('ipv6', 'address', @og_name_v6, address: '2000::1/127', port: nil)
+    assert_equal('2000::1/127', e.address)
+    e = entry_helper('ipv6', 'address', @og_name_v6, address: '2001::10/64', port: nil)
+    assert_equal('2001::10/64', e.address)
+  end
+
+  def test_ipv6_address_netmask
+    e = entry_helper('ipv6', 'address', @og_name_v6, address: '2000::1 2001::10', port: nil)
+    assert_equal('2000::1 2001::10', e.address)
+    e = entry_helper('ipv6', 'address', @og_name_v6, address: '2001::10 2002::2', port: nil)
+    assert_equal('2001::10 2002::2', e.address)
+  end
+
+  def test_ipv4_port
+    e = entry_helper('ipv4', 'port', @og_name_port, address: nil)
+    assert_equal('eq 200', e.port)
+    e = entry_helper('ipv4', 'port', @og_name_port, port: 'lt 100', address: nil)
+    assert_equal('lt 100', e.port)
+    e = entry_helper('ipv4', 'port', @og_name_port, port: 'neq 150', address: nil)
+    assert_equal('neq 150', e.port)
+    e = entry_helper('ipv4', 'port', @og_name_port, port: 'gt 350', address: nil)
+    assert_equal('gt 350', e.port)
+    e = entry_helper('ipv4', 'port', @og_name_port, port: 'range 400 1000', address: nil)
+    assert_equal('range 400 1000', e.port)
+  end
+end

--- a/tests/test_object_group.rb
+++ b/tests/test_object_group.rb
@@ -19,6 +19,7 @@ require_relative '../lib/cisco_node_utils/object_group_entry'
 # TestObject_group - Minitest for Object_group
 # node utility class
 class TestObjectGroup < CiscoTestCase
+  @skip_unless_supported = 'object_group'
   @@pre_clean_needed = true # rubocop:disable Style/ClassVars
 
   def setup

--- a/tests/test_object_group.rb
+++ b/tests/test_object_group.rb
@@ -19,25 +19,28 @@ require_relative '../lib/cisco_node_utils/object_group_entry'
 # TestObject_group - Minitest for Object_group
 # node utility class
 class TestObjectGroup < CiscoTestCase
+  @@pre_clean_needed = true # rubocop:disable Style/ClassVars
+
   def setup
     super
     @og_name_v4 = 'test-my-v4'
     @og_name_v6 = 'test-my-v6'
     @og_name_port = 'test-my-port'
-    no_og_list_my
+    remove_all_object_groups if @@pre_clean_needed
+    @@pre_clean_needed = false # rubocop:disable Style/ClassVars
   end
 
   def teardown
-    no_og_list_my
+    remove_all_object_groups
     super
   end
 
-  def no_og_list_my
-    %w(ip ipv6).each do |afi|
-      og_name = afi[/ipv6/] ? @og_name_v6 : @og_name_v4
-      config_no_warn('no object-group ' + afi + ' address ' + og_name)
+  def remove_all_object_groups
+    ObjectGroup.object_groups.each do |_afis, types|
+      types.each do |_type, grps|
+        grps.values.each(&:destroy)
+      end
     end
-    config_no_warn('no object-group ip port ' + @og_name_port)
   end
 
   def test_create_object_group


### PR DESCRIPTION
This PR is for adding node utils for object_group and object_group_entry. object_group is just for creating an object_group as a parent for object_group_entry. It has no properties. object_group_entry is similar to cisco_ace provider and it has 2 properties for creating ip address and port entries.
All minitest pass.