### PR TITLE
(maint) Bump Ruby version 2.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.2.2
-  - 2.1.6
-  - 2.0.0-p648 # specify non-clang version of ruby
+  - 2.5.1
+  - 2.4.4
+  - 2.4.1
 before_install:
- - gem install bundler -v '< 2'
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 
 script:
  - bundle exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changelog
   * Removed cache in `node_util.node`, which gave every inheriting class it's own cache.
 
 ### Changed
+  * Removed deprecated `Fixnum` and set minimum Ruby version to 2.4.1
 
 ### Removed
 

--- a/cisco_node_utils.gemspec
+++ b/cisco_node_utils.gemspec
@@ -25,10 +25,10 @@ Currently supports NX-OS nodes.
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version     = '>= 2.0.0'
+  spec.required_ruby_version     = '>= 2.4.1'
   spec.required_rubygems_version = '>= 2.1.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'kwalify', '~> 0.7.2'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'net-telnet', '~> 0.1.1'

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -151,7 +151,7 @@ module Cisco
       end
       if ref.multiple && ref.hash['get_data_format'] == :nxapi_structured
         return value if value.nil?
-        value = [value.to_s] if value.is_a?(String) || value.is_a?(Fixnum)
+        value = [value.to_s] if value.is_a?(String) || value.is_a?(Integer)
       end
       return value unless ref.kind
       value = massage_kind(value, ref)

--- a/lib/cisco_node_utils/tacacs_server_host.rb
+++ b/lib/cisco_node_utils/tacacs_server_host.rb
@@ -156,7 +156,7 @@ module Cisco
     end
 
     def encryption_key_set(enctype, password)
-      fail TypeError unless enctype.is_a? Fixnum
+      fail TypeError unless enctype.is_a? Integer
       fail ArgumentError if password && ![TACACS_SERVER_ENC_NONE,
                                           TACACS_SERVER_ENC_CISCO_TYPE_7,
                                           TACACS_SERVER_ENC_UNKNOWN,
@@ -195,7 +195,7 @@ module Cisco
     end
 
     def timeout=(t)
-      fail TypeError unless t.is_a? Fixnum
+      fail TypeError unless t.is_a? Integer
       return if t == timeout
 
       config_set('tacacs_server_host',

--- a/tests/test_bgp_af.rb
+++ b/tests/test_bgp_af.rb
@@ -331,7 +331,7 @@ class TestBgpAF < CiscoTestCase
 
     # Validate the collection
     routers.each do |asn, vrfs|
-      assert((asn.kind_of? Fixnum),
+      assert((asn.kind_of? Integer),
              'Error: Autonomous number must be a fixed number')
       refute_empty(vrfs, 'Error: Collection is empty')
 


### PR DESCRIPTION
This commit bumps the minimum Ruby version to 2.4.1
Also removed deprecated Fixnum