### PR TITLE
interface: performance fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
+++ b/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
@@ -8,7 +8,7 @@
 _template:
   context: ["interface <name>"]
   nexus:
-    get_command: "show running interface <name> all"
+    get_command: "show running interface <show_name> all"
 
 private_vlan_any:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'pvlan_any'

--- a/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
+++ b/lib/cisco_node_utils/cmd_ref/DEPRECATED.yaml
@@ -8,7 +8,7 @@
 _template:
   context: ["interface <name>"]
   nexus:
-    get_command: "show running interface all"
+    get_command: "show running interface <name> all"
 
 private_vlan_any:
   # DEPRECATED (REMOVING WITH RELEASE 2.0.0). USE 'pvlan_any'

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -3,9 +3,9 @@
 _template:
   context: ["interface <name>"]
   ios_xr:
-    get_command: "show running interface"
+    get_command: "show running interface <name>"
   nexus:
-    get_command: "show running interface all"
+    get_command: "show running interface <name> all"
 
 access_vlan:
   _exclude: [ios_xr]
@@ -20,7 +20,7 @@ all_interfaces:
     get_command: 'show running all-interfaces'
     get_value: '/^interface (.*)/'
   nexus:
-    get_command: "show running-config interface | section '^interface'"
+    get_command: "show running-config interface <name> | section '^interface'"
     get_value: '/(.*)/'
   get_context: ~
 
@@ -35,7 +35,7 @@ capabilities:
   _exclude: [ios_xr]
   multiple:
   get_context: ["<name>"]
-  get_command: "show interface capabilities"
+  get_command: "show interface <name> capabilities"
   get_value: '/(.*)/'
   default_value: [] # :raw default
 
@@ -498,14 +498,14 @@ stp_link_type:
 
 stp_mst_cost:
   multiple:
-  get_command: "show running interface"
+  get_command: "show running interface <name>"
   get_value: '/^spanning-tree mst (.*) cost (.*)$/'
   set_value: "<state> spanning-tree mst <range> cost <val>"
   default_value: []
 
 stp_mst_port_priority:
   multiple:
-  get_command: "show running interface"
+  get_command: "show running interface <name>"
   get_value: '/^spanning-tree mst (.*) port-priority (.*)$/'
   set_value: "<state> spanning-tree mst <range> port-priority <val>"
   default_value: []
@@ -522,21 +522,21 @@ stp_port_priority:
 
 stp_port_type:
   kind: string
-  get_command: "show running interface"
+  get_command: "show running interface <name>"
   get_value: '/^spanning-tree port type (.*)$/'
   set_value: "<state> spanning-tree port type <type>"
   default_value: ~
 
 stp_vlan_cost:
   multiple:
-  get_command: "show running interface"
+  get_command: "show running interface <name>"
   get_value: '/^spanning-tree vlan (.*) cost (.*)$/'
   set_value: "<state> spanning-tree vlan <range> cost <val>"
   default_value: []
 
 stp_vlan_port_priority:
   multiple:
-  get_command: "show running interface"
+  get_command: "show running interface <name>"
   get_value: '/^spanning-tree vlan (.*) port-priority (.*)$/'
   set_value: "<state> spanning-tree vlan <range> port-priority <val>"
   default_value: []

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -5,7 +5,7 @@ _template:
   ios_xr:
     get_command: "show running interface <name>"
   nexus:
-    get_command: "show running interface <name> all"
+    get_command: "show running interface <show_name> all"
 
 access_vlan:
   _exclude: [ios_xr]
@@ -20,7 +20,7 @@ all_interfaces:
     get_command: 'show running all-interfaces'
     get_value: '/^interface (.*)/'
   nexus:
-    get_command: "show running-config interface <name> | section '^interface'"
+    get_command: "show running-config interface <show_name> | section '^interface'"
     get_value: '/(.*)/'
   get_context: ~
 
@@ -35,7 +35,7 @@ capabilities:
   _exclude: [ios_xr]
   multiple:
   get_context: ["<name>"]
-  get_command: "show interface <name> capabilities"
+  get_command: "show interface <show_name> capabilities"
   get_value: '/(.*)/'
   default_value: [] # :raw default
 
@@ -47,7 +47,7 @@ default:
   multiple:
   set_context: ~
   set_value:   "default interface <name>"
-  get_command: "show running interface <name>"
+  get_command: "show running interface <show_name>"
   get_value:   '/(.*)/'
 
 description:
@@ -498,14 +498,14 @@ stp_link_type:
 
 stp_mst_cost:
   multiple:
-  get_command: "show running interface <name>"
+  get_command: "show running interface <show_name>"
   get_value: '/^spanning-tree mst (.*) cost (.*)$/'
   set_value: "<state> spanning-tree mst <range> cost <val>"
   default_value: []
 
 stp_mst_port_priority:
   multiple:
-  get_command: "show running interface <name>"
+  get_command: "show running interface <show_name>"
   get_value: '/^spanning-tree mst (.*) port-priority (.*)$/'
   set_value: "<state> spanning-tree mst <range> port-priority <val>"
   default_value: []
@@ -522,21 +522,21 @@ stp_port_priority:
 
 stp_port_type:
   kind: string
-  get_command: "show running interface <name>"
+  get_command: "show running interface <show_name>"
   get_value: '/^spanning-tree port type (.*)$/'
   set_value: "<state> spanning-tree port type <type>"
   default_value: ~
 
 stp_vlan_cost:
   multiple:
-  get_command: "show running interface <name>"
+  get_command: "show running interface <show_name>"
   get_value: '/^spanning-tree vlan (.*) cost (.*)$/'
   set_value: "<state> spanning-tree vlan <range> cost <val>"
   default_value: []
 
 stp_vlan_port_priority:
   multiple:
-  get_command: "show running interface <name>"
+  get_command: "show running interface <show_name>"
   get_value: '/^spanning-tree vlan (.*) port-priority (.*)$/'
   set_value: "<state> spanning-tree vlan <range> port-priority <val>"
   default_value: []

--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -35,7 +35,7 @@ capabilities:
   _exclude: [ios_xr]
   multiple:
   get_context: ["<name>"]
-  get_command: "show interface <show_name> capabilities"
+  get_command: "show interface <name> capabilities"
   get_value: '/(.*)/'
   default_value: [] # :raw default
 

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -229,7 +229,7 @@ module Cisco
     def bfd_echo
       return nil unless Feature.bfd_enabled?
       return nil if @name[/loop/i]
-      config_get('interface', 'bfd_echo', name: @name)
+      config_get('interface', 'bfd_echo', @get_args)
     end
 
     def bfd_echo=(val)

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -62,7 +62,7 @@ module Cisco
       # @show_name is used for get_command: keys; allows callers to limit
       # show command to a single interface
       @name = name.downcase
-      @get_args = { name: @name, show_name: nil}
+      @get_args = { name: @name, show_name: nil }
       @smr = config_get('interface', 'stp_mst_range')
       @svr = config_get('interface', 'stp_vlan_range')
       @match_found = false
@@ -84,11 +84,12 @@ module Cisco
       hash = {}
       single_intf ||= ''
       begin
-        intf_list = config_get('interface', 'all_interfaces', show_name: single_intf)
+        intf_list = config_get('interface', 'all_interfaces',
+                               show_name: single_intf)
       rescue CliError => e
         # ignore logical interfaces that may not exist yet;
         # invalid interface types should still raise
-        raise unless single_intf and e.clierror[/Invalid range/]
+        raise unless single_intf && e.clierror[/Invalid range/]
       end
       return hash if intf_list.nil?
 
@@ -122,7 +123,8 @@ module Cisco
     def self.filter(filter, id, single_intf)
       case filter
       when :pvlan_any
-        return false if config_get('interface', 'pvlan_any', name: id, show_name: single_intf)
+        return false if config_get('interface', 'pvlan_any',
+                                   name: id, show_name: single_intf)
 
       else
         # Just a basic pattern filter (:ethernet, :loopback, etc)
@@ -149,7 +151,7 @@ module Cisco
     def self.capabilities(intf, mode=:hash)
       array = []
       begin
-        array = config_get('interface', 'capabilities', @get_args)
+        array = config_get('interface', 'capabilities', name: intf)
       rescue CliError => e
         raise unless e.clierror[/Invalid command/]
       end
@@ -1445,7 +1447,8 @@ module Cisco
 
     def switchport_trunk_allowed_vlan
       return nil if switchport_mode == :disabled
-      vlans = config_get('interface', 'switchport_trunk_allowed_vlan', @get_args)
+      vlans = config_get('interface', 'switchport_trunk_allowed_vlan',
+                         @get_args)
       vlans = vlans.join(',') if vlans.is_a?(Array)
       vlans = Utils.normalize_range_array(vlans, :string) unless vlans == 'none'
       vlans
@@ -1750,7 +1753,8 @@ module Cisco
     # replaced instead of individually adding or removing vlans from the range.
     def switchport_pvlan_trunk_allowed_vlan
       return nil if switchport_mode == :disabled
-      vlans = config_get('interface', 'switchport_pvlan_trunk_allowed_vlan', @get_args)
+      vlans = config_get('interface', 'switchport_pvlan_trunk_allowed_vlan',
+                         @get_args)
       vlans = vlans.join(',') if vlans.is_a?(Array)
       vlans = Utils.normalize_range_array(vlans, :string) unless vlans == 'none'
       vlans

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -133,7 +133,12 @@ module Cisco
     # {"Model"=>"N7K-M132XP-12L", "Type"=>"10Gbase-SR", "Speed"=>"10,100,1000"}
     #
     def self.capabilities(intf, mode=:hash)
+      array = []
+    begin
       array = config_get('interface', 'capabilities', name: intf)
+    rescue CliError
+      # ignore invalid intf names; just return empty array/hash
+    end
       return array if mode == :raw
       hash = {}
       if array

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -74,9 +74,10 @@ module Cisco
       "interface #{name}"
     end
 
-    def self.interfaces(opt=nil)
+    def self.interfaces(opt=nil, single_intf=nil)
       hash = {}
-      intf_list = config_get('interface', 'all_interfaces')
+      single_intf ||= ''
+      intf_list = config_get('interface', 'all_interfaces', name: single_intf)
       return hash if intf_list.nil?
 
       # Massage intf_list data into an array that is easy

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -134,11 +134,11 @@ module Cisco
     #
     def self.capabilities(intf, mode=:hash)
       array = []
-    begin
-      array = config_get('interface', 'capabilities', name: intf)
-    rescue CliError
-      # ignore invalid intf names; just return empty array/hash
-    end
+      begin
+        array = config_get('interface', 'capabilities', name: intf)
+      rescue CliError => e
+        raise unless e.clierror[/Invalid command/]
+      end
       return array if mode == :raw
       hash = {}
       if array

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -176,7 +176,7 @@ class TestInterface < CiscoTestCase
 
     # Verify raise when bad interface name
     assert_raises(Cisco::CliError,
-                  "Did not raise CliError when invalid single_intf specified") do
+                  'Did not raise CliError when invalid single_intf specified') do
       Interface.interfaces(nil, 'MongoEthernet1/356')
     end
 
@@ -184,48 +184,48 @@ class TestInterface < CiscoTestCase
     Interface.new('loopback100').destroy
     no_loopback = Interface.interfaces(nil, 'loopback100')
     assert_empty(no_loopback,
-                 "Return value should be empty hash when non existent loopback")
+                 'Return value should be empty hash when non existent loopback')
 
     # Verify single_intf usage
     intf = interfaces[0]
     one = Interface.interfaces(nil, intf)
     assert_equal(one.keys.length, 1,
-                 "Invalid number of keys returned, should be 1")
+                 'Invalid number of keys returned, should be 1')
     assert_equal(one[intf].get_args[:show_name], intf,
-                 ":show_name should be intf name when intf specified")
+                 ':show_name should be intf name when intf specified')
 
-    # Verify "all" interfaces returned
+    # Verify 'all' interfaces returned
     all = Interface.interfaces
     assert_operator(all.keys.length, :>, 1,
-                 "Invalid number of keys returned, should exceed 1")
+                    'Invalid number of keys returned, should exceed 1')
     assert_empty(all[intf].get_args[:show_name],
-                 ":show_name should be empty string when intf is nil")
+                 ':show_name should be empty string when intf is nil')
 
     # Verify filter operations
     eth_count = all.keys.join.scan(/ethernet/).count
     filtered = Interface.interfaces(:ethernet)
     assert_equal(filtered.keys.length, eth_count,
-                 "filter returned invalid number of ethernet interfaces")
+                 'filter returned invalid number of ethernet interfaces')
 
     filtered = Interface.interfaces(:mgmt)
     assert_equal(filtered.keys.length, 1,
-                 "filter returned invalid number of mgmt interfaces")
+                 'filter returned invalid number of mgmt interfaces')
     assert_equal(filtered.keys[0], 'mgmt0',
-                 "filter returned incorrect interface name")
+                 'filter returned incorrect interface name')
 
     filtered = Interface.interfaces(:mgmt, intf)
     assert_empty(filtered,
-                 "mgmt filter returned interface when it should be an empty hash")
+                 'mgmt filter returned interface when it should be an empty hash')
 
     filtered = Interface.interfaces(:invalid_intf_pattern)
     assert_empty(filtered,
-                 "invalid filter returned interface when it should be an empty hash")
+                 'invalid filter returned interface when it should be an empty hash')
 
     filtered = Interface.interfaces(:ethernet, intf)
     assert_equal(filtered.keys.length, 1,
-                 "Invalid number of keys returned by ethernet filter with intf specified")
+                 'Invalid number of keys returned by ethernet filter with intf specified')
     assert_equal(filtered.keys[0], intf,
-                 "filter returned incorrect interface name")
+                 'filter returned incorrect interface name')
   end
 
   # Helper to get valid speeds for port

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -161,6 +161,73 @@ class TestInterface < CiscoTestCase
     end
   end
 
+  def test_non_existent_intf
+    # pre-clean: remove intf if it exists
+    Interface.new('loopback100').destroy
+
+    # Create from non-exist
+    interface = Interface.new('loopback100')
+    refute_nil(interface.name)
+    interface.destroy
+  end
+
+  def test_interfaces_api
+    # Test Interface.interfaces class method api
+
+    # Verify raise when bad interface name
+    assert_raises(Cisco::CliError,
+                  "Did not raise CliError when invalid single_intf specified") do
+      Interface.interfaces(nil, 'MongoEthernet1/356')
+    end
+
+    # Verify raise rescued when loopback does not exist ('Invalid range' rescued)
+    Interface.new('loopback100').destroy
+    no_loopback = Interface.interfaces(nil, 'loopback100')
+    assert_empty(no_loopback,
+                 "Return value should be empty hash when non existent loopback")
+
+    # Verify single_intf usage
+    intf = interfaces[0]
+    one = Interface.interfaces(nil, intf)
+    assert_equal(one.keys.length, 1,
+                 "Invalid number of keys returned, should be 1")
+    assert_equal(one[intf].get_args[:show_name], intf,
+                 ":show_name should be intf name when intf specified")
+
+    # Verify "all" interfaces returned
+    all = Interface.interfaces
+    assert_operator(all.keys.length, :>, 1,
+                 "Invalid number of keys returned, should exceed 1")
+    assert_empty(all[intf].get_args[:show_name],
+                 ":show_name should be empty string when intf is nil")
+
+    # Verify filter operations
+    eth_count = all.keys.join.scan(/ethernet/).count
+    filtered = Interface.interfaces(:ethernet)
+    assert_equal(filtered.keys.length, eth_count,
+                 "filter returned invalid number of ethernet interfaces")
+
+    filtered = Interface.interfaces(:mgmt)
+    assert_equal(filtered.keys.length, 1,
+                 "filter returned invalid number of mgmt interfaces")
+    assert_equal(filtered.keys[0], 'mgmt0',
+                 "filter returned incorrect interface name")
+
+    filtered = Interface.interfaces(:mgmt, intf)
+    assert_empty(filtered,
+                 "mgmt filter returned interface when it should be an empty hash")
+
+    filtered = Interface.interfaces(:invalid_intf_pattern)
+    assert_empty(filtered,
+                 "invalid filter returned interface when it should be an empty hash")
+
+    filtered = Interface.interfaces(:ethernet, intf)
+    assert_equal(filtered.keys.length, 1,
+                 "Invalid number of keys returned by ethernet filter with intf specified")
+    assert_equal(filtered.keys[0], intf,
+                 "filter returned incorrect interface name")
+  end
+
   # Helper to get valid speeds for port
   def capable_speed_values(interface)
     speed_capa = Interface.capabilities(interface.name)['Speed']

--- a/tests/test_interface_bdi.rb
+++ b/tests/test_interface_bdi.rb
@@ -26,8 +26,8 @@ class TestInterfaceBdi < CiscoTestCase
   def self.runnable_methods
     # We don't have a separate YAML file to key off, so we check platform
     return super if node.product_id[/N7/]
-    remove_method :setup
-    remove_method :teardown
+    remove_method :setup if instance_methods(false).include?(:setup)
+    remove_method :teardown if instance_methods(false).include?(:teardown)
     [:unsupported]
   end
 


### PR DESCRIPTION
#### Summary
Modified class method `Interface.interfaces` to allow queries for single interfaces.

Prior behavior was to initially capture and cache the state of all interfaces on the device. This approach is acceptable when managing all or most of the interfaces on the device, but performance may be unnecessarily slow when a user is managing only a handful of interfaces on a device that contains many hundreds or even thousands of interfaces.

This design change will be paired with a change to the Puppet module. The intent on the Puppet side is to allow the user to specify an interface count threshold in the manifest, which will determine when to use the cache-all approach vs single interface query.

#### Details
interface perf: `<show_name>` vs `<name>` for proper get_command usage

- Created a unique tag `<show_name>` to differentiate the `<name>` value used by the `get_command:` strings. This was necessary because the `context:` strings also used `<name>`, and not changing this causes the show command string to be interface specific at all times, even when we want the complete list of interfaces.

Add'l info:
 - `Interface.interfaces` uses `'all_interfaces'` `cmd_ref` values, and returns either a hash of all interfaces or a hash with just one interface.
 - The `command_reference` code searches for the same `context:` value in the hash, regardless of hash depth.
 - When there are multiple items in the hash we want to use `get_command:` without an interface specified, because that uses cached data instead of querying the device for each interface.
 - When there is a single interface in the hash we want to use the interface specific `get_command:` form, which returns a small amount of data very quickly.
 - Command output is cached and data is used for all getter calls - as long as each getter specifies the same `get_command:` pattern. If a different show command pattern is used it triggers a new query for the unique get_command string.