### PR TITLE
Fix for route map src proto sorting

### DIFF
--- a/lib/cisco_node_utils/route_map.rb
+++ b/lib/cisco_node_utils/route_map.rb
@@ -309,7 +309,7 @@ module Cisco
     # match source-protocol tcp udp
     def match_src_proto
       str = config_get('route_map', 'match_src_proto', @get_args)
-      str.empty? ? default_match_src_proto : str.split
+      str.empty? ? default_match_src_proto : str.split.sort
     end
 
     def match_src_proto=(list)

--- a/tests/test_route_map.rb
+++ b/tests/test_route_map.rb
@@ -152,11 +152,9 @@ class TestRouteMap < CiscoTestCase
   def test_match_src_proto
     rm = create_route_map
     assert_equal(rm.default_match_src_proto, rm.match_src_proto)
-    array = %w(tcp udp igmp)
+    array = %w(tcp udp igmp).sort
     rm.match_src_proto = array
-    # Protocol order not maintained in running config starting Greensboro.
-    # Sorting arrays to check equality.
-    assert_equal(array.sort, rm.match_src_proto.sort)
+    assert_equal(array, rm.match_src_proto)
     rm.match_src_proto = rm.default_match_src_proto
     assert_equal(rm.default_match_src_proto, rm.match_src_proto)
   end


### PR DESCRIPTION
This PR is for fixing PUPPET JIRA Issue: https://tickets.puppetlabs.com/browse/CISCO-80.
The problem here is that the show command output for  routemap match source protocol is different in different versions of software (it is neither sorted nor follows any pattern). 
The fix is to always sort the output (irrespective of the input) and compare it with sorted input. 
Note that this is only an issue with test code, the actual puppet resource command always sorts before comparing (done in the puppet type code) so there is no idempotent issue.

Tested on different platforms and different versions.