### PR TITLE
fix for virtual platforms and tacacs_global

### DIFF
--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -227,8 +227,7 @@ class CiscoTestCase < TestCase
   end
 
   def virtual_platform?
-    s = @device.cmd('show version')
-    s[/demo/] ? true : false
+    node.product_id[/N9K-NXOSV|N9K-9000v/] ? true : false
   end
 
   def interfaces

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -226,6 +226,11 @@ class CiscoTestCase < TestCase
     skip(msg) if Utils.image_version?(Regexp.new(pattern))
   end
 
+  def virtual_platform?
+    s = @device.cmd('show version')
+    s[/demo/] ? true : false
+  end
+
   def interfaces
     unless @@interfaces
       # Build the platform_info, used for interface lookup

--- a/tests/test_node_ext.rb
+++ b/tests/test_node_ext.rb
@@ -345,7 +345,8 @@ class TestNodeExt < CiscoTestCase
     assert_output_check(command: 'show version',
                         pattern: /.*\nLast reset.*\n\n?  Reason: (.*)\n/,
                         check:   node.last_reset_reason,
-                        msg:     'Error, Last reset reason does not match')
+                        msg:     'Error, Last reset reason does not match') unless
+      virtual_platform?
   end
 
   def test_get_system_cpu_utilization

--- a/tests/test_tacacs_global.rb
+++ b/tests/test_tacacs_global.rb
@@ -72,13 +72,15 @@ class TestTacacsGlobal < CiscoTestCase
     assert_equal(7, global.key_format)
     assert_equal('"WAWY_NZB"', global.key)
 
-    # second key change - modify key to type6
-    key_format = 6
-    # Must use a valid type6 password: CSCvb36266
-    key = 'JDYkqyIFWeBvzpljSfWmRZrmRSRE8'
-    global.encryption_key_set(key_format, key)
-    assert_equal(key_format, global.key_format)
-    assert_equal("\"#{key}\"", global.key)
+    unless Platform.image_version[/I2/]
+      # second key change - modify key to type6
+      key_format = 6
+      # Must use a valid type6 password: CSCvb36266
+      key = 'JDYkqyIFWeBvzpljSfWmRZrmRSRE8'
+      global.encryption_key_set(key_format, key)
+      assert_equal(key_format, global.key_format)
+      assert_equal("\"#{key}\"", global.key)
+    end
 
     # Remove global key
     global.encryption_key_set('', '')

--- a/tests/test_tacacs_global.rb
+++ b/tests/test_tacacs_global.rb
@@ -72,15 +72,13 @@ class TestTacacsGlobal < CiscoTestCase
     assert_equal(7, global.key_format)
     assert_equal('"WAWY_NZB"', global.key)
 
-    unless Platform.image_version[/I2/]
-      # second key change - modify key to type6
-      key_format = 6
-      # Must use a valid type6 password: CSCvb36266
-      key = 'JDYkqyIFWeBvzpljSfWmRZrmRSRE8'
-      global.encryption_key_set(key_format, key)
-      assert_equal(key_format, global.key_format)
-      assert_equal("\"#{key}\"", global.key)
-    end
+    # second key change - modify key to type6
+    key_format = 6
+    # Must use a valid type6 password: CSCvb36266
+    key = 'JDYkqyIFWeBvzpljSfWmRZrmRSRE8'
+    global.encryption_key_set(key_format, key)
+    assert_equal(key_format, global.key_format)
+    assert_equal("\"#{key}\"", global.key)
 
     # Remove global key
     global.encryption_key_set('', '')


### PR DESCRIPTION
This PR is for fixing minitest errors on virtual platforms and skipping keyformat 6 for I2 releases