### PR TITLE
Better vdc errmsg

### DIFF
--- a/lib/cisco_node_utils/vdc.rb
+++ b/lib/cisco_node_utils/vdc.rb
@@ -46,7 +46,7 @@ module Cisco
 
     def self.default_vdc_name
       vdc = config_get('vdc', 'default_vdc_name')
-      fail RuntimeError , 'default vdc not found, platform may not support vdc' if vdc.nil?
+      fail 'default vdc not found, platform may not support vdc' if vdc.nil?
       vdc
     end
 

--- a/lib/cisco_node_utils/vdc.rb
+++ b/lib/cisco_node_utils/vdc.rb
@@ -46,7 +46,7 @@ module Cisco
 
     def self.default_vdc_name
       vdc = config_get('vdc', 'default_vdc_name')
-      fail RuntimeError if vdc.nil?
+      fail RuntimeError , 'default vdc not found, platform may not support vdc' if vdc.nil?
       vdc
     end
 


### PR DESCRIPTION
We raised on non-existent VDCs but didn't include a message. Now we do.

Test:
```
> puppet device --deviceconfig ~/.puppet/device.conf --logdest console
Error: Could not prefetch cisco_vdc provider 'cisco': default vdc not found, platform may not support vdc
Error: Failed to apply catalog: default vdc not found, platform may not support vdc
```