### PR TITLE
remove ingress replication for n7k

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
@@ -16,8 +16,7 @@ all_vnis:
   get_value: '/^member vni (\d+|\d+-\d+) ?(associate-vrf)?$/'
 
 ingress_replication:
-  _exclude: [N5k, N6k]
-  os_version: 'N7k:8.1.1'
+  _exclude: [N5k, N6k, N7k]
   kind: string
   get_value: '/^ingress-replication protocol (\S+)$/'
   set_value: '<state> ingress-replication protocol <protocol>'
@@ -29,8 +28,7 @@ multicast_group:
   default_value: ''
 
 peer_list:
-  _exclude: [N5k, N6k]
-  os_version: 'N7k:8.1.1'
+  _exclude: [N5k, N6k, N7k]
   multiple:
   get_context:
     - '/^interface <name>$/i'

--- a/tests/test_vxlan_vtep_vni.rb
+++ b/tests/test_vxlan_vtep_vni.rb
@@ -120,7 +120,6 @@ class TestVxlanVtepVni < CiscoTestCase
       return
     end
 
-    skip_incompat_version?('vxlan_vtep_vni', 'ingress_replication')
     # Test non-default values
     vni.ingress_replication = 'static'
     assert_equal('static', vni.ingress_replication)
@@ -158,7 +157,6 @@ class TestVxlanVtepVni < CiscoTestCase
 
     # Test the case where an existing ingress_replication is removed before
     # configuring multicast_group
-    skip_incompat_version?('vxlan_vtep_vni', 'ingress_replication')
     unless validate_property_excluded?('vxlan_vtep_vni', 'ingress_replication')
       vni1.ingress_replication = 'static'
       assert_equal('static', vni1.ingress_replication)
@@ -185,7 +183,6 @@ class TestVxlanVtepVni < CiscoTestCase
       return
     end
 
-    skip_incompat_version?('vxlan_vtep_vni', 'peer_list')
     peer_list = ['1.1.1.1', '2.2.2.2', '3.3.3.3', '4.4.4.4']
 
     # Test: all peers when current is empty


### PR DESCRIPTION
This PR is for getting rid of ingress replication for n7k as it is not supported by the platform. Another PR for puppet module will be opened later.