### PR TITLE
Fix for Cisco-73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Changelog
    * `vlan`
    * `set_erspan_dscp`
    * `set_erspan_gre_proto`
+* Added ability to specify environment at run time
+
+Example:
+```ruby
+env = { host: '192.168.1.1', port: nil, username: 'admin', password: 'admin123', cookie: nil }
+Cisco::Environment.add_env('default', env)
+```
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changelog
   * `facility`
 * Extend interface with attributes:
    * `ipv6_redirects`
+* Extend ace with attributes:
+   * `proto_option`
+   * `vlan`
+   * `set_erspan_dscp`
+   * `set_erspan_gre_proto`
 
 ### Changed
 

--- a/lib/cisco_node_utils/ace.rb
+++ b/lib/cisco_node_utils/ace.rb
@@ -325,7 +325,7 @@ module Cisco
       @set_args[:set_erspan_gre_proto] =
           Utils.attach_prefix(set_erspan_gre_proto,
                               :set_erspan_gre_proto,
-                              'set-erspan-dscp')
+                              'set-erspan-gre-proto')
     end
 
     def time_range

--- a/lib/cisco_node_utils/ace.rb
+++ b/lib/cisco_node_utils/ace.rb
@@ -102,6 +102,9 @@ module Cisco
     # icmp ace getter
     def icmp_ace_get(str)
       # rubocop:disable Metrics/LineLength
+      # fragments is nvgen at a different location than all other
+      # proto_option so get rid of it so as not to mess up other fields
+      str.sub!('fragments ', '')
       regexp = Regexp.new('(?<seqno>\d+) (?<action>\S+)'\
                  ' *(?<proto>\d+|\S+)'\
                  ' *(?<src_addr>any|host \S+|[:\.0-9a-fA-F]+ [:\.0-9a-fA-F]+|[:\.0-9a-fA-F]+\/\d+|addrgroup \S+)'\

--- a/lib/cisco_node_utils/ace.rb
+++ b/lib/cisco_node_utils/ace.rb
@@ -108,27 +108,27 @@ module Cisco
                  ' *(?<dst_addr>any|host \S+|[:\.0-9a-fA-F]+ [:\.0-9a-fA-F]+|[:\.0-9a-fA-F]+\/\d+|addrgroup \S+)'\
                  ' *(?<proto_option>\S+)?'\
                  ' *(?<precedence>precedence \S+)?'\
-                 ' *(?<redirect>redirect \S+)?'\
                  ' *(?<dscp>dscp \S+)?'\
                  ' *(?<time_range>time-range \S+)?'\
                  ' *(?<packet_length>packet-length (range \d+ \d+|(lt|eq|gt|neq) \d+))?'\
                  ' *(?<ttl>ttl \d+)?'\
                  ' *(?<vlan>vlan \d+)?'\
                  ' *(?<set_erspan_gre_proto>set-erspan-gre-proto \d+)?'\
-                 ' *(?<set_erspan_dscp>set-erspan-dscp \d+)?')
+                 ' *(?<set_erspan_dscp>set-erspan-dscp \d+)?'\
+                 ' *(?<redirect>redirect \S+)?')
       regexp_no_proto_option = Regexp.new('(?<seqno>\d+) (?<action>\S+)'\
                  ' *(?<proto>\d+|\S+)'\
                  ' *(?<src_addr>any|host \S+|[:\.0-9a-fA-F]+ [:\.0-9a-fA-F]+|[:\.0-9a-fA-F]+\/\d+|addrgroup \S+)'\
                  ' *(?<dst_addr>any|host \S+|[:\.0-9a-fA-F]+ [:\.0-9a-fA-F]+|[:\.0-9a-fA-F]+\/\d+|addrgroup \S+)'\
                  ' *(?<precedence>precedence \S+)?'\
-                 ' *(?<redirect>redirect \S+)?'\
                  ' *(?<dscp>dscp \S+)?'\
                  ' *(?<time_range>time-range \S+)?'\
                  ' *(?<packet_length>packet-length (range \d+ \d+|(lt|eq|gt|neq) \d+))?'\
                  ' *(?<ttl>ttl \d+)?'\
                  ' *(?<vlan>vlan \d+)?'\
                  ' *(?<set_erspan_gre_proto>set-erspan-gre-proto \d+)?'\
-                 ' *(?<set_erspan_dscp>set-erspan-dscp \d+)?')
+                 ' *(?<set_erspan_dscp>set-erspan-dscp \d+)?'\
+                 ' *(?<redirect>redirect \S+)?')
       temp = regexp.match(str)
       po = temp[:proto_option]
       if po.nil?

--- a/lib/cisco_node_utils/ace.rb
+++ b/lib/cisco_node_utils/ace.rb
@@ -347,7 +347,13 @@ module Cisco
     end
 
     def set_erspan_dscp
-      Utils.extract_value(ace_get, 'set_erspan_dscp', 'set-erspan-dscp')
+      ret = Utils.extract_value(ace_get, 'set_erspan_dscp', 'set-erspan-dscp')
+      return ret if ret
+      # position of set_erspan_dscp is different in older release so check again
+      str = config_get('acl', 'ace', @get_args)
+      sstr = str.split
+      return sstr[sstr.index('set-erspan-dscp') + 1] if
+        sstr.include?('set-erspan-dscp')
     end
 
     def set_erspan_dscp=(set_erspan_dscp)
@@ -357,8 +363,15 @@ module Cisco
     end
 
     def set_erspan_gre_proto
-      Utils.extract_value(ace_get, 'set_erspan_gre_proto',
-                          'set-erspan-gre-proto')
+      ret = Utils.extract_value(ace_get, 'set_erspan_gre_proto',
+                                'set-erspan-gre-proto')
+      return ret if ret
+      # position of set_erspan_gre_proto is different in older release
+      # so check again
+      str = config_get('acl', 'ace', @get_args)
+      sstr = str.split
+      return sstr[sstr.index('set-erspan-gre-proto') + 1] if
+        sstr.include?('set-erspan-gre-proto')
     end
 
     def set_erspan_gre_proto=(set_erspan_gre_proto)

--- a/lib/cisco_node_utils/ace.rb
+++ b/lib/cisco_node_utils/ace.rb
@@ -74,7 +74,7 @@ module Cisco
       remark = Regexp.new('(?<seqno>\d+) remark (?<remark>.*)').match(str)
       return remark unless remark.nil?
 
-      # for icmp things are different
+      # specialized icmp protocol handling
       return icmp_ace_get(str) if str.include?('icmp')
 
       # rubocop:disable Metrics/LineLength

--- a/lib/cisco_node_utils/cmd_ref/acl.yaml
+++ b/lib/cisco_node_utils/cmd_ref/acl.yaml
@@ -12,7 +12,7 @@ _template:
 
 ace:
   get_value: '/^<seqno> .+$/'
-  set_value: '<state> <seqno> <action> <proto> <src_addr> <src_port> <dst_addr> <dst_port> <proto_option> <tcp_flags> <established> <precedence> <dscp> <http_method> <time_range> <packet_length> <ttl> <tcp_option_length> <redirect> <log> <vlan> <set_erspan_dscp> <set_erspan_gre_proto>'
+  set_value: '<state> <seqno> <action> <proto> <src_addr> <src_port> <dst_addr> <dst_port> <proto_option> <tcp_flags> <established> <precedence> <dscp> <http_method> <time_range> <packet_length> <ttl> <tcp_option_length> <redirect> <vlan> <set_erspan_dscp> <set_erspan_gre_proto> <log>'
 
 ace_destroy:
   set_value: 'no <seqno>'

--- a/lib/cisco_node_utils/cmd_ref/acl.yaml
+++ b/lib/cisco_node_utils/cmd_ref/acl.yaml
@@ -12,7 +12,7 @@ _template:
 
 ace:
   get_value: '/^<seqno> .+$/'
-  set_value: '<state> <seqno> <action> <proto> <src_addr> <src_port> <dst_addr> <dst_port> <proto_option> <tcp_flags> <established> <precedence> <dscp> <http_method> <time_range> <packet_length> <ttl> <tcp_option_length> <redirect> <vlan> <set_erspan_dscp> <set_erspan_gre_proto> <log>'
+  set_value: '<state> <seqno> <action> <proto> <src_addr> <src_port> <dst_addr> <dst_port> <proto_option> <tcp_flags> <established> <precedence> <dscp> <http_method> <time_range> <packet_length> <ttl> <tcp_option_length> <vlan> <redirect> <set_erspan_dscp> <set_erspan_gre_proto> <log>'
 
 ace_destroy:
   set_value: 'no <seqno>'

--- a/lib/cisco_node_utils/cmd_ref/acl.yaml
+++ b/lib/cisco_node_utils/cmd_ref/acl.yaml
@@ -12,7 +12,7 @@ _template:
 
 ace:
   get_value: '/^<seqno> .+$/'
-  set_value: '<state> <seqno> <action> <proto> <src_addr> <src_port> <dst_addr> <dst_port> <tcp_flags> <established> <precedence> <dscp> <http_method> <time_range> <packet_length> <ttl> <tcp_option_length> <redirect> <log>'
+  set_value: '<state> <seqno> <action> <proto> <src_addr> <src_port> <dst_addr> <dst_port> <proto_option> <tcp_flags> <established> <precedence> <dscp> <http_method> <time_range> <packet_length> <ttl> <tcp_option_length> <redirect> <log> <vlan> <set_erspan_dscp> <set_erspan_gre_proto>'
 
 ace_destroy:
   set_value: 'no <seqno>'

--- a/tests/test_ace.rb
+++ b/tests/test_ace.rb
@@ -219,7 +219,7 @@ class TestAce < CiscoTestCase
     afi = 'ipv4'
     val = 'port-channel1,port-channel2'
     a = ace_helper(afi, proto: 'icmp', proto_option: 'redirect',
-                   redirect: val, log: true)
+                   redirect: val, log: true, set_erspan_dscp: '3', set_erspan_gre_proto: '33')
     assert_equal(val, a.redirect)
     assert_equal('redirect', a.proto_option)
   end
@@ -283,16 +283,22 @@ class TestAce < CiscoTestCase
   end
 
   def test_set_erspan_dscp
-    val = '3'
     afi = 'ipv4'
-    a = ace_helper(afi, proto: 'icmp', set_erspan_dscp: val)
-    assert_equal(val, a.set_erspan_dscp)
+    val = 'port-channel1,port-channel2'
+    a = ace_helper(afi, proto: 'icmp', proto_option: 'redirect',
+                   redirect: val, log: true, set_erspan_dscp: '3', set_erspan_gre_proto: '33')
+    assert_equal('redirect', a.proto_option)
+    assert_equal(val, a.redirect)
+    assert_equal('3', a.set_erspan_dscp)
   end
 
   def test_set_erspan_gre_proto
-    val = '300'
     afi = 'ipv4'
-    a = ace_helper(afi, proto: 'icmp', set_erspan_gre_proto: val)
-    assert_equal(val, a.set_erspan_gre_proto)
+    val = 'port-channel1,port-channel2'
+    a = ace_helper(afi, proto: 'icmp', proto_option: 'redirect',
+                   redirect: val, log: true, set_erspan_gre_proto: '33')
+    assert_equal('redirect', a.proto_option)
+    assert_equal(val, a.redirect)
+    assert_equal('33', a.set_erspan_gre_proto)
   end
 end

--- a/tests/test_ace.rb
+++ b/tests/test_ace.rb
@@ -201,8 +201,6 @@ class TestAce < CiscoTestCase
       refute(ace_helper(afi).log)
       a = ace_helper(afi, proto: 'icmp', proto_option: 'redirect', log: true)
       assert(a.log)
-      a = ace_helper(afi, proto: 'icmp', proto_option: 'redirect', log: false)
-      refute(a.log)
     end
   end
 
@@ -211,6 +209,9 @@ class TestAce < CiscoTestCase
       refute(ace_helper(afi).log)
       a = ace_helper(afi, proto: 'icmp', proto_option: 'time-exceeded')
       assert_equal(a.proto_option, 'time-exceeded')
+      a = ace_helper(afi, proto: 'icmp', dscp: 'af11', proto_option: 'echo-reply')
+      assert_equal(a.proto_option, 'echo-reply')
+      assert_equal(a.dscp, 'af11')
     end
   end
 

--- a/tests/test_ace.rb
+++ b/tests/test_ace.rb
@@ -57,7 +57,7 @@ class TestAce < CiscoTestCase
     end
   rescue CliError => e
     skip('This property is not supported on this platform') if
-      e.message[/(Invalid parameter detected|Invalid command)/]
+      e.message[/(Invalid parameter detected|Invalid command|Invalid number)/]
     flunk(e.message)
   end
 
@@ -279,5 +279,19 @@ class TestAce < CiscoTestCase
     skip("This property has a known defect on the platform itself -\n"\
          'CSCuy47463: access-list ttl does not nvgen') if a.ttl.nil?
     assert_equal(val, a.ttl)
+  end
+
+  def test_set_erspan_dscp
+    val = '3'
+    afi = 'ipv4'
+    a = ace_helper(afi, proto: 'icmp', set_erspan_dscp: val)
+    assert_equal(val, a.set_erspan_dscp)
+  end
+
+  def test_set_erspan_gre_proto
+    val = '300'
+    afi = 'ipv4'
+    a = ace_helper(afi, proto: 'icmp', set_erspan_gre_proto: val)
+    assert_equal(val, a.set_erspan_gre_proto)
   end
 end

--- a/tests/test_ace.rb
+++ b/tests/test_ace.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR is for fixing issue cisco-73
https://tickets.puppetlabs.com/browse/CISCO-73

Basically the current ace provider implementation does not take care of icmp properly.
However, upon further inspection of CLIs, it is found that the CLIs differ between different versions of software and also between platforms.
* ```redirect``` can be just a keyword or it can be used with interfaces or they could both be used simultaneously.
* the position of ```redirect``` changes on the show run based on the software version.
* ```fragments``` is put a different location than other options even though the behavior is similar to other options.
* ```set_erspan_gre_proto``` and ```set_erspan_dscp``` positions change based on the software versions.

Due to all these weird quirks, the code checks some of the parameters on 2nd pass due to hit and miss regex patterns for the ```show run aclmgr``` output.

* For all the single word icmp parameter options, the name ```proto_option``` (instead of icmp...something) is given because this can be used to other protocols going forward and also because for setting the configuration the same pattern is used for all protocols (unlike get regex where it is different for icmp). 
* However, only ```icmp``` supports the ```proto_option``` in the near term.

Tested on n7k, n3k and n9k.
