### PR TITLE
(CISCO-75/76) Fix interface_hsrp_group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog
 ### Removed
 
 ### Issues Addressed
+* Removed default values for authentication in `interface_hsrp_group`
 
 ## [v1.9.0]
 

--- a/lib/cisco_node_utils/cmd_ref/interface_hsrp_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_hsrp_group.yaml
@@ -23,14 +23,14 @@ authentication_enc_type:
   default_value: '0'
 
 authentication_key_type:
-  default_value: 'key-chain'
+  default_value: ~
 
 authentication_string:
-  default_value: ''
+  default_value: ~
 
 authentication_timeout:
   kind: int
-  default_value: 0
+  default_value: ~
 
 group_name:
   get_value: '/^name (\S+)/'

--- a/lib/cisco_node_utils/interface_hsrp_group.rb
+++ b/lib/cisco_node_utils/interface_hsrp_group.rb
@@ -1,7 +1,7 @@
 #
 # October 2016, Sai Chintalapudi
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -96,6 +96,12 @@ module Cisco
     # authentication md5 key-string ABCXYZ timeout 22
     # authentication md5 key-string 7 12345678901234567890 timeout 22
     # authentication md5 key-string 7 123456789 compatibility timeout 22
+    # if passwd
+    #   req auth_enc_type
+    # if encrypted
+    #   req authentication_key_type, authentication_enc_type
+    #   if key-string
+    #     optional compat and timeout
     def authentication
       hash = {}
       hash[:auth_type] = default_authentication_auth_type
@@ -203,8 +209,13 @@ module Cisco
     end
 
     def authentication_timeout=(val)
-      @set_args[:tval] = val
-      @set_args[:timeout] = 'timeout'
+      if val.nil?
+        @set_args[:tval] = ''
+        @set_args[:timeout] = ''
+      else
+        @set_args[:tval] = val
+        @set_args[:timeout] = 'timeout'
+      end
     end
 
     def default_authentication_timeout
@@ -227,14 +238,14 @@ module Cisco
        :authentication_compatibility,
        :authentication_timeout,
       ].each do |p|
-        send(p.to_s + '=', attrs[p]) unless attrs[p].nil?
+        send(p.to_s + '=', attrs[p])
       end
-      return if @set_args[:passwd] == default_authentication_string
+      return if @set_args[:passwd].nil? || @set_args[:passwd].empty?
       @set_args[:state] = ''
       if @set_args[:authtype] == 'text'
         @set_args[:keytype] = @set_args[:enctype] = ''
         @set_args[:compatible] = @set_args[:timeout] = @set_args[:tval] = ''
-      elsif @set_args[:keytype] == default_authentication_key_type
+      elsif @set_args[:keytype] == 'key-chain'
         @set_args[:enctype] = @set_args[:compatible] = ''
         @set_args[:timeout] = @set_args[:tval] = ''
       end

--- a/tests/test_interface_hsrp_group.rb
+++ b/tests/test_interface_hsrp_group.rb
@@ -109,8 +109,7 @@ class TestInterfaceHsrpGroup < CiscoTestCase
   def test_auth_type_clear
     skip_legacy_defect?('7.3.0.D1.1', 'CSCuh90262: hsrp indentation')
     ihg = create_interface_hsrp_group_ipv4
-    assert_equal(ihg.default_authentication_string,
-                 ihg.authentication_string)
+    assert_nil(ihg.authentication_string)
     attrs = {}
     attrs[:authentication_auth_type] = 'cleartext'
     attrs[:authentication_string] = 'Test'
@@ -119,8 +118,7 @@ class TestInterfaceHsrpGroup < CiscoTestCase
     assert_equal('Test', ihg.authentication_string)
     attrs[:authentication_string] = ihg.default_authentication_string
     ihg.authentication_set(attrs)
-    assert_equal(ihg.default_authentication_string,
-                 ihg.authentication_string)
+    assert_nil(ihg.authentication_string)
 
     ihg = create_interface_hsrp_group_ipv6
     attrs[:authentication_auth_type] = 'cleartext'
@@ -130,8 +128,7 @@ class TestInterfaceHsrpGroup < CiscoTestCase
     assert_equal('Test', ihg.authentication_string)
     attrs[:authentication_string] = ihg.default_authentication_string
     ihg.authentication_set(attrs)
-    assert_equal(ihg.default_authentication_string,
-                 ihg.authentication_string)
+    assert_nil(ihg.authentication_string)
   end
 
   def test_auth_type_md5
@@ -147,8 +144,7 @@ class TestInterfaceHsrpGroup < CiscoTestCase
     assert_equal('MyMD5Password', ihg.authentication_string)
     attrs[:authentication_string] = ihg.default_authentication_string
     ihg.authentication_set(attrs)
-    assert_equal(ihg.default_authentication_string,
-                 ihg.authentication_string)
+    assert_nil(ihg.authentication_string)
     ihg = create_interface_hsrp_group_ipv6
     attrs[:authentication_string] = 'MyMD5Password'
     ihg.authentication_set(attrs)
@@ -157,8 +153,7 @@ class TestInterfaceHsrpGroup < CiscoTestCase
     assert_equal('MyMD5Password', ihg.authentication_string)
     attrs[:authentication_string] = ihg.default_authentication_string
     ihg.authentication_set(attrs)
-    assert_equal(ihg.default_authentication_string,
-                 ihg.authentication_string)
+    assert_nil(ihg.authentication_string)
   end
 
   def test_auth_key_string_enc_0
@@ -178,8 +173,7 @@ class TestInterfaceHsrpGroup < CiscoTestCase
     assert_equal('7', ihg.authentication_string)
     attrs[:authentication_string] = ihg.default_authentication_string
     ihg.authentication_set(attrs)
-    assert_equal(ihg.default_authentication_string,
-                 ihg.authentication_string)
+    assert_nil(ihg.authentication_string)
     ihg = create_interface_hsrp_group_ipv6
     attrs[:authentication_string] = '7'
     ihg.authentication_set(attrs)
@@ -189,8 +183,7 @@ class TestInterfaceHsrpGroup < CiscoTestCase
     assert_equal('7', ihg.authentication_string)
     attrs[:authentication_string] = ihg.default_authentication_string
     ihg.authentication_set(attrs)
-    assert_equal(ihg.default_authentication_string,
-                 ihg.authentication_string)
+    assert_nil(ihg.authentication_string)
   end
 
   def test_auth_key_string_enc_7
@@ -217,8 +210,7 @@ class TestInterfaceHsrpGroup < CiscoTestCase
     assert_equal('12345678901234567890', ihg.authentication_string)
     attrs[:authentication_string] = ihg.default_authentication_string
     ihg.authentication_set(attrs)
-    assert_equal(ihg.default_authentication_string,
-                 ihg.authentication_string)
+    assert_nil(ihg.authentication_string)
   end
 
   def test_auth_key_string_enc_7_compat_timeout_ipv4
@@ -250,8 +242,7 @@ class TestInterfaceHsrpGroup < CiscoTestCase
     assert_equal(false, ihg.authentication_compatibility)
     attrs[:authentication_string] = ihg.default_authentication_string
     ihg.authentication_set(attrs)
-    assert_equal(ihg.default_authentication_string,
-                 ihg.authentication_string)
+    assert_nil(ihg.authentication_string)
   end
 
   def test_auth_key_string_enc_7_compat_timeout_ipv6
@@ -283,8 +274,7 @@ class TestInterfaceHsrpGroup < CiscoTestCase
     assert_equal(false, ihg.authentication_compatibility)
     attrs[:authentication_string] = ihg.default_authentication_string
     ihg.authentication_set(attrs)
-    assert_equal(ihg.default_authentication_string,
-                 ihg.authentication_string)
+    assert_nil(ihg.authentication_string)
   end
 
   def test_auth_key_string_enc_0_compat_timeout_ipv4
@@ -315,8 +305,7 @@ class TestInterfaceHsrpGroup < CiscoTestCase
     assert_equal(3333, ihg.authentication_timeout)
     attrs[:authentication_string] = ihg.default_authentication_string
     ihg.authentication_set(attrs)
-    assert_equal(ihg.default_authentication_string,
-                 ihg.authentication_string)
+    assert_nil(ihg.authentication_string)
   end
 
   def test_auth_key_string_enc_0_compat_timeout_ipv6
@@ -347,8 +336,7 @@ class TestInterfaceHsrpGroup < CiscoTestCase
     assert_equal(3333, ihg.authentication_timeout)
     attrs[:authentication_string] = ihg.default_authentication_string
     ihg.authentication_set(attrs)
-    assert_equal(ihg.default_authentication_string,
-                 ihg.authentication_string)
+    assert_nil(ihg.authentication_string)
   end
 
   def test_preempt_ipv4


### PR DESCRIPTION
Removed default values for authentication.  There are not defaults that are sane in this context.  Users should supply explicit values.