### PR TITLE
Fix bgp, ospf, and route map testcases

### DIFF
--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -56,9 +56,9 @@ module Cisco
       end
       hash_final.merge!(hash_tmp)
       return hash_final
-    rescue Cisco::CliError => e
-      # cmd will syntax reject when feature is not enabled
-      raise unless e.clierror =~ /Syntax error/
+    rescue Cisco::CliError
+      # cmd will error when feature 'bgp' is not enabled
+      raise if Feature.bgp_enabled?
       return {}
     end
 

--- a/lib/cisco_node_utils/router_ospf.rb
+++ b/lib/cisco_node_utils/router_ospf.rb
@@ -38,9 +38,9 @@ module Cisco
         hash[name] = RouterOspf.new(name, false)
       end
       return hash
-    rescue Cisco::CliError => e
-      # cmd will syntax reject when feature is not enabled
-      raise unless e.clierror =~ /Syntax error/
+    rescue Cisco::CliError
+      # cmd will error when feature 'ospf' is not enabled
+      raise if Feature.ospf_enabled?
       return {}
     end
 

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -124,6 +124,7 @@ class TestBgpAF < CiscoTestCase
     # Tests that are successful even though a rule below says otherwise
     [:next_hop_route_map,            :nexus,  'default', %w(l2vpn evpn),       :success],
     [:additional_paths_send,         :nexus,  'default', %w(l2vpn evpn),       :runtime],
+    [:additional_paths_receive,      :nexus,  'default', %w(l2vpn evpn),       :runtime],
     [:additional_paths_selection,    :nexus,  'default', %w(l2vpn evpn),       :runtime],
     [:maximum_paths,                 :nexus,  'default', %w(l2vpn evpn),       :runtime],
     [:maximum_paths_ibgp,            :nexus,  'default', %w(l2vpn evpn),       :runtime],
@@ -173,6 +174,12 @@ class TestBgpAF < CiscoTestCase
           expect = :success
         when /I5.2|I5.3|I6/
           expect = :success if test == :maximum_paths || test == :maximum_paths_ibgp
+        when /I7/
+          expect = :success if (test == :maximum_paths ||
+                                test == :maximum_paths_ibgp ||
+                                test == :additional_paths_send ||
+                                test == :additional_paths_receive ||
+                                test == :additional_paths_selection)
         else
           expect = :CliError
         end

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -175,11 +175,11 @@ class TestBgpAF < CiscoTestCase
         when /I5.2|I5.3|I6/
           expect = :success if test == :maximum_paths || test == :maximum_paths_ibgp
         when /I7/
-          expect = :success if (test == :maximum_paths ||
-                                test == :maximum_paths_ibgp ||
-                                test == :additional_paths_send ||
-                                test == :additional_paths_receive ||
-                                test == :additional_paths_selection)
+          expect = :success if test == :maximum_paths ||
+                               test == :maximum_paths_ibgp ||
+                               test == :additional_paths_send ||
+                               test == :additional_paths_receive ||
+                               test == :additional_paths_selection
         else
           expect = :CliError
         end

--- a/tests/test_route_map.rb
+++ b/tests/test_route_map.rb
@@ -154,7 +154,9 @@ class TestRouteMap < CiscoTestCase
     assert_equal(rm.default_match_src_proto, rm.match_src_proto)
     array = %w(tcp udp igmp)
     rm.match_src_proto = array
-    assert_equal(array, rm.match_src_proto)
+    # Protocol order not maintained in running config starting Greensboro.
+    # Sorting arrays to check equality.
+    assert_equal(array.sort, rm.match_src_proto.sort)
     rm.match_src_proto = rm.default_match_src_proto
     assert_equal(rm.default_match_src_proto, rm.match_src_proto)
   end


### PR DESCRIPTION
This PR is for fixing minitest errors on greenboro.

1. BGP, OSPF show commands fail due to feature not enabled.
2. Protocol order not maintained in running config for route maps.
3. additional properties added to BGP AF in I7.

All required tests pass