### PR TITLE
Add Interface.interface_count api

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -14,6 +14,11 @@ access_vlan:
   set_value: "switchport access vlan <vlan>"
   default_value: 1
 
+all_count:
+  get_context: ~
+  get_command: "show running interface | incl ^interface | count"
+  get_value: '/\d+/'
+
 all_interfaces:
   multiple:
   ios_xr:

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -71,6 +71,10 @@ module Cisco
       "interface #{name}"
     end
 
+    def self.interface_count
+      config_get('interface', 'all_count').to_i
+    end
+
     def self.interfaces(opt=nil, single_intf=nil)
       hash = {}
       single_intf ||= ''

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -171,8 +171,9 @@ class TestInterface < CiscoTestCase
     interface.destroy
   end
 
-  def test_interfaces_api
-    # Test Interface.interfaces class method api
+  def test_interface_apis
+    assert_equal(Interface.interface_count, interface_count,
+                 'Interface.interface_count did not return the expected count')
 
     # Verify raise when bad interface name
     assert_raises(Cisco::CliError,


### PR DESCRIPTION
This api simply returns a count of interfaces based on what is found in show running.

Tested on all current regression platforms.