### PR TITLE
[WIP] Fix multisite_border_gateway_interface property

### DIFF
--- a/lib/cisco_node_utils/vxlan_vtep.rb
+++ b/lib/cisco_node_utils/vxlan_vtep.rb
@@ -181,10 +181,10 @@ module Cisco
     def multisite_border_gateway_interface=(val)
       set_args = { name: @name }
       set_args[:state] = val.empty? ? 'no' : ''
-      set_args[:lpbk_intf] = val.empty? ? 'loopback0' : val
+      # rubocop:disable LineLength
+      set_args[:lpbk_intf] = val.empty? ? multisite_border_gateway_interface : val
+      # rubocop:enable LineLength
       if set_args[:state] == 'no'
-        # 'no multisite border-gateway' doesn't work without interface
-        # defaulting to 'loopback0' still clears any configuration
         intf = multisite_border_gateway_interface
         unless intf == default_multisite_border_gateway_interface
           config_set('vxlan_vtep', 'multisite_bg_intf', set_args)


### PR DESCRIPTION
This PR fixes a problem in certain NX-OS images.  The code used to use `loopback0` as a way to clear out the `multisite_border_gateway_interface` setting but on some images, the following error message will be generated.

```
2019-01-17T13:18:22: %LIB-INFO: TestVxlanVtep#test_multisite_bg_interface:
2019-01-17T13:18:22: %LIB-INFO: Cisco::CliError: [#<Cisco::VxlanVtep:0x00000002268138>] The command 'no multisite border-gateway interface loopback0' was rejected with error:
2019-01-17T13:18:22: %LIB-INFO: NVE Multisite Border-Gateway interface does not match.
```

This fix calls the getter to get the correct interface instead of hardcoding `loopback0`.

Tested on: 7.0(3)I7.4 and 9.2(2)