### PR TITLE
Increase http.read_timeout for upgrades

### DIFF
--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -171,10 +171,9 @@ class Cisco::Client::NXAPI < Cisco::Client
   # the default value of 300 to accomodate commands that are known to
   # require more time to complete.
   def read_timeout_check(request)
-    if request.body[/install all|install force-all/]
-      debug("Increasing http read_timeout to 1000 for 'install all' command")
-      @http.read_timeout = 1000
-    end
+    return unless request.body[/install all|install force-all/]
+    debug("Increasing http read_timeout to 1000 for 'install all' command")
+    @http.read_timeout = 1000
   end
 
   # Sends a request to the NX API and returns the body of the request or

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -172,7 +172,7 @@ class Cisco::Client::NXAPI < Cisco::Client
   # require more time to complete.
   def read_timeout_check(request)
     if request.body[/install all|install force-all/]
-      puts "Increasing http read_timeout to 1000 for 'install all' command"
+      debug("Increasing http read_timeout to 1000 for 'install all' command")
       @http.read_timeout = 1000
     end
   end
@@ -211,7 +211,6 @@ class Cisco::Client::NXAPI < Cisco::Client
     # send the request and get the response
     debug("Sending HTTP request to NX-API at #{@http.address}:\n" \
           "#{request.to_hash}\n#{request.body}")
-    puts "READ TO: #{@http.read_timeout}"
     read_timeout_check(request)
     tries = 2
     begin

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -167,6 +167,16 @@ class Cisco::Client::NXAPI < Cisco::Client
     end
   end
 
+  # Helper method to increase the default @http.read_timeout value from
+  # the default value of 300 to accomodate commands that are known to
+  # require more time to complete.
+  def read_timeout_check(request)
+    if request.body[/install all|install force-all/]
+      puts "Increasing http read_timeout to 1000 for 'install all' command"
+      @http.read_timeout = 1000
+    end
+  end
+
   # Sends a request to the NX API and returns the body of the request or
   # handles errors that happen.
   # @raise Cisco::ConnectionRefused if NXAPI is disabled
@@ -201,6 +211,8 @@ class Cisco::Client::NXAPI < Cisco::Client
     # send the request and get the response
     debug("Sending HTTP request to NX-API at #{@http.address}:\n" \
           "#{request.to_hash}\n#{request.body}")
+    puts "READ TO: #{@http.read_timeout}"
+    read_timeout_check(request)
     tries = 2
     begin
       # Explicitly use http to avoid EOFError


### PR DESCRIPTION
The upgrade object uses the `install all` command that may require a longer net read timeout period then the default of 300 seconds.  This is particularly noticeable on `n3k` platforms.  This update adds a check in `nxapi/client.rb` to increase the net read timeout to 1000 seconds to handle the slower `install all` command.

**NOTE:** In the future this could in theory be used for other slow commands but the scope is currently limited to upgrades.

Tested on N3k and N9k platforms.

Full minitest results just to make sure the check does not impact any tests.

```shell
Job Information
    Name         : [ freeport(1),N3k,minitest(rel170_fix_n3k_upgrade),n3k-103 ]
    Start time   : 2017-09-28 11:56:54.781094
    Stop time    : 2017-09-28 14:24:37.695337
    Elapsed time : 2:27:42.914243
    Archive      : /auto/rtp-core/ats_shared/users/mwiebe/pyATS/users/mwiebe/archive/17-09/agents_job.2017Sep28_11:56:53.zip

Total Tasks    : 1

Overall Stats
    Passed     : 76
    Passx      : 0
    Failed     : 0
    Aborted    : 0
    Blocked    : 0
    Skipped    : 17
    Errored    : 0

    TOTAL      : 93

Success Rate   : 100.00 %

+------------------------------------------------------------------------------+
|                             Task Result Summary                              |
+------------------------------------------------------------------------------+
AgentsTests: agents.upgrade                                               PASSED
AgentsTests: agents.minitests                                             PASSED
AgentsTests: agents.minitest_results[suite=./test_aaa_authenticatio...    PASSED
AgentsTests: agents.minitest_results[suite=./test_aaa_authenticatio...    PASSED
AgentsTests: agents.minitest_results[suite=./test_aaa_authorization...    PASSED
AgentsTests: agents.minitest_results[suite=./test_ace.rb]                 PASSED
AgentsTests: agents.minitest_results[suite=./test_acl.rb]                 PASSED
AgentsTests: agents.minitest_results[suite=./test_bfd_global.rb]          PASSED
AgentsTests: agents.minitest_results[suite=./test_bgp_af.rb]              PASSED
AgentsTests: agents.minitest_results[suite=./test_bgp_af_aa.rb]           PASSED
AgentsTests: agents.minitest_results[suite=./test_bgp_neighbor.rb]        PASSED
AgentsTests: agents.minitest_results[suite=./test_bgp_neighbor_af.rb]     PASSED
AgentsTests: agents.minitest_results[suite=./test_bridge_domain.rb]      SKIPPED
AgentsTests: agents.minitest_results[suite=./test_bridge_domain_vni...   SKIPPED
AgentsTests: agents.minitest_results[suite=./test_client_utils.rb]        PASSED
AgentsTests: agents.minitest_results[suite=./test_cmn_utils.rb]           PASSED
AgentsTests: agents.minitest_results[suite=./test_command_config.rb]      PASSED
AgentsTests: agents.minitest_results[suite=./test_command_reference...    PASSED
AgentsTests: agents.minitest_results[suite=./test_dhcp_relay_global...    PASSED
AgentsTests: agents.minitest_results[suite=./test_dns_domain.rb]          PASSED
AgentsTests: agents.minitest_results[suite=./test_domain_name.rb]         PASSED
AgentsTests: agents.minitest_results[suite=./test_encapsulation.rb]      SKIPPED
AgentsTests: agents.minitest_results[suite=./test_evpn_vni.rb]           SKIPPED
AgentsTests: agents.minitest_results[suite=./test_fabricpath_global...   SKIPPED
AgentsTests: agents.minitest_results[suite=./test_fabricpath_topolo...   SKIPPED
AgentsTests: agents.minitest_results[suite=./test_feature.rb]             PASSED
AgentsTests: agents.minitest_results[suite=./test_grpc.rb]               SKIPPED
AgentsTests: agents.minitest_results[suite=./test_hsrp_global.rb]         PASSED
AgentsTests: agents.minitest_results[suite=./test_interface.rb]           PASSED
AgentsTests: agents.minitest_results[suite=./test_interface_bdi.rb]      SKIPPED
AgentsTests: agents.minitest_results[suite=./test_interface_channel...    PASSED
AgentsTests: agents.minitest_results[suite=./test_interface_hsrp.rb]      PASSED
AgentsTests: agents.minitest_results[suite=./test_interface_hsrp_gr...    PASSED
AgentsTests: agents.minitest_results[suite=./test_interface_ospf.rb]      PASSED
AgentsTests: agents.minitest_results[suite=./test_interface_portcha...    PASSED
AgentsTests: agents.minitest_results[suite=./test_interface_private...    PASSED
AgentsTests: agents.minitest_results[suite=./test_interface_service...   SKIPPED
AgentsTests: agents.minitest_results[suite=./test_interface_svi.rb]       PASSED
AgentsTests: agents.minitest_results[suite=./test_interface_switchp...    PASSED
AgentsTests: agents.minitest_results[suite=./test_itd_device_group.rb]   SKIPPED
AgentsTests: agents.minitest_results[suite=./test_itd_device_group_...   SKIPPED
AgentsTests: agents.minitest_results[suite=./test_itd_service.rb]        SKIPPED
AgentsTests: agents.minitest_results[suite=./test_logger.rb]              PASSED
AgentsTests: agents.minitest_results[suite=./test_name_server.rb]         PASSED
AgentsTests: agents.minitest_results[suite=./test_node.rb]                PASSED
AgentsTests: agents.minitest_results[suite=./test_node_ext.rb]            PASSED
AgentsTests: agents.minitest_results[suite=./test_node_util.rb]           PASSED
AgentsTests: agents.minitest_results[suite=./test_ntp_auth_key.rb]        PASSED
AgentsTests: agents.minitest_results[suite=./test_ntp_config.rb]          PASSED
AgentsTests: agents.minitest_results[suite=./test_ntp_server.rb]          PASSED
AgentsTests: agents.minitest_results[suite=./test_nxapi.rb]               PASSED
AgentsTests: agents.minitest_results[suite=./test_object_group.rb]        PASSED
AgentsTests: agents.minitest_results[suite=./test_overlay_global.rb]      PASSED
AgentsTests: agents.minitest_results[suite=./test_pim.rb]                 PASSED
AgentsTests: agents.minitest_results[suite=./test_pim_group_list.rb]      PASSED
AgentsTests: agents.minitest_results[suite=./test_pim_rp_address.rb]      PASSED
AgentsTests: agents.minitest_results[suite=./test_platform.rb]            PASSED
AgentsTests: agents.minitest_results[suite=./test_portchannel_globa...    PASSED
AgentsTests: agents.minitest_results[suite=./test_radius_global.rb]       PASSED
AgentsTests: agents.minitest_results[suite=./test_radius_server.rb]       PASSED
AgentsTests: agents.minitest_results[suite=./test_radius_server_gro...    PASSED
AgentsTests: agents.minitest_results[suite=./test_route_map.rb]           PASSED
AgentsTests: agents.minitest_results[suite=./test_router_bgp.rb]          PASSED
AgentsTests: agents.minitest_results[suite=./test_router_ospf.rb]         PASSED
AgentsTests: agents.minitest_results[suite=./test_router_ospf_area.rb]    PASSED
AgentsTests: agents.minitest_results[suite=./test_router_ospf_area_...    PASSED
AgentsTests: agents.minitest_results[suite=./test_router_ospf_vrf.rb]     PASSED
AgentsTests: agents.minitest_results[suite=./test_snmp_notification...    PASSED
AgentsTests: agents.minitest_results[suite=./test_snmpcommunity.rb]       PASSED
AgentsTests: agents.minitest_results[suite=./test_snmpgroup.rb]           PASSED
AgentsTests: agents.minitest_results[suite=./test_snmpnotification.rb]    PASSED
AgentsTests: agents.minitest_results[suite=./test_snmpserver.rb]          PASSED
AgentsTests: agents.minitest_results[suite=./test_snmpuser.rb]            PASSED
AgentsTests: agents.minitest_results[suite=./test_span_session.rb]        PASSED
AgentsTests: agents.minitest_results[suite=./test_stp_global.rb]          PASSED
AgentsTests: agents.minitest_results[suite=./test_syslog_server.rb]       PASSED
AgentsTests: agents.minitest_results[suite=./test_syslog_settings.rb]    SKIPPED
AgentsTests: agents.minitest_results[suite=./test_tacacs_global.rb]       PASSED
AgentsTests: agents.minitest_results[suite=./test_tacacs_server.rb]       PASSED
AgentsTests: agents.minitest_results[suite=./test_tacacs_server_gro...    PASSED
AgentsTests: agents.minitest_results[suite=./test_tacacs_server_hos...    PASSED
AgentsTests: agents.minitest_results[suite=./test_upgrade.rb]             PASSED
AgentsTests: agents.minitest_results[suite=./test_vdc.rb]                SKIPPED
AgentsTests: agents.minitest_results[suite=./test_vlan.rb]                PASSED
AgentsTests: agents.minitest_results[suite=./test_vlan_private.rb]        PASSED
AgentsTests: agents.minitest_results[suite=./test_vpc.rb]                 PASSED
AgentsTests: agents.minitest_results[suite=./test_vrf.rb]                 PASSED
AgentsTests: agents.minitest_results[suite=./test_vrf_af.rb]              PASSED
AgentsTests: agents.minitest_results[suite=./test_vtp.rb]                 PASSED
AgentsTests: agents.minitest_results[suite=./test_vxlan_vtep.rb]         SKIPPED
AgentsTests: agents.minitest_results[suite=./test_vxlan_vtep_vni.rb]     SKIPPED
AgentsTests: agents.minitest_results[suite=./test_yang.rb]               SKIPPED
AgentsTests: agents.minitest_results[suite=./test_yum.rb]                 PASSED
```