### PR TITLE
interface_hsrp_group: interface lookup enhancement

### DIFF
--- a/lib/cisco_node_utils/cmd_ref/interface_hsrp_group.yaml
+++ b/lib/cisco_node_utils/cmd_ref/interface_hsrp_group.yaml
@@ -3,10 +3,13 @@
 _exclude: [ios_xr, N5k, N6k]
 
 _template:
-  get_command: "show running hsrp | no-more"
+  get_command: "show running hsrp"
   context:
     - "interface <name>"
     - "hsrp <group> <iptype>"
+
+all_hsrp:
+  get_context: ~
 
 authentication:
   get_value: '/^authentication (.*)$/'
@@ -73,7 +76,7 @@ mac_addr:
   default_value: false
 
 preempt:
-  get_command: "show running hsrp all | no-more"
+  get_command: "show running hsrp all"
   get_value: '/^preempt delay minimum (\d+) reload (\d+) sync (\d+)/'
   set_value: '<state> preempt <delay> <minimum> <minval> <reload> <relval> <sync> <syncval>'
   default_value: false

--- a/lib/cisco_node_utils/interface_hsrp_group.rb
+++ b/lib/cisco_node_utils/interface_hsrp_group.rb
@@ -37,7 +37,9 @@ module Cisco
     def self.groups
       hash = {}
       return hash unless Feature.hsrp_enabled?
-      Interface.interfaces.each do|intf, _obj|
+      all_hsrp = config_get('interface_hsrp_group', 'all_hsrp')
+      interfaces = all_hsrp.scan(/interface (.*)/).flatten
+      interfaces.each do|intf|
         groups = config_get('interface_hsrp_group', 'groups', name: intf)
         next if groups.nil?
         hash[intf] = {}


### PR DESCRIPTION
The original code collected a list of every interface on the device, then walked each of those looking for hsrp groups. My change uses `show running hsrp` to collect only those interfaces that already have hsrp configs.

UT: minitest & beaker hsrp tests are 100% Pass