### PR TITLE
CISCO-77: cisco_interface add ipv6_redirects attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Changelog
   * `level`
 * Extend syslog_server with attribute:
   * `facility`
+* Extend interface with attributes:
+   * `ipv6_redirects`
 
 ### Changed
 

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -306,6 +306,13 @@ ipv6_dhcp_relay_src_intf:
   set_value: "<state> ipv6 dhcp relay source-interface <intf>"
   default_value: false
 
+ipv6_redirects:
+  _exclude: [ios_xr]
+  kind: boolean
+  get_value: '/^((?:no )?ipv6 redirects)$/'
+  set_value: "<state> ipv6 redirects"
+  default_value: true
+
 load_interval_counter_1_delay:
   _exclude: [ios_xr]
   kind: int

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -834,6 +834,21 @@ module Cisco
       config_get_default('interface', 'ipv6_dhcp_relay_src_intf')
     end
 
+    def ipv6_redirects
+      config_get('interface', 'ipv6_redirects', name: @name)
+    end
+
+    def ipv6_redirects=(redirects)
+      check_switchport(:disabled)
+      no_cmd = (redirects ? '' : 'no')
+      config_set('interface', 'ipv6_redirects',
+                 name: @name, state: no_cmd)
+    end
+
+    def default_ipv6_redirects
+      config_get_default('interface', 'ipv6_redirects')
+    end
+
     def feature_lacp?
       config_get('interface', 'feature_lacp')
     end

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -1,6 +1,6 @@
 # November 2015, Chris Van Heuveln
 #
-# Copyright (c) 2015-2017 Cisco and/or its affiliates.
+# Copyright (c) 2015-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2017 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -1250,6 +1250,27 @@ class TestInterface < CiscoTestCase
                  'Error: ip redirects default get value mismatch')
   end
 
+  def test_ipv6_redirects
+    interface = create_interface
+    interface.switchport_mode = :disabled if platform == :nexus
+
+    # check default value
+    assert_equal(interface.default_ipv6_redirects, interface.ipv6_redirects,
+                 'Error: ipv6 redirects default get value mismatch')
+
+    # set with value false
+    interface.ipv6_redirects = false
+    assert_equal(interface.ipv6_redirects, false)
+
+    # set with value true
+    interface.ipv6_redirects = true
+    assert_equal(interface.ipv6_redirects, true)
+
+    # get default and set
+    interface.ipv6_redirects = interface.default_ipv6_redirects
+    assert_equal(interface.ipv6_redirects, interface.default_ipv6_redirects)
+  end
+
   def config_from_hash(inttype_h)
     inttype_h.each do |k, v|
       config('feature interface-vlan') if (/^Vlan\d./).match(k.to_s)


### PR DESCRIPTION
Extends `interface.rb` to add ipv6_redirects attribute support.