### PR TITLE
fix system_image calls

### DIFF
--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -223,7 +223,7 @@ class CiscoTestCase < TestCase
 
   def skip_legacy_defect?(pattern, msg)
     msg = "Defect in legacy image: [#{msg}]"
-    skip(msg) if system_image.match(Regexp.new(pattern))
+    skip(msg) if Utils.image_version?(Regexp.new(pattern))
   end
 
   def interfaces


### PR DESCRIPTION
This PR is for using image_version instead of system_image calls. The latter uses bin file name which could be anything and so prone to errors.
All minitests pass on n9k-f platform where the problem is seen.