### PR TITLE
Add default state property to interface object

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -40,6 +40,13 @@ create:
   set_context: ~
   set_value: "interface <name>"
 
+default:
+  multiple:
+  set_context: ~
+  set_value:   "default interface <name>"
+  get_command: "show running interface <name>"
+  get_value:   '/(.*)/'
+
 description:
   kind: string
   get_value: '/^description (.*)/'

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -18,8 +18,11 @@ all_interfaces:
   multiple:
   ios_xr:
     get_command: 'show running all-interfaces'
+    get_value: '/^interface (.*)/'
+  nexus:
+    get_command: "show running-config interface | section '^interface'"
+    get_value: '/(.*)/'
   get_context: ~
-  get_value: '/^interface (.*)/'
 
 bfd_echo:
   _exclude: [ios_xr]

--- a/lib/cisco_node_utils/cmd_ref/interface_ospf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_ospf.yaml
@@ -6,6 +6,11 @@ _template:
   get_command: 'show running interface all'
   context: ["interface %s"]
 
+all_interfaces:
+  multiple:
+  get_context: ~
+  get_value: '/^interface (.*)/'
+
 area:
   get_value: '/^\s*ip router ospf (\S+) area (\S+)/'
   set_value: "%s ip router ospf %s area %s"

--- a/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
@@ -7,6 +7,11 @@ _template:
   get_context: ['/^interface %s$/i']
   set_context: ["interface %s"]
 
+all_interfaces:
+  multiple:
+  get_context: ~
+  get_value: '/^interface (.*)/'
+
 bfd_per_link:
   kind: boolean
   get_value: '/^bfd per-link$/'

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -141,7 +141,16 @@ module Cisco
     end
 
     def destroy
-      config_set('interface', 'destroy', name: @name)
+      if @name[/ethernet/]
+        config_set('interface', 'default', name: @name)
+      else
+        config_set('interface', 'destroy', name: @name)
+      end
+    end
+
+    def default?
+      state = config_get('interface', 'default', name: @name)
+      state.nil? ? true : false
     end
 
     def pvlan_enable

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -1,6 +1,6 @@
 # November 2015, Chris Van Heuveln
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -148,7 +148,7 @@ module Cisco
     end
 
     def destroy
-      if @name[/ethernet/]
+      if @name[/ethernet/] && !@name[/ethernet.*\.\d+/]
         config_set('interface', 'default', name: @name)
       else
         config_set('interface', 'destroy', name: @name)

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -595,6 +595,7 @@ module Cisco
     end
 
     def ipv4_dhcp_relay_info_trust=(state)
+      return false if !state && !Feature.dhcp_enabled?
       Feature.dhcp_enable if state
       config_set('interface', 'ipv4_dhcp_relay_info_trust',
                  name:  @name, state: state ? '' : 'no')
@@ -609,6 +610,7 @@ module Cisco
     end
 
     def ipv4_dhcp_relay_src_addr_hsrp=(state)
+      return false if !state && !Feature.dhcp_enabled?
       Feature.dhcp_enable if state
       config_set('interface', 'ipv4_dhcp_relay_src_addr_hsrp',
                  name:  @name, state: state ? '' : 'no')
@@ -627,8 +629,9 @@ module Cisco
 
     def ipv4_dhcp_relay_src_intf=(val)
       state = val == default_ipv4_dhcp_relay_src_intf ? 'no' : ''
-      intf = val == default_ipv4_dhcp_relay_src_intf ? '' : val
+      return false if state == 'no' && !Feature.dhcp_enabled?
       Feature.dhcp_enable if state.empty?
+      intf = val == default_ipv4_dhcp_relay_src_intf ? '' : val
       config_set('interface', 'ipv4_dhcp_relay_src_intf',
                  name:  @name, state: state, intf: intf)
     end
@@ -642,6 +645,7 @@ module Cisco
     end
 
     def ipv4_dhcp_relay_subnet_broadcast=(state)
+      return false if !state && !Feature.dhcp_enabled?
       Feature.dhcp_enable if state
       config_set('interface', 'ipv4_dhcp_relay_subnet_broadcast',
                  name:  @name, state: state ? '' : 'no')
@@ -656,6 +660,7 @@ module Cisco
     end
 
     def ipv4_dhcp_smart_relay=(state)
+      return false if !state && !Feature.dhcp_enabled?
       Feature.dhcp_enable if state
       config_set('interface', 'ipv4_dhcp_smart_relay',
                  name:  @name, state: state ? '' : 'no')
@@ -804,8 +809,9 @@ module Cisco
 
     def ipv6_dhcp_relay_src_intf=(val)
       state = val == default_ipv6_dhcp_relay_src_intf ? 'no' : ''
-      intf = val == default_ipv6_dhcp_relay_src_intf ? '' : val
+      return false if state == 'no' && !Feature.dhcp_enabled?
       Feature.dhcp_enable if state.empty?
+      intf = val == default_ipv6_dhcp_relay_src_intf ? '' : val
       config_set('interface', 'ipv6_dhcp_relay_src_intf',
                  name:  @name, state: state, intf: intf)
     end
@@ -1848,6 +1854,7 @@ module Cisco
       # TODO: throw UnsupportedError instead of returning false?
       return false unless switchport_vtp_mode_capable?
       no_cmd = (vtp_set) ? '' : 'no'
+      return false unless Feature.vtp_enabled? && no_cmd == ''
       config_set('interface', 'vtp', name: @name, state: no_cmd)
     end
 

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -51,7 +51,7 @@ module Cisco
     # Regexp to match various link bundle interface variants
     PORTCHANNEL = Regexp.new('(port-channel|Bundle-Ether)', Regexp::IGNORECASE)
 
-    attr_reader :name
+    attr_reader :name, :state_default
 
     def initialize(name, instantiate=true)
       fail TypeError unless name.is_a?(String)
@@ -60,6 +60,13 @@ module Cisco
       @smr = config_get('interface', 'stp_mst_range')
       @svr = config_get('interface', 'stp_vlan_range')
       @match_found = false
+      # Keep track of default vs non-default state for
+      # interfaces that cannot be created/destroyed.
+      @state_default = nil
+      # Track ethernet but not sub-interfaces
+      if @name[/ethernet/] && !@name[/ethernet.*\.\d+/]
+        @state_default = default?
+      end
       create if instantiate
     end
 

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -1857,8 +1857,9 @@ module Cisco
     def switchport_vtp=(vtp_set)
       # TODO: throw UnsupportedError instead of returning false?
       return false unless switchport_vtp_mode_capable?
+      return false if !vtp_set && !Feature.vtp_enabled?
+      Feature.vtp_enable if vtp_set
       no_cmd = (vtp_set) ? '' : 'no'
-      return false unless Feature.vtp_enabled? && no_cmd == ''
       config_set('interface', 'vtp', name: @name, state: no_cmd)
     end
 

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -152,9 +152,6 @@ module Cisco
     def create
       feature_vlan_set(true) if @name[/(vlan|bdi)/i]
       config_set('interface', 'create', name: @name)
-      if @name[/ethernet/] && !@name[/ethernet.*\.\d+/]
-        self.description = 'Managed by Puppet'
-      end
     rescue Cisco::CliError
       # Some XR platforms do not support channel-group configuration
       # on some OS versions. Since this is an OS version difference and not

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -79,12 +79,21 @@ module Cisco
       intf_list = config_get('interface', 'all_interfaces')
       return hash if intf_list.nil?
 
-      intf_list = intf_list.to_s.split('interface')
+      # Massage intf_list data into an array that is easy
+      # to work with.
+      intf_list.collect! { |x| x.strip || x }
+      intf_list.delete('')
+      intf_list = intf_list.join(' ').split('interface')
+      intf_list.delete('')
+
       intf_list.each do |id|
-        int_data = id.delete('"').split(',').select { |f| /\S+/.match(f) }
-        id = int_data[0].strip.downcase
-        next if id[/\[/]
+        int_data = id.strip.split(' ')
+        next if int_data[0].nil?
+        id = int_data[0].downcase
         next if opt && filter(opt, id)
+        # If there are any additional options associated
+        # with this interface then it's in a non-default
+        # state.
         default_state = int_data.size > 1 ? false : true
         hash[id] = Interface.new(id, false, default_state)
       end

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -152,6 +152,9 @@ module Cisco
     def create
       feature_vlan_set(true) if @name[/(vlan|bdi)/i]
       config_set('interface', 'create', name: @name)
+      if @name[/ethernet/] && !@name[/ethernet.*\.\d+/]
+        self.description = 'Managed by Puppet'
+      end
     rescue Cisco::CliError
       # Some XR platforms do not support channel-group configuration
       # on some OS versions. Since this is an OS version difference and not

--- a/lib/cisco_node_utils/interface_ospf.rb
+++ b/lib/cisco_node_utils/interface_ospf.rb
@@ -53,7 +53,7 @@ module Cisco
       fail TypeError unless ospf_name.is_a?(String) || ospf_name.nil?
       ints = {}
 
-      intf_list = config_get('interface', 'all_interfaces')
+      intf_list = config_get('interface_ospf', 'all_interfaces')
       return ints if intf_list.nil?
       intf_list.each do |name|
         match = config_get('interface_ospf', 'area', name)

--- a/lib/cisco_node_utils/interface_ospf.rb
+++ b/lib/cisco_node_utils/interface_ospf.rb
@@ -1,6 +1,6 @@
 # March 2015, Alex Hunsberger
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/cisco_node_utils/interface_portchannel.rb
+++ b/lib/cisco_node_utils/interface_portchannel.rb
@@ -1,6 +1,6 @@
 # December 2015, Sai Chintalapudi
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/cisco_node_utils/interface_portchannel.rb
+++ b/lib/cisco_node_utils/interface_portchannel.rb
@@ -38,7 +38,7 @@ module Cisco
 
     def self.interfaces
       hash = {}
-      intf_list = config_get('interface', 'all_interfaces')
+      intf_list = config_get('interface_portchannel', 'all_interfaces')
       return hash if intf_list.nil?
 
       intf_list.each do |id|

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -170,7 +170,7 @@ class TestBgpAF < CiscoTestCase
       # triggers a version check below.
       if expect == :runtime
         case Platform.image_version
-        when /8.0|8.1/
+        when /8.0|8.1|8.2/
           expect = :success
         when /I5.2|I5.3|I6/
           expect = :success if test == :maximum_paths || test == :maximum_paths_ibgp

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -4,7 +4,7 @@
 #
 # Richard Wellum, August, 2015
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1833,4 +1833,16 @@ class TestInterface < CiscoTestCase
     subif.destroy
     lb.destroy
   end
+
+  def test_destroy_physical
+    name = interfaces[0]
+    int = Interface.new(name)
+
+    int.description = 'destroy_pysical'
+    int.ipv4_addr_mask_set('192.168.0.1', '24')
+    refute(int.default?)
+
+    int.destroy
+    assert(int.default?)
+  end
 end

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2016 Cisco and/or its affiliates.
+# Copyright (c) 2013-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1837,16 +1837,27 @@ class TestInterface < CiscoTestCase
     lb.destroy
   end
 
-  def test_destroy_physical
+  def test_default_physical
     name = interfaces[0]
     int = Interface.new(name)
+    int.switchport_mode = :disabled
 
-    int.description = 'destroy_pysical'
+    # Verify l3 -> default
+    int.description = 'default_pysical'
     int.ipv4_addr_mask_set('192.168.0.1', '24')
     refute(int.default?)
 
     int.destroy
     assert(int.default?)
+
+    # Verify l2 trunk -> default
+    int.switchport_mode = :access
+    int.switchport_autostate_exclude = true
+    refute(int.default?)
+
+    int.destroy
+    assert(int.default?)
+  end
 
   def test_purge_config
     name = interfaces[0]


### PR DESCRIPTION
**This updates adds the following:**
  * Class variable `@state_default` used to indicate weather or not interface is in a default state. This information is only tracked for ethernet interfaces and excludes other types of interfaces that can be created and destroyed (vlan, loopback, sub-interfaces, port-channels etc...)
  * Refactor of the `self.interfaces` method to issue the `show run interfaces` command once and gather default and non-default state info for each interface from the single show command.
  * Fixes to various interface properties exposed by this change.

**NOTE:**
These changes are part set of diffs in the cisco puppet module that allow the `cisco_interface` type to treat physical and logical interfaces as truly `ensurable` resources.  Physical interfaces can now be created and destroyed logically so that they can be managed in the same way as a logical interfaces.

Puppet Changes: https://github.com/cisco/cisco-network-puppet-module/pull/470

**Tested on:**
N9k(I2, I6 and I7), N3k(I6), N7k(D1 and 8.2)