### PR TITLE
7k workaround for missing 'all' keyword on port-channels

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface.yaml
@@ -6,6 +6,8 @@ _template:
     get_command: "show running interface <name>"
   nexus:
     get_command: "show running interface <show_name> all"
+    N7k:
+      get_command: "show running interface all | section '^interface <show_name>'"
 
 access_vlan:
   _exclude: [ios_xr]

--- a/lib/cisco_node_utils/cmd_ref/interface_channel_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_channel_group.yaml
@@ -6,6 +6,9 @@ _template:
     get_command: "show running interface"
   nexus:
     get_command: "show running interface <show_name> all"
+    N7k:
+      get_command: "show running interface all | section '^interface <show_name>'"
+
 
 all_interfaces:
   multiple:

--- a/lib/cisco_node_utils/cmd_ref/interface_ospf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_ospf.yaml
@@ -5,6 +5,8 @@ _exclude: [ios_xr]
 _template:
   context: ['interface <name>']
   get_command: 'show running interface <show_name> all'
+    N7k:
+      get_command: "show running interface all | section '^interface <show_name>'"
 
 all_interfaces:
   multiple:

--- a/lib/cisco_node_utils/cmd_ref/interface_ospf.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_ospf.yaml
@@ -5,8 +5,8 @@ _exclude: [ios_xr]
 _template:
   context: ['interface <name>']
   get_command: 'show running interface <show_name> all'
-    N7k:
-      get_command: "show running interface all | section '^interface <show_name>'"
+  N7k:
+    get_command: "show running interface all | section '^interface <show_name>'"
 
 all_interfaces:
   multiple:


### PR DESCRIPTION
The interface performance fixes ran into a problem on N7k platforms because their cli is missing the `all` keyword; e.g. `show running interface port-channel 11 all`. So far it appears that only port-channels exhibit this problem.

This change allows the same functionality - it is marginally slower than the recently updated syntax, but still much faster than the original method of collecting all interfaces.