### PR TITLE
Interface.interfaces selection failure when 'interface' substrings present

### DIFF
--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -84,8 +84,9 @@ module Cisco
       rescue CliError => e
         # ignore logical interfaces that may not exist yet;
         # invalid interface types should still raise
-        raise unless single_intf &&
-          (e.clierror[/Invalid range/] || e.clierror[/Invalid interface format/])
+        raise unless
+          single_intf &&
+          (e.clierror[/Invalid range/] || e.clierror[/Invalid interface/])
       end
       return hash if intf_list.nil?
 

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -84,7 +84,8 @@ module Cisco
       rescue CliError => e
         # ignore logical interfaces that may not exist yet;
         # invalid interface types should still raise
-        raise unless single_intf && e.clierror[/Invalid range/]
+        raise unless single_intf &&
+          (e.clierror[/Invalid range/] || e.clierror[/Invalid interface format/])
       end
       return hash if intf_list.nil?
 

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -92,8 +92,7 @@ module Cisco
       # Use a MARKER to hide pesky 'interface' substrings
       intf_list.collect! { |x| x.strip || x }
       intf_list.delete('')
-      intf_list.collect! { |x| (x.sub('interface', '~!MARKER!~') unless
-        x[/^interface /]) || x }
+      intf_list.collect! { |x| (x.sub('interface', '~!MARKER!~') unless x[/^interface /]) || x } # rubocop:disable Metrics/LineLength
       intf_list = intf_list.join(' ').split('interface')
       intf_list.delete('')
       # Restore 'interface' substrings

--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -88,12 +88,16 @@ module Cisco
       end
       return hash if intf_list.nil?
 
-      # Massage intf_list data into an array that is easy
-      # to work with.
+      # Massage intf_list data into an array that is easy to work with.
+      # Use a MARKER to hide pesky 'interface' substrings
       intf_list.collect! { |x| x.strip || x }
       intf_list.delete('')
+      intf_list.collect! { |x| (x.sub('interface', '~!MARKER!~') unless
+        x[/^interface /]) || x }
       intf_list = intf_list.join(' ').split('interface')
       intf_list.delete('')
+      # Restore 'interface' substrings
+      intf_list.collect! { |x| x.sub('~!MARKER!~', 'interface') }
 
       intf_list.each do |id|
         int_data = id.strip.split(' ')


### PR DESCRIPTION
Symptom:
- Interface output with an `'interface'` substring causes the `intf_list` to include invalid interface id's.
  - e.g. the following will cause `split` to create an erroneous `interface 'hsrp'` from the line that follows the line with the substring on it:
```
interface portchannel100
  hsrp bfd
  hsrp use-bia scope interface
                     ^^^^^^^^^
  hsrp mac-refresh 350
```

  - result:
```
pry(Cisco::Interface)> intf_list
=> [" port-channel100 hsrp bfd hsrp version 2 hsrp delay minimum 100 reload 200 hsrp use-bia scope ",
 " hsrp mac-refresh 350 ",
   ^^^^ (bug: this is now a separate entry in intf_list)
  ...
```

- Found with `cisco_hsrp/test_interface_hsrp.rb`