### PR TITLE
 test_feature: n6k: test_nv_overlay needs check for unsupported hardware

### DIFF
--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -315,7 +315,7 @@ module Cisco
       patterns = [
         'Hardware is not capable of supporting',
         'is unsupported on this node',
-        'Feature NOT supported on this Platform'
+        'Feature NOT supported on this Platform',
       ]
       fail result[2]['body'] if
         result[2].is_a?(Hash) &&

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -156,6 +156,7 @@ class CiscoTestCase < TestCase
   def hardware_supports_feature?(message)
     patterns = ['Hardware is not capable of supporting',
                 'is unsupported on this node',
+                'Feature NOT supported on this Platform',
                ]
     skip('Skip test: Feature is unsupported on this device') if
       message[Regexp.union(patterns)]

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -185,7 +185,7 @@ class TestFeature < CiscoTestCase
       config_no_warn('no feature nv overlay')
       vdc_limit_f3_no_intf_needed(:set)
     end
-    feature('vni')
+    Feature.vni_enable
   rescue RuntimeError => e
     hardware_supports_feature?(e.message)
   end

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -185,7 +185,7 @@ class TestFeature < CiscoTestCase
       config_no_warn('no feature nv overlay')
       vdc_limit_f3_no_intf_needed(:set)
     end
-    Feature.vni_enable
+    feature('vni')
   rescue RuntimeError => e
     hardware_supports_feature?(e.message)
   end

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -84,6 +84,8 @@ class TestFeature < CiscoTestCase
 
     # Return testbed to pre-clean state
     config("no feature #{feat_str}") unless pre_clean_enabled
+  rescue RuntimeError => e
+    hardware_supports_feature?(e.message)
   end
 
   ###################


### PR DESCRIPTION
My N6k will display msg `Feature NOT supported on this Platform` when I try to do `feature nv overlay`.

The object code doesn't look for this so I added our `cli_error_check()` call to look at stdout msgs and modified `test_feature.rb` to skip tests when it detects a "not supported" msg.

Tested the failure testcase on all platforms.