### PR TITLE
interface perf fix: loosen raise check

### DIFF
--- a/lib/cisco_node_utils/interface.rb
+++ b/lib/cisco_node_utils/interface.rb
@@ -82,11 +82,9 @@ module Cisco
         intf_list = config_get('interface', 'all_interfaces',
                                show_name: single_intf)
       rescue CliError => e
-        # ignore logical interfaces that may not exist yet;
-        # invalid interface types should still raise
-        raise unless
-          single_intf &&
-          (e.clierror[/Invalid range/] || e.clierror[/Invalid interface/])
+        raise unless single_intf
+        # ignore logical interfaces that do not exist
+        debug 'Interface.interfaces ignoring CliError => ' + e.to_s
       end
       return hash if intf_list.nil?
 

--- a/lib/cisco_node_utils/interface_channel_group.rb
+++ b/lib/cisco_node_utils/interface_channel_group.rb
@@ -39,11 +39,9 @@ module Cisco
         all = config_get('interface_channel_group', 'all_interfaces',
                          show_name: single_intf)
       rescue CliError => e
-        # ignore logical interfaces that may not exist yet;
-        # invalid interface types should still raise
-        raise unless
-          single_intf &&
-          (e.clierror[/Invalid range/] || e.clierror[/Invalid interface/])
+        raise unless single_intf
+        # ignore logical interfaces that do not exist
+        debug 'InterfaceChannelGroup.interfaces ignoring CliError => ' + e.to_s
       end
       return hash if all.nil?
 

--- a/lib/cisco_node_utils/interface_evpn_multisite.rb
+++ b/lib/cisco_node_utils/interface_evpn_multisite.rb
@@ -35,11 +35,9 @@ module Cisco
         intf_list = config_get('interface_evpn_multisite', 'all_interfaces',
                                show_name: single_intf)
       rescue CliError => e
-        # ignore logical interfaces that may not exist yet;
-        # invalid interface types should still raise
-        raise unless
-          single_intf &&
-          (e.clierror[/Invalid range/] || e.clierror[/Invalid interface/])
+        raise unless single_intf
+        # ignore logical interfaces that do not exist
+        debug 'InterfaceEvpnMultisite.interfaces ignoring CliError => ' + e.to_s
       end
       return hash if intf_list.nil?
 

--- a/lib/cisco_node_utils/interface_ospf.rb
+++ b/lib/cisco_node_utils/interface_ospf.rb
@@ -63,11 +63,9 @@ module Cisco
         intf_list = config_get('interface_ospf', 'all_interfaces',
                                show_name: single_intf)
       rescue CliError => e
-        # ignore logical interfaces that may not exist yet;
-        # invalid interface types should still raise
-        raise unless
-          single_intf &&
-          (e.clierror[/Invalid range/] || e.clierror[/Invalid interface/])
+        raise unless single_intf
+        # ignore logical interfaces that do not exist
+        debug 'InterfaceOspf.interfaces ignoring CliError => ' + e.to_s
       end
       return ints if intf_list.nil?
       intf_list.each do |name|

--- a/lib/cisco_node_utils/itd_service.rb
+++ b/lib/cisco_node_utils/itd_service.rb
@@ -377,7 +377,7 @@ module Cisco
       # for boolean we need to do this
       send('load_bal_enable=', false) if attrs[:load_bal_enable] == ''
       @get_args = @set_args
-      config_set('itd_service', 'load_balance', @set_args)
+      config_set('itd_service', 'load_balance', @set_args) if lb_get
       set_args_keys_default
     end
 


### PR DESCRIPTION
Current code will raise when searching for specific interfaces that are not present on the device. 
The intent was to catch real CliErrors but there are several permutations of error messages involved so I'm removing the pattern match checks, and now only raise when we hit CliError while searching for all interfaces.

Also one minor issue with `itd_service`. Current code does a `no load-balance` regardless of whether there are actually any `load-balance` configs present; this change checks for existence first.

- Tested on n9k-108