### PR TITLE
Set host_reachability correctly when setting ingress_replication

### DIFF
--- a/lib/cisco_node_utils/vxlan_vtep_vni.rb
+++ b/lib/cisco_node_utils/vxlan_vtep_vni.rb
@@ -132,19 +132,13 @@ module Cisco
     def remove_add_ingress_replication(protocol)
       # Note: ingress-replication is not supported on all platforms.
       # Use to_s.empty check to also handle nil check.
-      if ingress_replication.to_s.empty?
-        set_host_reachability(@set_args[:name], protocol)
-        set_args_keys(state: '', protocol: protocol)
-        config_set('vxlan_vtep_vni', 'ingress_replication', @set_args)
-      else
-        # Sadly, the only way to change between protocols is to
-        # first remove the existing protocol.
+      unless ingress_replication.to_s.empty?
         set_args_keys(state: 'no', protocol: ingress_replication)
         config_set('vxlan_vtep_vni', 'ingress_replication', @set_args)
-        set_host_reachability(@set_args[:name], protocol)
-        set_args_keys(state: '', protocol: protocol)
-        config_set('vxlan_vtep_vni', 'ingress_replication', @set_args)
       end
+      set_host_reachability(@set_args[:name], protocol)
+      set_args_keys(state: '', protocol: protocol)
+      config_set('vxlan_vtep_vni', 'ingress_replication', @set_args)
     end
 
     def ingress_replication=(protocol)

--- a/lib/cisco_node_utils/vxlan_vtep_vni.rb
+++ b/lib/cisco_node_utils/vxlan_vtep_vni.rb
@@ -112,10 +112,28 @@ module Cisco
       config_get('vxlan_vtep_vni', 'ingress_replication', @get_args)
     end
 
+    def set_host_reachability(vtep_name, protocol)
+      # This is a helper method for the ingress_replication setter.
+      # In later versions of Nexus, a check was added to make sure
+      # the host_reachability setting is correct for the desired
+      # ingress_replication setting.
+      #
+      case protocol
+      when 'bgp'
+        host_reachability = 'evpn'
+      when 'static'
+        host_reachability = 'flood'
+      else
+        fail "Protocol #{protocol} currently not supported"
+      end
+      VxlanVtep.new(vtep_name).host_reachability = host_reachability
+    end
+
     def remove_add_ingress_replication(protocol)
       # Note: ingress-replication is not supported on all platforms.
       # Use to_s.empty check to also handle nil check.
       if ingress_replication.to_s.empty?
+        set_host_reachability(@set_args[:name], protocol)
         set_args_keys(state: '', protocol: protocol)
         config_set('vxlan_vtep_vni', 'ingress_replication', @set_args)
       else
@@ -123,6 +141,7 @@ module Cisco
         # first remove the existing protocol.
         set_args_keys(state: 'no', protocol: ingress_replication)
         config_set('vxlan_vtep_vni', 'ingress_replication', @set_args)
+        set_host_reachability(@set_args[:name], protocol)
         set_args_keys(state: '', protocol: protocol)
         config_set('vxlan_vtep_vni', 'ingress_replication', @set_args)
       end


### PR DESCRIPTION
**Summary:**
In later versions of Nexus, the vxlan vtep host reachability must be set properly before setting the ingress replication feature.

This update modified the `ingress_replication` setter to check the should intent for `protocol` and ensures that the vtep host reachability is set properly to support the protocol setting.

**Testing:**
Tests pass on n7k, n9k(latest, greensboro, freeport and camden), n9k-fretta)