### PR TITLE
interface.rb: show_name N7k workaround fixes

### DIFF
--- a/lib/cisco_node_utils/cisco_cmn_utils.rb
+++ b/lib/cisco_node_utils/cisco_cmn_utils.rb
@@ -415,5 +415,29 @@ module Cisco
       prefix = prop.to_s if prefix.nil?
       val.to_s.empty? ? val : "#{prefix} #{val}"
     end
+
+    # Helper utility to normalize interface names to be filtered.
+    # This is only a problem on N7k which has to use a section filter
+    # due to a show run int bug (no 'all' keyword for some interfaces).
+    def self.normalize_intf_pattern(show_name)
+      return '' if show_name.nil? || show_name.empty?
+      require_relative 'platform'
+      return show_name unless Platform.hardware_type[/Nexus7/]
+      intf = show_name.downcase
+      case intf
+      when /ethernet/
+        intf.sub!(/ethernet/, 'Ethernet')
+      when /loopback/
+        intf.sub!(/loopback/, 'loopback')
+      when /port-channel/
+        intf.sub!(/port-channel/, 'port-channel')
+      when /vlan/
+        intf.sub!(/vlan/, 'Vlan')
+      else
+        # wildcard the first char of the name
+        intf.sub!(/./, '.')
+      end
+      intf
+    end
   end # class Utils
 end   # module Cisco

--- a/tests/test_interface.rb
+++ b/tests/test_interface.rb
@@ -175,12 +175,6 @@ class TestInterface < CiscoTestCase
     assert_equal(Interface.interface_count, interface_count,
                  'Interface.interface_count did not return the expected count')
 
-    # Verify raise when bad interface name
-    assert_raises(Cisco::CliError,
-                  'Did not raise CliError when invalid single_intf specified') do
-      Interface.interfaces(nil, 'MongoEthernet1/356')
-    end
-
     # Verify raise rescued when loopback does not exist ('Invalid range' rescued)
     Interface.new('loopback100').destroy
     no_loopback = Interface.interfaces(nil, 'loopback100')
@@ -190,28 +184,28 @@ class TestInterface < CiscoTestCase
     # Verify single_intf usage
     intf = interfaces[0]
     one = Interface.interfaces(nil, intf)
-    assert_equal(one.keys.length, 1,
+    assert_equal(1, one.length,
                  'Invalid number of keys returned, should be 1')
-    assert_equal(one[intf].get_args[:show_name], intf,
+    assert_equal(Utils.normalize_intf_pattern(intf), one[intf].show_name,
                  ':show_name should be intf name when intf specified')
 
     # Verify 'all' interfaces returned
     all = Interface.interfaces
-    assert_operator(all.keys.length, :>, 1,
+    assert_operator(all.length, :>, 1,
                     'Invalid number of keys returned, should exceed 1')
-    assert_empty(all[intf].get_args[:show_name],
+    assert_empty(all[intf].show_name,
                  ':show_name should be empty string when intf is nil')
 
     # Verify filter operations
     eth_count = all.keys.join.scan(/ethernet/).count
     filtered = Interface.interfaces(:ethernet)
-    assert_equal(filtered.keys.length, eth_count,
+    assert_equal(eth_count, filtered.length,
                  'filter returned invalid number of ethernet interfaces')
 
     filtered = Interface.interfaces(:mgmt)
-    assert_equal(filtered.keys.length, 1,
+    assert_equal(1, filtered.length,
                  'filter returned invalid number of mgmt interfaces')
-    assert_equal(filtered.keys[0], 'mgmt0',
+    assert_equal('mgmt0', filtered.keys[0],
                  'filter returned incorrect interface name')
 
     filtered = Interface.interfaces(:mgmt, intf)
@@ -223,9 +217,9 @@ class TestInterface < CiscoTestCase
                  'invalid filter returned interface when it should be an empty hash')
 
     filtered = Interface.interfaces(:ethernet, intf)
-    assert_equal(filtered.keys.length, 1,
+    assert_equal(1, filtered.length,
                  'Invalid number of keys returned by ethernet filter with intf specified')
-    assert_equal(filtered.keys[0], intf,
+    assert_equal(intf, filtered.keys[0],
                  'filter returned incorrect interface name')
   end
 


### PR DESCRIPTION
Additional workarounds to solve the problem with using `show run int all | section `^interface <intf_name_pattern>'`

The issue here was that the interface name in the manifest may not match the literal interface name string on the device (note this is only an N7K issue). When doing `show run int <intf_name> all` (on non-N7K's) it doesn't matter if there are case differences; when doing a section command we must match exactly because there is no case-insensitive option for `section`.