### PR TITLE
(FM-7109) Add ability to dynamically specify environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Changelog
   * `facility`
 * Extend interface with attributes:
    * `ipv6_redirects`
+* Added ability to specify environment at run time
+
+Example:
+```ruby
+env = { host: '192.168.1.1', port: nil, username: 'admin', password: 'admin123', cookie: nil }
+Cisco::Environment.add_env('default', env)
+```
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ An example configuration file (illustrating each of the above scenarios) is prov
 
 *For security purposes, it is highly recommended that access to this file be restricted to only the owning user (`chmod 0600`).*
 
+Configuration may also be specified at runtime and can be used in the absence of configuration files or to override them.
+
+Example:
+```ruby
+env = { host: '192.168.1.1', port: nil, username: 'admin', password: 'admin123', cookie: nil }
+Cisco::Environment.add_env('default', env)
+```
+
 ## <a name="documentation">Documentation</a>
 
 ### Client
@@ -151,12 +159,18 @@ client2 = Cisco::Client.create('n9k')
 # Warning: Make sure to exclude devices using the 'no_proxy' environment variable
 # to ensure successful remote connections.
 
+# Add runtime configuration for remote device and connect
+env = { host: '192.168.1.1', port: nil, username: 'admin', password: 'admin123', cookie: nil }
+Cisco::Environment.add_env('remote', env)
+client3 = Cisco::Client.create('remote')
+
 # Use connections to get and set device state.
 client1.set(values: 'feature vtp')
 client1.set(values: 'vtp domain mycompany.com')
 puts client1.get(command: 'show vtp status | inc Domain')
 
 puts client2.get(command: 'show version')
+puts client3.get(command: 'show version')
 ```
 
 #### High-level Node API

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -37,7 +37,7 @@ begin
   os == 'ios_xr' || deps << Gem::Dependency.new('net_http_unix',
                                                 '~> 0.2', '>= 0.2.1')
   # NX-OS doesn't need gRPC
-  os == 'nexus' || deps << Gem::Dependency.new('grpc', '~> 0.12')
+  os == 'nexus' || deps << Gem::Dependency.new('grpc', '~> 1.14.1')
 
   deps.each do |dep|
     installed = dep.matching_specs

--- a/lib/cisco_node_utils/environment.rb
+++ b/lib/cisco_node_utils/environment.rb
@@ -1,6 +1,7 @@
+# August 2018
 # March 2016, Glenn F. Matthews
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -88,6 +89,12 @@ module Cisco
     rescue Psych::SyntaxError => e
       Cisco::Logger.error("Error loading #{path}: #{e}")
       {}
+    end
+
+    def self.add_env(env_name, env_hash)
+      fail ArgumentError, 'empty environment name' if env_name.empty?
+      fail TypeError, 'invalid environment hash' unless env_hash.is_a?(Hash)
+      @environments[env_name] = env_hash
     end
 
     def self.strings_to_symbols(hash)


### PR DESCRIPTION
This PR adds basic functionality for passing in environment data at run time
This is the building block for Puppet Device support, but should not affect other consumers of the gem.