### PR TITLE
Improve performance

### DIFF
--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -69,7 +69,7 @@ class Cisco::Client::NXAPI < Cisco::Client
     @address = @http.address
 
     # Make sure we can actually connect to the socket
-    get(command: 'show hostname')
+    # get(command: 'show hostname')
   end
 
   def self.validate_args(**kwargs)

--- a/lib/cisco_node_utils/client/nxapi/client.rb
+++ b/lib/cisco_node_utils/client/nxapi/client.rb
@@ -67,9 +67,6 @@ class Cisco::Client::NXAPI < Cisco::Client
     # also used as the default config by firefox.
     @http.read_timeout = 300
     @address = @http.address
-
-    # Make sure we can actually connect to the socket
-    # get(command: 'show hostname')
   end
 
   def self.validate_args(**kwargs)

--- a/lib/cisco_node_utils/cmd_ref/show_version.yaml
+++ b/lib/cisco_node_utils/cmd_ref/show_version.yaml
@@ -1,7 +1,7 @@
 # show_version
 ---
 _template:
-  get_command: 'sh version'
+  get_command: 'sh hardware'
   nexus:
     data_format: nxapi_structured
   ios_xr:
@@ -65,9 +65,9 @@ system_image:
     get_value: '/^\s*(\S*)\s*version.*\[Boot image\]$/'
 
 uptime:
-  # TODO: redundant with show_system, uptime?
+  get_command: 'sh system uptime'
   get_data_format: cli
-  get_value: '/uptime is (.*)/'
+  get_value: '/Kernel uptime:\s+(.*)/'
 
 version:
   nexus:

--- a/tests/test_platform.rb
+++ b/tests/test_platform.rb
@@ -110,7 +110,7 @@ class TestPlatform < CiscoTestCase
   end
 
   def test_uptime
-    s = @device.cmd('sh ver').scan(/uptime is (.*)/).flatten.first
+    s = @device.cmd('sh system uptime').scan(/Kernel uptime:\s+(.*)/).flatten.first
     # compare without seconds
     assert_equal(s.gsub(/\d+ sec/, ''), Platform.uptime.gsub(/\d+ sec/, ''))
   end


### PR DESCRIPTION
This PR is for improving node utils performance while getting the facts.
1. "Show version" is very slow command, replaced with "Show hardware"
2. Unnecessary http requests removed
3. Use "show system uptime" to get uptime instead of "show version" which is slow.

Tested on N3k, N7k and N9k. there are few errors which are unrelated to this PR.