### PR TITLE
fixes for nu minitest failures

### DIFF
--- a/tests/test_node_ext.rb
+++ b/tests/test_node_ext.rb
@@ -333,7 +333,7 @@ class TestNodeExt < CiscoTestCase
     if validate_property_excluded?('show_version', 'last_reset_time')
       assert_nil(node.last_reset_time)
     else
-      refute_nil(node.last_reset_time)
+      refute_nil(node.last_reset_time) unless virtual_platform?
     end
   end
 

--- a/tests/test_radius_global.rb
+++ b/tests/test_radius_global.rb
@@ -71,11 +71,13 @@ class TestRadiusGlobal < CiscoTestCase
       assert_match(/#{key}/, global.key)
       assert_match(/#{key}/, Cisco::RadiusGlobal.radius_global[id].key)
       assert_equal(7, global.key_format)
-      # Change to type 6
-      key = 'JDYkqyIFWeBvzpljSfWmRZrmRSRE8'
-      global.key_set(key, 6)
-      assert_match(/#{key}/, global.key)
-      assert_equal(6, global.key_format)
+      unless Platform.image_version[/I2|I4/] # legacy defect CSCvb57180
+        # Change to type 6
+        key = 'JDYkqyIFWeBvzpljSfWmRZrmRSRE8'
+        global.key_set(key, 6)
+        assert_match(/#{key}/, global.key)
+        assert_equal(6, global.key_format)
+      end
     elsif platform == :ios_xr
       global.key_set('QsEfThUkO', nil)
       assert(!global.key.nil?)


### PR DESCRIPTION
This PR is for fixing node_ext and radius_global minitest failures. 
1. reset_reason and time are not supported on virtual platforms
2. radius-server key type 6 is not supported on older platforms.