### PR TITLE
(NETDEV-30) Enhance syslog, tacacs, radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ Changelog
   * object_group (@saichint)
   * object_group_entry (@saichint)
 
+### Added
+* Extend syslog_server with attributes:
+   * `port`
+* Extend syslog_settings with attributes:
+  * `console`
+  * `monitor`
+  * `source_interface`
+* Extend radius_global with attributes:
+   * `source_interface`
+* Extend tacacs_global with attributes:
+  * `source_interface`
+
+### Changed
+* syslog_server initialize now uses options hash
+ * Prior to this release syslog_server accepted positional arguments for name,
+ level, and vrf.  New behavior is to pass attributes as a hash.
+
+ Example:
+ ```
+ options = { 'name' => '1.1.1.1', 'level' => '4', 'port' => '2154',
+             'vrf' => 'red' }
+ Cisco::SyslogServer.new(options, true)
+ ```
+* tacacs_global key removal fixed
+  * Prior to this release key removal was done by passing in a value of 8.  A
+  nil value is now used.  Added intelligence to determine key format
+  automatically for removal.
+
 ## [v1.7.0]
 
 ### New feature support

--- a/cisco_node_utils.gemspec
+++ b/cisco_node_utils.gemspec
@@ -31,6 +31,7 @@ Currently supports NX-OS nodes.
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'kwalify', '~> 0.7.2'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'net-telnet', '~> 0.1.1'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '= 0.35.1'

--- a/lib/cisco_node_utils/cmd_ref/radius_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/radius_global.yaml
@@ -23,6 +23,13 @@ retransmit:
   ios_xr:
     default_value: 3
 
+source_interface:
+  default_value: ~
+  get_value: '/^ip radius source-interface\s+(.*)$/'
+  set_value: '<state> ip radius source-interface <source_interface>'
+  nexus:
+    get_command: "show running-config all | include '^ip radius source-interface'"
+
 timeout:
   kind: int
   get_value: '/^radius-server timeout (\d+).*/'

--- a/lib/cisco_node_utils/cmd_ref/syslog_server.yaml
+++ b/lib/cisco_node_utils/cmd_ref/syslog_server.yaml
@@ -15,8 +15,9 @@ server:
   multiple: true
   nexus:
     get_command: "show running-config all | include '^logging server'"
-    get_value: '/^logging server (\S+).*/'
-    set_value: '<state> logging server <ip> <level> <vrf>'
+    # Returns <ip>, <level>, <port>, <vrf>
+    get_value: '/^(?:logging server )([^\s]+)(?: (\d+))?(?: port (\d+))?(?: use-vrf (\S+))?/'
+    set_value: '<state> logging server <ip> <level> <port> <vrf>'
   ios_xr:
     get_command: "show running-config logging"
     get_value: '/^logging (\S+).*/'

--- a/lib/cisco_node_utils/cmd_ref/syslog_settings.yaml
+++ b/lib/cisco_node_utils/cmd_ref/syslog_settings.yaml
@@ -2,8 +2,28 @@
 ---
 _exclude: [ios_xr]
 
+console:
+  default_value: 2
+  get_command: "show running-config all | include 'logging'"
+  # Returns <state> and <severity>
+  get_value: '/^(no)?\s*logging console\s*(\d)?/'
+  set_value: '<state> logging console <severity>'
+
+monitor:
+  default_value: 5
+  get_command: "show running-config all | include 'logging'"
+  # Returns <state> and <severity>
+  get_value: '/^(no)?\s*logging monitor\s*(\d)?/'
+  set_value: '<state> logging monitor <severity>'
+
+source_interface:
+  default_value: ~
+  get_command: "show running-config all | include 'logging'"
+  get_value: '/^logging source-interface\s+(.*)$/'
+  set_value: '<state> logging source-interface <source_interface>'
+
 timestamp:
-  get_command: "show running-config all | include '^logging timestamp'"
+  get_command: "show running-config all | include 'logging'"
   get_value: '/^logging timestamp (.*)$/'
   set_value: '<state> logging timestamp <units>'
   default_value: 'seconds'

--- a/lib/cisco_node_utils/cmd_ref/tacacs_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/tacacs_global.yaml
@@ -19,6 +19,13 @@ key_format:
   ios_xr:
     get_command: "show running-config tacacs-server"
 
+source_interface:
+  default_value: ~
+  get_value: '/^ip tacacs source-interface\s+(.*)$/'
+  set_value: '<state> ip tacacs source-interface <source_interface>'
+  nexus:
+    get_command: "show running-config all | include '^ip tacacs source-interface'"
+
 timeout:
   kind: int
   get_value: '/tacacs-server timeout\s+(\d+)/'

--- a/lib/cisco_node_utils/radius_global.rb
+++ b/lib/cisco_node_utils/radius_global.rb
@@ -2,7 +2,7 @@
 
 # Jonathan Tripathy et al., September 2015
 
-# Copyright (c) 2014-2016 Cisco and/or its affiliates.
+# Copyright (c) 2014-2017 Cisco and/or its affiliates.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -136,6 +136,30 @@ module Cisco
                    state: '',
                    key:   "#{value}")
       end
+    end
+
+    # Get default source interface
+    def default_source_interface
+      config_get_default('radius_global', 'source_interface')
+    end
+
+    # Set source interface
+    def source_interface=(name)
+      if name
+        config_set(
+          'radius_global', 'source_interface',
+          state: '', source_interface: name)
+      else
+        config_set(
+          'radius_global', 'source_interface',
+          state: 'no', source_interface: '')
+      end
+    end
+
+    # Get source interface
+    def source_interface
+      i = config_get('radius_global', 'source_interface')
+      i.nil? ? default_source_interface : i.downcase
     end
   end # class
 end # module

--- a/lib/cisco_node_utils/syslog_settings.rb
+++ b/lib/cisco_node_utils/syslog_settings.rb
@@ -2,7 +2,7 @@
 #
 # Jonathan Tripathy et al., September 2015
 #
-# Copyright (c) 2014-2016 Cisco and/or its affiliates.
+# Copyright (c) 2014-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,14 +42,82 @@ module Cisco
       name == other.name
     end
 
+    def default_console
+      config_get_default('syslog_settings', 'console')
+    end
+
+    def console
+      console = config_get('syslog_settings', 'console')
+      if console.is_a?(Array)
+        console = console[0] == 'no' ? 'unset' : console[1]
+      end
+      console
+    end
+
+    def console=(severity)
+      if severity
+        config_set(
+          'syslog_settings', 'console',
+          state: '', severity: severity)
+      else
+        config_set(
+          'syslog_settings', 'console',
+          state: 'no', severity: '')
+      end
+    end
+
+    def default_monitor
+      config_get_default('syslog_settings', 'monitor')
+    end
+
+    def monitor
+      monitor = config_get('syslog_settings', 'monitor')
+      if monitor.is_a?(Array)
+        monitor = monitor[0] == 'no' ? 'unset' : monitor[1]
+      end
+      monitor
+    end
+
+    def monitor=(severity)
+      if severity
+        config_set(
+          'syslog_settings', 'monitor',
+          state: '', severity: severity)
+      else
+        config_set(
+          'syslog_settings', 'monitor',
+          state: 'no', severity: '')
+      end
+    end
+
+    def default_source_interface
+      config_get_default('syslog_settings', 'source_interface')
+    end
+
+    def source_interface
+      i = config_get('syslog_settings', 'source_interface')
+      i.nil? ? default_source_interface : i.downcase
+    end
+
+    def source_interface=(name)
+      if name
+        config_set(
+          'syslog_settings', 'source_interface',
+          state: '', source_interface: name)
+      else
+        config_set(
+          'syslog_settings', 'source_interface',
+          state: 'no', source_interface: '')
+      end
+    end
+
     def timestamp
       config_get('syslog_settings', 'timestamp')
     end
 
     def timestamp=(val)
-      fail TypeError unless val.is_a?(String)
       fail TypeError \
-        unless %w(seconds milliseconds).include?(val)
+        unless %w(seconds milliseconds).include?(val.to_s)
 
       # There is no unset version as timestamp has a default value
       config_set('syslog_settings',
@@ -57,5 +125,8 @@ module Cisco
                  state: '',
                  units: val)
     end
+
+    alias_method :time_stamp_units, :timestamp
+    alias_method :time_stamp_units=, :timestamp=
   end # class
 end # module

--- a/tests/test_radius_global.rb
+++ b/tests/test_radius_global.rb
@@ -70,6 +70,12 @@ class TestRadiusGlobal < CiscoTestCase
       global.key_set(key, nil)
       assert_match(/#{key}/, global.key)
       assert_match(/#{key}/, Cisco::RadiusGlobal.radius_global[id].key)
+      assert_equal(7, global.key_format)
+      # Change to type 6
+      key = 'JDYkqyIFWeBvzpljSfWmRZrmRSRE8'
+      global.key_set(key, 6)
+      assert_match(/#{key}/, global.key)
+      assert_equal(6, global.key_format)
     elsif platform == :ios_xr
       global.key_set('QsEfThUkO', nil)
       assert(!global.key.nil?)
@@ -77,9 +83,23 @@ class TestRadiusGlobal < CiscoTestCase
     end
 
     # Setting back to default and re-checking
-    global.timeout = global.default_timeout
-    global.retransmit_count = global.default_retransmit_count
+    global.timeout = nil
+    global.retransmit_count = nil
+    global.key_set(nil, nil)
     assert_equal(global.timeout, global.default_timeout)
     assert_equal(global.retransmit_count, global.default_retransmit_count)
+    assert_nil(global.key)
+
+    # Default source interface
+    assert_nil(global.source_interface)
+
+    # Set source interface
+    interface = 'loopback0'
+    global.source_interface = interface
+    assert_equal(interface, global.source_interface)
+
+    # Remove source interface
+    global.source_interface = nil
+    assert_nil(global.source_interface)
   end
 end

--- a/tests/test_syslog_server.rb
+++ b/tests/test_syslog_server.rb
@@ -53,10 +53,9 @@ class TestSyslogServer < CiscoTestCase
     id = '1.2.3.4'
     refute_includes(Cisco::SyslogServer.syslogservers, id)
 
-    server = Cisco::SyslogServer.new(id, 2, 'default', true)
+    server = Cisco::SyslogServer.new({ 'name' => id, 'vrf' => 'default' }, true)
     assert_includes(Cisco::SyslogServer.syslogservers, id)
     assert_equal(server, Cisco::SyslogServer.syslogservers[id])
-    assert_equal(2, Cisco::SyslogServer.syslogservers[id].level)
 
     server.destroy
     refute_includes(Cisco::SyslogServer.syslogservers, id)
@@ -66,10 +65,9 @@ class TestSyslogServer < CiscoTestCase
     id = '2003::2'
     refute_includes(Cisco::SyslogServer.syslogservers, id)
 
-    server = Cisco::SyslogServer.new(id, 2, 'default', true)
+    server = Cisco::SyslogServer.new({ 'name' => id, 'vrf' => 'default' }, true)
     assert_includes(Cisco::SyslogServer.syslogservers, id)
     assert_equal(server, Cisco::SyslogServer.syslogservers[id])
-    assert_equal(2, Cisco::SyslogServer.syslogservers[id].level)
 
     server.destroy
     refute_includes(Cisco::SyslogServer.syslogservers, id)
@@ -81,14 +79,13 @@ class TestSyslogServer < CiscoTestCase
     refute_includes(Cisco::SyslogServer.syslogservers, id)
     refute_includes(Cisco::SyslogServer.syslogservers, id2)
 
-    server = Cisco::SyslogServer.new(id, 2, 'default', true)
-    server2 = Cisco::SyslogServer.new(id2, 3, 'default', true)
+    server = Cisco::SyslogServer.new({ 'name' => id, 'vrf' => 'default' }, true)
+    server2 = Cisco::SyslogServer.new({ 'name' => id2, 'vrf' => 'default' },
+                                      true)
     assert_includes(Cisco::SyslogServer.syslogservers, id)
     assert_equal(server, Cisco::SyslogServer.syslogservers[id])
-    assert_equal(2, Cisco::SyslogServer.syslogservers[id].level)
     assert_includes(Cisco::SyslogServer.syslogservers, id2)
     assert_equal(server2, Cisco::SyslogServer.syslogservers[id2])
-    assert_equal(3, Cisco::SyslogServer.syslogservers[id2].level)
 
     server.destroy
     server2.destroy
@@ -96,7 +93,7 @@ class TestSyslogServer < CiscoTestCase
     refute_includes(Cisco::SyslogServer.syslogservers, id2)
   end
 
-  def test_create_destroy_single_vrf_ipv4
+  def test_create_options
     if platform == :ios_xr
       config('vrf red')
     else
@@ -104,33 +101,16 @@ class TestSyslogServer < CiscoTestCase
     end
 
     id = '1.2.3.4'
+    options = { 'name' => id, 'level' => '4', 'port' => '2154', 'vrf' => 'red' }
 
     refute_includes(Cisco::SyslogServer.syslogservers, id)
 
-    server = Cisco::SyslogServer.new(id, 4, 'red', true)
+    server = Cisco::SyslogServer.new(options, true)
     assert_includes(Cisco::SyslogServer.syslogservers, id)
     assert_equal(server, Cisco::SyslogServer.syslogservers[id])
-    assert_equal(4, Cisco::SyslogServer.syslogservers[id].level)
-
-    server.destroy
-    refute_includes(Cisco::SyslogServer.syslogservers, id)
-  end
-
-  def test_create_destroy_single_vrf_ipv6
-    if platform == :ios_xr
-      config('vrf red')
-    else
-      config('vrf context red')
-    end
-
-    id = '2003::2'
-
-    refute_includes(Cisco::SyslogServer.syslogservers, id)
-
-    server = Cisco::SyslogServer.new(id, 5, 'red', true)
-    assert_includes(Cisco::SyslogServer.syslogservers, id)
-    assert_equal(server, Cisco::SyslogServer.syslogservers[id])
-    assert_equal(5, Cisco::SyslogServer.syslogservers[id].level)
+    assert_equal('4', Cisco::SyslogServer.syslogservers[id].level)
+    assert_equal('2154', Cisco::SyslogServer.syslogservers[id].port)
+    assert_equal('red', Cisco::SyslogServer.syslogservers[id].vrf)
 
     server.destroy
     refute_includes(Cisco::SyslogServer.syslogservers, id)

--- a/tests/test_tacacs_global.rb
+++ b/tests/test_tacacs_global.rb
@@ -1,7 +1,7 @@
 #
 # Minitest for TacacsGlobal class
 #
-# Copyright (c) 2014-2016 Cisco and/or its affiliates.
+# Copyright (c) 2014-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,31 +50,50 @@ class TestTacacsGlobal < CiscoTestCase
     assert_includes(Cisco::TacacsGlobal.tacacs_global, id)
     assert_equal(global, Cisco::TacacsGlobal.tacacs_global[id])
 
-    # Default Checking
+    # Default timeout
     assert_equal(global.default_timeout, global.timeout)
 
-    global.timeout = 5
-    assert_equal(5, Cisco::TacacsGlobal.tacacs_global[id].timeout)
-    assert_equal(5, global.timeout)
+    # Timeout update
+    global.timeout = 10
+    assert_equal(10, Cisco::TacacsGlobal.tacacs_global[id].timeout)
+    assert_equal(10, global.timeout)
 
-    # first change
-    key_format = 0
+    # Remove timeout
+    global.timeout = nil
+    assert_equal(global.default_timeout, global.timeout)
+
+    # Check there is no default key
+    assert_equal('', global.key)
+
+    # first key change - unencrypted key
     key = 'TEST_NEW'
-    global.encryption_key_set(key_format, key)
-    assert(!global.key.nil?)
-    assert(key_format, global.key_format)
+    global.encryption_key_set(nil, key)
+    # Device encypts key - verify return value
+    assert_equal(7, global.key_format)
+    assert_equal('"WAWY_NZB"', global.key)
 
-    # second change
+    # second key change - modify key to type6
     key_format = 6
-
     # Must use a valid type6 password: CSCvb36266
     key = 'JDYkqyIFWeBvzpljSfWmRZrmRSRE8'
     global.encryption_key_set(key_format, key)
-    assert(!global.key.nil?)
-    assert(key_format, global.key_format)
+    assert_equal(key_format, global.key_format)
+    assert_equal("\"#{key}\"", global.key)
 
-    # Setting back to default and re-checking
-    global.timeout = global.default_timeout
-    assert_equal(global.default_timeout, global.timeout)
+    # Remove global key
+    global.encryption_key_set('', '')
+    assert_equal('', global.key)
+
+    # Default source interface
+    assert_nil(global.source_interface)
+
+    # Set source interface
+    interface = 'loopback0'
+    global.source_interface = interface
+    assert_equal(interface, global.source_interface)
+
+    # Remove source interface
+    global.source_interface = nil
+    assert_nil(global.source_interface)
   end
 end


### PR DESCRIPTION
This PR enhances the existing syslog, tacacs, and radius types as specified in  puppetlabs/netdev_stdlib#25

syslog_server
- port

syslog_settings
- console
- monitor
- source_interface
- vrf

tacacs_global
- source_interface

radius_global
- source_interface


syslog_server initialize now uses options hash
  * Prior to this release ntp_server accepted positional arguments for id and
  prefer.  New behavior is to pass attributes as a hash.

  Example:
  ```
 options = { 'name' => '1.1.1.1', 'level' => '4', 'port' => '2154',
             'vrf' => 'red' }
 Cisco::SyslogServer.new(options, true)
  ```

* tacacs_global key removal fixed
  * Prior to this release key removal was done by passing in a value of 8.  A
  nil value is now used.  Added intelligence to determine key format
  automatically for removal.