### PR TITLE
rescue intf lookups when intf is non-existent

### DIFF
--- a/lib/cisco_node_utils/interface_channel_group.rb
+++ b/lib/cisco_node_utils/interface_channel_group.rb
@@ -35,8 +35,16 @@ module Cisco
     def self.interfaces(single_intf=nil)
       hash = {}
       single_intf ||= ''
-      all = config_get('interface_channel_group', 'all_interfaces',
-                       show_name: single_intf)
+      begin
+        all = config_get('interface_channel_group', 'all_interfaces',
+                         show_name: single_intf)
+      rescue CliError => e
+        # ignore logical interfaces that may not exist yet;
+        # invalid interface types should still raise
+        raise unless
+          single_intf &&
+          (e.clierror[/Invalid range/] || e.clierror[/Invalid interface/])
+      end
       return hash if all.nil?
 
       all.each do |id|

--- a/lib/cisco_node_utils/interface_evpn_multisite.rb
+++ b/lib/cisco_node_utils/interface_evpn_multisite.rb
@@ -31,8 +31,16 @@ module Cisco
     def self.interfaces(single_intf=nil)
       hash = {}
       single_intf ||= ''
-      intf_list = config_get('interface_evpn_multisite', 'all_interfaces',
-                             show_name: single_intf)
+      begin
+        intf_list = config_get('interface_evpn_multisite', 'all_interfaces',
+                               show_name: single_intf)
+      rescue CliError => e
+        # ignore logical interfaces that may not exist yet;
+        # invalid interface types should still raise
+        raise unless
+          single_intf &&
+          (e.clierror[/Invalid range/] || e.clierror[/Invalid interface/])
+      end
       return hash if intf_list.nil?
 
       intf_list.each do |id|

--- a/lib/cisco_node_utils/interface_ospf.rb
+++ b/lib/cisco_node_utils/interface_ospf.rb
@@ -59,8 +59,16 @@ module Cisco
       fail TypeError unless ospf_name.is_a?(String) || ospf_name.nil?
       ints = {}
       single_intf ||= ''
-      intf_list = config_get('interface_ospf', 'all_interfaces',
-                             show_name: single_intf)
+      begin
+        intf_list = config_get('interface_ospf', 'all_interfaces',
+                               show_name: single_intf)
+      rescue CliError => e
+        # ignore logical interfaces that may not exist yet;
+        # invalid interface types should still raise
+        raise unless
+          single_intf &&
+          (e.clierror[/Invalid range/] || e.clierror[/Invalid interface/])
+      end
       return ints if intf_list.nil?
       intf_list.each do |name|
         # Find interfaces with 'ip router ospf <name> area <area>'

--- a/tests/test_interface_channel_group.rb
+++ b/tests/test_interface_channel_group.rb
@@ -32,7 +32,7 @@ class TestInterfaceChanGrp < CiscoTestCase
   end
 
   # Test InterfaceChannelGroup.interfaces class method api
-  def test_interfaces_api
+  def test_interface_apis
     intf = interfaces[0]
     intf2 = interfaces[1]
 
@@ -49,6 +49,12 @@ class TestInterfaceChanGrp < CiscoTestCase
                     'Invalid number of keys returned, should exceed 1')
     assert_empty(all[intf2].get_args[:show_name],
                  ':show_name should be empty string when single_intf param is nil')
+
+    # Test non-existent loopback does NOT raise when calling interfaces
+    Interface.new('loopback543', false).destroy if
+      Interface.interfaces(nil, 'loopback543').any?
+    one = InterfaceChannelGroup.interfaces('loopback543')
+    assert_empty(one, 'InterfaceChannelGroup.interfaces hash should be empty')
   end
 
   def test_channel_group

--- a/tests/test_interface_evpn_multisite.rb
+++ b/tests/test_interface_evpn_multisite.rb
@@ -60,6 +60,14 @@ class TestInterfaceEvpnMultisite < CiscoTestCase
                     'Invalid number of keys returned, should exceed 1')
     assert_empty(all[intf2].get_args[:show_name],
                  ':show_name should be empty string when single_intf param is nil')
+
+    # Test non-existent interface does NOT raise when calling interfaces
+    Interface.new('loopback543', false).destroy if
+      Interface.interfaces(nil, 'loopback543').any?
+    no_intf = InterfaceEvpnMultisite.interfaces('loopback543')
+    assert_empty(no_intf,
+                 'InterfaceEvpnMultisite.interfaces hash should be empty')
+
     ms.destroy
   end
 

--- a/tests/test_interface_ospf.rb
+++ b/tests/test_interface_ospf.rb
@@ -101,13 +101,16 @@ class TestInterfaceOspf < CiscoTestCase
     assert_equal(one[intf2].get_args[:show_name], intf2,
                  ':show_name should be intf2 name when single_intf param specified')
 
-    # Test non-existent loopback raises fail
-    if Interface.interfaces(nil, 'loopback543').any?
-      Interface.new('loopback543', false).destroy
-    end
+    # Test non-existent loopback raises fail when calling initialize
+    Interface.new('loopback543', false).destroy if
+      Interface.interfaces(nil, 'loopback543').any?
     assert_raises(RuntimeError) do
       InterfaceOspf.new('loopback543', 'ospf_test', '0', false)
     end
+
+    # Test non-existent loopback does NOT raise when calling interfaces
+    one = InterfaceOspf.interfaces('ospf_test', 'loopback543')
+    assert_empty(one, 'InterfaceOspf.interfaces hash should be empty')
   end
 
   def test_get_set_area


### PR DESCRIPTION
When calling the various `interfaces` methods with a `single_intf`, the `config_get` will raise when an interface is not present (e.g. loopbacks, svis, etc).

These methods should return an empty hash when the interface does not exist, just as the previous code did when it collected all interfaces.

Tested on 9k and 7k.