### PR TITLE
Fixes for n9k-f and n3k-f

### DIFF
--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -113,6 +113,14 @@ module Cisco
       return true if Platform.chassis['pid'][ver_regexp]
     end
 
+    def self.fretta?
+      require_relative 'platform'
+      Platform.slots.each do |_x, row|
+        return true if row['pid'][/-R/]
+      end
+      false
+    end
+
     # Helper utility method for ip/prefix format networks.
     # For ip/prefix format '1.1.1.1/24' or '2000:123:38::34/64',
     # we need to mask the address using the prefix length so that they

--- a/lib/cisco_node_utils/cmd_ref/acl.yaml
+++ b/lib/cisco_node_utils/cmd_ref/acl.yaml
@@ -36,7 +36,7 @@ all_acls:
 
 fragments:
   # Note: The ACL 'fragments' keyword is independent of ACE 'fragments'
-  _exclude: [N5k, N6k]
+  _exclude: [N5k, N6k, N3k-F, N9k-F]
   get_value: '/fragments (\S+)$/'
   set_value: '<state> fragments <action>'
   default_value: ~

--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -113,6 +113,7 @@ vni:
     set_value: 'feature vn-segment-vlan-based'
 
 vtp:
+  _exclude: [N3k-F, N9k-F]
   kind: boolean
   get_value: '/^feature vtp$/'
   set_value: "<state> feature vtp"

--- a/lib/cisco_node_utils/cmd_ref/vtp.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vtp.yaml
@@ -1,6 +1,6 @@
 # vtp
 ---
-_exclude: [ios_xr]
+_exclude: [ios_xr, N3k-F, N9k-F]
 
 # VTP behaves differently across the various Nexus platforms and as a
 # result it's not currently possible to use a single 'show running'

--- a/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/vxlan_vtep_vni.yaml
@@ -16,7 +16,7 @@ all_vnis:
   get_value: '/^member vni (\d+|\d+-\d+) ?(associate-vrf)?$/'
 
 ingress_replication:
-  _exclude: [N5k, N6k, N7k]
+  _exclude: [N3k-F, N5k, N6k, N7k, N9k-F]
   kind: string
   get_value: '/^ingress-replication protocol (\S+)$/'
   set_value: '<state> ingress-replication protocol <protocol>'
@@ -35,7 +35,7 @@ multisite_ingress_replication:
   default_value: false
 
 peer_list:
-  _exclude: [N5k, N6k, N7k]
+  _exclude: [N3k-F, N5k, N6k, N7k, N9k-F]
   multiple:
   get_context:
     - '/^interface <name>$/i'

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -358,20 +358,13 @@ module Cisco
     def prod_qualifier(prod, inventory)
       case prod
       when /N9K/
-        # Two datapoints are used to determine if the current n9k
+        # one datapoint is used to determine if the current n9k
         # platform is a fretta based n9k or non-fretta.
         #
-        # 1) Image Version == 7.0(3)F*
-        # 2) Fabric Module == N9K-C9*-FM-R
-        if @cmd_ref
-          ver = os_version
-        else
-          ver = get(command:     'show version',
-                    data_format: :nxapi_structured)['kickstart_ver_str']
-        end
-        # Append -F for fretta platform.
+        # Fabric Module == N9K-C9*-FM-R
         inventory.each do |row|
-          if row['productid'][/N9K-C9...-FM-R/] && ver[/7.0\(3\)F/]
+          if row['productid'][/FM-R/]
+            # Append -F for fretta platform.
             return prod.concat('-F') unless prod[/-F/]
           end
         end

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -361,7 +361,7 @@ module Cisco
         # one datapoint is used to determine if the current n9k
         # platform is a fretta based n9k or non-fretta.
         #
-        # Fabric Module == N9K-C9*-FM-R
+        # Module == *FM-R
         inventory.each do |row|
           if row['productid'][/FM-R/]
             # Append -F for fretta platform.
@@ -369,14 +369,16 @@ module Cisco
           end
         end
       when /N3K/
-        if @cmd_ref
-          ver = os_version
-        else
-          ver = get(command:     'show version',
-                    data_format: :nxapi_structured)['kickstart_ver_str']
+        # one datapoint is used to determine if the current n3k
+        # platform is a fretta based n3k or non-fretta.
+        #
+        # Module == *-R
+        inventory.each do |row|
+          if row['productid'][/-R/]
+            # Append -F for fretta platform.
+            return prod.concat('-F') unless prod[/-F/]
+          end
         end
-        # Append -F for fretta platform.
-        return prod.concat('-F') if ver[/7.0\(3\)F/] && !prod[/-F/]
       end
       prod
     end

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -357,20 +357,9 @@ module Cisco
 
     def prod_qualifier(prod, inventory)
       case prod
-      when /N9K/
-        # one datapoint is used to determine if the current n9k
-        # platform is a fretta based n9k or non-fretta.
-        #
-        # Module == *FM-R
-        inventory.each do |row|
-          if row['productid'][/FM-R/]
-            # Append -F for fretta platform.
-            return prod.concat('-F') unless prod[/-F/]
-          end
-        end
-      when /N3K/
-        # one datapoint is used to determine if the current n3k
-        # platform is a fretta based n3k or non-fretta.
+      when /N(3|9)K/
+        # one datapoint is used to determine if the current n9k/n3k
+        # platform is a fretta based or non-fretta.
         #
         # Module == *-R
         inventory.each do |row|

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -550,7 +550,7 @@ class CiscoTestCase < TestCase
     when /N3K-C35/
       tag = 'n35'
     when /N3/
-      tag = Utils.image_version?(/7.0.3.F/) ? 'n3k-f' : 'n3k'
+      tag = Utils.fretta? ? 'n3k-f' : 'n3k'
     when /N5/
       tag = 'n5k'
     when /N6/
@@ -558,7 +558,7 @@ class CiscoTestCase < TestCase
     when /N7/
       tag = 'n7k'
     when /N9/
-      tag = Utils.image_version?(/7.0.3.F/) ? 'n9k-f' : 'n9k'
+      tag = Utils.fretta? ? 'n9k-f' : 'n9k'
     else
       fail "Unrecognized product_id: #{@product_id}"
     end

--- a/tests/cmd_config.yaml
+++ b/tests/cmd_config.yaml
@@ -12,7 +12,6 @@ nexus:
             feature hsrp
             feature lacp
             feature dhcp
-            feature vtp
 
   feature-disable:
     command: |
@@ -25,7 +24,6 @@ nexus:
             no feature hsrp
             no feature lacp
             no feature dhcp
-            no feature vtp
     nvgen: false
 
   feature-snmp-comm-acl-ro:

--- a/tests/test_acl.rb
+++ b/tests/test_acl.rb
@@ -169,7 +169,7 @@ class TestAcl < CiscoTestCase
   end
 
   def test_fragments
-    if node.product_id[/N(5|6)/]
+    if product_tag[/n(3k-f|5k|6k|9k-f)/]
       a = Acl.new('ipv4', 'acl_fragments')
       assert_nil(a.fragments)
       assert_nil(a.default_fragments)

--- a/tests/test_interface_switchport.rb
+++ b/tests/test_interface_switchport.rb
@@ -410,12 +410,13 @@ class TestInterfaceSwVtp < TestInterfaceSwitchport
 
   def setup
     super
-    skip('VTP is not supported on IOS XR') if platform == :ios_xr
+    skip('VTP is not supported on IOS XR or fretta') if
+      platform == :ios_xr || product_tag[/n(3|9)k-f/]
     @vtp = Vtp.new(true)
   end
 
   def teardown
-    vtp.destroy unless platform == :ios_xr
+    vtp.destroy unless platform == :ios_xr || product_tag[/n(3|9)k-f/]
     super
   end
 

--- a/tests/test_node_ext.rb
+++ b/tests/test_node_ext.rb
@@ -142,7 +142,7 @@ class TestNodeExt < CiscoTestCase
 
   def test_get_product_id
     # N3|9K Fretta product_id gets a '-F' appended so remove it for this check
-    if Utils.image_version?(/7.0.3.F/)
+    if product_tag[/n(3|9)k-f/]
       chassis = node.product_id.sub('-F', '')
     else
       chassis = node.product_id

--- a/tests/test_nxapi.rb
+++ b/tests/test_nxapi.rb
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative 'basetest'
+require_relative 'ciscotest'
 require_relative '../lib/cisco_node_utils/node'
 
 # TestNxapi - NXAPI client unit tests
-class TestNxapi < TestCase
+class TestNxapi < CiscoTestCase
   @@client = nil # rubocop:disable Style/ClassVars
 
   def self.runnable_methods
@@ -207,12 +207,22 @@ class TestNxapi < TestCase
 
   def test_unsupported
     # Add a method to the NXAPI that sends a request of invalid type
-    def client.hello
-      req('hello', 'world')
-    end
+    if !product_tag[/n(3|9)k-f/]
+      def client.hello
+        req('hello', 'world')
+      end
 
-    assert_raises Cisco::RequestNotSupported do
-      client.hello
+      assert_raises Cisco::RequestNotSupported do
+        client.hello
+      end
+    else
+      def client.hello
+        req('hello', 'world')
+      end
+
+      assert_raises Cisco::ClientError do
+        client.hello
+      end
     end
   end
 

--- a/tests/test_upgrade.rb
+++ b/tests/test_upgrade.rb
@@ -71,7 +71,7 @@ class TestUpgrade < CiscoTestCase
 
   def test_image_version
     version = Upgrade.image_version
-    assert_match(/^\d.\d\(\d\)\S+\(\S+\)$/, version)
+    assert_match(/^\d.\d\(\d(?:.\d+)?\)(?:\S+\(\S+\))?$/, version)
   end
 
   def test_box_online


### PR DESCRIPTION
* This PR is for fixing minitests and software versioning scheme which changed from older versions to latest versions on n3k-f and n9k-f.
* Some of the features like vtp, acl, vxlan_vtp_vni etc. have a different behavior for these platforms and this is addressed.

All tests pass on n9k, n9k-f, n3k-f