### PR TITLE
MT: n6k cleanups vrf_af, interface_ospf

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface_ospf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_ospf.yaml
@@ -21,7 +21,7 @@ bfd:
   # no config at all so need to grab the optional
   # match to get the whole config for checking
   # the mode
-  get_value: '/^\s*ip ospf bfd *(?:\S+)?$/'
+  get_value: '/^\s*ip ospf bfd *(?:\S*)$/'
   set_value: '%s ip ospf bfd %s'
   default_value: ~
 

--- a/tests/test_interface_ospf.rb
+++ b/tests/test_interface_ospf.rb
@@ -597,7 +597,11 @@ class TestInterfaceOspf < CiscoTestCase
           msg:     "Error: ip router ospf #{name} area #{hv[:area]} "\
                    "not found under #{ifname}")
 
-        assert_equal(hv[:bfd], interface.bfd, 'Error: get bfd failed')
+        if hv[:bfd].nil?
+          assert_nil(interface.bfd, 'Error: get bfd is not nil')
+        else
+          assert_equal(hv[:bfd], interface.bfd, 'Error: get bfd failed')
+        end
         assert_equal(hv[:cost], interface.cost, 'Error: get cost failed')
         assert_equal(hv[:hello], interface.hello_interval,
                      'Error: get hello interval failed')

--- a/tests/test_vrf_af.rb
+++ b/tests/test_vrf_af.rb
@@ -210,6 +210,8 @@ class TestVrfAf < CiscoTestCase
     should = v.default_route_target_import
     route_target_tester(v, af, opts, should, 'Test 4')
     v.destroy
+  rescue RuntimeError => e
+    hardware_supports_feature?(e.message)
   end
 
   def route_target_tester(v, af, opts, should, test_id)


### PR DESCRIPTION
* The ospf changes fix these two warnings:

```
TestInterfaceOspf#test_collect_mult_intf = /Users/cvanheuv/git/cisco-network-node-utils/lib/cisco_node_utils/client/utils.rb:127: 
warning: nested repeat operator '+' and '?' was replaced with '*' in regular expression: /^\s*ip ospf bfd *(?:\S+)?$/

WARN -- : DEPRECATED: Use assert_nil if expecting nil from test_interface_ospf.rb:600. 
This will fail in Minitest 6.
```