### PR TITLE
Bridge domain fixes

### DIFF
--- a/lib/cisco_node_utils/bridge_domain.rb
+++ b/lib/cisco_node_utils/bridge_domain.rb
@@ -129,7 +129,6 @@ module Cisco
     end
 
     def bd_name=(str)
-      str = '' unless str
       state = str.empty? ? 'no' : ''
       config_set('bridge_domain', 'bd_name', bd: @bd_ids, state: state,
                    name: str)

--- a/lib/cisco_node_utils/bridge_domain.rb
+++ b/lib/cisco_node_utils/bridge_domain.rb
@@ -124,15 +124,14 @@ module Cisco
     #                      PROPERTIES                      #
     ########################################################
 
-    # Bridge-Domain name assigning case
-    # bridge-domain 100
-    #   name bd100
     def bd_name
       match = config_get('bridge_domain', 'bd_name', bd: @bd_ids)
       match.each do |line|
         next unless line.include?('Name')
         regexp = Regexp.new('Name::\s(\S+)')
         name = regexp.match(line)
+        # if name is not set, it will be Bridge-Domain followed by bd
+        # like Bridge-domain101 for bd 101
         bname = name[1].include?('Bridge-Domain') ? default_bd_name : name[1]
         return bname
       end
@@ -149,9 +148,6 @@ module Cisco
       config_get_default('bridge_domain', 'bd_name')
     end
 
-    # Bridge-Domain type change to fabric-control
-    # bridge-domain 100
-    #   fabric-control
     # This type property can be defined only for one bd
     def fabric_control
       match = config_get('bridge_domain', 'fabric_control', bd: @bd_ids)
@@ -174,9 +170,6 @@ module Cisco
       config_get_default('bridge_domain', 'fabric_control')
     end
 
-    # Bridge-Domain Shutdown case
-    # bridge-domain 100
-    #   shutdown
     def shutdown
       match = config_get('bridge_domain', 'shutdown', bd: @bd_ids)
       match.each do |line|

--- a/lib/cisco_node_utils/bridge_domain.rb
+++ b/lib/cisco_node_utils/bridge_domain.rb
@@ -126,15 +126,7 @@ module Cisco
 
     def bd_name
       match = config_get('bridge_domain', 'bd_name', bd: @bd_ids)
-      match.each do |line|
-        next unless line.include?('Name')
-        regexp = Regexp.new('Name::\s(\S+)')
-        name = regexp.match(line)
-        # if name is not set, it will be Bridge-Domain followed by bd
-        # like Bridge-domain101 for bd 101
-        bname = name[1].include?('Bridge-Domain') ? default_bd_name : name[1]
-        return bname
-      end
+      match.include?('Bridge-Domain') ? default_bd_name : match
     end
 
     def bd_name=(str)
@@ -151,14 +143,7 @@ module Cisco
     # This type property can be defined only for one bd
     def fabric_control
       match = config_get('bridge_domain', 'fabric_control', bd: @bd_ids)
-      match.each do |line|
-        next unless line.include?('Configured fabric-control')
-        regexp = Regexp.new('Configured '\
-                            'fabric-control Bridge-Domain/VLAN\s+:\s+(\d+)')
-        fc = regexp.match(line)
-        fabric = fc[1] == @bd_ids ? true : false
-        return fabric
-      end
+      match == @bd_ids ? true : false
     end
 
     def fabric_control=(val)
@@ -172,13 +157,7 @@ module Cisco
 
     def shutdown
       match = config_get('bridge_domain', 'shutdown', bd: @bd_ids)
-      match.each do |line|
-        next unless line.include?('Administrative')
-        regexp = Regexp.new(' Administrative State:\s(\S+)')
-        astate = regexp.match(line)
-        shut = astate[1] == 'UP' ? false : true
-        return shut
-      end
+      match == 'Noshutdown' ? false : true
     end
 
     def shutdown=(val)

--- a/lib/cisco_node_utils/bridge_domain.rb
+++ b/lib/cisco_node_utils/bridge_domain.rb
@@ -128,7 +128,14 @@ module Cisco
     # bridge-domain 100
     #   name bd100
     def bd_name
-      config_get('bridge_domain', 'bd_name', bd: @bd_ids)
+      match = config_get('bridge_domain', 'bd_name', bd: @bd_ids)
+      match.each do |line|
+        next unless line.include?('Name')
+        regexp = Regexp.new('Name::\s(\S+)')
+        name = regexp.match(line)
+        bname = name[1].include?('Bridge-Domain') ? default_bd_name : name[1]
+        return bname
+      end
     end
 
     def bd_name=(str)
@@ -147,7 +154,15 @@ module Cisco
     #   fabric-control
     # This type property can be defined only for one bd
     def fabric_control
-      config_get('bridge_domain', 'fabric_control', bd: @bd_ids)
+      match = config_get('bridge_domain', 'fabric_control', bd: @bd_ids)
+      match.each do |line|
+        next unless line.include?('Configured fabric-control')
+        regexp = Regexp.new('Configured '\
+                            'fabric-control Bridge-Domain/VLAN\s+:\s+(\d+)')
+        fc = regexp.match(line)
+        fabric = fc[1] == @bd_ids ? true : false
+        return fabric
+      end
     end
 
     def fabric_control=(val)
@@ -163,7 +178,14 @@ module Cisco
     # bridge-domain 100
     #   shutdown
     def shutdown
-      config_get('bridge_domain', 'shutdown', bd: @bd_ids)
+      match = config_get('bridge_domain', 'shutdown', bd: @bd_ids)
+      match.each do |line|
+        next unless line.include?('Administrative')
+        regexp = Regexp.new(' Administrative State:\s(\S+)')
+        astate = regexp.match(line)
+        shut = astate[1] == 'UP' ? false : true
+        return shut
+      end
     end
 
     def shutdown=(val)

--- a/lib/cisco_node_utils/bridge_domain.rb
+++ b/lib/cisco_node_utils/bridge_domain.rb
@@ -125,19 +125,18 @@ module Cisco
     ########################################################
 
     def bd_name
-      match = config_get('bridge_domain', 'bd_name', bd: @bd_ids)
-      match.include?('Bridge-Domain') ? default_bd_name : match
+      config_get('bridge_domain', 'bd_name', bd: @bd_ids)
     end
 
     def bd_name=(str)
-      str = str.to_s
+      str = '' unless str
       state = str.empty? ? 'no' : ''
       config_set('bridge_domain', 'bd_name', bd: @bd_ids, state: state,
                    name: str)
     end
 
     def default_bd_name
-      config_get_default('bridge_domain', 'bd_name')
+      'Bridge-Domain' + @bd_ids
     end
 
     # This type property can be defined only for one bd

--- a/lib/cisco_node_utils/cmd_ref/bridge_domain.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bridge_domain.yaml
@@ -13,9 +13,10 @@ all_bds:
   get_value: '/^bridge-domain (\S+)/'
 
 bd_name:
-  multiple: true
+  get_data_format: nxapi_structured
   get_command: "show bridge-domain <bd>"
-  get_value: "(.*)"
+  get_context: ["TABLE_bd", "ROW_bd"]
+  get_value: ["bd-name"]
   set_value: "<state> name <name>"
   default_value: ~
 
@@ -27,16 +28,18 @@ destroy:
 
 # Configured fabric-control Bridge-Domain/VLAN    :  100
 fabric_control:
-  multiple: true
+  get_data_format: nxapi_structured
   get_command: "show bridge-domain summary"
-  get_value: "(.*)"
+  get_context: ~
+  get_value: ["fabric-control-bd"]
   set_value: "<state> fabric-control"
   default_value: false
 
 shutdown:
-  multiple: true
+  get_data_format: nxapi_structured
   get_command: "show bridge-domain <bd>"
-  get_value: "(.*)"
+  get_context: ["TABLE_bd", "ROW_bd"]
+  get_value: ["bd-admin-state"]
   set_value: "<state> shutdown"
   default_value: false
 

--- a/lib/cisco_node_utils/cmd_ref/bridge_domain.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bridge_domain.yaml
@@ -4,35 +4,31 @@
 _exclude: [N3k, N5k, N6k, N9k-F, N9k, ios_xr]
 
 _template:
+  get_command: "show running-config bridge-domain"
+  get_context: ~
   set_context: ["(?)bridge-domain <bd>"]
 
 all_bds:
   multiple: true
-  get_command: "show running-config bridge-domain"
-  get_context: ~
   get_value: '/^bridge-domain (\S+)/'
 
 bd_name:
   multiple: true
   get_command: "show bridge-domain <bd>"
-  get_context: ~
   get_value: "(.*)"
   set_value: "<state> name <name>"
   default_value: ~
 
 create:
-  get_context: ~
   set_value: "bridge-domain <bd>"
 
 destroy:
-  get_context: ~
   set_value: "no bridge-domain <bd>"
 
 # Configured fabric-control Bridge-Domain/VLAN    :  100
 fabric_control:
   multiple: true
   get_command: "show bridge-domain summary"
-  get_context: ~
   get_value: "(.*)"
   set_value: "<state> fabric-control"
   default_value: false
@@ -40,14 +36,11 @@ fabric_control:
 shutdown:
   multiple: true
   get_command: "show bridge-domain <bd>"
-  get_context: ~
   get_value: "(.*)"
   set_value: "<state> shutdown"
   default_value: false
 
 system_bridge_domain:
-  get_command: "show running-config bridge-domain"
-  get_context: ~
   get_value: '/^system bridge-domain (\S+)/'
   set_context: ~
   set_value: "system bridge-domain <oper> <bd>"

--- a/lib/cisco_node_utils/cmd_ref/bridge_domain.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bridge_domain.yaml
@@ -3,41 +3,20 @@
 ---
 _exclude: [N3k, N5k, N6k, N9k-F, N9k, ios_xr]
 
-# For the below name, shutdown commands we are going to use show running-config
-# bridge-domain cli which displays as below
-#
-# system bridge-domain 100-110
-#
-# bridge-domain 100-110
-#
-# bridge-domain 100
-#   shutdown
-#   fabric-control
-#   name bd100
-# bridge-domain 101
-# bridge-domain 102
-# ...
-# bridge-domain 108
-#   shutdown
-#   name bd108
-# bridge-domain 109
-#   shutdown
-# bridge-domain 110
-#   name bd110
-
 _template:
-  get_command: "show running-config bridge-domain"
-  get_context: ['/^bridge-domain <bd>\s$/']
   set_context: ["(?)bridge-domain <bd>"]
 
 all_bds:
   multiple: true
+  get_command: "show running-config bridge-domain"
   get_context: ~
   get_value: '/^bridge-domain (\S+)/'
 
 bd_name:
-  kind: string
-  get_value: '/name (\S+)/'
+  multiple: true
+  get_command: "show bridge-domain <bd>"
+  get_context: ~
+  get_value: "(.*)"
   set_value: "<state> name <name>"
   default_value: ~
 
@@ -51,19 +30,23 @@ destroy:
 
 # Configured fabric-control Bridge-Domain/VLAN    :  100
 fabric_control:
-  kind: boolean
-  get_value: '/fabric-control/'
+  multiple: true
+  get_command: "show bridge-domain summary"
+  get_context: ~
+  get_value: "(.*)"
   set_value: "<state> fabric-control"
   default_value: false
 
-# Same reason as for bd_name case above
 shutdown:
-  kind: boolean
-  get_value: '/shutdown/'
+  multiple: true
+  get_command: "show bridge-domain <bd>"
+  get_context: ~
+  get_value: "(.*)"
   set_value: "<state> shutdown"
   default_value: false
 
 system_bridge_domain:
+  get_command: "show running-config bridge-domain"
   get_context: ~
   get_value: '/^system bridge-domain (\S+)/'
   set_context: ~

--- a/lib/cisco_node_utils/cmd_ref/bridge_domain.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bridge_domain.yaml
@@ -18,7 +18,6 @@ bd_name:
   get_context: ["TABLE_bd", "ROW_bd"]
   get_value: ["bd-name"]
   set_value: "<state> name <name>"
-  default_value: ~
 
 create:
   set_value: "bridge-domain <bd>"

--- a/tests/test_bridge_domain.rb
+++ b/tests/test_bridge_domain.rb
@@ -116,6 +116,11 @@ class TestBridgeDomain < CiscoTestCase
     assert_equal(name, bd.bd_name,
                  'Error: Bridge-Domain name not updated to #{name}')
 
+    name = false
+    bd.bd_name = name
+    assert_equal(bd.default_bd_name, bd.default_bd_name,
+                 'Error: Bridge-Domain name not updated to default')
+
     bd.bd_name = bd.default_bd_name
     assert_equal(bd.default_bd_name, bd.bd_name,
                  'Error: Bridge-Domain name not restored to default')

--- a/tests/test_bridge_domain.rb
+++ b/tests/test_bridge_domain.rb
@@ -116,7 +116,7 @@ class TestBridgeDomain < CiscoTestCase
     assert_equal(name, bd.bd_name,
                  'Error: Bridge-Domain name not updated to #{name}')
 
-    name = false
+    name = ''
     bd.bd_name = name
     assert_equal(bd.default_bd_name, bd.default_bd_name,
                  'Error: Bridge-Domain name not updated to default')

--- a/tests/test_bridge_domain.rb
+++ b/tests/test_bridge_domain.rb
@@ -101,6 +101,8 @@ class TestBridgeDomain < CiscoTestCase
     refute(bd.shutdown)
     bd.shutdown = true
     assert(bd.shutdown)
+    bd.shutdown = false
+    refute(bd.shutdown)
     bd.destroy
   end
 


### PR DESCRIPTION
This PR is for fixing bridge domain. Previously the code was depending on a space beyond the bridge-domain to differentiate between two strings of bridge-domain which is error prone. This PR corrects the problem by using show bridge-domain summary and show bridge-domain <bridge-domain id> commands.
The tests all pass on old and new versions of software releases.
Tested beaker as well and it is fine.