### PR TITLE
fixes for greensboro

### DIFF
--- a/lib/cisco_node_utils/tacacs_server.rb
+++ b/lib/cisco_node_utils/tacacs_server.rb
@@ -30,11 +30,7 @@ module Cisco
 
     # Check feature enablement
     def self.enabled
-      config_get('tacacs_server', 'feature')
-    rescue Cisco::CliError => e
-      # cmd will syntax reject when feature is not enabled
-      raise unless e.clierror =~ /Syntax error/
-      return false
+      Feature.tacacs_enabled?
     end
 
     # Enable tacacs_server feature

--- a/lib/cisco_node_utils/vpc.rb
+++ b/lib/cisco_node_utils/vpc.rb
@@ -35,13 +35,10 @@ module Cisco
 
     def self.domains
       hash = {}
+      return hash unless Vpc.enabled
       my_domain = config_get('vpc', 'domain')
       hash[my_domain] = Vpc.new(my_domain, false) unless my_domain.nil?
       hash
-    rescue Cisco::CliError => e
-      # cmd will syntax reject when feature is not enabled
-      raise unless e.clierror =~ /Syntax error/
-      return {}
     end
 
     def self.enabled

--- a/lib/cisco_node_utils/vtp.rb
+++ b/lib/cisco_node_utils/vtp.rb
@@ -32,10 +32,12 @@ module Cisco
 
     # Get vtp domain name
     def self.domain
+      dom_def = config_get_default('vtp', 'domain')
       if Feature.vtp_enabled?
-        config_get('vtp', 'domain')
+        dom = config_get('vtp', 'domain')
+        return dom == '-' ? dom_def : dom
       else
-        config_get_default('vtp', 'domain')
+        dom_def
       end
     end
 

--- a/tests/test_vpc.rb
+++ b/tests/test_vpc.rb
@@ -138,6 +138,9 @@ class TestVpc < CiscoTestCase
     assert(vpc.layer3_peer_routing, 'layer3_peer_routing not getting set')
     vpc.layer3_peer_routing = false
     refute(vpc.layer3_peer_routing, 'layer3_peer_routing not getting disabled')
+    # reset peer gateway
+    vpc.peer_gateway = false
+    assert_equal(vpc.default_peer_gateway, vpc.peer_gateway)
   end
 
   def test_peer_keepalive


### PR DESCRIPTION
This PR is for fixing few minitest errors on greenboro.

1. show commands fail due to feature not enabled.
2. vtp domain is returning '-' for default instead of empty.
3. vpc peer_gateway is being changed during layer3_peer_routing set and peer_gateway test is checking for default value and so this test is failing based on the order of test execution. 

All required tests pass