### PR TITLE
Structured output needs to handle nil value cases

### DIFF
--- a/lib/cisco_node_utils/client/utils.rb
+++ b/lib/cisco_node_utils/client/utils.rb
@@ -151,7 +151,7 @@ class Cisco::Client
           end
           return final
         end
-        fail "No key \"#{filter}\" in #{data}" if data[filter].nil?
+        fail "No key \"#{filter}\" in #{data}" unless data.key?(filter)
         data = data[filter]
       end
     end

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -122,7 +122,10 @@ module Cisco
       value = value.is_a?(Hash) ? [value] : value
       data = nil
       value.each do |row|
-        data = row[data_key] if row[row_key].to_s[/#{row_index}/]
+        if row[row_key].to_s[/#{row_index}/]
+          data = row[data_key]
+          data = data.nil? ? '' : data
+        end
       end
       return value if data.nil?
       if regexp_filter


### PR DESCRIPTION
**Summary:**
The behavior has changed in h_dev images for some fields that have structured output. 

**For example:**

On h_dev:

```
{
  "ins_api": {
    "type": "cli_show",
    "version": "1.0",
    "sid": "eoc",
    "outputs": {
      "output": {
        "input": "show snmp",
        "msg": "Success",
        "code": "200",
        "body": {
          "sys_contact": null, <----------- Display unset values as null, (translates to nil in ruby)
          "sys_location": null,
```

On Older Images:

```
{
  "ins_api": {
    "type": "cli_show",
    "version": "1.0",
    "sid": "eoc",
    "outputs": {
      "output": {
        "input": "show snmp",
        "msg": "Success",
        "code": "200",
        "body": {
          "sys_contact": "",  <----------- Display unset values as empty
          "sys_location": "",
```

This update fixes our infra to handle both cases.