### PR TITLE
Fix interface_ospf setter

### DIFF
--- a/lib/cisco_node_utils/interface_ospf.rb
+++ b/lib/cisco_node_utils/interface_ospf.rb
@@ -182,7 +182,7 @@ module Cisco
         fail ArgumentError unless password.length > 0
         enctype = Encryption.symbol_to_cli(enctype)
         @set_args.merge!(state:    '',
-                         keyid:    current_keyid,
+                         keyid:    keyid,
                          algtype:  algtype,
                          enctype:  enctype,
                          password: password)


### PR DESCRIPTION
Fixes a problem where the setter was trying to set the keyid to `0` which is not a supported keyid value.  