### PR TITLE
Minitest: router_bgp fixes for n6k

### DIFF
--- a/lib/cisco_node_utils/bgp.rb
+++ b/lib/cisco_node_utils/bgp.rb
@@ -827,7 +827,7 @@ module Cisco
       # explicit values when removing the rd command. These restrictions are
       # not not needed in I3 and newer images.
       Feature.nv_overlay_evpn_enable if
-        Utils.nexus_i2_image || node.product_id[/N7/]
+        Utils.nexus_i2_image || node.product_id[/N[567]/]
 
       if rd == default_route_distinguisher
         return if route_distinguisher.empty?

--- a/tests/ciscotest.rb
+++ b/tests/ciscotest.rb
@@ -214,6 +214,12 @@ class CiscoTestCase < TestCase
       Gem::Version.new(lim) < Gem::Version.new(ver)
   end
 
+  def skip_if_UnsupportedCmdRef(feature_name, attribute_name) # rubocop:disable Style/MethodName
+    # Check if attr is excluded by the cmd_ref yaml
+    skip("UnsupportedCmdRef attribute: '#{attribute_name}'") if
+      cmd_ref.lookup(feature_name, attribute_name).is_a?(UnsupportedCmdRef)
+  end
+
   def skip_nexus_i2_image?
     skip("This property is not supported on Nexus 'I2' images") if
       Utils.nexus_i2_image

--- a/tests/test_interface_private_vlan.rb
+++ b/tests/test_interface_private_vlan.rb
@@ -196,6 +196,9 @@ class TestInterfacePVlan < CiscoTestCase
   end
 
   def test_sw_pvlan_trunk_association
+    # N6k trunk association does not update primary-secondary associations automatically
+    skip('Test behavior not supported on device') if node.product_id[/N(5|6)/]
+
     # Supports multiple instances of [[pri, sec], [pri2, sec2]]
     if validate_property_excluded?('interface',
                                    'switchport_pvlan_trunk_association')
@@ -254,6 +257,9 @@ class TestInterfacePVlan < CiscoTestCase
   end
 
   def test_sw_pvlan_mapping_trunk
+    # N6k mapping trunk does not update primary-secondary associations automatically
+    skip('Test behavior not supported on device') if node.product_id[/N(5|6)/]
+
     if validate_property_excluded?('interface',
                                    'switchport_pvlan_mapping_trunk')
       assert_raises(Cisco::UnsupportedError) do
@@ -269,7 +275,6 @@ class TestInterfacePVlan < CiscoTestCase
     assert_equal([['2', '4-8,10-11']], i.switchport_pvlan_mapping_trunk)
 
     # Same primary, but change range
-
     i.switchport_pvlan_mapping_trunk = ['2', '11,4-6,8']
     assert_equal([['2', '4-6,8,11']], i.switchport_pvlan_mapping_trunk)
 


### PR DESCRIPTION
* `rd` needs `nv overlay evpn` to expose cli
* nexus does not support nsr
* added a common method to check for attrs that are excluded from cmd_ref
  * `cmd_ref.lookup` returns type `UnsupportedCmdRef`