### PR TITLE
Fix legacy tacacs global failure

### DIFF
--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -226,6 +226,20 @@ class CiscoTestCase < TestCase
     skip(msg) if Utils.image_version?(Regexp.new(pattern))
   end
 
+  def step_unless_legacy_defect(pattern, msg)
+    if pattern.is_a?(String)
+      pattern = [pattern]
+    elsif !pattern.is_a?(Array)
+      fail 'Argument: pattern must be a String or Array object'
+    end
+    pattern.each do |pat|
+      if Utils.image_version?(Regexp.new(pat))
+        puts "Skip Step: Defect in legacy image: [#{msg}]"
+        return false
+      end
+    end
+  end
+
   def virtual_platform?
     node.product_id[/N9K-NXOSV|N9K-9000v/] ? true : false
   end

--- a/tests/test_tacacs_global.rb
+++ b/tests/test_tacacs_global.rb
@@ -77,13 +77,16 @@ class TestTacacsGlobal < CiscoTestCase
     assert_equal(7, global.key_format)
     assert_equal('"WAWY_NZB"', global.key)
 
-    # second key change - modify key to type6
-    key_format = 6
-    # Must use a valid type6 password: CSCvb36266
-    key = 'JDYkqyIFWeBvzpljSfWmRZrmRSRE8'
-    global.encryption_key_set(key_format, key)
-    assert_equal(key_format, global.key_format)
-    assert_equal("\"#{key}\"", global.key)
+    skip_versions = ['7.0.3.(I2|I3)', '7.0.3.I4.[1-7]']
+    if step_unless_legacy_defect(skip_versions, 'CSCvh72911: Cannot configure tacacs-server key 6')
+      # second key change - modify key to type6
+      key_format = 6
+      # Must use a valid type6 password: CSCvb36266
+      key = 'JDYkqyIFWeBvzpljSfWmRZrmRSRE8'
+      global.encryption_key_set(key_format, key)
+      assert_equal(key_format, global.key_format)
+      assert_equal("\"#{key}\"", global.key)
+    end
 
     # Remove global key
     global.encryption_key_set('', '')


### PR DESCRIPTION
**Summary of changes:**
  * Skips step inside the `test_tacacs_global` test case due to a legacy defect.
  * Adds a new method `step_unless_legacy_defect` that will take a list of regexp patterns matching image versions where the legacy defect is present.  This method allows us to skip specific steps inside a test that might be problematic on specific legacy versions.

**Testing:**
- Image where defect is present
```
Node under test:
  - name  - dplus-nx-1
  - type  - N9K-NXOSV
  - image - bootflash:///nxos.7.0.3.I4.7.bin

Skip Step: Defect in legacy image: [CSCvh72911: Cannot configure tacacs-server key 6]
TestTacacsGlobal#test_tacacs_global = 7.76 s = .

Finished in 9.464721s, 0.1057 runs/s, 1.5848 assertions/s.
```

- Image where defect is NOT present
```
Node under test:
  - name  - evergreen-nx-1
  - type  - N9K-NXOSV
  - image - bootflash:///nxos.7.0.3.I5.3.bin

TestTacacsGlobal#test_tacacs_global = 19.11 s = .

Finished in 21.469475s, 0.0466 runs/s, 0.7918 assertions/s.
```