### PR TITLE
platform.rb: fix cache overwrite bug

### DIFF
--- a/lib/cisco_node_utils/platform.rb
+++ b/lib/cisco_node_utils/platform.rb
@@ -128,36 +128,18 @@ module Cisco
     #                     'sn'    => 'SAL1812NTBP' },
     #       'Slot 2' => { ... }}
     def self.inventory_of(type)
-      # node.cache_flush # TODO: investigate why this is needed
       inv = config_get('inventory', 'all')
       inv_hsh = {}
       return inv_hsh if inv.nil?
-      if platform == :ios_xr
-        # XR gets a string so we have to process it directly
-        inv_arr = inv.scan(
-          /NAME:\s+"(#{type}[^"]*)",\s+
-           DESCR:\s+"([^"]*)"\s*
-           \n
-           PID:\s+(\S+)\s*,\s+
-           VID:\s+(\S+)\s*,\s+
-           SN:\s+(\S+)\s*/x).flatten
-        inv_arr.each do |entry|
-          inv_hsh[entry[0]] = { 'descr' => entry[1],
-                                'pid'   => entry[2],
-                                'vid'   => entry[3],
-                                'sn'    => entry[4] }
-        end
-      else
-        # Nexus gets structured output
-        inv.select! { |x| x['name'].include? type }
-        return inv_hsh if inv.empty?
-        # match desired output format
-        inv.each do |s|
-          inv_hsh[s['name'].tr('"', '')] = { 'descr' => s['desc'].tr('"', ''),
-                                             'pid'   => s['productid'],
-                                             'vid'   => s['vendorid'],
-                                             'sn'    => s['serialnum'] }
-        end
+      # Nexus gets structured output
+      inv_copy = inv.select { |x| x['name'].include? type }
+      return inv_hsh if inv_copy.empty?
+      # match desired output format
+      inv_copy.each do |s|
+        inv_hsh[s['name'].tr('"', '')] = { 'descr' => s['desc'].tr('"', ''),
+                                           'pid'   => s['productid'],
+                                           'vid'   => s['vendorid'],
+                                           'sn'    => s['serialnum'] }
       end
       inv_hsh
     end


### PR DESCRIPTION
Probably a day one issue for structured output. The problem was when a data item was not found, the `inv.select!` call was overwriting the actual `cache_hash` with a partially empty table; i.e.

```
cache_hash['cli_show']['show inventory'] => {"TABLE_inv"=>{"ROW_inv"=>[]}}
```
This caused future `Platform` calls to wrongly assume there was valid data in the cache - the cache wasn't empty because of the `"Table_inv"` entry but the data it pointed to was empty.

edit: I also got rid of the dead XR code.

Tested on all regression platforms.