### PR TITLE
Address default behavior change

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/ip_multicast.yaml
+++ b/lib/cisco_node_utils/cmd_ref/ip_multicast.yaml
@@ -7,12 +7,16 @@ _template:
 
 overlay_distributed_dr:
   context: ~
+  kind: boolean
   get_value: '^ip multicast overlay-distributed-dr$'
   set_value: "<state> ip multicast overlay-distributed-dr"
   default_value: false
 
 overlay_spt_only:
   context: ~
-  get_value: '^ip multicast overlay-spt-only$'
+  kind: boolean
+  auto_default: false
+  get_command: "show fabric multicast globals"
+  get_value: '^Overlay spt-only:\s+TRUE$'
   set_value: "<state> ip multicast overlay-spt-only"
-  default_value: false
+  default_value: true

--- a/lib/cisco_node_utils/ip_multicast.rb
+++ b/lib/cisco_node_utils/ip_multicast.rb
@@ -65,7 +65,7 @@ module Cisco
 
     def overlay_spt_only
       result = config_get('ip_multicast', 'overlay_spt_only')
-      result = result.nil? ? false : result
+      result.nil? ? false : result
     end
 
     def overlay_spt_only=(bool)

--- a/lib/cisco_node_utils/ip_multicast.rb
+++ b/lib/cisco_node_utils/ip_multicast.rb
@@ -64,23 +64,27 @@ module Cisco
     end
 
     def overlay_spt_only
-      config_get('ip_multicast', 'overlay_spt_only')
+      result = config_get('ip_multicast', 'overlay_spt_only')
+      result = result.nil? ? false : result
     end
 
     def overlay_spt_only=(bool)
       fail TypeError unless [true, false].include?(bool)
       @set_args[:state] = bool ? '' : 'no'
-      if @set_args[:state] == 'no'
-        unless overlay_spt_only == default_overlay_spt_only
-          config_set('ip_multicast', 'overlay_spt_only', @set_args)
-        end
-      else
-        config_set('ip_multicast', 'overlay_spt_only', @set_args)
-      end
+      config_set('ip_multicast', 'overlay_spt_only', @set_args)
     end
 
     def default_overlay_spt_only
-      config_get_default('ip_multicast', 'overlay_spt_only')
+      val = config_get_default('ip_multicast', 'overlay_spt_only')
+      # The default value for this property is different for older
+      # Nexus software verions.
+      #
+      # Versions: 7.0(3)I7(1), 7.0(3)I7(2), 7.0(3)I7(3)
+      #   Default State: false
+      #
+      # Versions: 7.0(3)I7(4) and later
+      #   Default State: true
+      node.os_version[/7\.0\(3\)I7\([1-3]\)/] ? !val : val
     end
   end
 end

--- a/tests/test_ip_multicast.rb
+++ b/tests/test_ip_multicast.rb
@@ -44,15 +44,15 @@ class TestIpMulticast < CiscoTestCase
     # Test Defaults
     have = ipm.overlay_distributed_dr
     should = ipm.default_overlay_distributed_dr
-    assert_equal(have, should, "overlay_distributed_dr does not match default value")
+    assert_equal(have, should, 'overlay_distributed_dr does not match default value')
 
     # Test property set
     ipm.overlay_distributed_dr = true
-    assert_equal(ipm.overlay_distributed_dr, true, "overlay_distributed_dr was not set")
+    assert_equal(ipm.overlay_distributed_dr, true, 'overlay_distributed_dr was not set')
 
     # Test property unset
     ipm.overlay_distributed_dr = false
-    assert_equal(ipm.overlay_distributed_dr, false, "overlay_distributed_dr was not unset")
+    assert_equal(ipm.overlay_distributed_dr, false, 'overlay_distributed_dr was not unset')
 
     ipm.destroy
   end
@@ -63,15 +63,15 @@ class TestIpMulticast < CiscoTestCase
     # Test Defaults
     have = ipm.overlay_spt_only
     should = ipm.default_overlay_spt_only
-    assert_equal(have, should, "overlay_spt_only does not match default value")
+    assert_equal(have, should, 'overlay_spt_only does not match default value')
 
     # Test property set
     ipm.overlay_spt_only = true
-    assert_equal(ipm.overlay_spt_only, true, "overlay_spt_only was not set")
+    assert_equal(ipm.overlay_spt_only, true, 'overlay_spt_only was not set')
 
     # Test property unset
     ipm.overlay_spt_only = false
-    assert_equal(ipm.overlay_spt_only, false, "overlay_spt_only was not unset")
+    assert_equal(ipm.overlay_spt_only, false, 'overlay_spt_only was not unset')
 
     ipm.destroy
   end

--- a/tests/test_ip_multicast.rb
+++ b/tests/test_ip_multicast.rb
@@ -38,31 +38,40 @@ class TestIpMulticast < CiscoTestCase
     super
   end
 
-  def test_ip_multicast
+  def test_overlay_distributed_dr
     ipm = IpMulticast.new
-    opts = %w(overlay_distributed_dr overlay_spt_only)
 
-    # test defaults
-    opts.each do |opt|
-      have = ipm.send("#{opt}")
-      should = ipm.send("default_#{opt}")
-      assert_equal(have, should, "#{opt} doesn't match the default")
-    end
+    # Test Defaults
+    have = ipm.overlay_distributed_dr
+    should = ipm.default_overlay_distributed_dr
+    assert_equal(have, should, "overlay_distributed_dr does not match default value")
 
-    # test property set
-    opts.each do |opt|
-      ipm.send("#{opt}=", true)
-      should = 'ip multicast ' + opt.tr('_', '-')
-      assert_equal(ipm.send("#{opt}"), should, "#{opt} was not set")
-    end
+    # Test property set
+    ipm.overlay_distributed_dr = true
+    assert_equal(ipm.overlay_distributed_dr, true, "overlay_distributed_dr was not set")
 
-    # unset property
-    opts.each do |opt|
-      ipm.send("#{opt}=", false)
-      should = false
-      assert_equal(ipm.send("#{opt}"), should, "#{opt} was not unset")
-      assert_equal(ipm.send("#{opt}"), ipm.send("default_#{opt}"), "#{opt} doesn't match default")
-    end
+    # Test property unset
+    ipm.overlay_distributed_dr = false
+    assert_equal(ipm.overlay_distributed_dr, false, "overlay_distributed_dr was not unset")
+
+    ipm.destroy
+  end
+
+  def test_overlay_spt_only
+    ipm = IpMulticast.new
+
+    # Test Defaults
+    have = ipm.overlay_spt_only
+    should = ipm.default_overlay_spt_only
+    assert_equal(have, should, "overlay_spt_only does not match default value")
+
+    # Test property set
+    ipm.overlay_spt_only = true
+    assert_equal(ipm.overlay_spt_only, true, "overlay_spt_only was not set")
+
+    # Test property unset
+    ipm.overlay_spt_only = false
+    assert_equal(ipm.overlay_spt_only, false, "overlay_spt_only was not unset")
 
     ipm.destroy
   end


### PR DESCRIPTION
**Summary:**
In recent image versions, there has been a default behavior change for `overlay_spt_only`.  In older image versions the feature defaults to off or `false` and in recent image versions the feature is now on by default or `true`.

This update:
* Updates the `overlay_spt_only` property to use the `show fabric multicast globals` command instead of `show running` which is not reliable for this property.
* Adds a `kind: boolean` check for both `overlay_distributed_dr` and `overlay_spt_only` properties.
* Adds `auto_default: false` to the `overlay_spt_only` property to make it easier to handle the different default states for different image versions.
* Adds a version check in `default_overlay_spt_only` 
* Separates the tests for both of the properties to make the results more granular.