### PR TITLE
Allow node cache to be reset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## [Unreleased]
+
+### Added
+  * `reset_instance` method to node. Allows a single instance of nodeutils to reset the environment cache.
+
+### Removed
+  * Removed cache in `node_util.node`, which gave every inheriting class it's own cache.
+
 ## [v1.10.0]
 
 ### New Cisco Resources

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -237,6 +237,11 @@ module Cisco
       @instance ||= new
     end
 
+    # Allow instance cache to be reset
+    def self.reset_instance
+      @instance = nil
+    end
+
     def initialize
       @client = Cisco::Client.create
       @cmd_ref = nil

--- a/lib/cisco_node_utils/node_util.rb
+++ b/lib/cisco_node_utils/node_util.rb
@@ -21,7 +21,7 @@ module Cisco
   # NodeUtil - generic functionality for node utility subclasses to use
   class NodeUtil
     def self.node
-      @node ||= Cisco::Node.instance
+      Cisco::Node.instance
     end
 
     def node


### PR DESCRIPTION
As each class inherits directly from `node_util`, each class has its own cache of `node`. This removes the per class cache.
Additionally a reset has been added that can be called prior to `Environment` allowing the new environment settings to be used.