### PR TITLE
New def values for n6k banner yaml

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/banner.yaml
+++ b/lib/cisco_node_utils/cmd_ref/banner.yaml
@@ -1,7 +1,11 @@
 # banner
 ---
 motd:
-  default_value: "User Access Verification\n"
+  N5k: &N6000
+    default_value: "Nexus 6000 Switch\n"
+  N6k: *N6000
+  else:
+    default_value: "User Access Verification\n"
   get_command: 'show banner motd'
   get_value: '/^.*$/m'
   set_value: '<state> banner motd <motd>'


### PR DESCRIPTION
```
> ruby test_banner.rb -v -e n6k-77
Run options: -v -e n6k-77 --seed 27405

# Running:

TestBanner#test_multiline_motd =
Node under test:
  - name    - n6k-77
  - type    - N6K-C6001-64P
  - image   - bootflash:///n6000-uk9.7.3.4.N1.1.bin
  - version - 7.3(4)N1(1)

6.21 s = S
TestBanner#test_single_motd = 1.38 s = .

Finished in 7.592080s, 0.2634 runs/s, 1.1854 assertions/s.

  1) Skipped:
TestBanner#test_multiline_motd [/Users/cvanheuv/git/cisco-network-node-utils/tests/ciscotest.rb:233]:
Defect in legacy image: [multiline banner configuration using nxapi not supported]

2 runs, 9 assertions, 0 failures, 0 errors, 1 skips
```