### PR TITLE
interface_service_vni: Create 'all_interfaces' key

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface_service_vni.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_service_vni.yaml
@@ -11,6 +11,11 @@ _template:
     - 'interface <name>'
     - 'service instance <sid> vni'
 
+all_interfaces:
+  multiple:
+  get_context: ~
+  get_value: '/^interface (.*)/'
+
 all_service_vni_ids:
   multiple:
   get_context:

--- a/lib/cisco_node_utils/interface_service_vni.rb
+++ b/lib/cisco_node_utils/interface_service_vni.rb
@@ -36,7 +36,7 @@ module Cisco
 
     def self.svc_vni_ids
       hash = {}
-      intf_list = config_get('interface', 'all_interfaces')
+      intf_list = config_get('interface_service_vni', 'all_interfaces')
       return hash if intf_list.nil?
 
       intf_list.each do |intf|


### PR DESCRIPTION
This change adds an `all_interfaces` lookup specific to `interface_service_vni`.

Interface lookups were failing due to this change:
https://github.com/cisco/cisco-network-node-utils/pull/562/files#diff-c49e70266ca94441d6f0a1a11ab9d52dR87