### PR TITLE
Extend nxapi client with https support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Changelog
 ### New Cisco Resources
 
 ### Added
+* Extend nxapi client for https support
+   * `use_ssl` will be true when `transport` is `https`
+   * now makes use of `port` for custom nxapi ports
 * Extend router_ospf_vrf with attribute:
    * `redistribute`
 * `reset_instance` method to node. Allows a single instance of nodeutils to reset the environment cache.

--- a/tests/basetest.rb
+++ b/tests/basetest.rb
@@ -85,6 +85,38 @@ class TestCase < Minitest::Test
     self.class.password
   end
 
+  def self.telnet_port
+    Cisco::Environment.environment[:telnet_port] || 23
+  end
+
+  def telnet_port
+    self.class.telnet_port
+  end
+
+  def self.port
+    Cisco::Environment.environment[:port] || address.split(':')[1]
+  end
+
+  def port
+    self.class.port
+  end
+
+  def self.transport
+    Cisco::Environment.environment[:transport] || 'http'
+  end
+
+  def transport
+    self.class.transport
+  end
+
+  def self.verify_mode
+    Cisco::Environment.environment[:verify_mode] || 'none'
+  end
+
+  def verify_mode
+    self.class.verify_mode
+  end
+
   def setup
     # Hack - populate environment from user-entered values from basetest.rb
     if Cisco::Environment.environments.empty?
@@ -92,13 +124,17 @@ class TestCase < Minitest::Test
         attr_writer :environments
       end
       Cisco::Environment.environments['default'] = {
-        host:     address.split(':')[0],
-        port:     address.split(':')[1],
-        username: username,
-        password: password,
+        host:        address.split(':')[0],
+        port:        port,
+        telnet_port: telnet_port,
+        transport:   transport,
+        verify_mode: verify_mode,
+        username:    username,
+        password:    password,
       }
     end
     @device = Net::Telnet.new('Host'    => address.split(':')[0],
+                              'Port'    => telnet_port,
                               'Timeout' => 240,
                               # NX-OS has a space after '#', IOS XR does not
                               'Prompt'  => /[$%#>] *\z/n,


### PR DESCRIPTION
* `transport` will control if `use_ssl` is true or not
* `verify_mode` has been added for when https mode is used, it selects based on `verify_mode` param being set to either 'none', 'peer', 'fail-no-peer' and 'client-once'

The following environment tests were used to verify https/http and host:port combinations.

```
nxapi_remote_http:
  host: localhost
  port: 7070
  telnet_port: 2222
  username: vagrant
  password: vagrant
host_and_port:
  host: localhost:7070
  telnet_port: 2222
  username: vagrant
  password: vagrant
nxapi_remote_https:
  host: localhost
  telnet_port: 2222
  transport: https
  port: 4431
  transport: https
  username: vagrant
  password: vagrant
```