### PR TITLE
Fix n56k support

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/inventory.yaml
+++ b/lib/cisco_node_utils/cmd_ref/inventory.yaml
@@ -22,15 +22,24 @@ productid:
     get_value: '/"Rack 0".*\n.*PID: ([^ ,]+)/'
   nexus:
     get_value: ["name \"Chassis\"", "productid"]
+  N5k: &productid5k
+    get_value: ["name Chassis", "productid"]
+  N6k: *productid5k
 
 serialnum:
   ios_xr:
     get_value: '/"Rack 0".*\n.*SN: ([^ ,]+)/'
   nexus:
     get_value: ["name \"Chassis\"", "serialnum"]
+  N5k: &serialnum5k
+    get_value: ["name Chassis", "serialnum"]
+  N6k: *serialnum5k
 
 versionid:
   ios_xr:
     get_value: '/"Rack 0".*\n.*VID: ([^ ,]+)/'
   nexus:
     get_value: ["name \"Chassis\"", "vendorid"]
+  N5k: &vendorid5k
+    get_value: ["name Chassis", "serialnum"]
+  N6k: *vendorid5k

--- a/lib/cisco_node_utils/cmd_ref/show_version.yaml
+++ b/lib/cisco_node_utils/cmd_ref/show_version.yaml
@@ -1,7 +1,15 @@
 # show_version
 ---
 _template:
-  get_command: 'sh hardware'
+  N5k: &template5k
+    get_command: 'sh version'
+  N6k: *template5k
+  N3k: &template3k
+    get_command: 'sh hardware'
+  N7k: *template3k
+  N9k: *template3k
+  N3k-F: *template3k
+  N9k-F: *template3k
   nexus:
     data_format: nxapi_structured
   ios_xr:


### PR DESCRIPTION
I discovered that we inadvertently broke our support for `n5k` and `n6k` devices.  This fix addresses the following:

1. The structured output for `show inventory` is slightly different between platforms.
2. The `sh hardware` command is not supported on `N5k` and `N6k` platforms.

**NOTE:** Currently running tests on N6k and N9k to validate the changes.