### PR TITLE
Fix interface default issues

### DIFF
--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -1085,7 +1085,7 @@ module Cisco
     end
 
     def storm_control_multicast=(val)
-      return if val == storm_control_broadcast
+      return if val == storm_control_multicast
       state = val == default_storm_control_multicast ? 'no' : ''
       level = val == default_storm_control_multicast ? '' : val
       config_set('interface', 'storm_control_multicast',
@@ -1102,7 +1102,7 @@ module Cisco
     end
 
     def storm_control_unicast=(val)
-      return if val == storm_control_broadcast
+      return if val == storm_control_unicast
       state = val == default_storm_control_unicast ? 'no' : ''
       level = val == default_storm_control_unicast ? '' : val
       config_set('interface', 'storm_control_unicast',

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -2025,7 +2025,7 @@ module Cisco
     end
 
     def vpc_peer_link=(state)
-      return if vpc_peerlink == state
+      return if vpc_peer_link == state
       no_cmd = (state ? '' : 'no')
       config_set('interface', 'vpc_peer_link', name: @name, state: no_cmd)
     end

--- a/tests/test_interface_private_vlan.rb
+++ b/tests/test_interface_private_vlan.rb
@@ -88,6 +88,7 @@ class TestInterfacePVlan < CiscoTestCase
       return
     end
 
+    i.switchport_mode = :access
     assert_equal(i.default_switchport_pvlan_host,
                  i.switchport_pvlan_host)
 
@@ -96,6 +97,7 @@ class TestInterfacePVlan < CiscoTestCase
 
     i.switchport_pvlan_host = false
     refute(i.switchport_pvlan_host)
+    i.switchport_mode = :disabled
   end
 
   def test_sw_pvlan_promiscuous
@@ -107,6 +109,7 @@ class TestInterfacePVlan < CiscoTestCase
       return
     end
 
+    i.switchport_mode = :access
     assert_equal(i.default_switchport_pvlan_promiscuous,
                  i.switchport_pvlan_promiscuous)
 
@@ -115,6 +118,7 @@ class TestInterfacePVlan < CiscoTestCase
 
     i.switchport_pvlan_promiscuous = false
     refute(i.switchport_pvlan_promiscuous)
+    i.switchport_mode = :disabled
   end
 
   def test_sw_pvlan_trunk_promiscuous
@@ -126,6 +130,7 @@ class TestInterfacePVlan < CiscoTestCase
       return
     end
 
+    i.switchport_mode = :access
     assert_equal(i.default_switchport_pvlan_trunk_promiscuous,
                  i.switchport_pvlan_trunk_promiscuous)
 
@@ -134,6 +139,7 @@ class TestInterfacePVlan < CiscoTestCase
 
     i.switchport_pvlan_trunk_promiscuous = false
     refute(i.switchport_pvlan_trunk_promiscuous)
+    i.switchport_mode = :disabled
   end
 
   def test_sw_pvlan_trunk_secondary
@@ -145,6 +151,7 @@ class TestInterfacePVlan < CiscoTestCase
       return
     end
 
+    i.switchport_mode = :access
     assert_equal(i.default_switchport_pvlan_trunk_secondary,
                  i.switchport_pvlan_trunk_secondary)
 
@@ -153,6 +160,7 @@ class TestInterfacePVlan < CiscoTestCase
 
     i.switchport_pvlan_trunk_secondary = false
     refute(i.switchport_pvlan_trunk_secondary)
+    i.switchport_mode = :disabled
   end
 
   # Helper to setup vlan associations
@@ -309,6 +317,7 @@ class TestInterfacePVlan < CiscoTestCase
       return
     end
 
+    i.switchport_mode = :access
     default = i.default_switchport_pvlan_trunk_allowed_vlan
     assert_equal(default, i.switchport_pvlan_trunk_allowed_vlan)
 
@@ -325,6 +334,7 @@ class TestInterfacePVlan < CiscoTestCase
     vlans = '500-528,530,532,534,587,590-593,597-598,600,602,604'
     i.switchport_pvlan_trunk_allowed_vlan = vlans
     assert_equal(vlans, i.switchport_pvlan_trunk_allowed_vlan)
+    i.switchport_mode = :disabled
   end
 
   def test_sw_pvlan_trunk_native_vlan
@@ -336,6 +346,7 @@ class TestInterfacePVlan < CiscoTestCase
       return
     end
 
+    i.switchport_mode = :access
     default = i.default_switchport_pvlan_trunk_native_vlan
     assert_equal(default, i.switchport_pvlan_trunk_native_vlan)
 
@@ -344,5 +355,6 @@ class TestInterfacePVlan < CiscoTestCase
 
     i.switchport_pvlan_trunk_native_vlan = default
     assert_equal(default, i.switchport_pvlan_trunk_native_vlan)
+    i.switchport_mode = :disabled
   end
 end

--- a/tests/test_interface_switchport.rb
+++ b/tests/test_interface_switchport.rb
@@ -80,11 +80,7 @@ class TestSwitchport < TestInterfaceSwitchport
 
   def test_access_vlan_sw_disabled
     interface.switchport_mode = :disabled
-    if platform == :ios_xr
-      assert_nil(interface.access_vlan)
-    else
-      assert_equal(DEFAULT_IF_ACCESS_VLAN, interface.access_vlan)
-    end
+    assert_nil(interface.access_vlan)
   end
 
   def test_access_vlan_sw_trunk


### PR DESCRIPTION
When the interface defaults were defined, there are few issues creeped in.
1. couple of typos
2. test issues where the interface needs to be put in switchport_mode for the corresponding properties to test.