### PR TITLE
Fix bfd_global slow_timer for irvine

### DIFF
--- a/lib/cisco_node_utils/bfd_global.rb
+++ b/lib/cisco_node_utils/bfd_global.rb
@@ -146,6 +146,8 @@ module Cisco
     end
 
     def ipv4_slow_timer=(val)
+      # Only set the value if it's not already configured and default
+      return if (val == default_ipv4_slow_timer && val == ipv4_slow_timer)
       set_args_keys(timer: val,
                     state: val == default_ipv4_slow_timer ? 'no' : '')
       config_set('bfd_global', 'ipv4_slow_timer', @set_args)
@@ -160,6 +162,8 @@ module Cisco
     end
 
     def ipv6_slow_timer=(val)
+      # Only set the value if it's not already configured and default
+      return if (val == default_ipv6_slow_timer && val == ipv6_slow_timer)
       set_args_keys(timer: val,
                     state: val == default_ipv6_slow_timer ? 'no' : '')
       config_set('bfd_global', 'ipv6_slow_timer', @set_args)

--- a/lib/cisco_node_utils/bfd_global.rb
+++ b/lib/cisco_node_utils/bfd_global.rb
@@ -147,7 +147,7 @@ module Cisco
 
     def ipv4_slow_timer=(val)
       # Only set the value if it's not already configured and default
-      return if (val == default_ipv4_slow_timer && val == ipv4_slow_timer)
+      return if val == default_ipv4_slow_timer && val == ipv4_slow_timer
       set_args_keys(timer: val,
                     state: val == default_ipv4_slow_timer ? 'no' : '')
       config_set('bfd_global', 'ipv4_slow_timer', @set_args)
@@ -163,7 +163,7 @@ module Cisco
 
     def ipv6_slow_timer=(val)
       # Only set the value if it's not already configured and default
-      return if (val == default_ipv6_slow_timer && val == ipv6_slow_timer)
+      return if val == default_ipv6_slow_timer && val == ipv6_slow_timer
       set_args_keys(timer: val,
                     state: val == default_ipv6_slow_timer ? 'no' : '')
       config_set('bfd_global', 'ipv6_slow_timer', @set_args)


### PR DESCRIPTION
Nxapi errors out if the slow timer values are not configured and we try to issue the `no` form of the cli.  This is also true if it's in the default state.