### PR TITLE
Fix CISCO-65 and CISCO-68

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/tacacs_server_host.yaml
+++ b/lib/cisco_node_utils/cmd_ref/tacacs_server_host.yaml
@@ -48,7 +48,7 @@ hosts:
 port:
   default_value: 49
   kind: int
-  get_value: '/^tacacs-server host <ip>.* port (\d+).*$/'
+  get_value: '/^tacacs-server host <ip>\s.*port (\d+).*$/'
   nexus:
     set_value: "tacacs-server host <ip> port <port>"
 
@@ -56,7 +56,7 @@ timeout:
   default_value: 0
   kind: int
   nexus:
-    get_value: '/^tacacs-server host <ip> .*timeout (\d+)/'
+    get_value: '/^tacacs-server host <ip>\s.*timeout (\d+)/'
     set_value: "<state> tacacs-server host <ip> timeout <timeout>"
   ios_xr:
     context: ["tacacs-server host <ip> port <port>"]

--- a/lib/cisco_node_utils/vlan.rb
+++ b/lib/cisco_node_utils/vlan.rb
@@ -47,7 +47,7 @@ module Cisco
       return hash if vlan_list.nil?
 
       vlan_list.each do |id|
-        hash[id] = Vlan.new(id, false)
+        hash[id.to_s] = Vlan.new(id, false)
       end
       hash
     end


### PR DESCRIPTION
This PR is for fixing the following issues:
1. https://tickets.puppetlabs.com/browse/CISCO-65
On n5k, if there are multiple vlans, the puppet resource ```cisco_vlan``` command is failing. This is due to the fact that, the ```show vlan br | json``` returns an integer for ```vlan_id``` and on all other platforms, it returns a string. Converting index to string solves it.
2. https://tickets.puppetlabs.com/browse/CISCO-68
If there are multiple tacacs servers like (192.168.1.1, 192.168.1.11 etc.) the regex pattern is matching both servers for 192.168.1.1 and the value for ```port``` attribute, it is returning is an array which is causing issue. Basically the regex pattern check is wrong which does not take the white space into account properly.
