### PR TITLE
Create version 1.9.0-dev

### DIFF
--- a/lib/cisco_node_utils/version.rb
+++ b/lib/cisco_node_utils/version.rb
@@ -14,7 +14,7 @@
 
 # Container module for version number only.
 module CiscoNodeUtils
-  VERSION = '1.9.0.dev'
+  VERSION = '1.9.0-dev'
   gem_version = Gem::Version.new(Gem::VERSION)
   min_gem_version = Gem::Version.new('2.1.0')
   fail 'Required rubygems version >= 2.1.0' if gem_version < min_gem_version

--- a/lib/cisco_node_utils/version.rb
+++ b/lib/cisco_node_utils/version.rb
@@ -14,7 +14,7 @@
 
 # Container module for version number only.
 module CiscoNodeUtils
-  VERSION = '1.8.0'
+  VERSION = '1.9.0-DEV'
   gem_version = Gem::Version.new(Gem::VERSION)
   min_gem_version = Gem::Version.new('2.1.0')
   fail 'Required rubygems version >= 2.1.0' if gem_version < min_gem_version

--- a/lib/cisco_node_utils/version.rb
+++ b/lib/cisco_node_utils/version.rb
@@ -14,7 +14,7 @@
 
 # Container module for version number only.
 module CiscoNodeUtils
-  VERSION = '1.9.0-DEV'
+  VERSION = '1.9.0.dev'
   gem_version = Gem::Version.new(Gem::VERSION)
   min_gem_version = Gem::Version.new('2.1.0')
   fail 'Required rubygems version >= 2.1.0' if gem_version < min_gem_version


### PR DESCRIPTION
This updates `lib/cisco_node_utils/version.rb` to use version `1.9.0-dev` in the develop branch.  When the gem is built and installed it will make it more obvious that this is a pre-release development gem.