### PR TITLE
rescue facter packages check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ before_install:
 
 script:
  - bundle exec rake
+env:
+  global:
+    - "BUNDLE_FORCE_RUBY_PLATFORM=1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 ### Removed
 
 ### Issues Addressed
+* `facter` may raise when `show install patches` in some environments
 
 ## [v2.0.0]
 

--- a/lib/cisco_node_utils/platform.rb
+++ b/lib/cisco_node_utils/platform.rb
@@ -40,7 +40,7 @@ module Cisco
       return {} if pkgs.nil?
       pkgs.each { |p| pkg_hsh[p[0]] = p[1].downcase }
     rescue RuntimeError => e
-      # best effort
+      raise unless e.message[/Invalid command/]
     ensure
       pkg_hsh
     end

--- a/lib/cisco_node_utils/platform.rb
+++ b/lib/cisco_node_utils/platform.rb
@@ -35,10 +35,13 @@ module Cisco
     # Ex: { 'n3000-uk9.6.0.2.U1.1.CSCaa12345.bin' => 'inactive committed',
     #       'n3000-uk9.6.0.2.U1.1.CSCaa12346.bin' => 'active', }
     def self.packages
+      pkg_hsh = {}
       pkgs = config_get('images', 'packages')
       return {} if pkgs.nil?
-      pkg_hsh = {}
       pkgs.each { |p| pkg_hsh[p[0]] = p[1].downcase }
+    rescue RuntimeError => e
+      # best effort
+    ensure
       pkg_hsh
     end
 

--- a/lib/cisco_node_utils/version.rb
+++ b/lib/cisco_node_utils/version.rb
@@ -14,7 +14,7 @@
 
 # Container module for version number only.
 module CiscoNodeUtils
-  VERSION = '2.0.0-dev'
+  VERSION = '2.0.1-dev'
   gem_version = Gem::Version.new(Gem::VERSION)
   min_gem_version = Gem::Version.new('2.1.0')
   fail 'Required rubygems version >= 2.1.0' if gem_version < min_gem_version

--- a/lib/cisco_node_utils/version.rb
+++ b/lib/cisco_node_utils/version.rb
@@ -14,7 +14,7 @@
 
 # Container module for version number only.
 module CiscoNodeUtils
-  VERSION = '2.0.1-dev'
+  VERSION = '2.0.0-dev'
   gem_version = Gem::Version.new(Gem::VERSION)
   min_gem_version = Gem::Version.new('2.1.0')
   fail 'Required rubygems version >= 2.1.0' if gem_version < min_gem_version


### PR DESCRIPTION
'show install patches' command is not available in all environments;
treating as a best effort check, returning empty hash on failure.

Symptom:
```
Error: [Cisco::Platform] The command 'show install patches' was rejected with error:
% Invalid command
```

