### PR TITLE
N3600 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Platform          | OS     | OS Version           |
 ------------------|--------|----------------------|
 Cisco Nexus N9k   | NX-OS  | 7.0(3)I2(1) and later
 Cisco Nexus N3k   | NX-OS  | 7.0(3)I2(1) and later
+Cisco Nexus N3K-F | NX-OS  | 7.0(3)F3(2) and later
 Cisco Nexus N5k   | NX-OS  | 7.3(0)N1(1) and later
 Cisco Nexus N6k   | NX-OS  | 7.3(0)N1(1) and later
 Cisco Nexus N7k   | NX-OS  | 7.3(0)D1(1) and later

--- a/lib/cisco_node_utils/aaa_authentication_login_service.rb
+++ b/lib/cisco_node_utils/aaa_authentication_login_service.rb
@@ -58,8 +58,8 @@ module Cisco
       if g_str.empty?
         # cannot remove default local, so do nothing in this case
         unless m == :local
-          unless node.product_id[/N9K-F/]
-            # TBD: These 'no' commands currently error on N9K-F
+          unless node.product_id[/N(3|9)K-F/]
+            # TBD: These 'no' commands currently error on N(3|9)K-F
             #   no aaa authentication login console local
             #   no aaa authentication login console none
             config_set('aaa_auth_login_service', 'method',

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -414,14 +414,11 @@ module Cisco
     # Nvgen as True With optional 'size <size>
     def event_history_cli
       match = config_get('bgp', 'event_history_cli', @get_args)
-      if match.is_a?(Array)
-        return 'false' if match[0] == 'no '
-        if match[1]
-          return match[1] if match[1][/\A\d+\z/]
-          return 'size_' + match[1]
-        end
-      end
-      default_event_history_cli
+      return unless match.is_a?(Array)
+      return 'false' if match[0] == 'no '
+      return unless match[1]
+      return match[1] if match[1][/\A\d+\z/]
+      'size_' + match[1]
     end
 
     def event_history_cli=(val)
@@ -432,23 +429,15 @@ module Cisco
       set_args_keys_default
     end
 
-    def default_event_history_cli
-      config_get_default('bgp', 'event_history_cli')
-    end
-
     # event-history detail [ size <size> ]
     # Nvgen as True With optional 'size <size>
     def event_history_detail
       match = config_get('bgp', 'event_history_detail', @get_args)
-      if match.is_a?(Array)
-        return 'false' if match[0] == 'no '
-        if match[1]
-          return match[1] if match[1][/\A\d+\z/]
-          return 'size_' + match[1]
-        end
-        return 'true'
-      end
-      default_event_history_detail
+      return unless match.is_a?(Array)
+      return 'false' if match[0] == 'no '
+      return 'true' unless match[1]
+      return match[1] if match[1][/\A\d+\z/]
+      'size_' + match[1]
     end
 
     def event_history_detail=(val)
@@ -459,22 +448,15 @@ module Cisco
       set_args_keys_default
     end
 
-    def default_event_history_detail
-      config_get_default('bgp', 'event_history_detail')
-    end
-
     # event-history errors [ size <size> ]
     # Nvgen as True With optional 'size <size>
     def event_history_errors
       match = config_get('bgp', 'event_history_errors', @get_args)
-      if match.is_a?(Array)
-        return 'false' if match[0] == 'no '
-        if match[1]
-          return match[1] if match[1][/\A\d+\z/]
-          return 'size_' + match[1]
-        end
-      end
-      default_event_history_errors
+      return unless match.is_a?(Array)
+      return 'false' if match[0] == 'no '
+      return unless match[1]
+      return match[1] if match[1][/\A\d+\z/]
+      'size_' + match[1]
     end
 
     def event_history_errors=(val)
@@ -485,22 +467,15 @@ module Cisco
       set_args_keys_default
     end
 
-    def default_event_history_errors
-      config_get_default('bgp', 'event_history_errors')
-    end
-
     # event-history events [ size <size> ]
     # Nvgen as True With optional 'size <size>
     def event_history_events
       match = config_get('bgp', 'event_history_events', @get_args)
-      if match.is_a?(Array)
-        return 'false' if match[0] == 'no '
-        if match[1]
-          return match[1] if match[1][/\A\d+\z/]
-          return 'size_' + match[1]
-        end
-      end
-      default_event_history_events
+      return unless match.is_a?(Array)
+      return 'false' if match[0] == 'no '
+      return unless match[1]
+      return match[1] if match[1][/\A\d+\z/]
+      'size_' + match[1]
     end
 
     def event_history_events=(val)
@@ -511,28 +486,15 @@ module Cisco
       set_args_keys_default
     end
 
-    def default_event_history_events
-      if Utils.image_version?(/7.0.3.I2|I3|I4/) ||
-         node.product_id[/(N5|N6|N7|N9.*-F)/]
-        config_get_default('bgp', 'event_history_events')
-      else
-        config_get('bgp', 'event_history_events_bytes', @get_args)
-      end
-    end
-
     # event-history objstore [ size <size> ]
     # Nvgen as True With optional 'size <size>
     def event_history_objstore
       match = config_get('bgp', 'event_history_objstore', @get_args)
-      if match.is_a?(Array)
-        return 'false' if match[0] == 'no '
-        if match[1]
-          return match[1] if match[1][/\A\d+\z/]
-          return 'size_' + match[1]
-        end
-        return 'true'
-      end
-      default_event_history_objstore
+      return unless match.is_a?(Array)
+      return 'false' if match[0] == 'no '
+      return 'true' unless match[1]
+      return match[1] if match[1][/\A\d+\z/]
+      'size_' + match[1]
     end
 
     def event_history_objstore=(val)
@@ -543,25 +505,15 @@ module Cisco
       set_args_keys_default
     end
 
-    def default_event_history_objstore
-      config_get_default('bgp', 'event_history_objstore')
-    end
-
     # event-history periodic [ size <size> ]
     # Nvgen as True With optional 'size <size>
     def event_history_periodic
       match = config_get('bgp', 'event_history_periodic', @get_args)
-      if match.is_a?(Array)
-        return 'false' if match[0] == 'no '
-        if match[1]
-          return match[1] if match[1][/\A\d+\z/]
-          return 'size_' + match[1]
-        end
-      else
-        return default_event_history_periodic
-      end
-      return 'true' unless default_event_history_periodic[/size/]
-      default_event_history_periodic
+      return unless match.is_a?(Array)
+      return 'false' if match[0] == 'no '
+      return unless match[1]
+      return match[1] if match[1][/\A\d+\z/]
+      'size_' + match[1]
     end
 
     def event_history_periodic=(val)
@@ -570,15 +522,6 @@ module Cisco
       @set_args[:state] = val[/false/] ? 'no' : ''
       config_set('bgp', 'event_history_periodic', @set_args)
       set_args_keys_default
-    end
-
-    def default_event_history_periodic
-      if Utils.image_version?(/7.0.3.I2|I3|I4/) ||
-         node.product_id[/(N5|N6|N7|N9.*-F)/]
-        config_get_default('bgp', 'event_history_periodic')
-      else
-        config_get('bgp', 'event_history_periodic_bytes', @get_args)
-      end
     end
 
     # Fast External fallover (Getter/Setter/Default)

--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -1,6 +1,6 @@
 # June 2015, Michael G Wiebe
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
+++ b/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
@@ -17,7 +17,7 @@ private_vlan_any:
 
 private_vlan_association:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'pvlan_association'
-  _exclude: [N9k-F]
+  _exclude: [N3k-F, N9k-F]
   multiple: true
   get_command: "show vlan private-vlan"
   get_context: ~
@@ -28,7 +28,7 @@ private_vlan_association:
 
 private_vlan_mapping:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'pvlan_mapping'
-  _exclude: [ios_xr, N9k-F]
+  _exclude: [ios_xr, N3k-F, N9k-F]
   multiple: true
   get_value: '/^private-vlan mapping (.*)$/'
   set_value: "<state> private-vlan mapping <vlans>"
@@ -36,7 +36,7 @@ private_vlan_mapping:
 
 private_vlan_type:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'pvlan_type'
-  _exclude: [N9k-F]
+  _exclude: [N3k-F, N9k-F]
   kind: string
   get_command: 'show vlan private-vlan type'
   get_context: ~
@@ -47,14 +47,14 @@ private_vlan_type:
 
 switchport_mode_private_vlan_host:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_host'
-  _exclude: [ios_xr, N9k-F]
+  _exclude: [ios_xr, N3k-F, N9k-F]
   get_value: '/^switchport mode private-vlan (.*)$/'
   set_value: "<state> switchport mode private-vlan <mode>"
   default_value: :disabled
 
 switchport_mode_private_vlan_host_association:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_host_association'
-  _exclude: [ios_xr, N9k-F]
+  _exclude: [ios_xr, N3k-F, N9k-F]
   multiple: true
   get_value: '/^switchport private-vlan host-association (.*)$/'
   set_value: "<state> switchport private-vlan host-association <vlan_pr> <vlan_sec>"
@@ -62,7 +62,7 @@ switchport_mode_private_vlan_host_association:
 
 switchport_mode_private_vlan_host_promiscous:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_promiscuous'
-  _exclude: [ios_xr, N9k-F]
+  _exclude: [ios_xr, N3k-F, N9k-F]
   multiple: true
   get_value: '/^switchport private-vlan mapping (\d+.*)$/'
   set_value: "<state> switchport private-vlan mapping <vlan_pr> <vlans>"
@@ -70,7 +70,7 @@ switchport_mode_private_vlan_host_promiscous:
 
 switchport_mode_private_vlan_trunk_promiscuous:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_trunk_promiscuous'
-  _exclude: [ios_xr, N3k, N9k-F]
+  _exclude: [ios_xr, N3k, N3k-F, N9k-F]
   kind: boolean
   get_value: '/^switchport mode private-vlan trunk promiscuous$/'
   set_value: "<state> switchport mode private-vlan trunk promiscuous"
@@ -78,7 +78,7 @@ switchport_mode_private_vlan_trunk_promiscuous:
 
 switchport_mode_private_vlan_trunk_secondary:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_trunk_secondary'
-  _exclude: [ios_xr, N3k, N9k-F]
+  _exclude: [ios_xr, N3k, N3k-F, N9k-F]
   kind: boolean
   get_value: '/^switchport mode private-vlan trunk secondary$/'
   set_value: "<state> switchport mode private-vlan trunk secondary"
@@ -86,7 +86,7 @@ switchport_mode_private_vlan_trunk_secondary:
 
 switchport_private_vlan_association_trunk:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_trunk_association'
-  _exclude: [ios_xr, N3k, N9k-F]
+  _exclude: [ios_xr, N3k, N3k-F, N9k-F]
   multiple: true
   #get_value: '/^switchport private-vlan association trunk (.*) (.*)$/'
   get_value: '/^switchport private-vlan association trunk (.*)$/'
@@ -95,7 +95,7 @@ switchport_private_vlan_association_trunk:
 
 switchport_private_vlan_mapping_trunk:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_mapping_trunk'
-  _exclude: [ios_xr, N3k, N9k-F]
+  _exclude: [ios_xr, N3k, N3k-F, N9k-F]
   multiple: true
   get_value: '/^switchport private-vlan mapping trunk (.*)$/'
   set_value: "<state> switchport private-vlan mapping trunk <vlan_pr> <vlans>"
@@ -103,7 +103,7 @@ switchport_private_vlan_mapping_trunk:
 
 switchport_private_vlan_trunk_allowed_vlan:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_trunk_allowed_vlan'
-  _exclude: [ios_xr, N9k-F]
+  _exclude: [ios_xr, N3k-F, N9k-F]
   multiple: true
   get_value: '/^switchport private-vlan trunk allowed vlan (.*)$/'
   set_value: "<state> switchport private-vlan trunk allowed vlan <oper> <vlans>"
@@ -111,7 +111,7 @@ switchport_private_vlan_trunk_allowed_vlan:
 
 switchport_private_vlan_trunk_native_vlan:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'switchport_pvlan_trunk_native_vlan'
-  _exclude: [ios_xr, N9k-F]
+  _exclude: [ios_xr, N3k-F, N9k-F]
   kind: int
   get_value: '/^switchport private-vlan trunk native vlan (.*)$/'
   set_value: "<state> switchport private-vlan trunk native vlan <vlan>"

--- a/lib/cisco_node_utils/cmd_ref/README_YAML.md
+++ b/lib/cisco_node_utils/cmd_ref/README_YAML.md
@@ -255,7 +255,8 @@ vrf:
 
 ### Product variants
 
-Various product categories can also be used as keys to subdivide attributes as needed. Supported categories currently include the various Nexus switch product lines (`N3k`, `N5k`, `N6k`. `N7k`, `N9k`). When using one or more product keys in this fashion, you can also use the special key `else` to handle all other products not specifically called out:
+Various product categories can also be used as keys to subdivide attributes as needed. Supported categories currently
+include the various Nexus switch product lines (`N3k`, `N3k-F`, `N5k`, `N6k`. `N7k`, `N9k`, `N9k-F`). When using one or more product keys in this fashion, you can also use the special key `else` to handle all other products not specifically called out:
 
 ```yaml
 # show_version.yaml

--- a/lib/cisco_node_utils/cmd_ref/aaa_authorization_service.yaml
+++ b/lib/cisco_node_utils/cmd_ref/aaa_authorization_service.yaml
@@ -28,6 +28,7 @@ remove_local_auth:
   N3k: &remove_local_allowed
     default_only: true
   N9k: *remove_local_allowed
+  N3k-F: *remove_local_allowed
   N9k-F: *remove_local_allowed
   N5k: *remove_local_allowed
   N6k: *remove_local_allowed

--- a/lib/cisco_node_utils/cmd_ref/bfd_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bfd_global.yaml
@@ -23,20 +23,20 @@ echo_rx_interval:
     default_value: 50
 
 fabricpath_interval:
-  _exclude: [N3k, N9k-F, N9k]
+  _exclude: [N3k, N3k-F, N9k-F, N9k]
   get_value: '/^bfd fabricpath interval (\d+) min_rx (\d+) multiplier (\d+)$/'
   set_value: '<state> bfd fabricpath interval <interval> min_rx <min_rx> multiplier <multiplier>'
   default_value: ['50', '50', '3']
 
 fabricpath_slow_timer:
-  _exclude: [N3k, N9k-F, N9k]
+  _exclude: [N3k, N3k-F, N9k-F, N9k]
   kind: int
   get_value: '/^bfd fabricpath slow-timer (\d+)$/'
   set_value: '<state> bfd fabricpath slow-timer <timer>'
   default_value: 2000
 
 fabricpath_vlan:
-  _exclude: [N3k, N9k-F, N9k]
+  _exclude: [N3k, N3k-F, N9k-F, N9k]
   kind: int
   get_value: '/^bfd fabricpath vlan (\d+)$/'
   set_value: '<state> bfd fabricpath vlan <vlan>'

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -170,7 +170,7 @@ event_history_events:
   set_value: '<state> event-history events <size>'
 
 event_history_objstore:
-  _exclude: [ios_xr]
+  _exclude: [ios_xr, N5k, N6k]
   os_version: 'N7k:8.0; N3k, N9k:7.0.3.I5.1, N9k-F:7.0.3.F3.2'
   get_value: '/^(no )?event-history objstore(?: size (\S+))?$/'
   set_value: '<state> event-history objstore <size>'

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -152,43 +152,33 @@ event_history_cli:
   _exclude: [ios_xr]
   get_value: '/^(no )?event-history cli(?: size (\S+))?$/'
   set_value: '<state> event-history cli <size>'
-  default_value: 'size_small'
 
 event_history_detail:
   _exclude: [ios_xr]
   get_value: '/^(no )?event-history detail(?: size (\S+))?$/'
   set_value: '<state> event-history detail <size>'
-  default_value: 'false'
 
 event_history_errors:
-  _exclude: [ios_xr]
+  _exclude: [ios_xr, N5k, N6k]
+  os_version: 'N7k:8.0; N3k, N9k:7.0.3.I5.1, N9k-F:7.0.3.F3.2'
   get_value: '/^(no )?event-history errors(?: size (\S+))?$/'
   set_value: '<state> event-history errors <size>'
-  default_value: 'size_medium'
 
 event_history_events:
   _exclude: [ios_xr]
   get_value: '/^(no )?event-history events(?: size (\S+))?$/'
   set_value: '<state> event-history events <size>'
-  default_value: 'size_small'
-
-event_history_events_bytes:
-  default_only: 'size_large'
 
 event_history_objstore:
   _exclude: [ios_xr]
+  os_version: 'N7k:8.0; N3k, N9k:7.0.3.I5.1, N9k-F:7.0.3.F3.2'
   get_value: '/^(no )?event-history objstore(?: size (\S+))?$/'
   set_value: '<state> event-history objstore <size>'
-  default_value: 'false'
 
 event_history_periodic:
   _exclude: [ios_xr]
   get_value: '/^(no )?event-history periodic(?: size (\S+))?$/'
   set_value: '<state> event-history periodic <size>'
-  default_value: 'size_small'
-
-event_history_periodic_bytes:
-  default_only: 'false'
 
 fast_external_fallover:
   kind: boolean

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -282,7 +282,7 @@ nsr:
   set_value: '<state> nsr'
 
 process_initialized:
-  _exclude: [ios_xr, N3k, N7k, N9k]
+  _exclude: [ios_xr, N3k, N3k-F, N7k, N9k, N9k-F]
   # bgp process initialization state
   kind: boolean
   context: ~

--- a/lib/cisco_node_utils/cmd_ref/bgp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp.yaml
@@ -160,7 +160,7 @@ event_history_detail:
 
 event_history_errors:
   _exclude: [ios_xr, N5k, N6k]
-  os_version: 'N7k:8.0; N3k, N9k:7.0.3.I5.1, N9k-F:7.0.3.F3.2'
+  os_version: 'N7k:8.0; N3k, N9k:7.0.3.I5.1; N9k-F:7.0.3.F3.2'
   get_value: '/^(no )?event-history errors(?: size (\S+))?$/'
   set_value: '<state> event-history errors <size>'
 
@@ -171,7 +171,7 @@ event_history_events:
 
 event_history_objstore:
   _exclude: [ios_xr, N5k, N6k]
-  os_version: 'N7k:8.0; N3k, N9k:7.0.3.I5.1, N9k-F:7.0.3.F3.2'
+  os_version: 'N7k:8.0; N3k, N9k:7.0.3.I5.1; N9k-F:7.0.3.F3.2'
   get_value: '/^(no )?event-history objstore(?: size (\S+))?$/'
   set_value: '<state> event-history objstore <size>'
 

--- a/lib/cisco_node_utils/cmd_ref/bgp_af.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp_af.yaml
@@ -11,7 +11,7 @@ _template:
     get_command: 'show running-config router bgp'
 
 additional_paths_install:
-  _exclude: [ios_xr, N3k, N9k-F, N9k]
+  _exclude: [ios_xr, N3k, N3k-F, N9k-F, N9k]
   kind: boolean
   get_value: '/^additional-paths install backup$/'
   set_value: '<state> additional-paths install backup'

--- a/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bgp_neighbor_af.yaml
@@ -194,6 +194,7 @@ soft_reconfiguration_in:
     get_value: '/^soft-reconfiguration inbound(?: always)?/'
     set_value: '<state> soft-reconfiguration inbound <always>'
   N3k: *soft_recon_always
+  N3k-F: *soft_recon_always
   N9k-F: *soft_recon_always
   N9k: *soft_recon_always
   else:

--- a/lib/cisco_node_utils/cmd_ref/bridge_domain.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bridge_domain.yaml
@@ -1,7 +1,7 @@
 # bridge_domain
 # bridge_domain feature is available only on n7k
 ---
-_exclude: [N3k, N5k, N6k, N9k-F, N9k, ios_xr]
+_exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k, ios_xr]
 
 _template:
   get_command: "show running-config bridge-domain"

--- a/lib/cisco_node_utils/cmd_ref/bridge_domain_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/bridge_domain_vni.yaml
@@ -1,6 +1,6 @@
 # bridge_domain
 ---
-_exclude: [N3k, N5k, N6k, N9k-F, N9k, ios_xr]
+_exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k, ios_xr]
 
 create:
   set_value: "bridge-domain <bd>"

--- a/lib/cisco_node_utils/cmd_ref/dhcp_relay_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/dhcp_relay_global.yaml
@@ -47,6 +47,7 @@ ipv4_relay:
     default_value: false
   N6k: *relay_default_false
   N7k: *relay_default_true
+  N3k-F: *relay_default_true
   N9k-F: *relay_default_true
   N9k: *relay_default_true
 
@@ -57,7 +58,7 @@ ipv4_smart_relay:
   default_value: false
 
 ipv4_src_addr_hsrp:
-  _exclude: [N3k, N9k-F, N9k]
+  _exclude: [N3k, N3k-F, N9k-F, N9k]
   kind: boolean
   get_value: '/^ip dhcp relay source-address hsrp$/'
   set_value: "<state> ip dhcp relay source-address hsrp"
@@ -69,14 +70,14 @@ ipv4_src_intf:
   default_value: false
 
 ipv4_sub_option_circuit_id_custom:
-  _exclude: [N7k, N9k-F]
+  _exclude: [N7k, N3k-F, N9k-F]
   kind: boolean
   get_value: '/^ip dhcp relay sub-option circuit-id customized$/'
   set_value: "<state> ip dhcp relay sub-option circuit-id customized"
   default_value: false
 
 ipv4_sub_option_circuit_id_string:
-  _exclude: [N5k, N6k, N7k, N9k-F]
+  _exclude: [N5k, N6k, N7k, N3k-F, N9k-F]
   os_version: 'N9k:7.0.3.I6.1'
   get_value: '/^ip dhcp relay sub-option circuit-id format-type string format (.*)$/'
   set_value: "<state> ip dhcp relay sub-option circuit-id format-type string <format> <word>"
@@ -117,6 +118,7 @@ ipv6_relay:
     default_value: false
   N6k: *v6_relay_default_false
   N7k: *v6_relay_default_true
+  N3k-F: *v6_relay_default_true
   N9k-F: *v6_relay_default_true
   N9k: *v6_relay_default_true
 

--- a/lib/cisco_node_utils/cmd_ref/encapsulation.yaml
+++ b/lib/cisco_node_utils/cmd_ref/encapsulation.yaml
@@ -1,7 +1,7 @@
 # encapsulation_profile_vni
 # encapsulation_profile_vni feature is available only on n7k
 ---
-_exclude: [N3k, N5k, N6k, N9k-F, N9k, ios_xr]
+_exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k, ios_xr]
 
 all_encaps:
   multiple: true

--- a/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
+++ b/lib/cisco_node_utils/cmd_ref/fabricpath.yaml
@@ -1,6 +1,6 @@
 # fabricpath
 ---
-_exclude: [N3k, N9k-F, N9k, ios_xr]
+_exclude: [N3k, N3k-F, N9k-F, N9k, ios_xr]
 
 aggregate_multicast_routes:
   _exclude: [N5k, N6k]

--- a/lib/cisco_node_utils/cmd_ref/fabricpath_topology.yaml
+++ b/lib/cisco_node_utils/cmd_ref/fabricpath_topology.yaml
@@ -1,7 +1,7 @@
 # fabricpath_topology
 ---
 # Fabricpath feature is not available on N3K and N9K
-_exclude: [N3k, N9k-F, N9k, ios_xr]
+_exclude: [N3k, N3k-F, N9k-F, N9k, ios_xr]
 
 _template:
   get_command: 'show running-config fabricpath all'

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -21,7 +21,7 @@ dhcp:
   set_value: "feature dhcp"
 
 fabric:
-  _exclude: [N3k, N9k-F, N9k]
+  _exclude: [N3k, N3k-F, N9k-F, N9k]
   get_command: "show feature-set"
   get_value: '/^fabric[\s\d]+(\w+)/'
   set_value: "<state> feature-set fabric"
@@ -32,7 +32,7 @@ fabric_forwarding:
   set_value: "feature fabric forwarding"
 
 fex:
-  _exclude: [C3064, C3132, N5k, N6k, N9k-F]
+  _exclude: [C3064, C3132, N5k, N6k, N3k-F, N9k-F]
   get_command: "show feature-set"
   get_value: '/^fex[\s\d]+(\w+)/'
   set_value: "<state> feature-set fex"
@@ -78,7 +78,7 @@ pim:
   set_value: 'feature pim'
 
 private_vlan:
-  _exclude: [N9k-F]
+  _exclude: [N3k-F, N9k-F]
   kind: boolean
   get_value: '/^feature private-vlan$/'
   set_value: "feature private-vlan"

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -201,7 +201,7 @@ ipv4_dhcp_relay_info_trust:
   default_value: false
 
 ipv4_dhcp_relay_src_addr_hsrp:
-  _exclude: [ios_xr, N3k, N9k-F, N9k]
+  _exclude: [ios_xr, N3k, N3k-F, N9k-F, N9k]
   kind: boolean
   get_value: '/^ip dhcp relay source-address hsrp$/'
   set_value: "<state> ip dhcp relay source-address hsrp"
@@ -389,7 +389,7 @@ pvlan_any:
 # 'switchport_pvlan_mapping_trunk' is the switchport-pvlan-trunk command
 pvlan_mapping:
   # SVI-only property
-  _exclude: [ios_xr, N9k-F]
+  _exclude: [ios_xr, N3k-F, N9k-F]
   get_value: '/^private-vlan mapping (.*)/'
   set_value: "<state> private-vlan mapping <vlan>"
   default_value: []
@@ -587,68 +587,68 @@ switchport_mode_port_channel:
   default_value: ""
 
 switchport_pvlan_host:
-  _exclude: [ios_xr, N9k-F]
+  _exclude: [ios_xr, N3k-F, N9k-F]
   kind: boolean
   get_value: '/^switchport mode private-vlan host$/'
   set_value: "<state> switchport mode private-vlan host"
   default_value: false
 
 switchport_pvlan_host_association:
-  _exclude: [ios_xr, N9k-F]
+  _exclude: [ios_xr, N3k-F, N9k-F]
   # Note this is NOT a multiple, unlike trunk association.
   get_value: '/^switchport private-vlan host-association (\d+) (\d+)$/'
   set_value: "<state> switchport private-vlan host-association <pri> <sec>"
   default_value: []
 
 switchport_pvlan_mapping:
-  _exclude: [ios_xr, N9k-F]
+  _exclude: [ios_xr, N3k-F, N9k-F]
   get_value: '/^switchport private-vlan mapping (\d+) (.*)$/'
   set_value: "<state> switchport private-vlan mapping <primary> <vlan>"
   default_value: []
 
 switchport_pvlan_mapping_trunk:
-  _exclude: [ios_xr, N3k, N9k-F]
+  _exclude: [ios_xr, N3k, N3k-F, N9k-F]
   multiple:
   get_value: '/^switchport private-vlan mapping trunk (\d+) (.*)$/'
   set_value: "<state> switchport private-vlan mapping trunk <primary> <range>"
   default_value: []
 
 switchport_pvlan_promiscuous:
-  _exclude: [ios_xr, N9k-F]
+  _exclude: [ios_xr, N3k-F, N9k-F]
   kind: boolean
   get_value: '/^switchport mode private-vlan promiscuous$/'
   set_value: "<state> switchport mode private-vlan promiscuous"
   default_value: false
 
 switchport_pvlan_trunk_allowed_vlan:
-  _exclude: [ios_xr, N9k-F]
+  _exclude: [ios_xr, N3k-F, N9k-F]
   multiple: true
   get_value: '/^switchport private-vlan trunk allowed vlan (?:add )?(\S+)$/'
   set_value: "switchport private-vlan trunk allowed vlan <range>"
   default_value: 'none'
 
 switchport_pvlan_trunk_association:
-  _exclude: [ios_xr, N3k, N9k-F]
+  _exclude: [ios_xr, N3k, N3k-F, N9k-F]
   multiple:
   get_value: '/^switchport private-vlan association trunk (\d+) (\d+)$/'
   set_value: "<state> switchport private-vlan association trunk <pri> <sec>"
   default_value: []
 
 switchport_pvlan_trunk_native_vlan:
-  _exclude: [ios_xr, N9k-F]
+  _exclude: [ios_xr, N3k-F, N9k-F]
   get_value: '/^switchport private-vlan trunk native vlan (.*)$/'
   set_value: "switchport private-vlan trunk native vlan <vlan>"
   default_value: '1'
 
 switchport_pvlan_trunk_promiscuous:
-  _exclude: [ios_xr, N3k, N9k-F]
+  _exclude: [ios_xr, N3k, N3k-F, N9k-F]
   kind: boolean
   get_value: '/^switchport mode private-vlan trunk promiscuous$/'
   set_value: "<state> switchport mode private-vlan trunk promiscuous"
   default_value: false
 
 switchport_pvlan_trunk_secondary:
-  _exclude: [ios_xr, N3k, N9k-F]
+  _exclude: [ios_xr, N3k, N3k-F, N9k-F]
   kind: boolean
   get_value: '/^switchport mode private-vlan trunk secondary$/'
   set_value: "<state> switchport mode private-vlan trunk secondary"
@@ -711,14 +711,14 @@ system_default_switchport_shutdown:
     default_only: true
 
 vlan_mapping:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   multiple:
   get_value: '/^switchport vlan mapping (\d+) (\d+)/'
   set_value: '<state> switchport vlan mapping <original> <translated>'
   default_value: []
 
 vlan_mapping_enable:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   kind: boolean
   get_value: '/^(no )?switchport vlan mapping enable/'
   set_value: '<state> switchport vlan mapping enable'

--- a/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_portchannel.yaml
@@ -43,6 +43,7 @@ lacp_max_bundle:
     default_value: 16
   N6k: *lacp_max_bundle_16
   N7k: *lacp_max_bundle_16
+  N3k-F: *lacp_max_bundle_32
   N9k-F: *lacp_max_bundle_32
   N9k: *lacp_max_bundle_32
 

--- a/lib/cisco_node_utils/cmd_ref/interface_service_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_service_vni.yaml
@@ -1,6 +1,6 @@
 # interface_service_vni
 ---
-_exclude: [N3k, N5k, N6k, N9k-F, N9k, ios_xr]
+_exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k, ios_xr]
 
 _template:
   get_command: 'show running interface all'

--- a/lib/cisco_node_utils/cmd_ref/itd_device_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/itd_device_group.yaml
@@ -1,6 +1,6 @@
 # itd_device_group
 ---
-_exclude: [N3k, N5k, N6k, N9k-F, ios_xr]
+_exclude: [N3k, N5k, N6k, N3k-F, N9k-F, ios_xr]
 
 _template:
   get_command: "show running-config all | section itd"

--- a/lib/cisco_node_utils/cmd_ref/itd_service.yaml
+++ b/lib/cisco_node_utils/cmd_ref/itd_service.yaml
@@ -1,6 +1,6 @@
 # itd_service
 ---
-_exclude: [N3k, N5k, N6k, N9k-F, ios_xr]
+_exclude: [N3k, N5k, N6k, N3k-F, N9k-F, ios_xr]
 
 _template:
   get_command: "show running-config all | section itd"

--- a/lib/cisco_node_utils/cmd_ref/ospf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ospf.yaml
@@ -32,7 +32,7 @@ log_adjacency:
   default_value: :none
 
 process_initialized:
-  _exclude: [ios_xr, N3k, N7k, N9k-F, N9k]
+  _exclude: [ios_xr, N3k, N7k, N3k-F, N9k-F, N9k]
   # ospf process initialization state
   kind: boolean
   context: ~

--- a/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
@@ -6,7 +6,7 @@ _template:
   get_command: "show running all"
 
 asymmetric:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   default_value: false
 
 bundle_hash:
@@ -18,23 +18,24 @@ bundle_hash:
   N9k-F: &bundle_hash_ip_l4port
     default_value: 'ip-l4port'
   N9k: *bundle_hash_ip_l4port
+  N3k-F: *bundle_hash_ip_l4port
 
 bundle_select:
   default_value: 'src-dst'
 
 concatenation:
-  _exclude: [N3k, N5k, N6k, N7k, N9k-F]
+  _exclude: [N3k, N5k, N6k, N7k, N3k-F, N9k-F]
   default_value: false
 
 hash_distribution:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   get_value: '/^port.channel hash.distribution (.*)$/'
   set_context:  ['terminal dont-ask']
   set_value: "port-channel hash-distribution %s"
   default_value: 'adaptive'
 
 hash_poly:
-  _exclude: [N3k, N7k, N9k-F, N9k]
+  _exclude: [N3k, N7k, N3k-F, N9k-F, N9k]
   default_value: ~
 
 load_balance_type:
@@ -50,9 +51,10 @@ load_balance_type:
     default_only: "no_hash"
   N9k: &load_balance_type_symmetry
     default_only: "symmetry"
+  N3k-F: *load_balance_type_no_hash
 
 load_defer:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   kind: int
   get_value: '/^port.channel load.defer (\d+)$/'
   set_value: "port-channel load-defer %s"
@@ -64,7 +66,7 @@ port_channel_load_balance:
   set_value: "port-channel load-balance %s %s %s %s %s %s"
 
 resilient:
-  _exclude: [N5k, N6k, N7k, N9k-F]
+  _exclude: [N5k, N6k, N7k, N3k-F, N9k-F]
   kind: boolean
   get_value: '/^port-channel load-balance resilient$/'
   set_value: "%s port-channel load-balance resilient"
@@ -80,5 +82,5 @@ rotate:
   default_value: 0
 
 symmetry:
-  _exclude: [N5k, N6k, N7k, N9k-F]
+  _exclude: [N5k, N6k, N7k, N3k-F, N9k-F]
   default_value: false

--- a/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
@@ -46,10 +46,10 @@ load_balance_type:
   N6k: *load_balance_type_ethernet
   N7k: &load_balance_type_asymmetric
     default_only: "asymmetric"
-  N9k-F: &load_balance_type_no_hash
-    default_only: "no_hash"
   N9k: &load_balance_type_symmetry
     default_only: "symmetry"
+  N9k-F: &load_balance_type_no_hash
+    default_only: "no_hash"
 
 load_defer:
   _exclude: [N3k, N5k, N6k, N9k-F, N9k]

--- a/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/portchannel_global.yaml
@@ -46,10 +46,10 @@ load_balance_type:
   N6k: *load_balance_type_ethernet
   N7k: &load_balance_type_asymmetric
     default_only: "asymmetric"
-  N9k: &load_balance_type_symmetry
-    default_only: "symmetry"
   N9k-F: &load_balance_type_no_hash
     default_only: "no_hash"
+  N9k: &load_balance_type_symmetry
+    default_only: "symmetry"
 
 load_defer:
   _exclude: [N3k, N5k, N6k, N9k-F, N9k]

--- a/lib/cisco_node_utils/cmd_ref/route_map.yaml
+++ b/lib/cisco_node_utils/cmd_ref/route_map.yaml
@@ -45,46 +45,46 @@ match_community_exact_match:
   default_value: false
 
 match_evpn_route_type:
-  _exclude: [N35, N3k, N9k, N9k-F]
+  _exclude: [N35, N3k, N3k-F, N9k, N9k-F]
   multiple:
   get_value: '/^match evpn route-type (.*)$/'
   set_value: "<state> match evpn route-type <type>"
   default_value: []
 
 match_evpn_route_type_1:
-  _exclude: [N35, N3k, N9k, N9k-F]
+  _exclude: [N35, N3k, N3k-F, N9k, N9k-F]
   default_value: false
 
 match_evpn_route_type_2_all:
-  _exclude: [N35, N3k, N9k, N9k-F]
+  _exclude: [N35, N3k, N3k-F, N9k, N9k-F]
   default_value: false
 
 match_evpn_route_type_2_mac_ip:
-  _exclude: [N35, N3k, N9k, N9k-F]
+  _exclude: [N35, N3k, N3k-F, N9k, N9k-F]
   default_value: false
 
 match_evpn_route_type_2_mac_only:
-  _exclude: [N35, N3k, N9k, N9k-F]
+  _exclude: [N35, N3k, N3k-F, N9k, N9k-F]
   default_value: false
 
 match_evpn_route_type_3:
-  _exclude: [N35, N3k, N9k, N9k-F]
+  _exclude: [N35, N3k, N3k-F, N9k, N9k-F]
   default_value: false
 
 match_evpn_route_type_4:
-  _exclude: [N35, N3k, N9k, N9k-F]
+  _exclude: [N35, N3k, N3k-F, N9k, N9k-F]
   default_value: false
 
 match_evpn_route_type_5:
-  _exclude: [N35, N3k, N9k, N9k-F]
+  _exclude: [N35, N3k, N3k-F, N9k, N9k-F]
   default_value: false
 
 match_evpn_route_type_6:
-  _exclude: [N35, N3k, N9k, N9k-F]
+  _exclude: [N35, N3k, N3k-F, N9k, N9k-F]
   default_value: false
 
 match_evpn_route_type_all:
-  _exclude: [N35, N3k, N9k, N9k-F]
+  _exclude: [N35, N3k, N3k-F, N9k, N9k-F]
   default_value: false
 
 match_ext_community:
@@ -195,13 +195,13 @@ match_ipv6_route_src_prefix_list:
   default_value: []
 
 match_length:
-  _exclude: [N35, N3k, N9k, N9k-F]
+  _exclude: [N35, N3k, N3k-F, N9k, N9k-F]
   get_value: '/^match length (\d+) (\d+)$/'
   set_value: "<state> match length <min> <max>"
   default_value: []
 
 match_mac_list:
-  _exclude: [N35, N3k, N9k, N9k-F]
+  _exclude: [N35, N3k, N3k-F, N9k, N9k-F]
   get_value: '/^match mac-list (.*)$/'
   set_value: "<state> match mac-list <mac>"
   default_value: []
@@ -213,7 +213,7 @@ match_metric:
   default_value: []
 
 match_ospf_area:
-  _exclude: [N5k, N6k, N7k, N9k-F]
+  _exclude: [N5k, N6k, N7k, N3k-F, N9k-F]
   os_version: 'N35:7.0.3.I7.1; N3k, N9k:7.0.3.I5.1'
   get_value: '/^match ospf-area (.*)$/'
   set_value: "<state> match ospf-area <area>"
@@ -275,7 +275,7 @@ match_tag:
   default_value: []
 
 match_vlan:
-  _exclude: [N35, N3k, N9k, N9k-F]
+  _exclude: [N35, N3k, N3k-F, N9k, N9k-F]
   get_value: '/^match vlan (.*)$/'
   set_value: "<state> match vlan <range>"
   default_value: ''
@@ -396,6 +396,7 @@ set_extcommunity_cost_device:
   N7k: *set_extcommunity_device_no_str
   N9k: *set_extcommunity_device_str
   N9k-F: *set_extcommunity_device_str
+  N3k-F: *set_extcommunity_device_str
 
 set_extcommunity_cost_igp:
   default_value: []
@@ -425,13 +426,13 @@ set_interface:
   default_value: false
 
 set_ipv4_default_next_hop:
-  _exclude: [N35, N5k, N6k, N9k, N9k-F]
+  _exclude: [N35, N5k, N6k, N3k-F, N9k, N9k-F]
   get_value: '/^set ip default next-hop (.*)$/'
   set_value: "<state> set ip default next-hop <nh>"
   default_value: []
 
 set_ipv4_default_next_hop_load_share:
-  _exclude: [N35, N5k, N6k, N9k, N9k-F]
+  _exclude: [N35, N5k, N6k, N3k-F, N9k, N9k-F]
   default_value: false
 
 set_ipv4_next_hop:
@@ -476,13 +477,13 @@ set_ipv4_prefix:
   default_value: false
 
 set_ipv6_default_next_hop:
-  _exclude: [N35, N5k, N6k, N9k, N9k-F]
+  _exclude: [N35, N5k, N6k, N3k-F, N9k, N9k-F]
   get_value: '/^set ipv6 default next-hop (.*)$/'
   set_value: "<state> set ipv6 default next-hop <nh>"
   default_value: []
 
 set_ipv6_default_next_hop_load_share:
-  _exclude: [N35, N5k, N6k, N9k, N9k-F]
+  _exclude: [N35, N5k, N6k, N3k-F, N9k, N9k-F]
   default_value: false
 
 set_ipv6_next_hop:
@@ -588,7 +589,7 @@ set_tag:
   default_value: false
 
 set_vrf:
-  _exclude: [N35, N3k, N5k, N6k, N9k, N9k-F]
+  _exclude: [N35, N3k, N5k, N6k, N3k-F, N9k, N9k-F]
   get_value: '/^set vrf (\S+)$/'
   set_value: "<state> set vrf <vrf>"
   default_value: false

--- a/lib/cisco_node_utils/cmd_ref/snmp_community.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_community.yaml
@@ -8,6 +8,7 @@ _template:
     get_context: ["TABLE_snmp_community", "ROW_snmp_community"]
   N9k: *template_structured
   N9k-F: *template_structured
+  N3k-F: *template_structured
 
 acl:
   N3k: &acl_structured_get
@@ -16,6 +17,7 @@ acl:
     set_value: "<state> snmp-server community <name> use-acl <acl>"
   N9k: *acl_structured_get
   N9k-F: *acl_structured_get
+  N3k-F: *acl_structured_get
   ios_xr:
     get_command: "show running snmp"
     get_value: '/^snmp-server community <name> IPv4 (.*)$/'
@@ -34,6 +36,7 @@ all_communities:
     get_value: 'community_name'
   N9k: *all_structured
   N9k-F: *all_structured
+  N3k-F: *all_structured
   N5k: &all_cli
     get_command: "show running snmp all"
     get_value: '/^snmp-server community (\S+) /'
@@ -57,6 +60,7 @@ group:
     get_value: ["community_name <name>", "grouporaccess", '/^(?:Community groupname:\s+)?(\S+)/']
   N9k: *group_structured_get
   N9k-F: *group_structured_get
+  N3k-F: *group_structured_get
   ios_xr: &group_cli_based_get
     kind: string
     get_command: "show running snmp all"

--- a/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
@@ -63,7 +63,11 @@ packet_size:
     default_value: 0
   N6k: *n5k_default_packet_size
   N7k: *n5k_default_packet_size
+  # On recent versions, packet size is fixed,
+  # so this change will take care of the fix but
+  # it could still fail in the older versions.
   N9k-F: *n3k_default_packet_size
+  N3k-F: *n3k_default_packet_size
 
 protocol:
   _exclude: [ios_xr]

--- a/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
+++ b/lib/cisco_node_utils/cmd_ref/snmp_server.yaml
@@ -63,7 +63,7 @@ packet_size:
     default_value: 0
   N6k: *n5k_default_packet_size
   N7k: *n5k_default_packet_size
-  N9k-F: *n5k_default_packet_size
+  N9k-F: *n3k_default_packet_size
 
 protocol:
   _exclude: [ios_xr]

--- a/lib/cisco_node_utils/cmd_ref/stp_global.yaml
+++ b/lib/cisco_node_utils/cmd_ref/stp_global.yaml
@@ -7,7 +7,7 @@ _template:
   get_command: "show running-config spanning-tree"
 
 bd_designated_priority:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   multiple:
   get_context: ['/^spanning-tree pseudo-information$/']
   get_value: '/^bridge-domain (.*) designated priority (.*)$/'
@@ -16,40 +16,40 @@ bd_designated_priority:
   default_value: []
 
 bd_forward_time:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   multiple:
   get_value: '/^spanning-tree bridge-domain (.*) forward-time (.*)$/'
   set_value: "<state> spanning-tree bridge-domain <range> forward-time <val>"
   default_value: []
 
 bd_hello_time:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   multiple:
   get_value: '/^spanning-tree bridge-domain (.*) hello-time (.*)$/'
   set_value: "<state> spanning-tree bridge-domain <range> hello-time <val>"
   default_value: []
 
 bd_max_age:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   multiple:
   get_value: '/^spanning-tree bridge-domain (.*) max-age (.*)$/'
   set_value: "<state> spanning-tree bridge-domain <range> max-age <val>"
   default_value: []
 
 bd_priority:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   multiple:
   get_value: '/^spanning-tree bridge-domain (.*) priority (.*)$/'
   set_value: "<state> spanning-tree bridge-domain <range> priority <val>"
   default_value: []
 
 bd_range:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   kind: string
   default_only: "2-3967"
 
 bd_root_priority:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   multiple:
   get_context: ['/^spanning-tree pseudo-information$/']
   get_value: '/^bridge-domain (.*) root priority (.*)$/'
@@ -78,7 +78,7 @@ bridge_assurance:
   default_value: true
 
 domain:
-  _exclude: [N9k-F]
+  _exclude: [N3k-F, N9k-F]
   os_version: 'N3k, N9k:7.0.3.I6.1'
   kind: int
   get_value: '/^spanning-tree domain (\d+)$/'

--- a/lib/cisco_node_utils/cmd_ref/vdc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vdc.yaml
@@ -3,7 +3,7 @@
 # The current simplified implementation assumes no admin-vdc and that the
 # default vdc name uses id 1. Full multi-vdc support is TBD.
 ---
-_exclude: [N3k, N5k, N6k, N9k-F, N9k, ios_xr]
+_exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k, ios_xr]
 
 _template:
   get_command: 'show run vdc all'

--- a/lib/cisco_node_utils/cmd_ref/vlan.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vlan.yaml
@@ -16,7 +16,7 @@ destroy:
   set_value: "no vlan %s"
 
 fabric_control:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   kind: boolean
   get_command: "show running-config vlan"
   get_context: ['/^vlan <vlan>/']
@@ -30,6 +30,7 @@ mapped_vni:
   N3k: &mapped_vni_n3_8_9k
     get_command: 'show running vlan'
   N9k-F: *mapped_vni_n3_8_9k
+  N3k-F: *mapped_vni_n3_8_9k
   N9k: *mapped_vni_n3_8_9k
   N5k: &mapped_vni_n5_6k
     get_command: 'show running vlan 1-4094'
@@ -50,7 +51,7 @@ mapped_vni_requires_nv_overlay:
     default_only: false
 
 mode:
-  _exclude: [N3k, N9k, N9k-F]
+  _exclude: [N3k, N3k-F, N9k, N9k-F]
   multiple: true
   get_command: "show vlan"
   # TBD: 'show vlan' is problematic and should be converted to use show run
@@ -70,7 +71,7 @@ name:
   set_value: "%s name %s ; end"
 
 pvlan_association:
-  _exclude: [N9k-F]
+  _exclude: [N3k-F, N9k-F]
   multiple: true
   get_command: "show vlan private-vlan"
   get_value: '/^<id>\s+(\d+)/'
@@ -79,7 +80,7 @@ pvlan_association:
   default_value: []
 
 pvlan_type:
-  _exclude: [N9k-F]
+  _exclude: [N3k-F, N9k-F]
   kind: string
   get_command: 'show vlan private-vlan type'
   get_value: '/^<id>\s+(\S+)/'

--- a/lib/cisco_node_utils/cmd_ref/vpc.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vpc.yaml
@@ -1,6 +1,6 @@
 # vpc
 ---
-_exclude: [ios_xr, N9k-F]
+_exclude: [ios_xr, N3k-F, N9k-F]
 
 _template:
   get_command:  'show running-config vpc all'
@@ -64,7 +64,7 @@ dual_active_exclude_interface_vlan_bridge_domain:
   default_value: 'none'
 
 fabricpath_emulated_switch_id:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   kind: int
   set_context:  ['terminal dont-ask', 'vpc domain <domain>']
   get_value: '/^fabricpath switch-id\s+(\d+)$/'
@@ -72,7 +72,7 @@ fabricpath_emulated_switch_id:
   default_value: false
 
 fabricpath_multicast_load_balance:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   kind: boolean
   get_value: '/^fabricpath multicast load-balance$/'
   set_value: "<state> fabricpath multicast load-balance"
@@ -118,14 +118,14 @@ peer_gateway:
 # Exclude everyone for now till the BD command is fully supported
 peer_gateway_exclude_bridge_domain:
   kind: string
-  _exclude: [N3k, N5k, N6k, N7k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N7k, N3k-F, N9k-F, N9k]
   set_context:  ['terminal dont-ask', 'vpc domain <domain>']
   get_value: '/^peer-gateway exclude bridge-domain\s+(\S+)/'
   set_value: "peer-gateway exclude-bridge-domain <range>"
   default_value: ''
 
 peer_gateway_exclude_vlan:
-  _exclude: [N3k, N9k-F, N9k]
+  _exclude: [N3k, N3k-F, N9k-F, N9k]
   kind: string
   set_context:  ['terminal dont-ask', 'vpc domain <domain>']
   get_value: '/^peer-gateway exclude-vlan\s(\S+)/'
@@ -181,11 +181,11 @@ peer_switch:
   default_value: false
 
 phy_port_vpc_module_pids:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   default_only: 'N7[K7]-(?:F2|F3|F4|M3)'
 
 port_channel_limit:
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   auto_default: false
   kind: boolean
   get_value: '/^port-channel limit/'
@@ -200,7 +200,7 @@ role_priority:
 
 self_isolation:
   kind: boolean
-  _exclude: [N3k, N5k, N6k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N3k-F, N9k-F, N9k]
   get_value: '/^self-isolation/'
   set_value: "<state> self-isolation"
   default_value: false
@@ -227,7 +227,7 @@ system_priority:
 # Exclude everyone for now till the track command is fully supported
 track:
   kind: int
-  _exclude: [N3k, N5k, N6k, N7k, N9k-F, N9k]
+  _exclude: [N3k, N5k, N6k, N7k, N3k-F, N9k-F, N9k]
   get_value: '/^track\s+(\d+)/'
   set_value: "<state> track <val>"
   default_value: 0

--- a/lib/cisco_node_utils/cmd_ref/vrf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vrf.yaml
@@ -76,6 +76,7 @@ vni: # TBD Should this move to the vni provider as vrf_vni?
     set_value: '<state> vni <id>'
     default_value: false
   N9k-F: *vni9k
+  N3k-F: *vni9k
 
 vpn_id:
   _exclude: [nexus]

--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep.yaml
@@ -32,6 +32,7 @@ mt_lite_support:
   N9k: &mt_lite_default
     default_only: true
   N9k-F: *mt_lite_default
+  N3k-F: *mt_lite_default
   N6k: *mt_lite_default
   N5k: *mt_lite_default
   else:

--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
@@ -49,7 +49,7 @@ suppress_arp:
   default_value: false
 
 suppress_uuc:
-  _exclude: [N9k-F, N9k]
+  _exclude: [N3k-F, N9k-F, N9k]
   os_version: 'N7k:8.1.1'
   kind: boolean
   get_value: '/^suppress-unknown-unicast$/'

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -437,7 +437,7 @@ module Cisco
       puts "DEBUG: #{text}" if @@debug
     end
 
-    KNOWN_PLATFORMS = %w(C3064 C3132 C3172 N35 N3k N5k N6k N7k N9k N9k-F
+    KNOWN_PLATFORMS = %w(C3064 C3132 C3172 N35 N3k N3k-F N5k N6k N7k N9k N9k-F
                          XRv9k)
 
     def self.platform_to_filter(platform)
@@ -454,6 +454,13 @@ module Cisco
         when 'N9k-F'
           # For fretta n9k we need to include the trailing -F
           /^N9.*-F$/
+        when 'N3k'
+          # For non-fretta n3k platforms we need to
+          # match everything except the trailing -F
+          /^N3...(?!.*-F)/
+        when 'N3k-F'
+          # For fretta n3k we need to include the trailing -F
+          /^N3.*-F$/
         else
           Regexp.new platform.tr('k', '')
         end

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -380,7 +380,7 @@ module Cisco
                     data_format: :nxapi_structured)['kickstart_ver_str']
         end
         # Append -F for fretta platform.
-        return 'N9K-F' if ver[/7.0\(3\)F/]
+        return 'N9k-F' if ver[/7.0\(3\)F/]
       end
       prod
     end

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -380,7 +380,7 @@ module Cisco
                     data_format: :nxapi_structured)['kickstart_ver_str']
         end
         # Append -F for fretta platform.
-        return 'N9k-3-F' if ver[/7.0\(3\)F/]
+        return prod.concat('-F') if ver[/7.0\(3\)F/] && !prod[/-F/]
       end
       prod
     end

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -380,7 +380,7 @@ module Cisco
                     data_format: :nxapi_structured)['kickstart_ver_str']
         end
         # Append -F for fretta platform.
-        return 'N9k-F' if ver[/7.0\(3\)F/]
+        return 'N9k-3-F' if ver[/7.0\(3\)F/]
       end
       prod
     end

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -372,6 +372,15 @@ module Cisco
             return prod.concat('-F') unless prod[/-F/]
           end
         end
+      when /N3K/
+        if @cmd_ref
+          ver = os_version
+        else
+          ver = get(command:     'show version',
+                    data_format: :nxapi_structured)['kickstart_ver_str']
+        end
+        # Append -F for fretta platform.
+        return 'N9K-F' if ver[/7.0\(3\)F/]
       end
       prod
     end

--- a/lib/cisco_node_utils/portchannel_global.rb
+++ b/lib/cisco_node_utils/portchannel_global.rb
@@ -113,7 +113,7 @@ module Cisco
           _parse_ethernet_params(hash, params)
         when :asymmetric # n7k
           _parse_asymmetric_params(hash, params, line)
-        when :no_hash # n9k-f
+        when :no_hash # n9k-f or n3k-f
           _parse_no_hash_params(hash, params)
         when :symmetry # n9k
           _parse_symmetry_params(hash, params, line)
@@ -213,7 +213,7 @@ module Cisco
         # port-channel load-balance dst ip-l4port rotate 4 asymmetric
         config_set('portchannel_global', 'port_channel_load_balance',
                    bselect, bhash, 'rotate', rot.to_s, asym, '')
-      when :no_hash # n9k-f
+      when :no_hash # n9k-f or n3k-f
         # port-channel load-balance dst ip-l4port rotate 4
         rot_str = rot.zero? ? '' : 'rotate'
         rot_val = rot.zero? ? '' : rot.to_s

--- a/spec/schema.yaml
+++ b/spec/schema.yaml
@@ -17,6 +17,7 @@ mapping:
           - 'C3172'
           - 'N35'
           - 'N3k'
+          - 'N3k-F'
           - 'N5k'
           - 'N6k'
           - 'N7k'
@@ -34,6 +35,7 @@ mapping:
       C3132: *base
       C3172: *base
       N3k: *base
+      N3k-F: *base
       N5k: *base
       N6k: *base
       N7k: *base

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -509,7 +509,7 @@ class CiscoTestCase < TestCase
     when /N3K-C35/
       tag = 'n35'
     when /N3/
-      tag = 'n3k'
+      tag = Utils.image_version?(/7.0.3.F/) ? 'n9k-f' : 'n3k'
     when /N5/
       tag = 'n5k'
     when /N6/

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -300,7 +300,8 @@ class CiscoTestCase < TestCase
     Vrf.vrfs.each do |vrf, obj|
       next if vrf[/management/]
       # TBD: Remove vrf workaround below after CSCuz56697 is resolved
-      config 'vrf context ' + vrf if node.product_id[/N9K.*-F/]
+      config 'vrf context ' + vrf if
+        node.product_id[/N9K.*-F/] || node.product_id[/N3K.*-F/]
       obj.destroy
     end
   end
@@ -464,7 +465,7 @@ class CiscoTestCase < TestCase
   # Returns the output of the command.
   def shell_command(command, context='bash')
     fail "shell_command api not supported on #{node.product_id}" unless
-      node.product_id[/N3K|N9K.*-F|N9K/]
+      node.product_id[/N3K|N3K.*-F|N9K.*-F|N9K/]
     unless context == 'bash' || context == 'guestshell'
       fail "Context must be either 'bash' or 'guestshell'"
     end
@@ -474,7 +475,7 @@ class CiscoTestCase < TestCase
   def backup_resolv_file(context='bash')
     # Configuration bleeding is only a problem on some platforms, so
     # only backup the resolv.conf file on required plaforms.
-    return unless node.product_id[/N3K|N9K.*-F|N9K/]
+    return unless node.product_id[/N3K|N3K.*-F|N9K.*-F|N9K/]
     time_stamp = Time.now.strftime('%Y-%m-%d_%H-%M-%S')
     backup_filename = "/tmp/resolv.conf.#{time_stamp}"
     shell_command("cp /etc/resolv.conf #{backup_filename}", context)
@@ -482,7 +483,7 @@ class CiscoTestCase < TestCase
   end
 
   def restore_resolv_file(filename, context='bash')
-    return unless node.product_id[/N3K|N9K.*-F|N9K/]
+    return unless node.product_id[/N3K|N3K.*-F|N9K.*-F|N9K/]
     shell_command("sudo cp #{filename} /etc/resolv.conf", context)
     shell_command("rm #{filename}", context)
   end
@@ -509,7 +510,7 @@ class CiscoTestCase < TestCase
     when /N3K-C35/
       tag = 'n35'
     when /N3/
-      tag = Utils.image_version?(/7.0.3.F/) ? 'n9k-f' : 'n3k'
+      tag = Utils.image_version?(/7.0.3.F/) ? 'n3k-f' : 'n3k'
     when /N5/
       tag = 'n5k'
     when /N6/

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2016 Cisco and/or its affiliates.
+# Copyright (c) 2013-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -170,7 +170,7 @@ class TestBgpAF < CiscoTestCase
       # triggers a version check below.
       if expect == :runtime
         case Platform.image_version
-        when /8.0|8.1/
+        when /8.0|8.1|F3.2/
           expect = :success
         when /I5.2|I5.3|I6/
           expect = :success if test == :maximum_paths || test == :maximum_paths_ibgp

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -4,7 +4,7 @@
 #
 # Richard Wellum, August, 2015
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -170,7 +170,7 @@ class TestBgpAF < CiscoTestCase
       # triggers a version check below.
       if expect == :runtime
         case Platform.image_version
-        when /8.0|8.1|F3.2/
+        when /8.0|8.1|8.2|F3.2/
           expect = :success
         when /I5.2|I5.3|I6/
           expect = :success if test == :maximum_paths || test == :maximum_paths_ibgp

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -103,7 +103,7 @@ class TestFeature < CiscoTestCase
   end
 
   def test_fabric_forwarding
-    if node.product_id[/N(3)/]
+    if node.product_id[/N(3)/] && !node.product_id.include?('-F')
       assert_nil(Feature.fabric_forwarding_enabled?)
       assert_raises(Cisco::UnsupportedError) do
         Feature.fabric_forwarding_enable
@@ -126,7 +126,7 @@ class TestFeature < CiscoTestCase
   end
 
   def test_nv_overlay_evpn
-    if node.product_id[/N(3)/]
+    if node.product_id[/N(3)/] && !node.product_id.include?('-F')
       assert_nil(Feature.nv_overlay_evpn_enabled?)
       assert_raises(Cisco::UnsupportedError) { Feature.nv_overlay_evpn_enable }
       return

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -629,7 +629,7 @@ class TestInterface < CiscoTestCase
   end
 
   def test_speed
-    skip_legacy_defect?('7.0.3.I5.2', 'CSCvd41419')
+    skip_legacy_defect?('7.0.3.I5.2|7.0.3.F3', 'CSCvd41419')
     interface = Interface.new(interfaces[0])
     if validate_property_excluded?('interface', 'speed')
       assert_nil(interface.speed)
@@ -665,7 +665,7 @@ class TestInterface < CiscoTestCase
   end
 
   def test_duplex
-    skip_legacy_defect?('7.0.3.I5.2', 'CSCvd41419')
+    skip_legacy_defect?('7.0.3.I5.2|7.0.3.F3', 'CSCvd41419')
     interface = Interface.new(interfaces[0])
     if validate_property_excluded?('interface', 'duplex')
       assert_nil(interface.duplex)
@@ -820,7 +820,7 @@ class TestInterface < CiscoTestCase
   end
 
   def test_negotiate_auto_ethernet
-    skip_legacy_defect?('7.0.3.I5.2', 'CSCvd41419')
+    skip_legacy_defect?('7.0.3.I5.2|7.0.3.F3', 'CSCvd41419')
     inf_name = interfaces[0]
     interface = Interface.new(inf_name)
 

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -629,7 +629,7 @@ class TestInterface < CiscoTestCase
   end
 
   def test_speed
-    skip_legacy_defect?('7.0.3.I5.2|7.0.3.F3', 'CSCvd41419')
+    skip_legacy_defect?('7.0.3.I5|7.0.3.F3', 'CSCvd41419')
     interface = Interface.new(interfaces[0])
     if validate_property_excluded?('interface', 'speed')
       assert_nil(interface.speed)
@@ -665,7 +665,7 @@ class TestInterface < CiscoTestCase
   end
 
   def test_duplex
-    skip_legacy_defect?('7.0.3.I5.2|7.0.3.F3', 'CSCvd41419')
+    skip_legacy_defect?('7.0.3.I5|7.0.3.F3', 'CSCvd41419')
     interface = Interface.new(interfaces[0])
     if validate_property_excluded?('interface', 'duplex')
       assert_nil(interface.duplex)
@@ -820,7 +820,7 @@ class TestInterface < CiscoTestCase
   end
 
   def test_negotiate_auto_ethernet
-    skip_legacy_defect?('7.0.3.I5.2|7.0.3.F3', 'CSCvd41419')
+    skip_legacy_defect?('7.0.3.I5|7.0.3.F3', 'CSCvd41419')
     inf_name = interfaces[0]
     interface = Interface.new(inf_name)
 

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2016 Cisco and/or its affiliates.
+# Copyright (c) 2013-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_node_ext.rb
+++ b/tests/test_node_ext.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2016 Cisco and/or its affiliates.
+# Copyright (c) 2013-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_node_ext.rb
+++ b/tests/test_node_ext.rb
@@ -141,10 +141,8 @@ class TestNodeExt < CiscoTestCase
   end
 
   def test_get_product_id
-    # N9K Fretta product_id gets a '-F' appended so remove it for this check
+    # N3|9K Fretta product_id gets a '-F' appended so remove it for this check
     if Utils.image_version?(/7.0.3.F/)
-      skip('Test Not supported on this platform') if
-        /N9k-3-F/ =~ node.product_id
       chassis = node.product_id.sub('-F', '')
     else
       chassis = node.product_id

--- a/tests/test_node_ext.rb
+++ b/tests/test_node_ext.rb
@@ -143,6 +143,8 @@ class TestNodeExt < CiscoTestCase
   def test_get_product_id
     # N9K Fretta product_id gets a '-F' appended so remove it for this check
     if Utils.image_version?(/7.0.3.F/)
+      skip('Test Not supported on this platform') if
+        /N9k-3-F/ =~ node.product_id
       chassis = node.product_id.sub('-F', '')
     else
       chassis = node.product_id

--- a/tests/test_portchannel_global.rb
+++ b/tests/test_portchannel_global.rb
@@ -45,6 +45,7 @@ class TestPortchannelGlobal < CiscoTestCase
 
   def n3k_in_n3k_mode?
     return unless /N3/ =~ node.product_id
+    return if node.product_id.include?('-F')
     mode = config('show system switch-mode')
     # note: an n3k in n9k mode displays: 'system switch-mode n9k'
     patterns = ['system switch-mode n3k',

--- a/tests/test_route_map.rb
+++ b/tests/test_route_map.rb
@@ -1338,7 +1338,8 @@ class TestRouteMap < CiscoTestCase
 
   def test_extcommunity_rt
     # bug CSCvc92395 on fretta and n9k
-    skip('platform not supported for this test') if product_tag[/n9k/]
+    skip('platform not supported for this test') if
+      product_tag[/n9k/] || product_tag[/n3k-f/]
     rm = create_route_map
     assert_equal(rm.default_set_extcommunity_rt_additive,
                  rm.set_extcommunity_rt_additive)

--- a/tests/test_route_map.rb
+++ b/tests/test_route_map.rb
@@ -964,7 +964,7 @@ class TestRouteMap < CiscoTestCase
   end
 
   def test_set_ipv4_default_next_hop
-    skip('platform not supported for this test') if product_tag[/(n35|n5k|n6k|n9k|n9k-f)/]
+    skip('platform not supported for this test') if product_tag[/(n35|n5k|n6k|n9k|n9k-f|n3k-f)/]
     arr = %w(1.1.1.1 2.2.2.2 3.3.3.3)
     rm = lset_ip_next_hop_helper(v4dnh: arr)
     assert_equal(arr, rm.set_ipv4_default_next_hop)
@@ -1064,7 +1064,7 @@ class TestRouteMap < CiscoTestCase
   end
 
   def test_set_ipv6_default_next_hop
-    skip('platform not supported for this test') if product_tag[/(n35|n5k|n6k|n9k|n9k-f)/]
+    skip('platform not supported for this test') if product_tag[/(n35|n5k|n6k|n9k|n9k-f|n3k-f)/]
     arr = %w(2000::1 2000::11 2000::22)
     rm = lset_ip_next_hop_helper(v6dnh: arr)
     assert_equal(arr, rm.set_ipv6_default_next_hop)

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -3,7 +3,7 @@
 #
 # Mike Wiebe, June, 2015
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2017 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_router_bgp.rb
+++ b/tests/test_router_bgp.rb
@@ -60,14 +60,6 @@ def setup_vrf
   create_bgp_vrf(@asnum, @vrf)
 end
 
-def newer_image_version?
-  new = true
-  new = false if Utils.image_version?(/7.0.3.I2|I3|I4/) ||
-                 node.product_id[/(N5|N6|N7|N9.*-F)/]
-  new = true if Utils.image_version?(/8.0|8.1/)
-  new
-end
-
 # TestRouterBgp - Minitest for RouterBgp class
 class TestRouterBgp < CiscoTestCase
   @@pre_clean_needed = true # rubocop:disable Style/ClassVars
@@ -595,31 +587,12 @@ class TestRouterBgp < CiscoTestCase
     if validate_property_excluded?('bgp', 'event_history_cli')
       assert_nil(bgp.event_history_cli)
       assert_raises(Cisco::UnsupportedError) do
-        bgp.event_history_cli = 'true'
+        bgp.event_history_cli = 'size_large'
       end
       return
     end
-    assert_equal(bgp.default_event_history_cli, bgp.event_history_cli)
-    bgp.event_history_cli = 'true'
-    assert_equal(bgp.default_event_history_cli, bgp.event_history_cli)
-    bgp.event_history_cli = 'false'
-    assert_equal('false', bgp.event_history_cli)
-    bgp.event_history_cli = 'size_small'
-    assert_equal('size_small', bgp.event_history_cli)
     bgp.event_history_cli = 'size_large'
     assert_equal('size_large', bgp.event_history_cli)
-    bgp.event_history_cli = 'size_medium'
-    assert_equal('size_medium', bgp.event_history_cli)
-    bgp.event_history_cli = 'size_disable'
-    if newer_image_version?
-      assert_equal('false', bgp.event_history_cli)
-    else
-      assert_equal('size_disable', bgp.event_history_cli)
-    end
-    bgp.event_history_cli = '100000'
-    assert_equal('100000', bgp.event_history_cli)
-    bgp.event_history_cli = bgp.default_event_history_cli
-    assert_equal(bgp.default_event_history_cli, bgp.event_history_cli)
   end
 
   def test_event_history_detail
@@ -627,31 +600,12 @@ class TestRouterBgp < CiscoTestCase
     if validate_property_excluded?('bgp', 'event_history_detail')
       assert_nil(bgp.event_history_detail)
       assert_raises(Cisco::UnsupportedError) do
-        bgp.event_history_detail = 'true'
+        bgp.event_history_detail = 'size_large'
       end
       return
     end
-    assert_equal(bgp.default_event_history_detail, bgp.event_history_detail)
-    bgp.event_history_detail = 'true'
-    assert_equal('true', bgp.event_history_detail)
-    bgp.event_history_detail = 'false'
-    assert_equal(bgp.default_event_history_detail, bgp.event_history_detail)
-    bgp.event_history_detail = 'size_small'
-    assert_equal('size_small', bgp.event_history_detail)
     bgp.event_history_detail = 'size_large'
     assert_equal('size_large', bgp.event_history_detail)
-    bgp.event_history_detail = 'size_medium'
-    assert_equal('size_medium', bgp.event_history_detail)
-    bgp.event_history_detail = 'size_disable'
-    if newer_image_version?
-      assert_equal('false', bgp.event_history_detail)
-    else
-      assert_equal('size_disable', bgp.event_history_detail)
-    end
-    bgp.event_history_detail = '100000'
-    assert_equal('100000', bgp.event_history_detail)
-    bgp.event_history_detail = bgp.default_event_history_detail
-    assert_equal(bgp.default_event_history_detail, bgp.event_history_detail)
   end
 
   def test_event_history_errors
@@ -663,25 +617,9 @@ class TestRouterBgp < CiscoTestCase
       end
       return
     end
-    skip('platform not supported for this test') unless newer_image_version?
-    assert_equal(bgp.default_event_history_errors, bgp.event_history_errors)
-    bgp.event_history_errors = 'true'
-    assert_equal(bgp.default_event_history_errors, bgp.event_history_errors)
-    bgp.event_history_errors = 'false'
-    assert_equal('false', bgp.event_history_errors)
-    bgp.event_history_errors = 'size_small'
-    assert_equal('size_small', bgp.event_history_errors) unless
-      Utils.image_version?(/8.0|8.1/)
+    skip_incompat_version?('bgp', 'event_history_errors')
     bgp.event_history_errors = 'size_large'
     assert_equal('size_large', bgp.event_history_errors)
-    bgp.event_history_errors = 'size_medium'
-    assert_equal('size_medium', bgp.event_history_errors)
-    bgp.event_history_errors = 'size_disable'
-    assert_equal('false', bgp.event_history_errors)
-    bgp.event_history_errors = '100000'
-    assert_equal('100000', bgp.event_history_errors)
-    bgp.event_history_errors = bgp.default_event_history_errors
-    assert_equal(bgp.default_event_history_errors, bgp.event_history_errors)
   end
 
   def test_event_history_events
@@ -689,31 +627,12 @@ class TestRouterBgp < CiscoTestCase
     if validate_property_excluded?('bgp', 'event_history_events')
       assert_nil(bgp.event_history_events)
       assert_raises(Cisco::UnsupportedError) do
-        bgp.event_history_events = 'true'
+        bgp.event_history_events = 'size_medium'
       end
       return
     end
-    assert_equal(bgp.default_event_history_events, bgp.event_history_events)
-    bgp.event_history_events = 'true'
-    assert_equal(bgp.default_event_history_events, bgp.event_history_events)
-    bgp.event_history_events = 'false'
-    assert_equal('false', bgp.event_history_events)
-    bgp.event_history_events = 'size_small'
-    assert_equal('size_small', bgp.event_history_events)
-    bgp.event_history_events = 'size_large'
-    assert_equal('size_large', bgp.event_history_events)
     bgp.event_history_events = 'size_medium'
     assert_equal('size_medium', bgp.event_history_events)
-    bgp.event_history_events = 'size_disable'
-    if newer_image_version?
-      assert_equal('false', bgp.event_history_events)
-    else
-      assert_equal('size_disable', bgp.event_history_events)
-    end
-    bgp.event_history_events = '100000'
-    assert_equal('100000', bgp.event_history_events)
-    bgp.event_history_events = bgp.default_event_history_events
-    assert_equal(bgp.default_event_history_events, bgp.event_history_events)
   end
 
   def test_event_history_objstore
@@ -725,24 +644,9 @@ class TestRouterBgp < CiscoTestCase
       end
       return
     end
-    skip('platform not supported for this test') unless newer_image_version?
-    assert_equal(bgp.default_event_history_objstore, bgp.event_history_objstore)
-    bgp.event_history_objstore = 'true'
-    assert_equal('true', bgp.event_history_objstore)
-    bgp.event_history_objstore = 'false'
-    assert_equal(bgp.default_event_history_objstore, bgp.event_history_objstore)
-    bgp.event_history_objstore = 'size_small'
-    assert_equal('size_small', bgp.event_history_objstore)
-    bgp.event_history_objstore = 'size_large'
-    assert_equal('size_large', bgp.event_history_objstore)
+    skip_incompat_version?('bgp', 'event_history_objstore')
     bgp.event_history_objstore = 'size_medium'
     assert_equal('size_medium', bgp.event_history_objstore)
-    bgp.event_history_objstore = 'size_disable'
-    assert_equal('false', bgp.event_history_objstore)
-    bgp.event_history_objstore = '100000'
-    assert_equal('100000', bgp.event_history_objstore)
-    bgp.event_history_objstore = bgp.default_event_history_objstore
-    assert_equal(bgp.default_event_history_objstore, bgp.event_history_objstore)
   end
 
   def test_event_history_periodic
@@ -750,41 +654,12 @@ class TestRouterBgp < CiscoTestCase
     if validate_property_excluded?('bgp', 'event_history_periodic')
       assert_nil(bgp.event_history_periodic)
       assert_raises(Cisco::UnsupportedError) do
-        bgp.event_history_periodic = 'true'
+        bgp.event_history_periodic = 'size_large'
       end
       return
     end
-    assert_equal(bgp.default_event_history_periodic,
-                 bgp.event_history_periodic)
-    bgp.event_history_periodic = 'false'
-    assert_equal('false', bgp.event_history_periodic) unless
-      Utils.image_version?(/8.0|8.1/)
-    bgp.event_history_periodic = 'size_small'
-    assert_equal('size_small', bgp.event_history_periodic)
     bgp.event_history_periodic = 'size_large'
     assert_equal('size_large', bgp.event_history_periodic)
-    bgp.event_history_periodic = 'size_medium'
-    assert_equal('size_medium', bgp.event_history_periodic)
-    bgp.event_history_periodic = '100000'
-    assert_equal('100000', bgp.event_history_periodic)
-    bgp.event_history_periodic = 'size_disable'
-    if newer_image_version?
-      assert_equal(bgp.default_event_history_periodic,
-                   bgp.event_history_periodic)
-    else
-      assert_equal('size_disable', bgp.event_history_periodic)
-    end
-    bgp.event_history_periodic = 'true'
-    if newer_image_version?
-      assert_equal('true', bgp.event_history_periodic) unless
-        Utils.image_version?(/8.0|8.1/)
-    else
-      assert_equal(bgp.default_event_history_periodic,
-                   bgp.event_history_periodic)
-    end
-    bgp.event_history_periodic = bgp.default_event_history_periodic
-    assert_equal(bgp.default_event_history_periodic,
-                 bgp.event_history_periodic)
   end
 
   def test_fast_external_fallover

--- a/tests/test_router_ospf_area.rb
+++ b/tests/test_router_ospf_area.rb
@@ -52,16 +52,16 @@ class TestRouterOspfArea < CiscoTestCase
     av.stub = true
     assert_equal(2, RouterOspfArea.areas['Wolfpack'].size)
     av.destroy
-    # on n9k-f (only), we cannot remove "area <area> default-cost 1",
+    # on n(3|9)k-f (only), we cannot remove "area <area> default-cost 1",
     # unless the entire ospf router is removed. The default value of
     # default_cost is 1 and so this is just a cosmetic issue but
     # need to skip the below test as the size will be wrong.
     # platform as the size will be wrong. bug ID: CSCva04066
     assert_equal(1, RouterOspfArea.areas['Wolfpack'].size) unless
-      /N9K.*-F/ =~ node.product_id
+      /N(3|9)K.*-F/ =~ node.product_id
     ad.destroy
     assert_empty(RouterOspfArea.areas) unless
-      /N9K.*-F/ =~ node.product_id
+      /N(3|9)K.*-F/ =~ node.product_id
   end
 
   def test_authentication
@@ -237,21 +237,21 @@ class TestRouterOspfArea < CiscoTestCase
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
     assert_equal(ad.default_nssa_route_map, ad.nssa_route_map)
-    # on n9k-f (only), we cannot configure
+    # on n(3|9)k-f (only), we cannot configure
     # "area <area> nssa default-information-originate",
     # properly if we reset it first. It is only configuring nssa
     # but not the other parameters. bug ID: CSCva11482
     hash[:nssa_route_map] = 'aaa'
     ad.nssa_set(hash)
     assert_equal(true, ad.nssa)
-    if node.product_id[/N9K-F/]
+    if node.product_id[/N(3|9)K-F/]
       refute(ad.nssa_default_originate)
     else
       assert(ad.nssa_default_originate)
     end
     assert_equal(ad.default_nssa_no_redistribution, ad.nssa_no_redistribution)
     assert_equal(ad.default_nssa_no_summary, ad.nssa_no_summary)
-    if node.product_id[/N9K-F/]
+    if node.product_id[/N(3|9)K-F/]
       refute_equal('aaa', ad.nssa_route_map)
     else
       assert_equal('aaa', ad.nssa_route_map)


### PR DESCRIPTION
1. This PR is for adding support to N3600. 
2. Event_history properties for bgp are now version independent

Tests run on n3k, n7k, n9k and n9k-f and they pass