### PR TITLE
interface_ospf: interface lookup performance fixes

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface_ospf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_ospf.yaml
@@ -63,7 +63,7 @@ message_digest_key_id:
   default_value: 0
 
 message_digest_key_set:
-  set_value: '<state> ip ospf message-digest-key <keyid> <algtype> <enctype> <enc>'
+  set_value: '<state> ip ospf message-digest-key <keyid> <algtype> <enctype> <password>'
 
 message_digest_password:
   default_value: ~

--- a/lib/cisco_node_utils/cmd_ref/interface_ospf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_ospf.yaml
@@ -3,8 +3,8 @@
 _exclude: [ios_xr]
 
 _template:
-  get_command: 'show running interface all'
-  context: ["interface %s"]
+  context: ['interface <name>']
+  get_command: 'show running interface <show_name> all'
 
 all_interfaces:
   multiple:
@@ -13,7 +13,7 @@ all_interfaces:
 
 area:
   get_value: '/^\s*ip router ospf (\S+) area (\S+)/'
-  set_value: "%s ip router ospf %s area %s"
+  set_value: '<state> ip router ospf <ospf_name> area <area>'
 
 bfd:
   # the config can be 'ip ospf bfd' or
@@ -22,31 +22,31 @@ bfd:
   # match to get the whole config for checking
   # the mode
   get_value: '/^\s*ip ospf bfd *(?:\S*)$/'
-  set_value: '%s ip ospf bfd %s'
+  set_value: '<state> ip ospf bfd <disable>'
   default_value: ~
 
 cost:
   kind: int
   get_value: '/^\s*ip ospf cost (\d+)/'
-  set_value: "%s ip ospf cost %s"
+  set_value: '<state> ip ospf cost <cost>'
   default_value: 0
 
 dead_interval:
   kind: int
   get_value: '/^\s*ip ospf dead-interval (\d+)/'
-  set_value: "%s ip ospf dead-interval %s"
+  set_value: '<state> ip ospf dead-interval <interval>'
   default_value: 40
 
 hello_interval:
   kind: int
   get_value: '/^\s*ip ospf hello-interval (\d+)/'
-  set_value: "%s ip ospf hello-interval %s"
+  set_value: '<state> ip ospf hello-interval <interval>'
   default_value: 10
 
 message_digest:
   kind: boolean
   get_value: '/^\s*ip ospf authentication message-digest/'
-  set_value: "%s ip ospf authentication message-digest"
+  set_value: '<state> ip ospf authentication message-digest'
   default_value: false
 
 message_digest_alg_type:
@@ -63,7 +63,7 @@ message_digest_key_id:
   default_value: 0
 
 message_digest_key_set:
-  set_value: "%s ip ospf message-digest-key %s %s %s %s"
+  set_value: '<state> ip ospf message-digest-key <keyid> <algtype> <enctype> <enc>'
 
 message_digest_password:
   default_value: ~
@@ -72,12 +72,12 @@ message_digest_password:
 mtu_ignore:
   kind: boolean
   get_value: '/^\s*ip ospf mtu-ignore/'
-  set_value: "%s ip ospf mtu-ignore"
+  set_value: '<state> ip ospf mtu-ignore'
   default_value: false
 
 network_type:
   get_value: '/^\s*ip ospf network (\S+)$/'
-  set_value: "%s ip ospf network %s"
+  set_value: '<state> ip ospf network <network_type>'
 
 network_type_default:
   default_value: 'broadcast'
@@ -88,23 +88,23 @@ network_type_loopback_default:
 passive_interface:
   kind: boolean
   get_value: '/^\s*ip ospf passive-interface/'
-  set_value: "%s ip ospf passive-interface"
+  set_value: '<state> ip ospf passive-interface'
   default_value: false
 
 priority:
   kind: int
   get_value: '/^\s*ip ospf priority (\d+)/'
-  set_value: "%s ip ospf priority %s"
+  set_value: '<state> ip ospf priority <priority>'
   default_value: 1
 
 shutdown:
   kind: boolean
   get_value: '/^\s*ip ospf shutdown/'
-  set_value: "%s ip ospf shutdown"
+  set_value: '<state> ip ospf shutdown'
   default_value: false
 
 transmit_delay:
   kind: int
   get_value: '/^\s*ip ospf transmit-delay (\d+)/'
-  set_value: "%s ip ospf transmit-delay %s"
+  set_value: '<state> ip ospf transmit-delay <delay>'
   default_value: 1

--- a/lib/cisco_node_utils/interface_ospf.rb
+++ b/lib/cisco_node_utils/interface_ospf.rb
@@ -162,24 +162,24 @@ module Cisco
       config_get_default('interface_ospf', 'message_digest_password')
     end
 
-    def message_digest_key_set(keyid, algtype, enctype, enc)
+    def message_digest_key_set(keyid, algtype, enctype, password)
       current_keyid = message_digest_key_id
       if keyid == default_message_digest_key_id && current_keyid != keyid
-        @set_args.merge!(state:   'no',
-                         keyid:   current_keyid,
-                         algtype: '',
-                         enctype: '',
-                         enc:     '')
+        @set_args.merge!(state:    'no',
+                         keyid:    current_keyid,
+                         algtype:  '',
+                         enctype:  '',
+                         password: '')
         config_set('interface_ospf', 'message_digest_key_set', @set_args)
       elsif keyid != default_message_digest_key_id
-        fail TypeError unless enc.is_a?(String)
-        fail ArgumentError unless enc.length > 0
+        fail TypeError unless password.is_a?(String)
+        fail ArgumentError unless password.length > 0
         enctype = Encryption.symbol_to_cli(enctype)
-        @set_args.merge!(state:   '',
-                         keyid:   current_keyid,
-                         algtype: algtype,
-                         enctype: enctype,
-                         enc:     enc)
+        @set_args.merge!(state:    '',
+                         keyid:    current_keyid,
+                         algtype:  algtype,
+                         enctype:  enctype,
+                         password: password)
         config_set('interface_ospf', 'message_digest_key_set', @set_args)
       end
       set_args_keys_default

--- a/lib/cisco_node_utils/interface_ospf.rb
+++ b/lib/cisco_node_utils/interface_ospf.rb
@@ -98,8 +98,8 @@ module Cisco
       self.message_digest = default_message_digest
       message_digest_key_set(default_message_digest_key_id, '', '', '')
       self.cost = default_cost
-      destroy_hello_interval
-      destroy_dead_interval
+      destroy_interval('hello_interval')
+      destroy_interval('dead_interval')
       self.bfd = default_bfd
       self.mtu_ignore = default_mtu_ignore
       self.priority = default_priority
@@ -218,10 +218,10 @@ module Cisco
       set_args_keys_default
     end
 
-    def destroy_hello_interval
+    def destroy_interval(prop)
       # Helper to remove cli completely
       @set_args.merge!(state: 'no', interval: '')
-      config_set('interface_ospf', 'hello_interval', @set_args)
+      config_set('interface_ospf', prop, @set_args)
       set_args_keys_default
     end
 
@@ -236,13 +236,6 @@ module Cisco
     def dead_interval=(interval)
       # Previous behavior always sets interval and ignores 'no' cmd
       @set_args.merge!(state: '', interval: interval.to_i)
-      config_set('interface_ospf', 'dead_interval', @set_args)
-      set_args_keys_default
-    end
-
-    def destroy_dead_interval
-      # Helper to remove cli completely
-      @set_args.merge!(state: 'no', interval: '')
       config_set('interface_ospf', 'dead_interval', @set_args)
       set_args_keys_default
     end

--- a/lib/cisco_node_utils/interface_ospf.rb
+++ b/lib/cisco_node_utils/interface_ospf.rb
@@ -26,7 +26,7 @@ module Cisco
     attr_reader :intf_name, :ospf_name, :area
     attr_accessor :get_args
 
-    def initialize(intf_name, ospf_name, area, create=true)
+    def initialize(intf_name, ospf_name, area, create=true, single_intf=nil)
       fail TypeError unless intf_name.is_a? String
       fail TypeError unless ospf_name.is_a? String
       fail TypeError unless area.is_a? String
@@ -36,12 +36,12 @@ module Cisco
 
       # normalize
       @intf_name = intf_name.downcase
+      @show_name = single_intf ||= ''
       fail "interface #{@intf_name} does not exist" if
-        Interface.interfaces[@intf_name].nil?
-
+        Interface.interfaces(nil, single_intf)[@intf_name].nil?
       @ospf_name = ospf_name
       @area = area
-      @get_args = { name: intf_name, show_name: nil }
+      @get_args = { name: intf_name, show_name: @show_name }
       set_args_keys_default
 
       return unless create
@@ -71,8 +71,7 @@ module Cisco
         area = match[1]
         next unless ospf_name.nil? || ospf == ospf_name
         int = name.downcase
-        ints[int] = InterfaceOspf.new(int, ospf, area, false)
-        ints[int].get_args[:show_name] = single_intf
+        ints[int] = InterfaceOspf.new(int, ospf, area, false, single_intf)
       end
       ints
     end

--- a/tests/test_interface_ospf.rb
+++ b/tests/test_interface_ospf.rb
@@ -77,7 +77,7 @@ class TestInterfaceOspf < CiscoTestCase
     assert_equal(one.keys.length, 1,
                  'Invalid number of keys returned, should be 1')
     assert_equal(one[intf].get_args[:show_name], intf,
-                 ':show_name should be intf name when intf specified')
+                 ':show_name should be intf name when single_intf param specified')
 
     # Verify 'all' interfaces returned
     Interface.new(intf2)
@@ -86,20 +86,20 @@ class TestInterfaceOspf < CiscoTestCase
     assert_operator(all.keys.length, :>, 1,
                     'Invalid number of keys returned, should exceed 1')
     assert_empty(all[intf2].get_args[:show_name],
-                 ':show_name should be empty string when intf2 is nil')
+                 ':show_name should be empty string when single_intf param is nil')
 
     # Test with ospf_name parameter specified
     all = InterfaceOspf.interfaces('ospf_test')
     assert_operator(all.keys.length, :>, 1,
                     'Invalid number of keys returned, should exceed 1')
     assert_empty(all[intf2].get_args[:show_name],
-                 ':show_name should be empty string when intf2 is nil')
+                 ':show_name should be empty string when single_intf param is nil')
 
     one = InterfaceOspf.interfaces('ospf_test', intf2)
     assert_equal(one.keys.length, 1,
                  'Invalid number of keys returned, should be 1')
     assert_equal(one[intf2].get_args[:show_name], intf2,
-                 ':show_name should be intf2 name when intf2 specified')
+                 ':show_name should be intf2 name when single_intf param specified')
   end
 
   def test_get_set_area

--- a/tests/test_interface_ospf.rb
+++ b/tests/test_interface_ospf.rb
@@ -62,7 +62,7 @@ class TestInterfaceOspf < CiscoTestCase
   end
 
   # Test InterfaceOspf.interfaces class method api
-  def test_interfaces_api
+  def test_interface_apis
     intf = interfaces[0]
     intf2 = interfaces[1]
 

--- a/tests/test_interface_ospf.rb
+++ b/tests/test_interface_ospf.rb
@@ -100,6 +100,14 @@ class TestInterfaceOspf < CiscoTestCase
                  'Invalid number of keys returned, should be 1')
     assert_equal(one[intf2].get_args[:show_name], intf2,
                  ':show_name should be intf2 name when single_intf param specified')
+
+    # Test non-existent loopback raises fail
+    if Interface.interfaces(nil, 'loopback543').any?
+      Interface.new('loopback543', false).destroy
+    end
+    assert_raises(RuntimeError) do
+      InterfaceOspf.new('loopback543', 'ospf_test', '0', false)
+    end
   end
 
   def test_get_set_area

--- a/tests/test_interface_ospf.rb
+++ b/tests/test_interface_ospf.rb
@@ -369,6 +369,14 @@ class TestInterfaceOspf < CiscoTestCase
     interface.hello_interval = interface.default_hello_interval
     refute_show_match(pattern: /\s+ip ospf hello-interval(.*)/,
                       msg:     'Error: default hello-interval set failed')
+
+    # Test destroy_interval helper method
+    interface.hello_interval = interval
+    interface.destroy_interval('hello_interval')
+    refute_show_match(
+      command: show_cmd(interface.intf_name),
+      pattern: /\s+ip ospf hello-interval/,
+      msg:     'ip ospf hello-interval not removed')
   end
 
   def test_dead_inv
@@ -403,6 +411,14 @@ class TestInterfaceOspf < CiscoTestCase
     assert_show_match(
       pattern: /^\s+ip ospf dead-interval #{interface.default_dead_interval}/,
       msg:     'Error: default dead-interval set failed')
+
+    # Test destroy_interval helper method
+    interface.dead_interval = interval
+    interface.destroy_interval('dead_interval')
+    refute_show_match(
+      command: show_cmd(interface.intf_name),
+      pattern: /\s+ip ospf dead-interval/,
+      msg:     'ip ospf dead-interval not removed')
   end
 
   def test_bfd


### PR DESCRIPTION
**Summary**
Part 2 of the interface lookup performance work.
Ref #630

- Modified class method InterfaceOspf.interfaces to allow queries for single interfaces.
- interface_ospf.yaml is one of the early implementations and it was still using positional fields instead of named fields. This created a larger effort to implement the interface performance changes.
- interface_ospf.rb is the only consumer of the InterfaceOspf class.