### PR TITLE
interface_evpn_multisite: intf lookup perf fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface_evpn_multisite.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_evpn_multisite.yaml
@@ -3,7 +3,7 @@
 _exclude: [ios_xr, N3k, N3k-F, N5k, N6k, N7k, N9k-F]
 
 _template:
-  get_command: "show running interface all"
+  get_command: "show running interface <show_name> all"
   context:
     - "interface <interface>"
 

--- a/lib/cisco_node_utils/interface_evpn_multisite.rb
+++ b/lib/cisco_node_utils/interface_evpn_multisite.rb
@@ -20,6 +20,7 @@ module Cisco
   # node_utils class for interface_evpn_multisite
   class InterfaceEvpnMultisite < NodeUtil
     attr_reader :interface, :tracking
+    attr_accessor :get_args, :show_name
 
     def initialize(interface)
       fail TypeError unless interface.is_a?(String)
@@ -27,14 +28,18 @@ module Cisco
       @get_args = @set_args = { interface: @interface }
     end
 
-    def self.interfaces
+    def self.interfaces(single_intf=nil)
       hash = {}
-      intf_list = config_get('interface_evpn_multisite', 'all_interfaces')
+      single_intf ||= ''
+      intf_list = config_get('interface_evpn_multisite', 'all_interfaces',
+                             show_name: single_intf)
       return hash if intf_list.nil?
 
       intf_list.each do |id|
         id = id.downcase
         intf = InterfaceEvpnMultisite.new(id)
+        intf.show_name = single_intf
+        intf.get_args[:show_name] = single_intf
         hash[id] = intf if intf.tracking
       end
       hash

--- a/lib/cisco_node_utils/vxlan_vtep.rb
+++ b/lib/cisco_node_utils/vxlan_vtep.rb
@@ -79,7 +79,7 @@ module Cisco
     ########################################################
 
     def description
-      config_get('interface', 'description', name: @name)
+      config_get('interface', 'description', name: @name, show_name: @name)
     end
 
     def description=(desc)

--- a/tests/test_interface_evpn_multisite.rb
+++ b/tests/test_interface_evpn_multisite.rb
@@ -36,6 +36,32 @@ class TestInterfaceEvpnMultisite < CiscoTestCase
     config("default interface #{intf}")
   end
 
+  # Test InterfaceEvpnMultisite.interfaces class method api
+  def test_interfaces_api
+    # setup
+    ms = EvpnMultisite.new(100)
+    intf = interfaces[0]
+    intf2 = interfaces[1]
+    for i in [intf, intf2] do
+      InterfaceEvpnMultisite.new(i).enable('dci-tracking')
+    end
+
+    # Verify single_intf usage
+    one = InterfaceEvpnMultisite.interfaces(intf)
+    assert_equal(one.keys.length, 1,
+                 'Invalid number of keys returned, should be 1')
+    assert_equal(one[intf].get_args[:show_name], intf,
+                 ':show_name should be intf name when single_intf param specified')
+
+    # Verify 'all' interfaces
+    all = InterfaceEvpnMultisite.interfaces
+    assert_operator(all.keys.length, :>, 1,
+                    'Invalid number of keys returned, should exceed 1')
+    assert_empty(all[intf2].get_args[:show_name],
+                 ':show_name should be empty string when single_intf param is nil')
+    ms.destroy
+  end
+
   def test_enable_disable
     interface = interfaces[0]
     intf_ms = InterfaceEvpnMultisite.new(interface)

--- a/tests/test_interface_evpn_multisite.rb
+++ b/tests/test_interface_evpn_multisite.rb
@@ -37,12 +37,13 @@ class TestInterfaceEvpnMultisite < CiscoTestCase
   end
 
   # Test InterfaceEvpnMultisite.interfaces class method api
-  def test_interfaces_api
+  def test_interface_apis
     # setup
     ms = EvpnMultisite.new(100)
     intf = interfaces[0]
     intf2 = interfaces[1]
-    for i in [intf, intf2] do
+    interface_ethernet_default(intf2)
+    [intf, intf2].each do |i|
       InterfaceEvpnMultisite.new(i).enable('dci-tracking')
     end
 

--- a/tests/test_node_ext.rb
+++ b/tests/test_node_ext.rb
@@ -37,8 +37,8 @@ class TestNodeExt < CiscoTestCase
     node.client.set(context: ['interface loopback0'], values: ['shutdown'])
     node.client.set(values: ['interface loopback1', 'no shutdown'])
 
-    result = node.config_get('interface', 'shutdown', name: 'loopback1',
-                             show_name: 'loopback1')
+    result = node.config_get('interface', 'shutdown',
+                             name: 'loopback1', show_name: 'loopback1')
     refute(result)
   end
 

--- a/tests/test_node_ext.rb
+++ b/tests/test_node_ext.rb
@@ -37,7 +37,8 @@ class TestNodeExt < CiscoTestCase
     node.client.set(context: ['interface loopback0'], values: ['shutdown'])
     node.client.set(values: ['interface loopback1', 'no shutdown'])
 
-    result = node.config_get('interface', 'shutdown', name: 'loopback1')
+    result = node.config_get('interface', 'shutdown', name: 'loopback1',
+                             show_name: 'loopback1')
     refute(result)
   end
 


### PR DESCRIPTION
#### Summary
Part 4 (of 4) of the interface lookup performance work.
Ref #630 

- Modified class method `InterfaceEvpnMultisite.interfaces` to allow queries for single interfaces.
- `interface_evpn_multisite.rb` is the only consumer of the `InterfaceEvpnMultisite` class (aside from test scripts).