### PR TITLE
cisco_ace fix

### DIFF
--- a/lib/cisco_node_utils/ace.rb
+++ b/lib/cisco_node_utils/ace.rb
@@ -235,6 +235,7 @@ module Cisco
 
     def established
       match = ace_get
+      return nil unless remark.nil?
       return false if match.nil?
       return false unless match.names.include?('established')
       match[:established] == 'established' ? true : false
@@ -318,6 +319,7 @@ module Cisco
 
     def log
       match = ace_get
+      return nil unless remark.nil?
       return false if match.nil?
       return false unless match.names.include?('log')
       match[:log] == 'log' ? true : false

--- a/tests/test_ace.rb
+++ b/tests/test_ace.rb
@@ -66,6 +66,8 @@ class TestAce < CiscoTestCase
     %w(ipv4 ipv6).each do |afi|
       a = ace_helper(afi, remark: afi)
       assert_equal(afi, a.remark)
+      assert_nil(a.log)
+      assert_nil(a.established)
     end
   end
 


### PR DESCRIPTION
This PR is for fixing ace issue:
when remark property is being set, log and established should be nil.
Added validation on the puppet module side as well.
All minitests pass