### PR TITLE
minitest n6k: test_vni dependency

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/feature.yaml
+++ b/lib/cisco_node_utils/cmd_ref/feature.yaml
@@ -31,6 +31,12 @@ fabric_forwarding:
   get_value: '/^feature fabric forwarding$/'
   set_value: "feature fabric forwarding"
 
+fabricpath:
+  _exclude: [N3k, N3k-F, N9k-F, N9k]
+  get_command: "show feature-set"
+  get_value: '/^fabricpath[\s\d]+(\w+)/'
+  set_value: "<state> feature-set fabricpath"
+
 fex:
   _exclude: [C3048, C3064, C3132, N5k, N6k, N3k-F, N9k-F]
   get_command: "show feature-set"

--- a/lib/cisco_node_utils/feature.rb
+++ b/lib/cisco_node_utils/feature.rb
@@ -80,6 +80,27 @@ module Cisco
       config_get('feature', 'fabric')
     end
 
+    # ---------------------------
+    def self.fabricpath_enable
+      # install feature-set and enable it
+      return if fabricpath_enabled?
+      config_set('feature', 'fabricpath', state: 'install') unless
+        fabricpath_installed?
+      config_set('feature', 'fabricpath', state: '')
+    end
+
+    def self.fabricpath_enabled?
+      config_get('feature', 'fabricpath') =~ /^enabled/
+    end
+
+    def self.fabricpath_installed?
+      config_get('feature', 'fabricpath') !~ /^uninstalled/
+    end
+
+    def self.fabricpath_supported?
+      config_get('feature', 'fabricpath')
+    end
+
     #  ---------------------------
     def self.fabric_forwarding_enable
       return if fabric_forwarding_enabled?

--- a/tests/test_feature.rb
+++ b/tests/test_feature.rb
@@ -173,7 +173,8 @@ class TestFeature < CiscoTestCase
 
   def test_vn_segment_vlan_based
     vxlan_linecard?
-    Feature.nv_overlay_enable unless node.product_id[/N3/]
+    Feature.fabricpath_enable if node.product_id[/N(5|6)/]
+    Feature.nv_overlay_enable unless node.product_id[/N(3|5|6)/]
     feature('vn_segment_vlan_based')
   rescue RuntimeError => e
     hardware_supports_feature?(e.message)
@@ -187,6 +188,7 @@ class TestFeature < CiscoTestCase
       config_no_warn('no feature nv overlay')
       vdc_limit_f3_no_intf_needed(:set)
     end
+    Feature.fabricpath_enable if node.product_id[/N(5|6)/]
     feature('vni')
   rescue RuntimeError => e
     hardware_supports_feature?(e.message)
@@ -220,6 +222,28 @@ class TestFeature < CiscoTestCase
 
     Feature.fabric_enable
     assert(Feature.fabric_enabled?, "(#{fs}) is not enabled")
+  end
+
+  def test_feature_set_fabricpath
+    if node.product_id[/N(3|8|9)/]
+      assert_nil(Feature.fabricpath_enabled?)
+      assert_raises(Cisco::UnsupportedError) { Feature.fabricpath_enable }
+      return
+    end
+    vdc_limit_f3_no_intf_needed(:set)
+    fs = 'feature-set fabricpath'
+    # Get current state of the feature-set
+    feature_set_installed = Feature.fabricpath_installed?
+
+    config("no #{fs} ; no install #{fs}") if feature_set_installed
+    refute_show_match(
+      command: "show running | i '^install #{fs}$'",
+      pattern: /^install #{fs}$/,
+      msg:     "(#{fs}) is still configured",
+    )
+
+    Feature.fabricpath_enable
+    assert(Feature.fabricpath_enabled?, "(#{fs}) is not enabled")
   end
 
   def test_feature_set_fex

--- a/tests/test_vrf.rb
+++ b/tests/test_vrf.rb
@@ -222,6 +222,8 @@ class TestVrf < CiscoTestCase
     assert_empty(v.route_distinguisher,
                  'v route_distinguisher should *NOT* be configured')
     v.destroy
+  rescue RuntimeError => e
+    hardware_supports_feature?(e.message)
   end
 
   def test_vpn_id


### PR DESCRIPTION
* n6k has feature-set fabricpath dependency
* Added getter/setter to feature.rb
* test_vn_segment_vlan_based was being skipped before; added fabricpath_enable to it and now it runs on n6k

Tested both testcases on n6k, n7k, n9k
