### PR TITLE
Add C3064 exclude for feature-set fex

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -32,7 +32,7 @@ fabric_forwarding:
   set_value: "feature fabric forwarding"
 
 fex:
-  _exclude: [C3064, C3132, N5k, N6k, N3k-F, N9k-F]
+  _exclude: [C3048, C3064, C3132, N5k, N6k, N3k-F, N9k-F]
   get_command: "show feature-set"
   get_value: '/^fex[\s\d]+(\w+)/'
   set_value: "<state> feature-set fex"

--- a/lib/cisco_node_utils/command_reference.rb
+++ b/lib/cisco_node_utils/command_reference.rb
@@ -437,8 +437,8 @@ module Cisco
       puts "DEBUG: #{text}" if @@debug
     end
 
-    KNOWN_PLATFORMS = %w(C3064 C3132 C3172 N35 N3k N3k-F N5k N6k N7k N9k N9k-F
-                         XRv9k)
+    KNOWN_PLATFORMS = %w(C3048 C3064 C3132 C3172 N35 N3k N3k-F N5k N6k N7k N9k
+                         N9k-F XRv9k)
 
     def self.platform_to_filter(platform)
       if KNOWN_PLATFORMS.include?(platform)

--- a/spec/schema.yaml
+++ b/spec/schema.yaml
@@ -12,6 +12,7 @@ mapping:
           - 'ios_xr'
           - 'nexus'
           # Product IDs
+          - 'C3048'
           - 'C3064'
           - 'C3132'
           - 'C3172'
@@ -31,6 +32,7 @@ mapping:
       # Platform and product filters
       ios_xr: *base
       nexus: *base
+      C3048: *base
       C3064: *base
       C3132: *base
       C3172: *base


### PR DESCRIPTION
The `install feature-set fex` command is excluded on all of our n3k platforms except `C3048`.  This command is not supported on the 3048 platform so this defines the platform and adds the exclude in `feature.yaml`.