### PR TITLE
Fix structured output cache problem

### DIFF
--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -89,7 +89,6 @@ module Cisco
         ref.hash['get_value'] = get_args[:value]
         ref.hash['drill_down'] = true
         get_args[:value] = nil
-        cache_flush
       end
       [get_args, ref]
     end
@@ -343,21 +342,22 @@ module Cisco
       if @cmd_ref
         prod = config_get('inventory', 'productid')
         all  = config_get('inventory', 'all')
-        prod_qualifier(prod, all)
+        id = prod_qualifier(prod, all)
       else
         # We use this function to *find* the appropriate CommandReference
         if @client.platform == :nexus
           entries = get(command:     'show inventory',
                         data_format: :nxapi_structured)
           prod = entries['TABLE_inv']['ROW_inv'][0]['productid']
-          prod_qualifier(prod, entries['TABLE_inv']['ROW_inv'])
+          id = prod_qualifier(prod, entries['TABLE_inv']['ROW_inv'])
         elsif @client.platform == :ios_xr
           # No support for structured output for this command yet
           output = get(command:     'show inventory',
                        data_format: :cli)
-          return /NAME: .*\nPID: (\S+)/.match(output)[1]
+          id = /NAME: .*\nPID: (\S+)/.match(output)[1]
         end
       end
+      return id
     end
 
     def prod_qualifier(prod, inventory)

--- a/lib/cisco_node_utils/node.rb
+++ b/lib/cisco_node_utils/node.rb
@@ -342,22 +342,21 @@ module Cisco
       if @cmd_ref
         prod = config_get('inventory', 'productid')
         all  = config_get('inventory', 'all')
-        id = prod_qualifier(prod, all)
+        prod_qualifier(prod, all)
       else
         # We use this function to *find* the appropriate CommandReference
         if @client.platform == :nexus
           entries = get(command:     'show inventory',
                         data_format: :nxapi_structured)
           prod = entries['TABLE_inv']['ROW_inv'][0]['productid']
-          id = prod_qualifier(prod, entries['TABLE_inv']['ROW_inv'])
+          prod_qualifier(prod, entries['TABLE_inv']['ROW_inv'])
         elsif @client.platform == :ios_xr
           # No support for structured output for this command yet
           output = get(command:     'show inventory',
                        data_format: :cli)
-          id = /NAME: .*\nPID: (\S+)/.match(output)[1]
+          return /NAME: .*\nPID: (\S+)/.match(output)[1]
         end
       end
-      return id
     end
 
     def prod_qualifier(prod, inventory)

--- a/tests/test_node_ext.rb
+++ b/tests/test_node_ext.rb
@@ -144,8 +144,10 @@ class TestNodeExt < CiscoTestCase
   def test_get_product_id
     # N3|9K Fretta product_id gets a '-F' appended so remove it for this check
     if product_tag[/n(3|9)k-f/]
+      node.client.cache_flush
       chassis = node.product_id.sub('-F', '')
     else
+      node.client.cache_flush
       chassis = node.product_id
     end
     assert_output_check(command: 'show inventory',


### PR DESCRIPTION
This PR fixes a problem where queries using structured output do not rely on cached output when they should be.

This PR also fixes a test that was was failing because it was trying to access stale `show inventory` data from a previous method call.  The fix is to clear the cache for this test so that it gets the correct data for the test.

Structured output tests run against n9k, n3k, n7k, n6k.