### PR TITLE
interface_channel_group: intf lookup perf fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface_channel_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_channel_group.yaml
@@ -5,7 +5,7 @@ _template:
   ios_xr:
     get_command: "show running interface"
   nexus:
-    get_command: "show running interface all"
+    get_command: "show running interface <show_name> all"
 
 all_interfaces:
   multiple:

--- a/lib/cisco_node_utils/interface_channel_group.rb
+++ b/lib/cisco_node_utils/interface_channel_group.rb
@@ -22,6 +22,7 @@ module Cisco
   # Interface - node utility class for general interface config management
   class InterfaceChannelGroup < NodeUtil
     attr_reader :name
+    attr_accessor :get_args, :show_name
 
     def initialize(name)
       validate_args(name)
@@ -31,14 +32,18 @@ module Cisco
       "interface_channel_group #{name}"
     end
 
-    def self.interfaces
+    def self.interfaces(single_intf=nil)
       hash = {}
-      all = config_get('interface_channel_group', 'all_interfaces')
+      single_intf ||= ''
+      all = config_get('interface_channel_group', 'all_interfaces',
+                       show_name: single_intf)
       return hash if all.nil?
 
       all.each do |id|
         id = id.downcase
         hash[id] = InterfaceChannelGroup.new(id)
+        hash[id].show_name = single_intf
+        hash[id].get_args[:show_name] = single_intf
       end
       hash
     end
@@ -53,7 +58,7 @@ module Cisco
     end
 
     def set_args_keys(hash={}) # rubocop:disable Style/AccessorMethodName
-      @get_args = { name: @name }
+      @get_args = { name: @name, show_name: @show_name }
       @set_args = @get_args.merge!(hash) unless hash.empty?
     end
 

--- a/tests/test_interface_channel_group.rb
+++ b/tests/test_interface_channel_group.rb
@@ -31,6 +31,26 @@ class TestInterfaceChanGrp < CiscoTestCase
     interface_cleanup(@intf.name)
   end
 
+  # Test InterfaceChannelGroup.interfaces class method api
+  def test_interfaces_api
+    intf = interfaces[0]
+    intf2 = interfaces[1]
+
+    # Verify single_intf usage
+    one = InterfaceChannelGroup.interfaces(intf)
+    assert_equal(one.keys.length, 1,
+                 'Invalid number of keys returned, should be 1')
+    assert_equal(one[intf].get_args[:show_name], intf,
+                 ':show_name should be intf name when single_intf param specified')
+
+    # Verify 'all' interfaces
+    all = InterfaceChannelGroup.interfaces
+    assert_operator(all.keys.length, :>, 1,
+                    'Invalid number of keys returned, should exceed 1')
+    assert_empty(all[intf2].get_args[:show_name],
+                 ':show_name should be empty string when single_intf param is nil')
+  end
+
   def test_channel_group
     skip if platform == :nexus
     i = @intf


### PR DESCRIPTION
#### Summary
Part 3 of the interface lookup performance work.
Ref #630 

- Modified class method `InterfaceChannelGroup.interfaces` to allow queries for single interfaces.
- `interface_channel_group.rb` is the only consumer of the `InterfaceChannelGroup` class (aside from test scripts).